### PR TITLE
Report channel rpc errors properly

### DIFF
--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -81,7 +81,7 @@ pub enum ChannelCommand {
     TxCollaborationCommand(TxCollaborationCommand),
     // TODO: maybe we should automatically send commitment_signed message after receiving
     // tx_complete event.
-    CommitmentSigned(RpcReplyPort<Result<(), String>>),
+    CommitmentSigned(),
     AddTlc(AddTlcCommand, RpcReplyPort<Result<AddTlcResponse, String>>),
     RemoveTlc(RemoveTlcCommand, RpcReplyPort<Result<(), String>>),
     Shutdown(ShutdownCommand, RpcReplyPort<Result<(), String>>),
@@ -748,18 +748,7 @@ impl<S> ChannelActor<S> {
             ChannelCommand::TxCollaborationCommand(tx_collaboration_command) => {
                 self.handle_tx_collaboration_command(state, tx_collaboration_command)
             }
-            ChannelCommand::CommitmentSigned(reply) => {
-                match self.handle_commitment_signed_command(state) {
-                    Ok(_) => {
-                        let _ = reply.send(Ok(()));
-                        Ok(())
-                    }
-                    Err(err) => {
-                        let _ = reply.send(Err(err.to_string()));
-                        Err(err)
-                    }
-                }
-            }
+            ChannelCommand::CommitmentSigned() => self.handle_commitment_signed_command(state),
             ChannelCommand::AddTlc(command, reply) => {
                 match self.handle_add_tlc_command(state, command) {
                     Ok(tlc_id) => {

--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -81,10 +81,10 @@ pub enum ChannelCommand {
     TxCollaborationCommand(TxCollaborationCommand),
     // TODO: maybe we should automatically send commitment_signed message after receiving
     // tx_complete event.
-    CommitmentSigned(),
+    CommitmentSigned(RpcReplyPort<Result<(), String>>),
     AddTlc(AddTlcCommand, RpcReplyPort<Result<AddTlcResponse, String>>),
     RemoveTlc(RemoveTlcCommand, RpcReplyPort<Result<(), String>>),
-    Shutdown(ShutdownCommand),
+    Shutdown(ShutdownCommand, RpcReplyPort<Result<(), String>>),
 }
 
 #[derive(Debug)]
@@ -748,7 +748,18 @@ impl<S> ChannelActor<S> {
             ChannelCommand::TxCollaborationCommand(tx_collaboration_command) => {
                 self.handle_tx_collaboration_command(state, tx_collaboration_command)
             }
-            ChannelCommand::CommitmentSigned() => self.handle_commitment_signed_command(state),
+            ChannelCommand::CommitmentSigned(reply) => {
+                match self.handle_commitment_signed_command(state) {
+                    Ok(_) => {
+                        let _ = reply.send(Ok(()));
+                        Ok(())
+                    }
+                    Err(err) => {
+                        let _ = reply.send(Err(err.to_string()));
+                        Err(err)
+                    }
+                }
+            }
             ChannelCommand::AddTlc(command, reply) => {
                 match self.handle_add_tlc_command(state, command) {
                     Ok(tlc_id) => {
@@ -775,7 +786,18 @@ impl<S> ChannelActor<S> {
                     }
                 }
             }
-            ChannelCommand::Shutdown(command) => self.handle_shutdown_command(state, command),
+            ChannelCommand::Shutdown(command, reply) => {
+                match self.handle_shutdown_command(state, command) {
+                    Ok(_) => {
+                        let _ = reply.send(Ok(()));
+                        Ok(())
+                    }
+                    Err(err) => {
+                        let _ = reply.send(Err(err.to_string()));
+                        Err(err)
+                    }
+                }
+            }
         }
     }
 
@@ -1641,7 +1663,7 @@ impl ChannelActorState {
         let (mut to_local_amount, mut to_remote_amount) =
             (self.to_local_amount, self.to_remote_amount);
 
-        debug!("Updating local state on revoke_and_ack message {}, current commitment number: {:?}, to_local_amount: {}, to_remote_amount: {}", 
+        debug!("Updating local state on revoke_and_ack message {}, current commitment number: {:?}, to_local_amount: {}, to_remote_amount: {}",
             if is_received { "received" } else { "sent" }, commitment_numbers, to_local_amount, to_remote_amount);
 
         self.tlcs.values_mut().for_each(|tlc| {
@@ -3204,7 +3226,7 @@ impl ChannelActorState {
     pub fn build_commitment_tx(&self, local: bool) -> (TransactionView, [u8; 32], Vec<u8>) {
         let version = self.get_current_commitment_number(local);
         debug!(
-            "Building {} commitment transaction #{} with local commtiment number {} and remote commitment number {}", 
+            "Building {} commitment transaction #{} with local commtiment number {} and remote commitment number {}",
             if local { "local" } else { "remote" }, version,
             self.get_local_commitment_number(), self.get_remote_commitment_number()
         );

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -3,6 +3,7 @@ mod channel;
 mod config;
 mod invoice;
 mod peer;
+mod utils;
 
 use crate::{
     cch::CchCommand,

--- a/src/rpc/utils.rs
+++ b/src/rpc/utils.rs
@@ -1,0 +1,34 @@
+#[macro_export]
+macro_rules! log_and_error {
+    ($params:expr, $err:expr) => {{
+        error!("channel request params {:?} => error: {:?}", $params, $err);
+        Err(ErrorObjectOwned::owned(
+            CALL_EXECUTION_FAILED_CODE,
+            $err,
+            Some($params),
+        ))
+    }};
+}
+
+#[macro_export]
+macro_rules! handle_actor_call {
+    ($actor:expr, $message:expr, $params:expr) => {
+        match call!($actor, $message) {
+            Ok(result) => match result {
+                Ok(res) => Ok(res),
+                Err(e) => log_and_error!($params, e),
+            },
+            Err(e) => log_and_error!($params, e.to_string()),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! handle_actor_cast {
+    ($actor:expr, $message:expr, $params:expr) => {
+        match $actor.cast($message) {
+            Ok(_) => Ok(()),
+            Err(err) => log_and_error!($params, format!("{}", err)),
+        }
+    };
+}

--- a/tests/bruno/e2e/udt/10-node2-send-shutdown-channel-error.bru
+++ b/tests/bruno/e2e/udt/10-node2-send-shutdown-channel-error.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Node2 send shutdown channel1, error shutdowno
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "shutdown_channel",
+    "params": [
+      {
+        "channel_id": "{{N1N2_CHANNEL_ID}}",
+        "close_script": {
+          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
+          "hash_type": "data",
+          "args": "0x0101010101010101010101010101010101010101"
+        },
+        "fee": "0xbebc200"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isDefined
+  res.body.result: isUndefined
+}
+
+script:post-response {
+  // Channel is already shutdown in previous step, will return proper error
+  await new Promise(r => setTimeout(r, 100));
+}


### PR DESCRIPTION
When I was working on the shutdown auto-accept feature, I found that sending a shutdown command to a channel that is already closed will make the node crash.

This PR will report channel RPC errors properly.