### PR TITLE
Lock bruno/cli verison

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
             fi
           done
 
-          (cd ./tests/bruno; npm exec -- @usebruno/cli run e2e/${{ matrix.workflow }} -r --env ${{ matrix.test_env }} ${{ matrix.extra_bru_args }} ) &
+          (cd ./tests/bruno; npm exec -- @usebruno/cli@1.20.0 run e2e/${{ matrix.workflow }} -r --env ${{ matrix.test_env }} ${{ matrix.extra_bru_args }} ) &
 
           # -n means we will exit when any of the background processes exits.
           # https://www.gnu.org/software/bash/manual/bash.html#index-wait

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
             fi
           done
 
-          (cd ./tests/bruno; npm exec -- @usebruno/cli@1.20.1 run e2e/${{ matrix.workflow }} -r --env ${{ matrix.test_env }} ${{ matrix.extra_bru_args }} ) &
+          (cd ./tests/bruno; npm exec -- @usebruno/cli@1.20.0 run e2e/${{ matrix.workflow }} -r --env ${{ matrix.test_env }} ${{ matrix.extra_bru_args }} ) &
 
           # -n means we will exit when any of the background processes exits.
           # https://www.gnu.org/software/bash/manual/bash.html#index-wait

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
             fi
           done
 
-          (cd ./tests/bruno; npm exec -- @usebruno/cli@1.20.0 run e2e/${{ matrix.workflow }} -r --env ${{ matrix.test_env }} ${{ matrix.extra_bru_args }} ) &
+          (cd ./tests/bruno; npm exec -- @usebruno/cli@1.20.1 run e2e/${{ matrix.workflow }} -r --env ${{ matrix.test_env }} ${{ matrix.extra_bru_args }} ) &
 
           # -n means we will exit when any of the background processes exits.
           # https://www.gnu.org/software/bash/manual/bash.html#index-wait

--- a/tests/bruno/e2e/3-nodes-transfer/06-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/3-nodes-transfer/06-ckb-generate-blocks.bru
@@ -1,5 +1,5 @@
 meta {
-  name: generate a few blocks for channel 1
+  name: generate a few epochs for channel 1
   type: http
   seq: 6
 }
@@ -17,39 +17,17 @@ headers {
 
 body:json {
   {
-    "id": {{iteration}},
+    "id": 42,
     "jsonrpc": "2.0",
-    "method": "generate_block",
-    "params": []
+    "method": "generate_epochs",
+    "params": ["0x2"]
   }
-}
-
-vars:post-response {
-  max_iterations: 10
 }
 
 assert {
   res.status: eq 200
 }
 
-script:pre-request {
-  // Script taken from https://github.com/usebruno/bruno/discussions/385#discussioncomment-8015350
-  // This does not seem to work.
-  if(bru.getVar("iteration") === undefined){
-    console.log("Started generating blocks for channel 1...");
-    bru.setVar("iteration", 0);
-  }
-}
-
 script:post-response {
-  if(bru.getVar("iteration") < bru.getVar("max_iterations") -1){
-    bru.setVar("iteration", bru.getVar("iteration") + 1);
-    // This is the name of this bruno file, set this to continue generating blocks.
-    bru.setNextRequest("generate a few blocks for channel 1");
-  } else {
-    // Don't know why it takes so long for funding transaction to be confirmed.
-    await new Promise(r => setTimeout(r, 5000));
-  }
-  await new Promise(r => setTimeout(r, 10));
-  console.log("Generated the " + bru.getVar("iteration") + "th block");
+  await new Promise(r => setTimeout(r, 5000));
 }

--- a/tests/bruno/e2e/3-nodes-transfer/10-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/3-nodes-transfer/10-ckb-generate-blocks.bru
@@ -1,5 +1,5 @@
 meta {
-  name: generate a few blocks for channel 2
+  name: generate a few epochs for channel 2
   type: http
   seq: 10
 }
@@ -17,39 +17,17 @@ headers {
 
 body:json {
   {
-    "id": {{iteration}},
+    "id": 42,
     "jsonrpc": "2.0",
-    "method": "generate_block",
-    "params": []
+    "method": "generate_epochs",
+    "params": ["0x2"]
   }
-}
-
-vars:post-response {
-  max_iterations: 20
 }
 
 assert {
   res.status: eq 200
 }
 
-script:pre-request {
-  // Script taken from https://github.com/usebruno/bruno/discussions/385#discussioncomment-8015350
-  // This does not seem to work.
-  if(bru.getVar("iteration") === undefined){
-    console.log("Started generating blocks for channel 2...");
-    bru.setVar("iteration", 0);
-  }
-}
-
 script:post-response {
-  if(bru.getVar("iteration") < bru.getVar("max_iterations") -1){
-    bru.setVar("iteration", bru.getVar("iteration") + 1);
-    // This is the name of this bruno file, set this to continue generating blocks.
-    bru.setNextRequest("generate a few blocks for channel 2");
-  } else {
-    // Don't know why it takes so long for funding transaction to be confirmed.
-    await new Promise(r => setTimeout(r, 5000));
-  }
-  await new Promise(r => setTimeout(r, 10));
-  console.log("Generated the " + bru.getVar("iteration") + "th block");
+  await new Promise(r => setTimeout(r, 5000));
 }

--- a/tests/bruno/e2e/open-use-close-a-channel/06-generate-a-few-blocks.bru
+++ b/tests/bruno/e2e/open-use-close-a-channel/06-generate-a-few-blocks.bru
@@ -1,5 +1,5 @@
 meta {
-  name: generate a few blocks
+  name: generate a few epochs
   type: http
   seq: 6
 }
@@ -17,40 +17,17 @@ headers {
 
 body:json {
   {
-    "id": {{iteration}},
+    "id": 42,
     "jsonrpc": "2.0",
-    "method": "generate_block",
-    "params": []
+    "method": "generate_epochs",
+    "params": ["0x2"]
   }
-}
-
-vars:post-response {
-  max_iterations: 10
 }
 
 assert {
   res.status: eq 200
 }
 
-script:pre-request {
-  // Script taken from https://github.com/usebruno/bruno/discussions/385#discussioncomment-8015350
-  // This does not seem to work.
-  if(bru.getVar("iteration") === undefined){
-    console.log("Started generating blocks...");
-    bru.setVar("iteration", 0);
-  }
-}
-
 script:post-response {
-  if(bru.getVar("iteration") < bru.getVar("max_iterations") -1){
-    bru.setVar("iteration", bru.getVar("iteration") + 1);
-    // This is the name of this bruno file, set this to continue generating blocks.
-    bru.setNextRequest("generate a few blocks");
-  } else {
-    console.log("Stopping generating blocks");
-    // Don't know why it takes so long for funding transaction to be confirmed.
-    await new Promise(r => setTimeout(r, 5000));
-  }
-  await new Promise(r => setTimeout(r, 10));
-  console.log("Generated the " + bru.getVar("iteration") + "th block");
+  await new Promise(r => setTimeout(r, 5000));
 }

--- a/tests/bruno/e2e/reestablish/06-generate-a-few-blocks.bru
+++ b/tests/bruno/e2e/reestablish/06-generate-a-few-blocks.bru
@@ -1,5 +1,5 @@
 meta {
-  name: generate a few blocks
+  name: generate a few epochs
   type: http
   seq: 6
 }
@@ -17,40 +17,17 @@ headers {
 
 body:json {
   {
-    "id": {{iteration}},
+    "id": 42,
     "jsonrpc": "2.0",
-    "method": "generate_block",
-    "params": []
+    "method": "generate_epochs",
+    "params": ["0x2"]
   }
-}
-
-vars:post-response {
-  max_iterations: 10
 }
 
 assert {
   res.status: eq 200
 }
 
-script:pre-request {
-  // Script taken from https://github.com/usebruno/bruno/discussions/385#discussioncomment-8015350
-  // This does not seem to work.
-  if(bru.getVar("iteration") === undefined){
-    console.log("Started generating blocks...");
-    bru.setVar("iteration", 0);
-  }
-}
-
 script:post-response {
-  if(bru.getVar("iteration") < bru.getVar("max_iterations") -1){
-    bru.setVar("iteration", bru.getVar("iteration") + 1);
-    // This is the name of this bruno file, set this to continue generating blocks.
-    bru.setNextRequest("generate a few blocks");
-  } else {
-    console.log("Stopping generating blocks");
-    // Don't know why it takes so long for funding transaction to be confirmed.
-    await new Promise(r => setTimeout(r, 5000));
-  }
-  await new Promise(r => setTimeout(r, 10));
-  console.log("Generated the " + bru.getVar("iteration") + "th block");
+  await new Promise(r => setTimeout(r, 5000));
 }

--- a/tests/bruno/e2e/udt/06-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/udt/06-ckb-generate-blocks.bru
@@ -1,5 +1,5 @@
 meta {
-  name: generate a few blocks for channel 2
+  name: generate a few epochs
   type: http
   seq: 6
 }
@@ -17,39 +17,17 @@ headers {
 
 body:json {
   {
-    "id": {{iteration}},
+    "id": 42,
     "jsonrpc": "2.0",
-    "method": "generate_block",
-    "params": []
+    "method": "generate_epochs",
+    "params": ["0x2"]
   }
-}
-
-vars:post-response {
-  max_iterations: 10
 }
 
 assert {
   res.status: eq 200
 }
 
-script:pre-request {
-  // Script taken from https://github.com/usebruno/bruno/discussions/385#discussioncomment-8015350
-  // This does not seem to work.
-  if(bru.getVar("iteration") === undefined){
-    console.log("Started generating blocks for channel 2...");
-    bru.setVar("iteration", 0);
-  }
-}
-
 script:post-response {
-  if(bru.getVar("iteration") < bru.getVar("max_iterations") -1){
-    bru.setVar("iteration", bru.getVar("iteration") + 1);
-    // This is the name of this bruno file, set this to continue generating blocks.
-    bru.setNextRequest("generate a few blocks for channel 2");
-  } else {
-    // Don't know why it takes so long for funding transaction to be confirmed.
-    await new Promise(r => setTimeout(r, 5000));
-  }
-  await new Promise(r => setTimeout(r, 10));
-  console.log("Generated the " + bru.getVar("iteration") + "th block");
+  await new Promise(r => setTimeout(r, 5000));
 }


### PR DESCRIPTION
The hack in https://github.com/nervosnetwork/cfn-node/blob/f740c4b54570162dd509f98ef38c53b895725732/tests/bruno/e2e/open-use-close-a-channel/06-generate-a-few-blocks.bru no longer works. We will have a

> Too many jumps, possible infinite loop

error in the newest version (1.20.1) of bruno. For now, we just lock bruno to an older version. 1.20.0 is the newest working version.