### PR TITLE
Test revoking old commitment tx

### DIFF
--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -5307,14 +5307,14 @@ mod tests {
             .expect("accept channel success");
         let new_channel_id = accept_channel_result.new_channel_id;
 
-        let commitment_tx = node_a
+        let commitment_tx = node_b
             .expect_to_process_event(|event| match event {
                 NetworkServiceEvent::RemoteCommitmentSigned(peer_id, channel_id, num, tx) => {
                     println!(
                         "Commitment tx (#{}) {:?} from {:?} for channel {:?} received",
                         num, &tx, peer_id, channel_id
                     );
-                    assert_eq!(peer_id, &node_b.peer_id);
+                    assert_eq!(peer_id, &node_a.peer_id);
                     assert_eq!(channel_id, &new_channel_id);
                     Some(tx.clone())
                 }

--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -5225,6 +5225,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_revoke_old_commitment_transaction() {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .pretty()
+            .init();
+
         let [mut node_a, mut node_b] = NetworkNode::new_n_interconnected_nodes(2)
             .await
             .try_into()

--- a/src/ckb/channel.rs
+++ b/src/ckb/channel.rs
@@ -1471,6 +1471,14 @@ pub struct ChannelActorState {
     // This value is guaranteed to be 0 when channel is just created.
     pub commitment_numbers: CommitmentNumbers,
 
+    // We need remote commitment number to build a local commitment transaction,
+    // (required to derive payment keys and construct the list of all TLCs).
+    // This list is all the remote commitment numbers when a local commitment
+    // is committed (i.e. a RevokeAndAck message is received from remote).
+    // The nth element in this list is the remote commitment number of the nth
+    // local commitment transaction.
+    pub remote_commitment_numbers_when_committed_locally: Vec<u64>,
+
     // Below are fields that are only usable after the channel is funded,
     // (or at some point of the state).
 
@@ -1754,6 +1762,7 @@ impl ChannelActorState {
                 selected_contest_delay: remote_delay,
             }),
             commitment_numbers: Default::default(),
+            remote_commitment_numbers_when_committed_locally: Default::default(),
             remote_shutdown_script: None,
             remote_nonce: Some(remote_nonce),
             remote_commitment_points: vec![first_commitment_point, second_commitment_point],
@@ -1808,6 +1817,7 @@ impl ChannelActorState {
             remote_channel_parameters: None,
             remote_nonce: None,
             commitment_numbers: Default::default(),
+            remote_commitment_numbers_when_committed_locally: Default::default(),
             remote_commitment_points: vec![],
             funding_source_lock_script: None,
             local_shutdown_script: None,
@@ -2011,6 +2021,8 @@ impl ChannelActorState {
 
         if is_received {
             self.increment_local_commitment_number();
+            self.remote_commitment_numbers_when_committed_locally
+                .push(self.get_remote_commitment_number());
         } else {
             self.increment_remote_commitment_number();
         }
@@ -3289,6 +3301,8 @@ impl ChannelActorState {
 
     pub fn on_channel_ready(&mut self, network: &ActorRef<NetworkActorMessage>) {
         self.update_state(ChannelState::ChannelReady());
+        self.remote_commitment_numbers_when_committed_locally
+            .push(INITIAL_COMMITMENT_NUMBER);
         self.increment_local_commitment_number();
         self.increment_remote_commitment_number();
         network
@@ -3949,10 +3963,18 @@ impl ChannelActorState {
 
     fn get_local_commitment_witnesses(&self, commitment_number: u64) -> Vec<u8> {
         debug_assert!(commitment_number < self.get_local_commitment_number());
+        debug_assert_eq!(
+            self.get_local_commitment_number(),
+            self.remote_commitment_numbers_when_committed_locally.len() as u64
+        );
         // TODO: we need to persist the remote commitment number while this local commitment
         // transaction is commited, and look it up here.
-        self.build_commitment_transaction_witnesses(true, commitment_number, 0)
-            .0
+        self.build_commitment_transaction_witnesses(
+            true,
+            commitment_number,
+            self.remote_commitment_numbers_when_committed_locally[commitment_number as usize],
+        )
+        .0
     }
 
     fn get_previous_local_commitment_witnesses(&self) -> Vec<u8> {

--- a/src/ckb/network.rs
+++ b/src/ckb/network.rs
@@ -146,16 +146,30 @@ pub enum NetworkServiceEvent {
     // We should sign a commitment transaction and send it to the other party.
     CommitmentSignaturePending(PeerId, Hash256, u64),
     // We have signed a commitment transaction and sent it to the other party.
-    // The last element is the witnesses for this commitment transaction.
-    // The TransactionView here is not a valid commitment transaction per se,
-    // as we need the other party's signature.
-    LocalCommitmentSigned(PeerId, Hash256, u64, TransactionView, Vec<u8>),
+    LocalCommitmentSigned(
+        PeerId,          /* Peer Id */
+        Hash256,         /* Channel Id */
+        u64,             /* Commitment number */
+        TransactionView, /* Commitment transaction, not valid per se (requires other party's signature) */
+        Vec<u8>,         /* Commitment transaction witness */
+    ),
+    // A RevokeAndAck is received from the peer. Other data relevant to this
+    // RevokeAndAck message are also assembled here. The watch tower may use this.
+    // TODO: We also need transaction hash from the event `LocalCommitmentSigned` above
+    // for the watch tower to watch older transactions being broadcasted.
+    RevokeAndAckReceived(
+        PeerId,  /* Peer Id */
+        Hash256, /* Channel Id */
+        u64,     /* Commitment number */
+        Privkey, /* Revocation secret */
+        Pubkey,  /* Revocation base point */
+        Vec<u8>, /* Commitment transaction witness */
+        Pubkey,  /* Next commitment point */
+    ),
     // The other party has signed a valid commitment transaction,
     // and we successfully assemble the partial signature from other party
     // to create a complete commitment transaction.
     RemoteCommitmentSigned(PeerId, Hash256, u64, TransactionView),
-    // A RevokeAndAck is received from the peer.
-    RevokeAndAckReceived(PeerId, Hash256, u64, Privkey, Pubkey, Vec<u8>, Pubkey),
 }
 
 /// Events that can be sent to the network actor. Except for NetworkServiceEvent,

--- a/src/ckb/network.rs
+++ b/src/ckb/network.rs
@@ -155,7 +155,7 @@ pub enum NetworkServiceEvent {
     // to create a complete commitment transaction.
     RemoteCommitmentSigned(PeerId, Hash256, u64, TransactionView),
     // A RevokeAndAck is received from the peer.
-    RevokeAndAckReceived(PeerId, Hash256, u64, Privkey, Vec<u8>, Pubkey),
+    RevokeAndAckReceived(PeerId, Hash256, u64, Privkey, Pubkey, Vec<u8>, Pubkey),
 }
 
 /// Events that can be sent to the network actor. Except for NetworkServiceEvent,

--- a/src/ckb/network.rs
+++ b/src/ckb/network.rs
@@ -19,7 +19,7 @@ use super::channel::{
 };
 use super::fee::{calculate_commitment_tx_fee, default_minimal_ckb_amount};
 use super::key::blake2b_hash_with_salt;
-use super::types::{Hash256, OpenChannel, Pubkey};
+use super::types::{Hash256, OpenChannel, Privkey, Pubkey};
 use super::{
     channel::{ChannelActor, ChannelCommand, ChannelInitializationParameter},
     types::CFNMessage,
@@ -154,7 +154,8 @@ pub enum NetworkServiceEvent {
     // and we successfully assemble the partial signature from other party
     // to create a complete commitment transaction.
     RemoteCommitmentSigned(PeerId, Hash256, u64, TransactionView),
-    RevokeAndAckReceived(PeerId, Hash256, u64, Hash256, Pubkey),
+    // A RevokeAndAck is received from the peer.
+    RevokeAndAckReceived(PeerId, Hash256, u64, Privkey, Vec<u8>, Pubkey),
 }
 
 /// Events that can be sent to the network actor. Except for NetworkServiceEvent,

--- a/src/ckb/types.rs
+++ b/src/ckb/types.rs
@@ -307,6 +307,10 @@ impl Privkey {
         let sk = Scalar::from(self);
         (scalar + sk).unwrap().into()
     }
+
+    pub fn sign_ecdsa(&self, message: &[u8; 32]) -> secp256k1::ecdsa::Signature {
+        secp256k1_instance().sign_ecdsa(&secp256k1::Message::from_digest(*message), &self.0)
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/ckb/types.rs
+++ b/src/ckb/types.rs
@@ -312,6 +312,13 @@ impl Privkey {
     // But we don't want to depend on ckb-crypto because ckb-crypto depends on
     // a different version of secp256k1.
     pub fn sign_ecdsa_recoverable(&self, message: &[u8; 32]) -> [u8; 65] {
+        tracing::debug!(
+            "Signing message with private key {:?}, public key: {:?}, pubkey hash: {:?},  message {:?}",
+            hex::encode(self.as_ref()),
+            self.pubkey(),
+            hex::encode(ckb_hash::blake2b_256(self.pubkey().serialize())),
+            hex::encode(message)
+        );
         let (rec_id, data) = secp256k1_instance()
             .sign_ecdsa_recoverable(&secp256k1::Message::from_digest(*message), &self.0)
             .serialize_compact();

--- a/src/ckb/types.rs
+++ b/src/ckb/types.rs
@@ -308,8 +308,17 @@ impl Privkey {
         (scalar + sk).unwrap().into()
     }
 
-    pub fn sign_ecdsa(&self, message: &[u8; 32]) -> secp256k1::ecdsa::Signature {
-        secp256k1_instance().sign_ecdsa(&secp256k1::Message::from_digest(*message), &self.0)
+    // Essentially https://docs.rs/ckb-crypto/latest/ckb_crypto/secp/struct.Privkey.html#method.sign_recoverable
+    // But we don't want to depend on ckb-crypto because ckb-crypto depends on
+    // a different version of secp256k1.
+    pub fn sign_ecdsa_recoverable(&self, message: &[u8; 32]) -> [u8; 65] {
+        let (rec_id, data) = secp256k1_instance()
+            .sign_ecdsa_recoverable(&secp256k1::Message::from_digest(*message), &self.0)
+            .serialize_compact();
+        let mut result = [0; 65];
+        result[0..64].copy_from_slice(data.as_slice());
+        result[64] = rec_id.to_i32() as u8;
+        result
     }
 }
 


### PR DESCRIPTION
This PR adds a unit test to check that we can revoke an older commitment transaction.

While developing on this PR, I found a few bugs in current implementation.

- There is an incompatibility between the way of hashing commitment lock witnesses in cfn-node and cfn-scripts. https://github.com/nervosnetwork/cfn-node/issues/129
- The current way of deriving revocation public key is wrong. We can't obtain the correct private key when the counterparty reveals his revocation secret.
- We are skipping one commitment point while sending and verifying `RevokeAndAck` messages.
- The commitment transaction outputs should use both the revocation key and delayed output key of the same party.

I also made one change that is required to construct the revocation transaction.
- [Save remote commitment numbers whenever a new local commitment transaction is committed · Issue #132 · nervosnetwork/cfn-node](https://github.com/nervosnetwork/cfn-node/issues/132)