### PR TITLE
Remove log macros and fix log node prefix

### DIFF
--- a/src/actors.rs
+++ b/src/actors.rs
@@ -1,6 +1,6 @@
-use crate::{debug, error};
 use ractor::{async_trait as rasync_trait, Actor, ActorProcessingErr, ActorRef, SupervisionEvent};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tracing::{debug, error};
 
 /// A root actor that listens for cancellation token and stops all sub actors (those who started by spawn_linked).
 pub struct RootActor;

--- a/src/cch/service.rs
+++ b/src/cch/service.rs
@@ -37,23 +37,23 @@ impl CchService {
         loop {
             select! {
                 _ = self.token.cancelled() => {
-                    crate::debug!("Cancellation received, shutting down cch service");
+                    tracing::debug!("Cancellation received, shutting down cch service");
                     break;
                 }
                 command = self.command_receiver.recv() => {
                     match command {
                         None => {
-                            crate::debug!("Command receiver completed, shutting down tentacle service");
+                            tracing::debug!("Command receiver completed, shutting down tentacle service");
                             break;
                         }
                         Some(command) => {
                             let command_name = command.name();
-                            crate::info!("Process cch command {}", command_name);
+                            tracing::info!("Process cch command {}", command_name);
 
                             match self.process_command(command).await {
                                 Ok(_) => {}
                                 Err(err) => {
-                                    crate::error!("Error processing command {}: {:?}", command_name, err);
+                                    tracing::error!("Error processing command {}: {:?}", command_name, err);
                                 }
                             }
                         }
@@ -64,7 +64,7 @@ impl CchService {
     }
 
     async fn process_command(&mut self, command: CchCommand) -> Result<()> {
-        crate::debug!("CchCommand received: {:?}", command);
+        tracing::debug!("CchCommand received: {:?}", command);
         match command {
             CchCommand::SendBTC(send_btc) => self.send_btc(send_btc).await,
         }
@@ -74,7 +74,7 @@ impl CchService {
         let duration_since_epoch = SystemTime::now().duration_since(UNIX_EPOCH)?;
 
         let invoice = Bolt11Invoice::from_str(&send_btc.btc_pay_req)?;
-        crate::debug!("BTC invoice: {:?}", invoice);
+        tracing::debug!("BTC invoice: {:?}", invoice);
 
         let expiry = invoice
             .expires_at()
@@ -91,7 +91,7 @@ impl CchService {
             .amount_milli_satoshis()
             .ok_or(CchError::BTCInvoiceMissingAmount)?;
 
-        crate::debug!("SendBTC expiry: {:?}", expiry);
+        tracing::debug!("SendBTC expiry: {:?}", expiry);
         let (ratio_ckb_shannons, ratio_btc_msat) =
             match (self.config.ratio_ckb_shannons, self.config.ratio_btc_msat) {
                 (Some(ratio_ckb_shannons), Some(ratio_btc_msat)) => {
@@ -116,7 +116,7 @@ impl CchService {
         };
 
         // TODO: Return it as the RPC response
-        crate::info!("SendBTCOrder: {}", serde_json::to_string(&order)?);
+        tracing::info!("SendBTCOrder: {}", serde_json::to_string(&order)?);
         self.orders_db.insert_send_btc_order(order).await?;
 
         Ok(())

--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -1,5 +1,5 @@
-use crate::{debug, error, info, warn};
 use bitflags::bitflags;
+use tracing::{debug, error, info, warn};
 
 use ckb_hash::{blake2b_256, new_blake2b};
 use ckb_sdk::Since;
@@ -908,7 +908,7 @@ where
     type State = ChannelActorState;
     type Arguments = ChannelInitializationParameter;
 
-    async fn pre_start(
+        async fn pre_start(
         &self,
         myself: ActorRef<Self::Msg>,
         args: Self::Arguments,

--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -908,7 +908,7 @@ where
     type State = ChannelActorState;
     type Arguments = ChannelInitializationParameter;
 
-        async fn pre_start(
+    async fn pre_start(
         &self,
         myself: ActorRef<Self::Msg>,
         args: Self::Arguments,

--- a/src/ckb/key.rs
+++ b/src/ckb/key.rs
@@ -1,6 +1,6 @@
-use crate::warn;
 use ckb_hash::new_blake2b;
 use std::{fs, path::Path};
+use tracing::warn;
 
 // TODO: we need to securely erase the key.
 // We wrap the key in a struct to obtain create a function to obtain secret entropy from this key.

--- a/src/ckb/network.rs
+++ b/src/ckb/network.rs
@@ -1,4 +1,3 @@
-use crate::{debug, error, info, warn};
 use ckb_jsonrpc_types::Status;
 use ckb_types::core::TransactionView;
 use ckb_types::packed::{OutPoint, Script, Transaction};
@@ -11,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 use tentacle::secio::SecioKeyPair;
+use tracing::{debug, error, info, warn};
 
 use tentacle::{
     async_trait,

--- a/src/ckb_chain/actor.rs
+++ b/src/ckb_chain/actor.rs
@@ -59,7 +59,7 @@ impl Actor for CkbChainActor {
         let pub_key_hash = ckb_hash::blake2b_256(pub_key.serialize());
         let funding_source_lock_script =
             get_script_by_contract(Contract::Secp256k1Lock, &pub_key_hash[0..20]);
-        crate::info!(
+        tracing::info!(
             "[{}] funding lock args: {}",
             myself.get_name().unwrap_or_default(),
             funding_source_lock_script.args()
@@ -115,7 +115,7 @@ impl Actor for CkbChainActor {
                                 RpcError::Rpc(e)
                                     if (e.code.code() == -1107 || e.code.code() == -1111) =>
                                 {
-                                    crate::warn!(
+                                    tracing::warn!(
                                         "[{}] transaction { } already in pool",
                                         myself.get_name().unwrap_or_default(),
                                         tx.hash(),
@@ -123,7 +123,7 @@ impl Actor for CkbChainActor {
                                     Ok(())
                                 }
                                 _ => {
-                                    crate::error!(
+                                    tracing::error!(
                                         "[{}] send transaction {} failed: {:?}",
                                         myself.get_name().unwrap_or_default(),
                                         tx.hash(),
@@ -146,7 +146,7 @@ impl Actor for CkbChainActor {
                 },
                 reply_port,
             ) => {
-                crate::info!(
+                tracing::info!(
                     "[{}] trace transaction {} with {} confs",
                     myself.get_name().unwrap_or_default(),
                     tx_hash,
@@ -174,7 +174,7 @@ impl Actor for CkbChainActor {
                                                 .then_some(ckb_jsonrpc_types::Status::Committed)
                                         }
                                         Err(err) => {
-                                            crate::error!(
+                                            tracing::error!(
                                                 "[{}] get tip block number failed: {:?}",
                                                 actor_name,
                                                 err
@@ -189,7 +189,7 @@ impl Actor for CkbChainActor {
                                 _ => None,
                             },
                             Err(err) => {
-                                crate::error!(
+                                tracing::error!(
                                     "[{}] get transaction status failed: {:?}",
                                     actor_name,
                                     err
@@ -244,9 +244,9 @@ mod test_utils {
     use super::super::contracts::MockContext;
     use super::CkbChainMessage;
 
-    use crate::{debug, error};
     use ckb_types::packed::Byte32;
     use ractor::{call_t, Actor, ActorProcessingErr, ActorRef};
+    use tracing::{debug, error};
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum CellStatus {

--- a/src/ckb_chain/config.rs
+++ b/src/ckb_chain/config.rs
@@ -74,7 +74,7 @@ impl CkbChainConfig {
 
         let warn = |m: bool, d: &str| {
             if m {
-                crate::warn!(
+                tracing::warn!(
                     "Your secret file's permission is not {}, path: {:?}. \
                 Please fix it as soon as possible",
                     d,

--- a/src/ckb_chain/contracts.rs
+++ b/src/ckb_chain/contracts.rs
@@ -1,4 +1,3 @@
-use crate::debug;
 use ckb_types::{
     core::{DepType, ScriptHashType},
     packed::{CellDep, CellDepVec, CellDepVecBuilder, OutPoint, Script},
@@ -6,6 +5,7 @@ use ckb_types::{
 };
 use regex::Regex;
 use std::{collections::HashMap, env, str::FromStr, sync::Arc};
+use tracing::debug;
 
 use crate::ckb::{config::CkbNetwork, types::Hash256};
 
@@ -231,7 +231,7 @@ impl ContractsContext {
         match network {
             #[cfg(test)]
             CkbNetwork::Mocknet => {
-                crate::warn!("Initializing mock context for testing.");
+                tracing::warn!("Initializing mock context for testing.");
                 MockContext::new().into()
             }
             CkbNetwork::Dev => {

--- a/src/ckb_chain/funding/funding_tx.rs
+++ b/src/ckb_chain/funding/funding_tx.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use super::super::FundingError;
 use crate::{ckb::serde_utils::EntityHex, ckb_chain::contracts::get_udt_cell_deps};
 
-use crate::{debug, warn};
+use tracing::{debug, warn};
 use anyhow::anyhow;
 use ckb_sdk::{
     constants::SIGHASH_TYPE_HASH,

--- a/src/ckb_chain/funding/funding_tx.rs
+++ b/src/ckb_chain/funding/funding_tx.rs
@@ -1,9 +1,5 @@
-use std::collections::{HashMap, HashSet};
-
 use super::super::FundingError;
 use crate::{ckb::serde_utils::EntityHex, ckb_chain::contracts::get_udt_cell_deps};
-
-use tracing::{debug, warn};
 use anyhow::anyhow;
 use ckb_sdk::{
     constants::SIGHASH_TYPE_HASH,
@@ -28,6 +24,8 @@ use molecule::{
 };
 use serde::Deserialize;
 use serde_with::serde_as;
+use std::collections::{HashMap, HashSet};
+use tracing::{debug, warn};
 
 /// Funding transaction wrapper.
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use std::{fs::File, io::BufReader, path::PathBuf, process::exit, str::FromStr};
 
-use crate::error;
 use clap::CommandFactory;
 use clap_serde_derive::{
     clap::{self, Parser},
@@ -8,6 +7,7 @@ use clap_serde_derive::{
 };
 use home::home_dir;
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 use crate::{ckb_chain::CkbChainConfig, CchConfig, CkbConfig, LdkConfig, RpcConfig};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,28 +22,10 @@ pub mod actors;
 
 pub mod tasks;
 
-fn get_prefix() -> &'static str {
+pub fn get_node_prefix() -> &'static str {
     static INSTANCE: once_cell::sync::OnceCell<String> = once_cell::sync::OnceCell::new();
     INSTANCE.get_or_init(|| std::env::var("LOG_PREFIX").unwrap_or_else(|_| "".to_string()))
 }
-
-macro_rules! define_node_log_functions {
-    ($($level:ident => $tracing_fn:ident),+) => {
-        $(
-            pub fn $level(args: std::fmt::Arguments) {
-                tracing::$tracing_fn!("{}{}", get_prefix(), args);
-            }
-        )+
-    };
-}
-
-define_node_log_functions!(
-    node_debug => debug,
-    node_warn => warn,
-    node_error => error,
-    node_info => info,
-    node_trace => trace
-);
 
 pub mod macros {
     #[macro_export]
@@ -65,42 +47,6 @@ pub mod macros {
                     return;
                 }
             }
-        };
-    }
-
-    /// A macro to simplify the usage of `debug_with_node_prefix` function.
-    #[macro_export]
-    macro_rules! debug {
-        ($($arg:tt)*) => {
-            $crate::node_debug(format_args!($($arg)*))
-        };
-    }
-
-    #[macro_export]
-    macro_rules! warn {
-        ($($arg:tt)*) => {
-            $crate::node_warn(format_args!($($arg)*))
-        };
-    }
-
-    #[macro_export]
-    macro_rules! error {
-        ($($arg:tt)*) => {
-            $crate::node_error(format_args!($($arg)*))
-        };
-    }
-
-    #[macro_export]
-    macro_rules! info {
-        ($($arg:tt)*) => {
-            $crate::node_info(format_args!($($arg)*))
-        };
-    }
-
-    #[macro_export]
-    macro_rules! trace {
-        ($($arg:tt)*) => {
-            $crate::node_trace(format_args!($($arg)*))
         };
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 use cfn_node::ckb_chain::contracts::init_contracts_context;
 use cfn_node::store::Store;
-use cfn_node::{debug, error, info, trace};
 use ractor::Actor;
 use tentacle::multiaddr::Multiaddr;
 use tokio::sync::mpsc;
 use tokio::{select, signal};
+use tracing::{debug, error, info, info_span, trace};
+use tracing_subscriber::field::MakeExt;
 use tracing_subscriber::{fmt, EnvFilter};
 
 use std::str::FromStr;
@@ -17,14 +18,33 @@ use cfn_node::tasks::{
     cancel_tasks_and_wait_for_completion, new_tokio_cancellation_token, new_tokio_task_tracker,
 };
 use cfn_node::{start_cch, start_ckb, start_ldk, start_rpc, Config};
+use core::default::Default;
+use tracing_subscriber::fmt::format;
 
 #[tokio::main]
 pub async fn main() {
+    let node_formatter = format::debug_fn(|writer, field, value| {
+        if field.name() == "id" {
+            write!(
+                writer,
+                "{}: {:?} on {}",
+                field,
+                value,
+                cfn_node::get_node_prefix()
+            )
+        } else {
+            write!(writer, "{}: {:?}", field, value)
+        }
+    })
+    .delimited(", ");
+
     fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .pretty()
-        .with_target(false)
+        .fmt_fields(node_formatter)
         .init();
+
+    let _span = info_span!("node", node = cfn_node::get_node_prefix()).entered();
 
     let config = Config::parse();
     debug!("Parsed config: {:?}", &config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,9 @@ use tracing_subscriber::fmt::format;
 
 #[tokio::main]
 pub async fn main() {
+    // ractor will set "id" for each actor:
+    // https://github.com/slawlor/ractor/blob/67d657e4cdcb8884a9ccc9b758704cbb447ac163/ractor/src/actor/mod.rs#L701
+    // here we map it with the node prefix
     let node_formatter = format::debug_fn(|writer, field, value| {
         if field.name() == "id" {
             write!(

--- a/src/rpc/channel.rs
+++ b/src/rpc/channel.rs
@@ -11,7 +11,6 @@ use crate::ckb::{
     types::{Hash256, LockTime, RemoveTlcFail, RemoveTlcFulfill},
     NetworkActorCommand, NetworkActorMessage,
 };
-use crate::error;
 use crate::{handle_actor_call, handle_actor_cast, log_and_error};
 use ckb_jsonrpc_types::Script;
 use ckb_types::core::FeeRate;

--- a/src/rpc/peer.rs
+++ b/src/rpc/peer.rs
@@ -1,5 +1,4 @@
 use crate::ckb::{NetworkActorCommand, NetworkActorMessage};
-use crate::error;
 use crate::log_and_error;
 use jsonrpsee::{
     core::async_trait, proc_macros::rpc, types::error::CALL_EXECUTION_FAILED_CODE,

--- a/src/rpc/utils.rs
+++ b/src/rpc/utils.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! log_and_error {
     ($params:expr, $err:expr) => {{
-        error!("channel request params {:?} => error: {:?}", $params, $err);
+        tracing::error!("channel request params {:?} => error: {:?}", $params, $err);
         Err(ErrorObjectOwned::owned(
             CALL_EXECUTION_FAILED_CODE,
             $err,

--- a/tests/nodes/start.sh
+++ b/tests/nodes/start.sh
@@ -47,12 +47,12 @@ start() {
 }
 
 if [ "$#" -ne 1 ]; then
-    LOG_PREFIX=$'[node 1] ' start -d 1 &
-    LOG_PREFIX=$'[node 2] ' start -d 2 &
-    LOG_PREFIX=$'[node 3] ' start -d 3 &
+    LOG_PREFIX=$'[node 1]' start -d 1 &
+    LOG_PREFIX=$'[node 2]' start -d 2 &
+    LOG_PREFIX=$'[node 3]' start -d 3 &
 else
     for id in "$@"; do
-        LOG_PREFIX="[$id]"$' ' start -d "$id" &
+        LOG_PREFIX="[$id]"$'' start -d "$id" &
     done
 fi
 


### PR DESCRIPTION
There are two drawbacks for https://github.com/nervosnetwork/cfn-node/pull/120

1. we're losing source file and line number in log event
2. we macros don't support all argument format: https://docs.rs/tracing/latest/tracing/macro.info.html


There are several methods to propagate the span to spawned tasks:

1. `instrument` when using tokio spawn or actor span:
```rust
Actor::spawn_linked(...).instrument(span).await;
```

2. `instrument` with macors for a function
```rust
#[tracing::instrument(name = "Actor", skip(self, myself, args), fields(id = crate::get_node_prefix()))]
async fn pre_start(
        &self,
        myself: ActorRef<Self::Msg>,
        args: Self::Arguments,
    ) -> Result<Self::State, ActorProcessingErr> {
...
}
```

This PR use a trivial [hack](https://github.com/nervosnetwork/cfn-node/pull/127/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR29) to achieve it, I think it's more general since developers may forget to set `instrument` for actors.
