### PR TITLE
Fix get sent/received tlc value

### DIFF
--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -1601,11 +1601,15 @@ impl ChannelActorState {
     }
 
     pub fn get_sent_tlc_balance(&self) -> u128 {
-        self.get_tlc_value_sent_by_local(true)
+        self.get_active_offered_tlcs(true)
+            .map(|tlc| tlc.tlc.amount)
+            .sum::<u128>()
     }
 
     pub fn get_received_tlc_balance(&self) -> u128 {
-        self.get_tlc_value_received_from_remote(false)
+        self.get_active_received_tlcs(false)
+            .map(|tlc| tlc.tlc.amount)
+            .sum::<u128>()
     }
 
     fn update_state(&mut self, new_state: ChannelState) {
@@ -1806,8 +1810,11 @@ impl ChannelActorState {
             }
         };
         if tlc.is_offered() {
+            // TODO: We should actually also consider all our fulfilled tlcs here.
+            // Because this is also the amount that we can actually spend.
             let sent_tlc_value = self.get_sent_tlc_balance();
-            debug_assert!(self.to_local_amount > sent_tlc_value);
+            debug!("Value of local sent tlcs: {}", sent_tlc_value);
+            debug_assert!(self.to_local_amount >= sent_tlc_value);
             // TODO: handle transaction fee here.
             if sent_tlc_value + tlc.amount > self.to_local_amount {
                 return Err(ProcessingChannelError::InvalidParameter(format!(
@@ -1816,8 +1823,11 @@ impl ChannelActorState {
                 )));
             }
         } else {
+            // TODO: We should actually also consider all their fulfilled tlcs here.
+            // Because this is also the amount that we can actually spend.
             let received_tlc_value = self.get_received_tlc_balance();
-            debug_assert!(self.to_remote_amount > received_tlc_value);
+            debug!("Value of remote received tlcs: {}", received_tlc_value);
+            debug_assert!(self.to_remote_amount >= received_tlc_value);
             // TODO: handle transaction fee here.
             if received_tlc_value + tlc.amount > self.to_remote_amount {
                 return Err(ProcessingChannelError::InvalidParameter(format!(
@@ -2087,18 +2097,6 @@ impl ChannelActorState {
             Self::should_tlc_be_included_in_commitment_tx(info, local_commitment)
                 && info.is_offered()
         })
-    }
-
-    fn get_tlc_value_sent_by_local(&self, local_commitment: bool) -> u128 {
-        if local_commitment {
-            self.get_active_offered_tlcs(local_commitment)
-                .map(|tlc| tlc.tlc.amount)
-                .sum::<u128>()
-        } else {
-            self.get_active_received_tlcs(local_commitment)
-                .map(|tlc| tlc.tlc.amount)
-                .sum::<u128>()
-        }
     }
 
     // The parameter local indicates whether we are interested in the value sent by the local party.


### PR DESCRIPTION
Something is wrong with current calculation of the amount of sent/received money. The error is discovered by @chenyukang while developing https://github.com/nervosnetwork/cfn-node/pull/69 . This PR is currently untested. There are still a lot of things I need to improve (first, the TODO listed in the code, second, make a test case to ensure the balance is calculated correctly). This is meant to be a hotfix.