### PR TITLE
Add network actor state store

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -1,3 +1,4 @@
+use super::serde_utils::EntityHex;
 use ckb_hash::blake2b_256;
 use ckb_jsonrpc_types::{Status, TxStatus};
 use ckb_types::core::TransactionView;
@@ -12,6 +13,7 @@ use ractor::{
 use rand::Rng;
 use secp256k1::Message;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
@@ -1984,9 +1986,11 @@ pub struct NetworkActorState<S> {
     broadcasted_message_queue: Vec<(PeerId, FiberBroadcastMessage)>,
 }
 
-#[derive(Default, Clone)]
+#[serde_as]
+#[derive(Default, Clone, Serialize, Deserialize)]
 pub struct PersistentNetworkActorState {
     // Outpoint to channel id mapping.
+    #[serde_as(as = "Vec<(EntityHex, _)>")]
     outpoint_channel_map: HashMap<OutPoint, Hash256>,
 }
 

--- a/src/fiber/test_utils.rs
+++ b/src/fiber/test_utils.rs
@@ -118,11 +118,26 @@ pub fn gen_sha256_hash() -> Hash256 {
     result.into()
 }
 
+pub fn get_fiber_config<P: AsRef<Path>>(base_dir: P, node_name: Option<&str>) -> FiberConfig {
+    let base_dir = base_dir.as_ref();
+    FiberConfig {
+        announced_node_name: node_name
+            .or(base_dir.file_name().unwrap().to_str())
+            .map(Into::into),
+        announce_listening_addr: Some(true),
+        base_dir: Some(PathBuf::from(base_dir)),
+        auto_accept_channel_ckb_funding_amount: Some(0), // Disable auto accept for unit tests
+        ..Default::default()
+    }
+}
+
 #[derive(Debug)]
 pub struct NetworkNode {
     /// The base directory of the node, will be deleted after this struct dropped.
-    pub base_dir: TempDir,
+    pub base_dir: Arc<TempDir>,
+    pub node_name: Option<String>,
     pub listening_addrs: Vec<MultiAddr>,
+    pub store: MemoryStore,
     pub network_actor: ActorRef<NetworkActorMessage>,
     pub chain_actor: ActorRef<CkbChainMessage>,
     pub peer_id: PeerId,
@@ -134,18 +149,34 @@ impl NetworkNode {
         Self::new_with_node_name(None).await
     }
 
-    pub async fn new_with_node_name(node_name: Option<String>) -> Self {
-        let base_dir = TempDir::new("fnn-test");
-        let fiber_config = FiberConfig {
-            announced_node_name: node_name
-                .as_deref()
-                .or(base_dir.as_ref().file_name().unwrap().to_str())
-                .map(Into::into),
-            announce_listening_addr: Some(true),
-            base_dir: Some(PathBuf::from(base_dir.as_ref())),
-            auto_accept_channel_ckb_funding_amount: Some(0), // Disable auto accept for unit tests
-            ..Default::default()
-        };
+    pub fn get_fiber_config(&self) -> FiberConfig {
+        get_fiber_config(self.base_dir.as_ref(), self.node_name.as_deref())
+    }
+
+    pub async fn stop(&mut self) {
+        self.network_actor.kill();
+        let my_peer_id = self.peer_id.clone();
+        self.expect_event(
+            |event| matches!(event, NetworkServiceEvent::NetworkStopped(id) if id == &my_peer_id),
+        )
+        .await;
+    }
+
+    pub async fn restart(&mut self) {
+        let base_dir = self.base_dir.clone();
+        let node_name = self.node_name.clone();
+        let store = self.store.clone();
+        self.stop().await;
+        let new = Self::new_with_base_dir_and_store(node_name, base_dir, store).await;
+        *self = new;
+    }
+
+    pub async fn new_with_base_dir_and_store(
+        node_name: Option<String>,
+        base_dir: Arc<TempDir>,
+        store: MemoryStore,
+    ) -> Self {
+        let fiber_config = get_fiber_config(base_dir.as_ref(), node_name.as_deref());
 
         let root = ROOT_ACTOR.get_or_init(get_test_root_actor).await.clone();
         let (event_sender, mut event_receiver) = mpsc::channel(10000);
@@ -163,7 +194,7 @@ impl NetworkNode {
             NetworkActor::new(
                 event_sender,
                 chain_actor.clone(),
-                MemoryStore::default(),
+                store.clone(),
                 public_key.into(),
             ),
             NetworkActorStartArguments {
@@ -197,12 +228,20 @@ impl NetworkNode {
 
         Self {
             base_dir,
+            node_name,
             listening_addrs: announced_addrs,
+            store,
             network_actor,
             chain_actor,
             peer_id,
             event_emitter: event_receiver,
         }
+    }
+
+    pub async fn new_with_node_name(node_name: Option<String>) -> Self {
+        let base_dir = Arc::new(TempDir::new("fnn-test"));
+        let store = MemoryStore::default();
+        Self::new_with_base_dir_and_store(node_name, base_dir, store).await
     }
 
     pub async fn new_n_interconnected_nodes(n: usize) -> Vec<Self> {
@@ -286,8 +325,8 @@ impl NetworkNode {
     }
 }
 
-#[derive(Clone, Default)]
-struct MemoryStore {
+#[derive(Clone, Default, Debug)]
+pub struct MemoryStore {
     network_actor_sate_map: Arc<RwLock<HashMap<PeerId, PersistentNetworkActorState>>>,
     channel_actor_state_map: Arc<RwLock<HashMap<Hash256, ChannelActorState>>>,
     channels_map: Arc<RwLock<HashMap<OutPoint, ChannelInfo>>>,
@@ -513,5 +552,11 @@ mod tests {
     #[tokio::test]
     async fn test_create_two_interconnected_nodes() {
         let _two_nodes = NetworkNode::new_n_interconnected_nodes(2).await;
+    }
+
+    #[tokio::test]
+    async fn test_restart_network_node() {
+        let mut node = NetworkNode::new().await;
+        node.restart().await;
     }
 }

--- a/src/fiber/test_utils.rs
+++ b/src/fiber/test_utils.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 use super::graph::PaymentSession;
+use super::network::{NetworkActorStateStore, PersistentNetworkActorState};
 use super::{
     channel::{ChannelActorState, ChannelActorStateStore, ChannelState},
     types::Hash256,
@@ -287,6 +288,7 @@ impl NetworkNode {
 
 #[derive(Clone, Default)]
 struct MemoryStore {
+    network_actor_sate_map: Arc<RwLock<HashMap<PeerId, PersistentNetworkActorState>>>,
     channel_actor_state_map: Arc<RwLock<HashMap<Hash256, ChannelActorState>>>,
     channels_map: Arc<RwLock<HashMap<OutPoint, ChannelInfo>>>,
     nodes_map: Arc<RwLock<HashMap<Pubkey, NodeInfo>>>,
@@ -294,6 +296,19 @@ struct MemoryStore {
     payment_sessions: Arc<RwLock<HashMap<Hash256, PaymentSession>>>,
     invoice_store: Arc<RwLock<HashMap<Hash256, CkbInvoice>>>,
     invoice_hash_to_preimage: Arc<RwLock<HashMap<Hash256, Hash256>>>,
+}
+
+impl NetworkActorStateStore for MemoryStore {
+    fn get_network_actor_state(&self, id: &PeerId) -> Option<PersistentNetworkActorState> {
+        self.network_actor_sate_map.read().unwrap().get(id).cloned()
+    }
+
+    fn insert_network_actor_state(&self, id: &PeerId, state: PersistentNetworkActorState) {
+        self.network_actor_sate_map
+            .write()
+            .unwrap()
+            .insert(id.clone(), state);
+    }
 }
 
 impl NetworkGraphStateStore for MemoryStore {

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,6 +221,7 @@ pub async fn main() {
         None => None,
     };
 
+    info!("Registering ctrl-c handler");
     signal::ctrl_c().await.expect("Failed to listen for event");
     info!("Received Ctrl-C, shutting down");
     if let Some(handle) = rpc_server_handle {

--- a/src/store.rs
+++ b/src/store.rs
@@ -2,6 +2,7 @@ use crate::{
     fiber::{
         channel::{ChannelActorState, ChannelActorStateStore, ChannelState},
         graph::{ChannelInfo, NetworkGraphStateStore, NodeInfo, PaymentSession},
+        network::{NetworkActorStateStore, PersistentNetworkActorState},
         types::{Hash256, Pubkey},
     },
     invoice::{CkbInvoice, InvoiceError, InvoiceStore},
@@ -218,6 +219,14 @@ enum KeyValue {
     NodeInfo(Pubkey, NodeInfo),
     ChannelInfo(OutPoint, ChannelInfo),
     WatchtowerChannel(Hash256, ChannelData),
+}
+
+impl NetworkActorStateStore for Store {
+    fn get_network_actor_state(&self, id: &PeerId) -> Option<PersistentNetworkActorState> {
+        None
+    }
+
+    fn insert_network_actor_state(&self, id: &PeerId, state: PersistentNetworkActorState) {}
 }
 
 impl ChannelActorStateStore for Store {


### PR DESCRIPTION
Some fields of the network actor state need to be persisted. For example, when we are sending/receiving a new payment, we need to lookup channel id corresponding to the channel outpoint. A recent bug is that, on a new start, node forgets its old channel outpoint to channel id mapping, thus unable to send a payment. This PR add a store interface and implementation to persist part of the network actor state.