### PR TITLE
chore(test): add tests for invoice check signature

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -69,7 +69,7 @@ use crate::ckb::{CkbChainMessage, FundingRequest, FundingTx, TraceTxRequest, Tra
 use crate::fiber::channel::{
     AddTlcCommand, AddTlcResponse, TxCollaborationCommand, TxUpdateCommand,
 };
-use crate::fiber::graph::{ChannelInfo, NodeInfo, PaymentSession};
+use crate::fiber::graph::{ChannelInfo, PaymentSession};
 use crate::fiber::types::{
     secp256k1_instance, FiberChannelMessage, PaymentOnionPacket, PeeledPaymentOnionPacket,
     TxSignatures,

--- a/src/invoice/invoice_impl.rs
+++ b/src/invoice/invoice_impl.rs
@@ -157,8 +157,8 @@ impl CkbInvoice {
         hash
     }
 
-    /// Checks if the signature is valid for the included payee public key or if none exists if it's
-    /// valid for the recovered signature (which should always be true?).
+    /// Checks if the signature is valid for the included payee public key
+    /// and also check the invoice data is consistent with the signature
     fn validate_signature(&self) -> bool {
         if self.signature.is_none() {
             return true;


### PR DESCRIPTION

we have `build_with_sign` support for signature to make sure invoice is not modified after generated.

maybe we need to use it for PRC: https://github.com/nervosnetwork/fiber/blob/cc111f84902104b35eb286a76634980e6ceb1683/src/rpc/invoice.rs#L114