### PR TITLE
Funding tx management (CKB Only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "chrono",
  "ckb-crypto",
  "ckb-hash 0.115.0",
+ "ckb-jsonrpc-types",
  "ckb-sdk",
  "ckb-types",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ bitcoin = { version = "0.30.2", features = ["serde"] }
 bitcoin-bech32 = "0.12"
 bech32 = "0.8"
 libc = "0.2"
-
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 rand = "0.8.5"
 serde_json = { version = "1.0" }
@@ -51,6 +50,7 @@ once_cell = "1.19.0"
 tokio-util = { version = "0.7.10", features = ["rt"] }
 molecule = { version = "0.7.5", default-features = false }
 ckb-types = "0.114.0"
+ckb-jsonrpc-types = "0.114.0"
 ckb-crypto = "0.114.0"
 serde_with = { version = "3.7.0", features = ["macros", "base64"] }
 hex = "0.4.3"
@@ -58,7 +58,7 @@ tower = "0.4.13"
 axum = "0.7.5"
 bitflags = "2.5.0"
 ckb-hash = "0.115.0"
-secp256k1 = { version = "0.28.0", features = ["serde"] }
+secp256k1 = { version = "0.28.0", features = ["serde", "recovery"] }
 musig2 = { version = "0.0.11", features = ["secp256k1", "serde"] }
 ractor = "0.9.7"
 
@@ -70,4 +70,3 @@ panic = "abort"
 
 [dev-dependencies]
 tempfile = "3.10.1"
-

--- a/examples/funding.rs
+++ b/examples/funding.rs
@@ -1,0 +1,201 @@
+/// # How to Use This Example
+///
+/// Start CKB dev net first. Set the test account as the miner.
+///
+///
+/// ```text
+/// ckb init -c dev --force --ba-arg 0xc8328aabcd9b9e8e64fbc566c4385c3bdeb219d7
+/// ```
+///
+/// Transfer some CKB to the address
+///
+/// ```text
+/// ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqgx5lf4pczpamsfam48evs0c8nvwqqa59qapt46f`
+/// ```
+///
+/// Run the example:
+///
+/// ```text
+/// cargo run --example funding /tmp/ckb-local /tmp/ckb-remote
+/// ```
+use ckb_pcn_node::{
+    ckb::types::Hash256,
+    ckb_chain::{
+        CkbChainActor, CkbChainConfig, CkbChainMessage, FundingRequest, FundingTx, TraceTxRequest,
+    },
+};
+use ckb_types::packed;
+use ractor::{call_t, cast, Actor, ActorRef};
+use std::{env, path::PathBuf};
+
+#[tokio::main]
+pub async fn main() {
+    env_logger::init();
+
+    let (local_config, remote_config) = prepare();
+
+    let (local_actor, local_handle) = Actor::spawn(
+        Some("local actor".to_string()),
+        CkbChainActor {},
+        local_config,
+    )
+    .await
+    .expect("start local actor");
+
+    let (remote_actor, remote_handle) = Actor::spawn(
+        Some("remote actor".to_string()),
+        CkbChainActor {},
+        remote_config,
+    )
+    .await
+    .expect("start remote actor");
+
+    run(&local_actor, &remote_actor).await;
+
+    local_actor.stop(None);
+    local_handle.await.expect("Actor failed to exit cleanly");
+    remote_actor.stop(None);
+    remote_handle.await.expect("Actor failed to exit cleanly");
+}
+
+fn prepare() -> (CkbChainConfig, CkbChainConfig) {
+    let args: Vec<String> = env::args().collect();
+    let local_path = PathBuf::from(&args[1]);
+    let remote_path = PathBuf::from(&args[2]);
+    let _ = std::fs::create_dir_all(&local_path);
+    let _ = std::fs::create_dir_all(&remote_path);
+
+    // Dev net test account that has 20 billions of CKB tokens in the genesis block.
+    std::fs::write(
+        local_path.join("key"),
+        "d00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc",
+    )
+    .expect("Unable to write to file");
+    // privkey for ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqgx5lf4pczpamsfam48evs0c8nvwqqa59qapt46f
+    std::fs::write(
+        remote_path.join("key"),
+        "cccd5f7e693b60447623fb71a5983f15a426938c33699b1a81d1239cfa656cd1",
+    )
+    .expect("Unable to write to file");
+
+    let rpc_url = "http://127.0.0.1:8114".to_string();
+    return (
+        CkbChainConfig {
+            base_dir: Some(local_path),
+            rpc_url: rpc_url.clone(),
+            funding_source_lock_script_code_hash: make_h256(
+                "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            ),
+            funding_source_lock_script_hash_type: ckb_jsonrpc_types::ScriptHashType::Type,
+            funding_cell_lock_script_code_hash: make_h256(
+                "0x8090ce20be9976e2407511502acebf74ac1cfed10d7b35b7f33f56c9bd0daec6",
+            ),
+            funding_cell_lock_script_hash_type: ckb_jsonrpc_types::ScriptHashType::Type,
+        },
+        CkbChainConfig {
+            base_dir: Some(remote_path),
+            rpc_url: rpc_url.clone(),
+            funding_source_lock_script_code_hash: make_h256(
+                "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            ),
+            funding_source_lock_script_hash_type: ckb_jsonrpc_types::ScriptHashType::Type,
+            funding_cell_lock_script_code_hash: make_h256(
+                "0x8090ce20be9976e2407511502acebf74ac1cfed10d7b35b7f33f56c9bd0daec6",
+            ),
+            funding_cell_lock_script_hash_type: ckb_jsonrpc_types::ScriptHashType::Type,
+        },
+    );
+}
+
+const TIMEOUT_MS: u64 = 60000;
+
+async fn run(local: &ActorRef<CkbChainMessage>, remote: &ActorRef<CkbChainMessage>) {
+    let mut tx = FundingTx::new();
+    let funding_cell_lock_script_args = packed::Bytes::default();
+
+    // The only party to fund goes first. Or the one who does not pay fee goes first for dual funding.
+    tx = call_t!(
+        local,
+        CkbChainMessage::Fund,
+        TIMEOUT_MS,
+        tx,
+        FundingRequest {
+            udt_info: None,
+            funding_cell_lock_script_args: funding_cell_lock_script_args.clone(),
+            local_amount: 12000000000,
+            local_fee_rate: 0,
+            remote_amount: 10000000000,
+        }
+    )
+    .expect("local calls")
+    .expect("local funds");
+    log_tx("local funded", &tx);
+
+    // The one who pays fee goes next.
+    tx = call_t!(
+        remote,
+        CkbChainMessage::Fund,
+        TIMEOUT_MS,
+        tx,
+        FundingRequest {
+            udt_info: None,
+            funding_cell_lock_script_args: funding_cell_lock_script_args.clone(),
+            local_amount: 10000000000,
+            local_fee_rate: 1000,
+            remote_amount: 12000000000,
+        }
+    )
+    .expect("remote calls")
+    .expect("remote funds");
+    log_tx("remote funded", &tx);
+
+    // Now tx is ready and the funding cell out point is available. Exchange and confirm commitment tx.
+
+    // Exchange funding tx signatures once commitment txs are confirmed.
+    tx = call_t!(local, CkbChainMessage::Sign, TIMEOUT_MS, tx)
+        .expect("local calls")
+        .expect("local signs");
+    log_tx("local signed", &tx);
+    tx = call_t!(remote, CkbChainMessage::Sign, TIMEOUT_MS, tx)
+        .expect("remote calls")
+        .expect("remote signs");
+    log_tx("remote signed", &tx);
+
+    let tx = tx.take().expect("take tx");
+    // Broadcast funding tx and waiting for confs
+    cast!(local, CkbChainMessage::SendTx(tx.clone())).expect("local sends");
+    log::info!("tx sent: {}", tx.hash());
+
+    let status = call_t!(
+        local,
+        CkbChainMessage::TraceTx,
+        TIMEOUT_MS,
+        TraceTxRequest {
+            tx_hash: tx.hash(),
+            confirmations: 3
+        }
+    )
+    .expect("remote calls");
+
+    log::info!("tx status of {}: {:?}", tx.hash(), status);
+}
+
+fn make_h256(hex: &str) -> Hash256 {
+    let mut buf = [0u8; 32];
+    hex::decode_to_slice(&hex[2..], &mut buf).expect("decode hash256");
+    Hash256::from(buf)
+}
+
+fn log_tx(name: &str, tx: &FundingTx) {
+    match tx.as_ref() {
+        Some(tx) => {
+            let tx: ckb_jsonrpc_types::TransactionView = tx.clone().into();
+            log::info!(
+                "tx[{}]: {}",
+                name,
+                serde_json::to_string_pretty(&tx).expect("serde json")
+            )
+        }
+        None => log::info!("tx[{}]: None", name),
+    }
+}

--- a/src/ckb_chain/actor.rs
+++ b/src/ckb_chain/actor.rs
@@ -1,0 +1,200 @@
+use ckb_sdk::CkbRpcClient;
+use ckb_types::{core::TransactionView, packed, prelude::*};
+use ractor::{
+    concurrency::{sleep, Duration},
+    Actor, ActorProcessingErr, ActorRef, RpcReplyPort,
+};
+
+use super::{funding::FundingContext, CkbChainConfig, FundingError, FundingRequest, FundingTx};
+
+pub struct CkbChainActor;
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub struct CkbChainState {
+    config: CkbChainConfig,
+    secret_key: secp256k1::SecretKey,
+    funding_source_lock_script: packed::Script,
+}
+
+#[derive(Debug)]
+pub struct TraceTxRequest {
+    pub tx_hash: packed::Byte32,
+    // How many confirmations required to consider the transaction committed.
+    pub confirmations: u64,
+}
+
+#[derive(Debug)]
+pub enum CkbChainMessage {
+    Fund(
+        FundingTx,
+        FundingRequest,
+        RpcReplyPort<Result<FundingTx, FundingError>>,
+    ),
+    Sign(FundingTx, RpcReplyPort<Result<FundingTx, FundingError>>),
+    SendTx(TransactionView),
+    TraceTx(TraceTxRequest, RpcReplyPort<ckb_jsonrpc_types::Status>),
+}
+
+#[ractor::async_trait]
+impl Actor for CkbChainActor {
+    type Msg = CkbChainMessage;
+    type State = CkbChainState;
+    type Arguments = CkbChainConfig;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        config: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let secret_key = config.read_secret_key()?;
+
+        let secp = secp256k1::Secp256k1::new();
+        let pub_key = secret_key.public_key(&secp);
+        let pub_key_hash = ckb_hash::blake2b_256(pub_key.serialize());
+        let funding_source_lock_script =
+            config.build_funding_source_lock_script((&pub_key_hash[0..20]).pack());
+        log::info!(
+            "[{}] funding lock args: {}",
+            myself.get_name().unwrap_or_default(),
+            funding_source_lock_script.args()
+        );
+
+        Ok(CkbChainState {
+            config,
+            secret_key,
+            funding_source_lock_script,
+        })
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        use CkbChainMessage::*;
+        match message {
+            Fund(tx, request, reply_port) => {
+                let context = state.build_funding_context(&request);
+                if !reply_port.is_closed() {
+                    tokio::task::block_in_place(move || {
+                        let result = tx.fulfill(request, context);
+                        if !reply_port.is_closed() {
+                            reply_port.send(result).expect("reply ok");
+                        }
+                    });
+                }
+            }
+            Sign(tx, reply_port) => {
+                if !reply_port.is_closed() {
+                    let secret_key = state.secret_key.clone();
+                    let rpc_url = state.config.rpc_url.clone();
+                    tokio::task::block_in_place(move || {
+                        let result = tx.sign(secret_key, rpc_url);
+                        if !reply_port.is_closed() {
+                            reply_port.send(result).expect("reply ok");
+                        }
+                    });
+                }
+            }
+            SendTx(tx) => {
+                let rpc_url = state.config.rpc_url.clone();
+                tokio::task::block_in_place(move || {
+                    let ckb_client = CkbRpcClient::new(&rpc_url);
+                    if let Err(err) = ckb_client.send_transaction(tx.data().into(), None) {
+                        log::error!(
+                            "[{}] send transaction failed: {:?}",
+                            myself.get_name().unwrap_or_default(),
+                            err
+                        );
+                    }
+                });
+            }
+            TraceTx(
+                TraceTxRequest {
+                    tx_hash,
+                    confirmations,
+                },
+                reply_port,
+            ) => {
+                log::info!(
+                    "[{}] trace transaction {} with {} confs",
+                    myself.get_name().unwrap_or_default(),
+                    tx_hash,
+                    confirmations
+                );
+                // TODO: Need a better way to trace the transaction.
+                while !reply_port.is_closed() {
+                    let actor_name = myself.get_name().unwrap_or_default();
+                    let rpc_url = state.config.rpc_url.clone();
+                    let tx_hash = tx_hash.clone();
+                    let status = tokio::task::block_in_place(move || {
+                        let ckb_client = CkbRpcClient::new(&rpc_url);
+                        match ckb_client.get_transaction_status(tx_hash.unpack()) {
+                            Ok(resp) => match resp.tx_status.status {
+                                ckb_jsonrpc_types::Status::Committed => {
+                                    match ckb_client.get_tip_block_number() {
+                                        Ok(tip_number) => {
+                                            let tip_number: u64 = tip_number.into();
+                                            let commit_number: u64 = resp
+                                                .tx_status
+                                                .block_number
+                                                .unwrap_or_default()
+                                                .into();
+                                            (tip_number >= commit_number + confirmations)
+                                                .then_some(ckb_jsonrpc_types::Status::Committed)
+                                        }
+                                        Err(err) => {
+                                            log::error!(
+                                                "[{}] get tip block number failed: {:?}",
+                                                actor_name,
+                                                err
+                                            );
+                                            None
+                                        }
+                                    }
+                                }
+                                ckb_jsonrpc_types::Status::Rejected => {
+                                    Some(ckb_jsonrpc_types::Status::Rejected)
+                                }
+                                _ => None,
+                            },
+                            Err(err) => {
+                                log::error!(
+                                    "[{}] get transaction status failed: {:?}",
+                                    actor_name,
+                                    err
+                                );
+                                None
+                            }
+                        }
+                    });
+                    match status {
+                        Some(status) => {
+                            if !reply_port.is_closed() {
+                                reply_port.send(status).expect("reply ok");
+                            }
+                            return Ok(());
+                        }
+                        None => sleep(Duration::from_secs(5)).await,
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CkbChainState {
+    fn build_funding_context(&self, request: &FundingRequest) -> FundingContext {
+        FundingContext {
+            secret_key: self.secret_key.clone(),
+            rpc_url: self.config.rpc_url.clone(),
+            funding_source_lock_script: self.funding_source_lock_script.clone(),
+            funding_cell_lock_script: self
+                .config
+                .build_funding_cell_lock_script(request.funding_cell_lock_script_args.clone()),
+        }
+    }
+}

--- a/src/ckb_chain/config.rs
+++ b/src/ckb_chain/config.rs
@@ -1,0 +1,126 @@
+use ckb_types::{packed, prelude::*};
+use clap_serde_derive::ClapSerde;
+use molecule::prelude::*;
+use secp256k1::SecretKey;
+use std::{
+    io::{ErrorKind, Read},
+    path::PathBuf,
+};
+
+use crate::ckb::types::Hash256;
+
+pub const DEFAULT_CKB_CHAIN_BASE_DIR_NAME: &str = "ckb-chain";
+const DEFAULT_CKB_CHAIN_NODE_RPC_URL: &str = "http://127.0.0.1:8114";
+
+#[derive(ClapSerde, Debug, Clone)]
+pub struct CkbChainConfig {
+    /// ckb base directory
+    #[arg(
+        name = "CKB_CHAIN_BASE_DIR",
+        long = "ckb-chain-base-dir",
+        env,
+        help = format!("base directory for ckb chain actor [default: $BASE_DIR/{}]", DEFAULT_CKB_CHAIN_BASE_DIR_NAME)
+    )]
+    pub base_dir: Option<PathBuf>,
+
+    #[default(DEFAULT_CKB_CHAIN_NODE_RPC_URL.to_string())]
+    #[arg(
+        name = "CKB_CHAIN_NODE_RPC_URL",
+        long = "ckb-chain-node-rpc-url",
+        env,
+        help = "rpc url to connect the ckb node [default: http://127.0.0.1:8114]"
+    )]
+    pub rpc_url: String,
+
+    #[arg(skip)]
+    pub funding_source_lock_script_code_hash: Hash256,
+
+    #[default(ckb_jsonrpc_types::ScriptHashType::Type)]
+    #[arg(skip)]
+    pub funding_source_lock_script_hash_type: ckb_jsonrpc_types::ScriptHashType,
+
+    #[arg(skip)]
+    pub funding_cell_lock_script_code_hash: Hash256,
+
+    #[default(ckb_jsonrpc_types::ScriptHashType::Type)]
+    #[arg(skip)]
+    pub funding_cell_lock_script_hash_type: ckb_jsonrpc_types::ScriptHashType,
+}
+
+impl CkbChainConfig {
+    pub fn base_dir(&self) -> &PathBuf {
+        self.base_dir.as_ref().expect("have set base dir")
+    }
+
+    pub fn create_base_dir(&self) -> crate::Result<()> {
+        if !self.base_dir().exists() {
+            std::fs::create_dir_all(self.base_dir()).map_err(Into::into)
+        } else {
+            Ok(())
+        }
+    }
+
+    // TODO: Use keystore and password to read secret key and add an RPC method to authorize the secret key access.
+    pub fn read_secret_key(&self) -> crate::Result<SecretKey> {
+        self.create_base_dir()?;
+        let path = self.base_dir().join("key");
+        let mut file = std::fs::File::open(&path)?;
+
+        let warn = |m: bool, d: &str| {
+            if m {
+                log::warn!(
+                    "Your secret file's permission is not {}, path: {:?}. \
+                Please fix it as soon as possible",
+                    d,
+                    path
+                )
+            }
+        };
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            warn(
+                file.metadata()?.permissions().mode() & 0o177 != 0,
+                "less than 0o600",
+            );
+        }
+        #[cfg(not(unix))]
+        {
+            warn(!file.metadata()?.permissions().readonly(), "readonly");
+        }
+
+        let mut key_hex: String = Default::default();
+        file.read_to_string(&mut key_hex)?;
+        let key_bin = hex::decode(key_hex.trim())
+            .map_err(|_| std::io::Error::new(ErrorKind::InvalidData, "invalid secret key data"))?;
+        SecretKey::from_slice(&key_bin).map_err(|_| {
+            std::io::Error::new(ErrorKind::InvalidData, "invalid secret key data").into()
+        })
+    }
+
+    pub fn build_funding_source_lock_script(&self, args: packed::Bytes) -> packed::Script {
+        packed::Script::new_builder()
+            .code_hash(self.funding_source_lock_script_code_hash.into())
+            .hash_type(packed::Byte::new(
+                ckb_types::core::ScriptHashType::from(
+                    self.funding_source_lock_script_hash_type.clone(),
+                )
+                .into(),
+            ))
+            .args(args)
+            .build()
+    }
+
+    pub fn build_funding_cell_lock_script(&self, args: packed::Bytes) -> packed::Script {
+        packed::Script::new_builder()
+            .code_hash(self.funding_cell_lock_script_code_hash.into())
+            .hash_type(Byte::new(
+                ckb_types::core::ScriptHashType::from(
+                    self.funding_cell_lock_script_hash_type.clone(),
+                )
+                .into(),
+            ))
+            .args(args)
+            .build()
+    }
+}

--- a/src/ckb_chain/error.rs
+++ b/src/ckb_chain/error.rs
@@ -1,0 +1,28 @@
+use ckb_sdk::{tx_builder::TxBuilderError, unlock::UnlockError, RpcError};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum FundingError {
+    #[error("Funding tx is absent")]
+    AbsentTx,
+    #[error("Failed to call CKB node RPC: {0}")]
+    CkbRpcError(#[from] RpcError),
+
+    #[error("Failed to build CKB tx: {0}")]
+    CkbTxBuilderError(#[from] TxBuilderError),
+
+    #[error("Failed to sign CKB tx: {0}")]
+    CkbTxUnlockError(#[from] UnlockError),
+
+    #[error("Dead cell found in the tx")]
+    DeadCell,
+
+    #[error("The channel is invalid to fund")]
+    InvalidChannel,
+}
+
+#[derive(Error, Debug)]
+pub enum CkbChainError {
+    #[error("Funding error: {0}")]
+    FundingError(#[from] FundingError),
+}

--- a/src/ckb_chain/funding/funding_tx.rs
+++ b/src/ckb_chain/funding/funding_tx.rs
@@ -1,0 +1,279 @@
+use std::collections::HashMap;
+
+use super::super::FundingError;
+use ckb_sdk::{
+    constants::SIGHASH_TYPE_HASH,
+    traits::{
+        CellCollector, CellDepResolver, DefaultCellCollector, DefaultCellDepResolver,
+        DefaultHeaderDepResolver, DefaultTransactionDependencyProvider, HeaderDepResolver,
+        SecpCkbRawKeySigner, TransactionDependencyProvider,
+    },
+    tx_builder::{unlock_tx, CapacityBalancer, TxBuilder, TxBuilderError},
+    unlock::{ScriptUnlocker, SecpSighashUnlocker},
+    CkbRpcClient, ScriptId,
+};
+use ckb_types::{
+    core::{BlockView, Capacity, TransactionView},
+    packed,
+    prelude::*,
+};
+use molecule::{
+    bytes::{BufMut as _, BytesMut},
+    prelude::*,
+};
+
+/// Funding transaction wrapper.
+///
+/// It includes extra fields to verify the transaction.
+#[derive(Clone, Debug, Default)]
+pub struct FundingTx {
+    tx: Option<TransactionView>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, Default)]
+pub struct FundingUdtInfo {
+    /// The UDT type script
+    type_script: packed::Script,
+    /// CKB amount to be provided by the local party.
+    local_ckb_amount: u64,
+    /// CKB amount to be provided by the remote party.
+    remote_ckb_amount: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FundingRequest {
+    /// UDT channel info
+    pub udt_info: Option<FundingUdtInfo>,
+    /// The funding cell lock script args
+    pub funding_cell_lock_script_args: packed::Bytes,
+    /// Assets amount to be provided by the local party
+    pub local_amount: u64,
+    /// Fee to be provided by the local party
+    pub local_fee_rate: u64,
+    /// Assets amount to be provided by the remote party
+    pub remote_amount: u64,
+}
+
+// TODO: trace locked cells
+#[derive(Clone)]
+pub struct FundingContext {
+    pub secret_key: secp256k1::SecretKey,
+    pub rpc_url: String,
+    pub funding_source_lock_script: packed::Script,
+    pub funding_cell_lock_script: packed::Script,
+}
+
+#[allow(dead_code)]
+struct FundingTxBuilder {
+    funding_tx: FundingTx,
+    request: FundingRequest,
+    context: FundingContext,
+}
+
+impl TxBuilder for FundingTxBuilder {
+    fn build_base(
+        &self,
+        _cell_collector: &mut dyn CellCollector,
+        _cell_dep_resolver: &dyn CellDepResolver,
+        _header_dep_resolver: &dyn HeaderDepResolver,
+        _tx_dep_provider: &dyn TransactionDependencyProvider,
+    ) -> Result<TransactionView, TxBuilderError> {
+        let funding_cell = self
+            .build_funding_cell()
+            .map_err(|err| TxBuilderError::Other(err.into()))?;
+
+        // Funding cell does not need new cell deps and header deps. The type script deps will be added with inputs.
+        let mut outputs: Vec<packed::CellOutput> = vec![funding_cell.0];
+        let mut outputs_data: Vec<packed::Bytes> = vec![funding_cell.1];
+
+        if let Some(ref tx) = self.funding_tx.tx {
+            for (i, output) in tx.outputs().into_iter().enumerate().skip(1) {
+                outputs.push(output.clone());
+                outputs_data.push(tx.outputs_data().get(i).unwrap_or_default().clone());
+            }
+        }
+
+        let builder = match self.funding_tx.tx {
+            Some(ref tx) => tx.as_advanced_builder(),
+            None => packed::Transaction::default().as_advanced_builder(),
+        };
+        let tx = builder
+            .set_outputs(outputs)
+            .set_outputs_data(outputs_data)
+            .build();
+
+        Ok(tx)
+    }
+}
+
+impl FundingTxBuilder {
+    fn build_funding_cell(&self) -> Result<(packed::CellOutput, packed::Bytes), FundingError> {
+        // If outputs is not empty, assume that the remote party has already funded.
+        let remote_funded = self
+            .funding_tx
+            .tx
+            .as_ref()
+            .map(|tx| !tx.outputs().is_empty())
+            .unwrap_or(false);
+
+        match self.request.udt_info {
+            Some(ref udt_info) => {
+                let mut udt_amount = self.request.local_amount as u128;
+                let mut ckb_amount = udt_info.local_ckb_amount;
+
+                // To make tx building easier, do not include the amount not funded yet in the
+                // funding cell.
+                if remote_funded {
+                    udt_amount += self.request.remote_amount as u128;
+                    ckb_amount = ckb_amount
+                        .checked_add(udt_info.remote_ckb_amount)
+                        .ok_or(FundingError::InvalidChannel)?;
+                }
+
+                let udt_output = packed::CellOutput::new_builder()
+                    .capacity(Capacity::shannons(ckb_amount).pack())
+                    .type_(Some(udt_info.type_script.clone()).pack())
+                    .lock(self.context.funding_cell_lock_script.clone())
+                    .build();
+                let mut data = BytesMut::with_capacity(16);
+                data.put(&udt_amount.to_le_bytes()[..]);
+
+                // TODO: xudt extension
+                Ok((udt_output, data.freeze().pack()))
+            }
+            None => {
+                let mut ckb_amount = self.request.local_amount;
+                if remote_funded {
+                    ckb_amount = ckb_amount
+                        .checked_add(self.request.remote_amount)
+                        .ok_or(FundingError::InvalidChannel)?;
+                }
+                let ckb_output = packed::CellOutput::new_builder()
+                    .capacity(Capacity::shannons(ckb_amount).pack())
+                    .lock(self.context.funding_cell_lock_script.clone())
+                    .build();
+                Ok((ckb_output, packed::Bytes::default()))
+            }
+        }
+    }
+
+    fn build(self) -> Result<FundingTx, FundingError> {
+        // Build ScriptUnlocker
+        let signer = SecpCkbRawKeySigner::new_with_secret_keys(vec![]);
+        let sighash_unlocker = SecpSighashUnlocker::from(Box::new(signer) as Box<_>);
+        let sighash_script_id = ScriptId::new_type(SIGHASH_TYPE_HASH.clone());
+        let mut unlockers = HashMap::default();
+        unlockers.insert(
+            sighash_script_id,
+            Box::new(sighash_unlocker) as Box<dyn ScriptUnlocker>,
+        );
+
+        let sender = self.context.funding_source_lock_script.clone();
+        // Build CapacityBalancer
+        let placeholder_witness = packed::WitnessArgs::new_builder()
+            .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 65])).pack())
+            .build();
+        let balancer =
+            CapacityBalancer::new_simple(sender, placeholder_witness, self.request.local_fee_rate);
+
+        let ckb_client = CkbRpcClient::new(&self.context.rpc_url);
+        let cell_dep_resolver = {
+            let genesis_block = ckb_client.get_block_by_number(0.into()).unwrap().unwrap();
+            DefaultCellDepResolver::from_genesis(&BlockView::from(genesis_block)).unwrap()
+        };
+        let header_dep_resolver = DefaultHeaderDepResolver::new(&self.context.rpc_url);
+        let mut cell_collector = DefaultCellCollector::new(&self.context.rpc_url);
+        let tx_dep_provider = DefaultTransactionDependencyProvider::new(&self.context.rpc_url, 10);
+
+        let (tx, _) = self
+            .build_unlocked(
+                &mut cell_collector,
+                &cell_dep_resolver,
+                &header_dep_resolver,
+                &tx_dep_provider,
+                &balancer,
+                &unlockers,
+            )
+            .unwrap();
+
+        let mut funding_tx = self.funding_tx;
+        funding_tx.update_for_self(tx)?;
+        Ok(funding_tx)
+    }
+}
+
+impl FundingTx {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn take(&mut self) -> Option<TransactionView> {
+        self.tx.take()
+    }
+
+    pub fn as_ref(&self) -> Option<&TransactionView> {
+        self.tx.as_ref()
+    }
+
+    pub fn into_inner(self) -> Option<TransactionView> {
+        self.tx
+    }
+
+    pub fn fulfill(
+        self,
+        request: FundingRequest,
+        context: FundingContext,
+    ) -> Result<Self, FundingError> {
+        let builder = FundingTxBuilder {
+            funding_tx: self,
+            request,
+            context,
+        };
+        builder.build()
+    }
+
+    pub fn sign(
+        mut self,
+        secret_key: secp256k1::SecretKey,
+        rpc_url: String,
+    ) -> Result<Self, FundingError> {
+        // Convert between different versions of secp256k1.
+        // This app requires 0.28 because of:
+        // ```
+        // #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+        // pub struct Signature(pub Secp256k1Signature);
+        // ```
+        //
+        // However, ckb-sdk-rust still uses 0.24.
+        let signer = SecpCkbRawKeySigner::new_with_secret_keys(vec![std::str::FromStr::from_str(
+            hex::encode(secret_key.as_ref()).as_ref(),
+        )
+        .unwrap()]);
+        let sighash_unlocker = SecpSighashUnlocker::from(Box::new(signer) as Box<_>);
+        let sighash_script_id = ScriptId::new_type(SIGHASH_TYPE_HASH.clone());
+        let mut unlockers = HashMap::default();
+        unlockers.insert(
+            sighash_script_id,
+            Box::new(sighash_unlocker) as Box<dyn ScriptUnlocker>,
+        );
+        let tx = self.take().ok_or(FundingError::AbsentTx)?;
+        let tx_dep_provider = DefaultTransactionDependencyProvider::new(&rpc_url, 10);
+
+        let (tx, _) = unlock_tx(tx.clone(), &tx_dep_provider, &unlockers)?;
+        self.update_for_self(tx)?;
+        Ok(self)
+    }
+
+    // TODO: verify the transaction
+    pub fn update_for_self(&mut self, tx: TransactionView) -> Result<(), FundingError> {
+        self.tx = Some(tx);
+        Ok(())
+    }
+
+    // TODO: verify the transaction
+    pub fn update_for_peer(&mut self, tx: TransactionView) -> Result<(), FundingError> {
+        self.tx = Some(tx);
+        Ok(())
+    }
+}

--- a/src/ckb_chain/funding/mod.rs
+++ b/src/ckb_chain/funding/mod.rs
@@ -1,0 +1,4 @@
+mod funding_tx;
+
+pub(crate) use funding_tx::FundingContext;
+pub use funding_tx::{FundingRequest, FundingTx, FundingUdtInfo};

--- a/src/ckb_chain/mod.rs
+++ b/src/ckb_chain/mod.rs
@@ -1,0 +1,9 @@
+mod actor;
+mod config;
+mod error;
+mod funding;
+
+pub use actor::{CkbChainActor, CkbChainMessage, TraceTxRequest};
+pub use config::{CkbChainConfig, DEFAULT_CKB_CHAIN_BASE_DIR_NAME};
+pub use error::{CkbChainError, FundingError};
+pub use funding::{FundingRequest, FundingTx, FundingUdtInfo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 mod config;
 pub use config::Config;
 
+pub mod ckb_chain;
+
 pub mod ldk;
 pub use ldk::{start_ldk, LdkConfig};
 pub mod ckb;


### PR DESCRIPTION
The sepc256k1 private key must be saved as a file using the path "ckb_chain/key". The file must encode the private key as hex without the "0x" prefix.

Example config:

```yaml
ckb_chain:
  # sighash_all
  funding_source_lock_script_code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"
  funding_source_lock_script_hash_type: "type"

  # funding lock
  funding_cell_lock_script_code_hash: "0x8090ce20be9976e2407511502acebf74ac1cfed10d7b35b7f33f56c9bd0daec6"
  funding_cell_lock_script_hash_type: "type"

services:
  - ckb_chain
```