### PR TITLE
fix e2e tests

### DIFF
--- a/tests/bruno/e2e/connect_peer.bru
+++ b/tests/bruno/e2e/connect_peer.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{ NODE3_RPC_URL }}
+  url: {{NODE3_RPC_URL}}
   body: json
   auth: none
 }
@@ -19,7 +19,7 @@ body:json {
   {
     "request": {
       "Command": {
-        "ConnectPeer": "{{ NODE1_ADDR }}"
+        "ConnectPeer": "{{NODE1_ADDR}}"
       }
     }
   }

--- a/tests/bruno/e2e/open_channel.bru
+++ b/tests/bruno/e2e/open_channel.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{ NODE3_RPC_URL }}
+  url: {{NODE3_RPC_URL}}
   body: json
   auth: none
 }
@@ -20,7 +20,7 @@ body:json {
     "request": {
       "Command": {
         "SendPcnMessage": {
-          "peer_id": "{{ NODE1_PEERID }}",
+          "peer_id": "{{NODE1_PEERID}}",
           "message": {
             "OpenChannel": {
               "chain_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/tests/bruno/e2e/send_test_message.bru
+++ b/tests/bruno/e2e/send_test_message.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{ NODE3_RPC_URL }}
+  url: {{NODE3_RPC_URL}}
   body: json
   auth: none
 }
@@ -20,7 +20,7 @@ body:json {
     "request": {
       "Command": {
         "SendPcnMessage": {
-          "peer_id": "{{ NODE1_PEERID }}",
+          "peer_id": "{{NODE1_PEERID}}",
           "message": {
             "TestMessage": {
               "bytes": "aGVsbG8gd29ybGQK"

--- a/tests/nodes/start.sh
+++ b/tests/nodes/start.sh
@@ -7,6 +7,8 @@ nodes_dir="$(dirname "$script_dir")/nodes"
 
 cd "$nodes_dir" || exit 1
 
+chmod 600 */ckb/sk
+
 start() {
     cargo run -- "$@"
 }


### PR DESCRIPTION
- Fix bruno files. The bruno-cli does not support spaces around the variable names.
- Fix secret key permissions.
