### PR TITLE
Fix bugs in channel announcement

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -1638,7 +1638,7 @@ where
                 debug!("Channel announcement transaction found: {:?}", &tx);
 
                 let pubkey = channel_announcement.ckb_key.serialize();
-                let pubkey_hash = blake2b_256(pubkey.as_slice());
+                let pubkey_hash = &blake2b_256(pubkey.as_slice())[0..20];
                 match tx.inner.outputs.first() {
                     None => {
                         return Err(Error::InvalidParameter(format!(


### PR DESCRIPTION
This is a bug caused by code merging: https://github.com/nervosnetwork/fiber/pull/158/files#diff-176f6d4f89e68f8dda8ca44f71496fbfc28d7fbf135f1b5f2795c8a183a0bc18R1641

And PR https://github.com/nervosnetwork/fiber/pull/157 expose the error to RPC, so that we found this issue:
https://github.com/nervosnetwork/fiber/pull/157/files#diff-176f6d4f89e68f8dda8ca44f71496fbfc28d7fbf135f1b5f2795c8a183a0bc18R1385-R1393

