### PR TITLE
Stop actors instead of killing them

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -1099,7 +1099,9 @@ where
                 );
                 if let NetworkSyncStatus::Running(state) = &mut state.sync_status {
                     if let Some(actor) = state.active_syncers.remove(&peer_id) {
-                        actor.get_cell().kill();
+                        actor
+                            .get_cell()
+                            .stop(Some("stopping syncer normally".to_string()));
                     }
                     debug!("Changing sync succeeded/failed counter");
                     match reason {


### PR DESCRIPTION
https://docs.rs/ractor/latest/ractor/actor/actor_cell/struct.ActorCell.html#method.kill Kill will give the actor no chance to run post_stop. So they may have no chance to clean up.