### PR TITLE
Fix the repeated shutdown message issue

### DIFF
--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -655,7 +655,10 @@ impl<S: ChannelActorStateStore> ChannelActor<S> {
                 debug!("Handling shutdown command in ChannelReady state");
                 ShuttingDownFlags::empty()
             }
-            ChannelState::ShuttingDown(flags) => flags,
+            ChannelState::ShuttingDown(flags) => {
+                debug!("we already in shutting down state: {:?}", &flags);
+                return Ok(());
+            }
             _ => {
                 debug!("Handling shutdown command in state {:?}", &state.state);
                 return Err(ProcessingChannelError::InvalidState(format!(


### PR DESCRIPTION
In the e2e test `reestablish`, there is an extra shutdown command if auto shutdown happened.

Suppose A send shutdown command, A will send a peer message to B, and if B auto accept shutdown, B will reply a shutdown to A immediately.

Now A is already in state `ShuttingDown`, if A received another shutdown command, based on the current code, it will continue to send shutdown peer message to B, which will cause state inconsistent and there is an error `Musig2VerifyError(BadSignature)`.

In this fix, A will ignore the extra shutdown command when it's already in `ShuttingDown` state.