### PR TITLE
chore(rpc): trivial fix on rpc doc

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -2078,7 +2078,8 @@ impl NetworkSyncState {
                     // TODO: we may want more than one successful syncing.
                     false
                 } else {
-                    debug!("Adding peer to dynamic syncing peers list: peer {:?}, succeeded syncing {}, failed syncing {}, pinned syncing peers {}", peer_id, self.succeeded, self.failed, self.pinned_syncing_peers.len());
+                    debug!("Adding peer to dynamic syncing peers list: peer {:?}, succeeded syncing {}, failed syncing {}, pinned syncing peers {}",
+                        peer_id, self.succeeded, self.failed, self.pinned_syncing_peers.len());
                     true
                 }
             } else {

--- a/src/rpc/README.md
+++ b/src/rpc/README.md
@@ -338,13 +338,16 @@ Returns a struct with these fields:
 * `open_channel_auto_accept_min_ckb_funding_amount`: The minimum CKB funding amount for automatically accepting open channel requests, serialized as a hexadecimal string.
 * `auto_accept_channel_ckb_funding_amount`: The CKB funding amount for automatically accepting channel requests, serialized as a hexadecimal string.
 * `tlc_locktime_expiry_delta`: The locktime expiry delta for Time-Locked Contracts (TLC), serialized as a hexadecimal string.
-* `tlc_min_value`: The minimum value for Time-Locked Contracts (TLC), serialized as a hexadecimal string.
-* `tlc_max_value`: The maximum value for Time-Locked Contracts (TLC), serialized as a hexadecimal string.
+* `tlc_min_value`: The minimum value for Time-Locked Contracts (TLC), serialized as a hexadecimal string, `0` means no minimum value limit.
+* `tlc_max_value`: The maximum value for Time-Locked Contracts (TLC), serialized as a hexadecimal string, `0` means no maximum value limit.
 * `tlc_fee_proportional_millionths`: The fee proportional to the value of Time-Locked Contracts (TLC), expressed in millionths and serialized as a hexadecimal string.
 * `channel_count`: The number of channels associated with the node, serialized as a hexadecimal string.
 * `pending_channel_count`: The number of pending channels associated with the node, serialized as a hexadecimal string.
 * `peers_count`: The number of peers connected to the node, serialized as a hexadecimal string.
-* `network_sync_status`: The synchronization status of the node within the network.
+* `network_sync_status`: The synchronization status of the node within the network, possible values are :
+    * `NotRunning`: The syncing is not running, but we have all the information to start syncing.
+    * `Running`: We should start running the syncing immediately or the syncing is already in progress.
+    * `Done`: Syncing done, unless we restart the node, we don't have to sync again
 * `udt_cfg_infos`: An array of UDT configuration objects, each object contains the following fields:
     * `name`: The name of the UDT
     * `script`: The type script configuration of the UDT, with feilds of

--- a/src/rpc/info.rs
+++ b/src/rpc/info.rs
@@ -18,9 +18,6 @@ use tentacle::{multiaddr::MultiAddr, secio::PeerId};
 
 use super::graph::UdtCfgInfos;
 
-#[derive(Serialize, Deserialize, Debug)]
-pub(crate) struct NodeInfoParams {}
-
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct NodeInfoResult {
@@ -68,7 +65,7 @@ impl<S> InfoRpcServerImpl<S> {
 #[rpc(server)]
 trait InfoRpc {
     #[method(name = "node_info")]
-    async fn node_info(&self, params: NodeInfoParams) -> Result<NodeInfoResult, ErrorObjectOwned>;
+    async fn node_info(&self) -> Result<NodeInfoResult, ErrorObjectOwned>;
 }
 
 #[async_trait]
@@ -76,14 +73,14 @@ impl<S> InfoRpcServer for InfoRpcServerImpl<S>
 where
     S: ChannelActorStateStore + Send + Sync + 'static,
 {
-    async fn node_info(&self, _params: NodeInfoParams) -> Result<NodeInfoResult, ErrorObjectOwned> {
+    async fn node_info(&self) -> Result<NodeInfoResult, ErrorObjectOwned> {
         let version = env!("CARGO_PKG_VERSION").to_string();
         let commit_hash = crate::get_git_versin().to_string();
 
         let message =
             |rpc_reply| NetworkActorMessage::Command(NetworkActorCommand::NodeInfo((), rpc_reply));
 
-        handle_actor_call!(self.actor, message, _params).map(|response| NodeInfoResult {
+        handle_actor_call!(self.actor, message, ()).map(|response| NodeInfoResult {
             version,
             commit_hash,
             public_key: response.public_key,


### PR DESCRIPTION
- Closes #236
- remove unnecessary params in `info_node`.
