### PR TITLE
 Fix using the wrong commitment point for revocation

### DIFF
--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -3243,50 +3243,60 @@ impl ChannelActorState {
     }
 
     fn build_current_commitment_transaction_witnesses(&self, local: bool) -> Vec<u8> {
-        let commitment_number = self.get_current_commitment_number(local);
+        let local_commitment_number = self.get_local_commitment_number();
+        let remote_commitment_number = self.get_remote_commitment_number();
+        let commitment_number = if local {
+            local_commitment_number
+        } else {
+            remote_commitment_number
+        };
         debug!(
-            "Building current commitment transaction witnesses for {} party, commitment number: {}",
+            "Building {} commitment transaction #{}'s witnesses (commitment numbers: local {}, remote {})",
             if local { "local" } else { "remote" },
-            commitment_number
-        );
-        self.build_commitment_transaction_witnesses(local, commitment_number)
-    }
-
-    // We need this function both for building new commitment transaction and revoking old commitment transaction.
-    fn build_commitment_transaction_witnesses(
-        &self,
-        local: bool,
-        commitment_number: u64,
-    ) -> Vec<u8> {
-        debug!(
-            "Building {} commitment transaction witnesses for commitment number {}",
-            if local { "local" } else { "remote" },
-            commitment_number
+            commitment_number,
+            local_commitment_number,
+            remote_commitment_number
         );
         let (delayed_epoch, delayed_payment_key, revocation_key) = {
-            let (delay, commitment_point, base_delayed_payment_key, base_revocation_key) = if local
-            {
+            let (
+                delay,
+                // delayed_payment and revocation keys.
+                // The two fields below are used to derive a pubkey for the delayed payment.
+                // The delayed_payment_commitment_point is held by the broadcaster.
+                delayed_payment_commitment_point,
+                delayed_payment_base_key,
+                // The two fields below are used to derive a pubkey for the revocation.
+                // Unlike delayed_payment_commitment_point above, the revocation key is held
+                // by the counter-signatory until this commitment transaction is revoked.
+                revocation_commitment_point,
+                revocation_base_key,
+            ) = if local {
                 (
                     self.get_local_channel_parameters().selected_contest_delay,
-                    self.get_local_commitment_point(commitment_number),
+                    self.get_local_commitment_point(remote_commitment_number),
                     self.get_local_channel_parameters()
                         .delayed_payment_base_key(),
+                    self.get_remote_commitment_point(local_commitment_number),
                     self.get_local_channel_parameters().revocation_base_key(),
                 )
             } else {
                 (
                     self.get_remote_channel_parameters().selected_contest_delay,
-                    self.get_remote_commitment_point(commitment_number),
+                    self.get_remote_commitment_point(local_commitment_number),
                     self.get_remote_channel_parameters()
                         .delayed_payment_base_key(),
+                    self.get_local_commitment_point(remote_commitment_number),
                     self.get_remote_channel_parameters().revocation_base_key(),
                 )
             };
-            debug!("Got base witness parameters: delayed time: {:?}, delayed_payment_key: {:?}, revocation_key: {:?}", delay, base_delayed_payment_key, base_revocation_key);
+            debug!("Got base witness parameters: delayed time: {:?}, delayed_payment_key: {:?}, revocation_key: {:?}", delay, delayed_payment_base_key, revocation_base_key);
             (
                 delay,
-                derive_delayed_payment_pubkey(base_delayed_payment_key, &commitment_point),
-                derive_revocation_pubkey(base_revocation_key, &commitment_point),
+                derive_delayed_payment_pubkey(
+                    delayed_payment_base_key,
+                    &delayed_payment_commitment_point,
+                ),
+                derive_revocation_pubkey(revocation_base_key, &revocation_commitment_point),
             )
         };
 

--- a/tests/bruno/e2e/open-use-close-a-channel/12-add-tlc-from-NODE3.bru
+++ b/tests/bruno/e2e/open-use-close-a-channel/12-add-tlc-from-NODE3.bru
@@ -1,7 +1,7 @@
 meta {
-  name: remove tlc from NODE3
+  name: add tlc from NODE3
   type: http
-  seq: 13
+  seq: 12
 }
 
 post {
@@ -19,14 +19,13 @@ body:json {
   {
     "id": "42",
     "jsonrpc": "2.0",
-    "method": "remove_tlc",
+    "method": "add_tlc",
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "tlc_id": "{{TLC_ID2}}",
-        "reason": {
-          "error_code": "0x2a"
-        }
+        "amount": "0x11e1a300",
+        "payment_hash": "0x29449e2cc6f56a691253fe88e3a378171c81573b09247010b4f1cb8c806e1e38",
+        "expiry": 40
       }
     ]
   }
@@ -34,10 +33,11 @@ body:json {
 
 assert {
   res.body.error: isUndefined
-  res.body.result: isNull
+  res.body.result.tlc_id: isDefined
 }
 
 script:post-response {
   // Sleep for sometime to make sure current operation finishes before next request starts.
   await new Promise(r => setTimeout(r, 100));
+  bru.setVar("TLC_ID6", res.body.result.tlc_id);
 }

--- a/tests/bruno/e2e/open-use-close-a-channel/13-remove-tlc-from-NODE1.bru
+++ b/tests/bruno/e2e/open-use-close-a-channel/13-remove-tlc-from-NODE1.bru
@@ -1,0 +1,43 @@
+meta {
+  name: remove tlc from NODE1
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "remove_tlc",
+    "params": [
+      {
+        "channel_id": "{{CHANNEL_ID}}",
+        "tlc_id": "{{TLC_ID1}}",
+        "reason": {
+          "payment_preimage": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        }
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 100));
+}

--- a/tests/bruno/e2e/open-use-close-a-channel/14-remove-tlc-from-NODE3.bru
+++ b/tests/bruno/e2e/open-use-close-a-channel/14-remove-tlc-from-NODE3.bru
@@ -1,11 +1,11 @@
 meta {
-  name: remove tlc from NODE1
+  name: remove tlc from NODE3
   type: http
-  seq: 12
+  seq: 14
 }
 
 post {
-  url: {{NODE1_RPC_URL}}
+  url: {{NODE3_RPC_URL}}
   body: json
   auth: none
 }
@@ -23,9 +23,9 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "tlc_id": "{{TLC_ID1}}",
+        "tlc_id": "{{TLC_ID2}}",
         "reason": {
-          "payment_preimage": "0x0000000000000000000000000000000000000000000000000000000000000000"
+          "error_code": "0x2a"
         }
       }
     ]

--- a/tests/bruno/e2e/open-use-close-a-channel/21-remove-tlc-from-NODE1.bru
+++ b/tests/bruno/e2e/open-use-close-a-channel/21-remove-tlc-from-NODE1.bru
@@ -1,0 +1,43 @@
+meta {
+  name: remove tlc from NODE1
+  type: http
+  seq: 21
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "remove_tlc",
+    "params": [
+      {
+        "channel_id": "{{CHANNEL_ID}}",
+        "tlc_id": "{{TLC_ID6}}",
+        "reason": {
+          "error_code": "0x2a"
+        }
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 100));
+}


### PR DESCRIPTION
There is currently a bug can be reproduced by repeatedly add tlcs from one party. It will trigger index out of bound panic. This is because we are using the wrong commitment number to obtain remote commitment point (which we have not kept in an array). This PR add the repro to the e2e test. Admittedly this is not enough, we need a "real" test to verify the created commitment transaction is valid (e.g. can be revoked when a revocation secret is revealed).