### PR TITLE
[chore]: code cleanup and refactor

### DIFF
--- a/src/fiber/graph.rs
+++ b/src/fiber/graph.rs
@@ -288,14 +288,14 @@ where
                 );
             }
         }
-        if let Some(node) = self.nodes.get_mut(&channel_info.node1()) {
+        if let Some(node) = self.nodes.get(&channel_info.node1()) {
             self.store.insert_node(node.clone());
         } else {
             // It is possible that the node announcement is after broadcasted after the channel announcement.
             // So don't just ignore the channel even if we didn't find the node info here.
             warn!("Node1 not found for channel {:?}", &channel_info);
         }
-        if let Some(node) = self.nodes.get_mut(&channel_info.node2()) {
+        if let Some(node) = self.nodes.get(&channel_info.node2()) {
             self.store.insert_node(node.clone());
         } else {
             warn!("Node2 not found for channel {:?}", &channel_info);

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -69,7 +69,7 @@ use crate::ckb::{CkbChainMessage, FundingRequest, FundingTx, TraceTxRequest, Tra
 use crate::fiber::channel::{
     AddTlcCommand, AddTlcResponse, TxCollaborationCommand, TxUpdateCommand,
 };
-use crate::fiber::graph::{ChannelInfo, NodeInfo, PaymentSession};
+use crate::fiber::graph::{ChannelInfo, PaymentSession};
 use crate::fiber::types::{
     secp256k1_instance, FiberChannelMessage, PaymentOnionPacket, PeeledPaymentOnionPacket,
     TxSignatures,


### PR DESCRIPTION
1. `get_mut` is unnecessary since we don't change it
2. remove the extra ` on ` in log when there is no prefix environment.