### PR TITLE
Fix shutdown fee issue with shutdown scripts

### DIFF
--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -47,7 +47,7 @@ use crate::{
 
 use super::{
     config::{DEFAULT_CHANNEL_MINIMAL_CKB_AMOUNT, MIN_UDT_OCCUPIED_CAPACITY},
-    fee::default_minimal_ckb_amount,
+    fee::{calculate_shutdown_tx_fee, default_minimal_ckb_amount},
     hash_algorithm::HashAlgorithm,
     key::blake2b_hash_with_salt,
     network::CFNMessageWithPeerId,
@@ -387,7 +387,7 @@ impl<S: ChannelActorStateStore> ChannelActor<S> {
 
                 let mut flags = flags | ShuttingDownFlags::THEIR_SHUTDOWN_SENT;
 
-                if state.check_valid_to_auto_accept() {
+                if state.check_valid_to_auto_accept_shutdown() {
                     let funding_source_lock_script =
                         state.funding_source_lock_script.as_ref().unwrap();
                     self.network
@@ -665,7 +665,7 @@ impl<S: ChannelActorStateStore> ChannelActor<S> {
             }
         };
 
-        state.check_shutdown_fee_rate(command.fee_rate)?;
+        state.check_shutdown_fee_rate(command.fee_rate, &command.close_script)?;
         self.network
             .send_message(NetworkActorMessage::new_command(
                 NetworkActorCommand::SendCFNMessage(CFNMessageWithPeerId {
@@ -1828,7 +1828,11 @@ impl ChannelActorState {
         Ok(())
     }
 
-    fn check_shutdown_fee_rate(&self, fee_rate: FeeRate) -> ProcessingChannelResult {
+    fn check_shutdown_fee_rate(
+        &self,
+        fee_rate: FeeRate,
+        close_script: &Script,
+    ) -> ProcessingChannelResult {
         if fee_rate.as_u64() < self.commitment_fee_rate {
             return Err(ProcessingChannelError::InvalidParameter(format!(
                 "Fee rate {} is less than commitment fee rate {}",
@@ -1836,8 +1840,9 @@ impl ChannelActorState {
             )));
         }
 
-        let fee = calculate_commitment_tx_fee(fee_rate.as_u64(), &self.funding_udt_type_script);
-        debug!("shutdown fee: {:?}", fee);
+        let mut cloned = self.clone();
+        cloned.local_shutdown_script = Some(close_script.clone());
+        let fee = calculate_shutdown_tx_fee(fee_rate.as_u64(), &cloned);
 
         let available_max_fee = if self.funding_udt_type_script.is_none() {
             self.to_local_amount as u64 + self.local_reserved_ckb_amount - MIN_OCCUPIED_CAPACITY
@@ -2570,14 +2575,14 @@ impl ChannelActorState {
         &self.get_remote_channel_parameters().pubkeys.funding_pubkey
     }
 
-    fn check_valid_to_auto_accept(&self) -> bool {
+    fn check_valid_to_auto_accept_shutdown(&self) -> bool {
         let Some(remote_fee_rate) = self.remote_shutdown_fee_rate else {
             return false;
         };
         if remote_fee_rate < self.commitment_fee_rate {
             return false;
         }
-        let fee = calculate_commitment_tx_fee(remote_fee_rate, &self.funding_udt_type_script);
+        let fee = calculate_shutdown_tx_fee(remote_fee_rate, &self);
         let remote_available_max_fee = if self.funding_udt_type_script.is_none() {
             self.to_remote_amount as u64 + self.remote_reserved_ckb_amount - MIN_OCCUPIED_CAPACITY
         } else {
@@ -2805,6 +2810,17 @@ impl ChannelActorState {
                     u64::MAX,
                     &shutdown_tx,
                 )?;
+
+                assert_eq!(
+                    tx.data().serialized_size_in_block(),
+                    commitment_tx_size(
+                        &self.funding_udt_type_script,
+                        Some((
+                            self.local_shutdown_script.clone().unwrap(),
+                            self.remote_shutdown_script.clone().unwrap()
+                        ))
+                    )
+                );
 
                 network
                     .send_message(NetworkActorMessage::new_event(
@@ -3039,7 +3055,7 @@ impl ChannelActorState {
 
         assert_eq!(
             tx.data().serialized_size_in_block(),
-            commitment_tx_size(&self.funding_udt_type_script)
+            commitment_tx_size(&self.funding_udt_type_script, None)
         );
 
         let num = self.get_current_commitment_number(false);
@@ -3538,11 +3554,8 @@ impl ChannelActorState {
             ) => (
                 local_shutdown_script,
                 remote_shutdown_script,
-                calculate_commitment_tx_fee(local_shutdown_fee_rate, &self.funding_udt_type_script),
-                calculate_commitment_tx_fee(
-                    remote_shutdown_fee_rate,
-                    &self.funding_udt_type_script,
-                ),
+                calculate_shutdown_tx_fee(local_shutdown_fee_rate, &self),
+                calculate_shutdown_tx_fee(remote_shutdown_fee_rate, &self),
             ),
             _ => {
                 return Err(ProcessingChannelError::InvalidState(format!(

--- a/src/ckb/fee.rs
+++ b/src/ckb/fee.rs
@@ -1,4 +1,4 @@
-use super::channel::FUNDING_CELL_WITNESS_LEN;
+use super::channel::{ChannelActorState, FUNDING_CELL_WITNESS_LEN};
 use super::config::{DEFAULT_CHANNEL_MINIMAL_CKB_AMOUNT, DEFAULT_UDT_MINIMAL_CKB_AMOUNT};
 use crate::ckb_chain::contracts::{get_cell_deps, get_script_by_contract, Contract};
 use ckb_types::core::TransactionBuilder;
@@ -20,29 +20,46 @@ pub(crate) fn default_minimal_ckb_amount(is_udt: bool) -> u64 {
     }
 }
 
-pub(crate) fn commitment_tx_size(udt_type_script: &Option<Script>) -> usize {
-    // Note: here we must add args, otherwise the total transaction size will be different
-    let dummy_script = get_script_by_contract(Contract::Secp256k1Lock, &[0u8; 20]);
+pub(crate) fn commitment_tx_size(
+    udt_type_script: &Option<Script>,
+    shutdown_scripts: Option<(Script, Script)>,
+) -> usize {
+    let (script_a, script_b) =
+        if let Some((local_shutdown_script, remote_shutdown_script)) = shutdown_scripts {
+            (local_shutdown_script, remote_shutdown_script)
+        } else {
+            let script = get_script_by_contract(Contract::Secp256k1Lock, &[0u8; 20]);
+            (script.clone(), script)
+        };
 
     let cell_deps = get_cell_deps(vec![Contract::FundingLock], udt_type_script);
 
     let (outputs, outputs_data) = if let Some(type_script) = udt_type_script {
-        let dummy_output = CellOutput::new_builder()
-            .lock(dummy_script)
+        let output_a = CellOutput::new_builder()
+            .lock(script_a)
+            .type_(Some(type_script.clone()).pack())
+            .capacity(0.pack())
+            .build();
+        let output_b = CellOutput::new_builder()
+            .lock(script_b)
             .type_(Some(type_script.clone()).pack())
             .capacity(0.pack())
             .build();
         let dummy_output_data = (0_u128).to_le_bytes().pack();
 
-        let outputs = [dummy_output.clone(), dummy_output];
+        let outputs = [output_a, output_b];
         let outputs_data = [dummy_output_data.clone(), dummy_output_data];
         (outputs, outputs_data.to_vec())
     } else {
-        let dummy_output = CellOutput::new_builder()
+        let output_a = CellOutput::new_builder()
             .capacity(0.pack())
-            .lock(dummy_script)
+            .lock(script_a)
             .build();
-        let outputs = [dummy_output.clone(), dummy_output];
+        let output_b = CellOutput::new_builder()
+            .capacity(0.pack())
+            .lock(script_b)
+            .build();
+        let outputs = [output_a, output_b];
         (outputs, vec![Bytes::default(); 2])
     };
 
@@ -60,8 +77,6 @@ pub(crate) fn commitment_tx_size(udt_type_script: &Option<Script>) -> usize {
     mock_commitment_tx.data().serialized_size_in_block()
 }
 
-/// Note: we use this function to calculate both commitment transaction and shutdown transaction
-/// shutdown transaction is just a special commitment transaction.
 pub(crate) fn calculate_commitment_tx_fee(fee_rate: u64, udt_type_script: &Option<Script>) -> u64 {
     debug!(
         "calculate_commitment_tx_fee: {} udt_script: {:?}",
@@ -69,8 +84,36 @@ pub(crate) fn calculate_commitment_tx_fee(fee_rate: u64, udt_type_script: &Optio
     );
     let fee_rate: FeeRate = FeeRate::from_u64(fee_rate);
 
-    let tx_size = commitment_tx_size(udt_type_script) as u64;
+    let tx_size = commitment_tx_size(udt_type_script, None) as u64;
     let res = fee_rate.fee(tx_size).as_u64();
     debug!("calculate_commitment_tx_fee return: {}", res);
+    res
+}
+
+/// Note: the shutdown scripts are optional, if not provided, the default lock script will be used
+pub(crate) fn calculate_shutdown_tx_fee(fee_rate: u64, state: &ChannelActorState) -> u64 {
+    let udt_type_script = &state.funding_udt_type_script;
+    let shutdown_scripts = (
+        state.remote_shutdown_script.clone().unwrap_or(
+            state
+                .funding_source_lock_script
+                .clone()
+                .expect("no funding source lock script"),
+        ),
+        state.local_shutdown_script.clone().unwrap_or(
+            state
+                .funding_source_lock_script
+                .clone()
+                .expect("no funding source lock script"),
+        ),
+    );
+    debug!(
+        "calculate_shutdown_tx_fee: {} udt_script: {:?}",
+        fee_rate, udt_type_script
+    );
+    let fee_rate: FeeRate = FeeRate::from_u64(fee_rate);
+    let tx_size = commitment_tx_size(udt_type_script, Some(shutdown_scripts)) as u64;
+    let res = fee_rate.fee(tx_size).as_u64();
+    debug!("calculate_shutdown_tx_fee return: {}", res);
     res
 }


### PR DESCRIPTION
This assertion is triggered because we used dummy lock script when calculating shutdown fee:
https://github.com/nervosnetwork/cfn-node/actions/runs/9850541311/job/27195924130#step:5:140
