### PR TITLE
Refactor tlc saving in channel state and fix a few bugs

### DIFF
--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -3154,10 +3154,15 @@ impl ChannelActorState {
             );
             Ok((tx, message))
         } else {
+            debug!(
+                "Final balance partition before shutting down: local {} (fee {}), remote {} (fee {})",
+                self.to_local_amount, local_shutdown_fee,
+                self.to_remote_amount, remote_shutdown_fee
+            );
             let local_value = (self.to_local_amount - local_shutdown_fee) as u64;
             let remote_value = (self.to_remote_amount - remote_shutdown_fee) as u64;
             debug!(
-                "Building shutdown transaction with values: {} {}",
+                "Building shutdown transaction with values: local {}, remote {}",
                 local_value, remote_value
             );
             let local_output = CellOutput::new_builder()

--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -3695,8 +3695,14 @@ impl TLC {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DetailedTLCInfo {
     tlc: TLC,
-    // The commitment number of the party that offered this tlc
-    // (also called offerer) when this tlc is created.
+    // The commitment numbers of both parties when this tlc is created
+    // as the offerer sees it.
+    // TODO: There is a potential bug here. The commitment number of the
+    // receiver may have been updated by the time this tlc is included
+    // in a commitment of the offerer. Currently we assume that the commitment
+    // number of the receiver when the time this tlc is actually committed by
+    // the offerer is just the same as the commitment number of the receiver
+    // when the this tlc is created.
     created_at: CommitmentNumbers,
     // The commitment number of the party that received this tlc
     // (also called receiver) when this tlc is first included in

--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -1614,6 +1614,22 @@ impl ChannelActorState {
         }
     }
 
+    pub fn get_local_balance(&self) -> u128 {
+        self.to_local_amount
+    }
+
+    pub fn get_remote_balance(&self) -> u128 {
+        self.to_remote_amount
+    }
+
+    pub fn get_sent_tlc_balance(&self) -> u128 {
+        self.get_tlc_value_sent_by_local(true)
+    }
+
+    pub fn get_received_tlc_balance(&self) -> u128 {
+        self.get_tlc_value_received_from_remote(false)
+    }
+
     fn update_state(&mut self, new_state: ChannelState) {
         debug!(
             "Updating channel state from {:?} to {:?}",
@@ -1812,7 +1828,7 @@ impl ChannelActorState {
             }
         };
         if tlc.is_offered() {
-            let sent_tlc_value = self.get_tlc_value_sent_by_local(true);
+            let sent_tlc_value = self.get_sent_tlc_balance();
             debug_assert!(self.to_local_amount > sent_tlc_value);
             // TODO: handle transaction fee here.
             if sent_tlc_value + tlc.amount > self.to_local_amount {
@@ -1822,7 +1838,7 @@ impl ChannelActorState {
                 )));
             }
         } else {
-            let received_tlc_value = self.get_tlc_value_received_from_remote(false);
+            let received_tlc_value = self.get_received_tlc_balance();
             debug_assert!(self.to_remote_amount > received_tlc_value);
             // TODO: handle transaction fee here.
             if received_tlc_value + tlc.amount > self.to_remote_amount {

--- a/src/ckb/network.rs
+++ b/src/ckb/network.rs
@@ -141,6 +141,11 @@ pub enum NetworkServiceEvent {
     ChannelClosed(PeerId, Hash256, TransactionView),
     // We should sign a commitment transaction and send it to the other party.
     CommitmentSignaturePending(PeerId, Hash256, u64),
+    // We have signed a commitment transaction and sent it to the other party.
+    // The last element is the witnesses for this commitment transaction.
+    // The TransactionView here is not a valid commitment transaction per se,
+    // as we need the other party's signature.
+    LocalCommitmentSigned(PeerId, Hash256, u64, TransactionView, Vec<u8>),
     // The other party has signed a valid commitment transaction,
     // and we successfully assemble the partial signature from other party
     // to create a complete commitment transaction.
@@ -191,8 +196,15 @@ pub enum NetworkActorEvent {
     /// A funding transaction has been confirmed.
     FundingTransactionFailed(OutPoint),
 
+    /// A commitment transaction is signed by us and has sent to the other party.
+    LocalCommitmentSigned(PeerId, Hash256, u64, TransactionView, Vec<u8>),
+
     /// Network service events to be sent to outside observers.
-    /// We will not do any processing on these events.
+    /// These events may be both present at `NetworkActorEvent` and
+    /// this branch of `NetworkActorEvent`. This is because some events
+    /// (e.g. `ChannelClosed`)require some processing internally,
+    /// and they are also interesting to outside observers.
+    /// Once we processed these events, we will send them to outside observers.
     NetworkServiceEvent(NetworkServiceEvent),
 }
 
@@ -460,6 +472,25 @@ where
             }
             NetworkActorEvent::FundingTransactionFailed(_outpoint) => {
                 unimplemented!("handling funding transaction failed");
+            }
+            NetworkActorEvent::LocalCommitmentSigned(
+                peer_id,
+                channel_id,
+                version,
+                tx,
+                witnesses,
+            ) => {
+                // TODO: We should save the witnesses to the channel state.
+                // Notify outside observers.
+                myself
+                    .send_message(NetworkActorMessage::new_event(
+                        NetworkActorEvent::NetworkServiceEvent(
+                            NetworkServiceEvent::LocalCommitmentSigned(
+                                peer_id, channel_id, version, tx, witnesses,
+                            ),
+                        ),
+                    ))
+                    .expect("myself alive");
             }
         }
         Ok(())

--- a/src/ckb/types.rs
+++ b/src/ckb/types.rs
@@ -982,7 +982,7 @@ impl TryFrom<molecule_cfn::RevokeAndAck> for RevokeAndAck {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RemoveTlcFulfill {
     pub payment_preimage: Hash256,
 }
@@ -1005,7 +1005,7 @@ impl TryFrom<molecule_cfn::RemoveTlcFulfill> for RemoveTlcFulfill {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RemoveTlcFail {
     pub error_code: u32,
 }
@@ -1028,7 +1028,7 @@ impl TryFrom<molecule_cfn::RemoveTlcFail> for RemoveTlcFail {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RemoveTlcReason {
     RemoveTlcFulfill(RemoveTlcFulfill),
     RemoveTlcFail(RemoveTlcFail),


### PR DESCRIPTION
This PR refactored TLC fields in channel state. We will save all the tlcs in a unified tlcs field. This make it more convenient to see when a tlc is added/removed. When refactoring this I also found a few bugs. Below are the changes in this PR.

1. A notification for local commitment signed `LocalCommitmentSigned` is added. This may be used to notify watch tower that some transactions are now broadcastable by the peer.
2. We now have complete information for when a tlc is added/removed.
3. Previously commitment number is updated on `RevokeAndAck` from the peer received. This effectively makes local/remote commitment number always the same. We should instead update commitment numbers on `CommitmentSigned` messages sent or received. This PR fixes that.
4. The commitment number used to obtain remote commitment point should always be local commitment number (instead of remote commitment number). This asymmetry takes some time to understand, and previously we implemented in the wrong way. A remote commitment point is only obtained when `RevokeAndAck` is received from the remote party. And `RevokeAndAck` is sent only when the remote party receives a `CommitmentSigned` message. This is exactly when the local commitment transaction is updated.