### PR TITLE
Trivial fix on coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 /tests/deploy/udt-init/target
 tests/nodes/.ports
 /coverage-report
-/coverage-report.info
+/*.info


### PR DESCRIPTION
1. `RUST_LOG=off` to remove noise messages from unit test.
2. Add `make coverage` for convinent
3. Ignore lines with all empty spaces, or only `)`, `}`, `);` etc.
