### PR TITLE
Fix two bugs

### DIFF
--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -1416,8 +1416,8 @@ impl ChannelActorState {
         remote_delay: LockTime,
         remote_pubkeys: ChannelBasePublicKeys,
         remote_nonce: PubNonce,
-        remote_commitment_point: Pubkey,
-        remote_prev_commitment_point: Pubkey,
+        first_commitment_point: Pubkey,
+        second_commitment_point: Pubkey,
     ) -> Self {
         let signer = InMemorySigner::generate_from_seed(seed);
         let local_pubkeys = signer.to_channel_public_keys(INITIAL_COMMITMENT_NUMBER);
@@ -1458,7 +1458,7 @@ impl ChannelActorState {
             remote_commitment_number: INITIAL_COMMITMENT_NUMBER,
             remote_shutdown_script: None,
             remote_nonce: Some(remote_nonce),
-            remote_commitment_points: vec![remote_prev_commitment_point, remote_commitment_point],
+            remote_commitment_points: vec![first_commitment_point, second_commitment_point],
             local_shutdown_signature: None,
             local_shutdown_fee: None,
             remote_shutdown_signature: None,


### PR DESCRIPTION
This PR fixes two important bugs.

The first bug is that we saved the commitment points for acceptor in the wrong order! This is discovered by https://github.com/contrun/ckb-pcn-node/pull/59/commits/9218b25b11fad60a873736e52eb150aec647b2d2, which tries to send `CommitmentSigned` messages from both sides, thus discovered a mismatch between per commitment point and per commitment secret.

The second bug is that we are using the wrong per commitment point to construct commitment transaction. We should use the current commitment number (and obtain the current commitment point) to construct commitment transaction. Previously, we used previous commitment number. This bug goes undiscovered because we didn't actually use commitment point to derive new public keys. We just copy the old keys. Thus commitment transaction are still the same for both parties.