### PR TITLE
chore: change cch startup failure log level

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,10 +151,11 @@ pub async fn main() {
             .await
             {
                 Err(err) => {
-                    error!("Cross-chain service failed to start: {}", err);
                     if ignore_startup_failure {
+                        info!("Cross-chain service failed to start and is ignored by the config option ignore_startup_failure: {}", err);
                         None
                     } else {
+                        error!("Cross-chain service failed to start: {}", err);
                         return;
                     }
                 }


### PR DESCRIPTION
Change to info when the failure is ignored in the config.