### PR TITLE
check CKB amount range when open channel

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -2641,11 +2641,19 @@ where
         udt_type_script: &Option<Script>,
     ) -> Result<(u128, u64), ProcessingChannelError> {
         let reserved_ckb_amount = default_minimal_ckb_amount(udt_type_script.is_some());
-        if udt_type_script.is_none() && funding_amount < reserved_ckb_amount.into() {
-            return Err(ProcessingChannelError::InvalidParameter(format!(
-                "The value of the channel should be greater than the reserve amount: {}",
-                reserved_ckb_amount
-            )));
+        if udt_type_script.is_none() {
+            if funding_amount < reserved_ckb_amount.into() {
+                return Err(ProcessingChannelError::InvalidParameter(format!(
+                    "The value of the channel should be greater than the reserve amount: {}",
+                    reserved_ckb_amount
+                )));
+            }
+            if funding_amount >= u64::MAX as u128 {
+                return Err(ProcessingChannelError::InvalidParameter(format!(
+                    "The CKB amount of the channel should be less than {:?}",
+                    u64::MAX
+                )));
+            }
         }
         let funding_amount = if udt_type_script.is_some() {
             funding_amount

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -2644,7 +2644,7 @@ where
         if udt_type_script.is_none() {
             if funding_amount < reserved_ckb_amount.into() {
                 return Err(ProcessingChannelError::InvalidParameter(format!(
-                    "The value of the channel should be greater than the reserve amount: {}",
+                    "The funding amount should be greater than the reserved amount: {}",
                     reserved_ckb_amount
                 )));
             }

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -2650,7 +2650,7 @@ where
             }
             if funding_amount >= u64::MAX as u128 {
                 return Err(ProcessingChannelError::InvalidParameter(format!(
-                    "The CKB amount of the channel should be less than {:?}",
+                    "The funding amount should be less than {:?}",
                     u64::MAX
                 )));
             }

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -745,10 +745,11 @@ async fn test_open_channel_with_invalid_ckb_amount_range() {
         ))
     };
     let open_channel_result = call!(node_a.network_actor, message).expect("node_a alive");
+    eprintln!("{:?}", open_channel_result.as_ref().err().unwrap());
     assert!(open_channel_result
         .err()
         .unwrap()
-        .contains("The CKB amount of the channel should be less than 18446744073709551615"));
+        .contains("The funding amount should be less than 18446744073709551615"));
 }
 
 #[tokio::test]

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -720,6 +720,38 @@ async fn do_test_channel_with_simple_update_operation(algorithm: HashAlgorithm) 
 }
 
 #[tokio::test]
+async fn test_open_channel_with_invalid_ckb_amount_range() {
+    init_tracing();
+
+    let [node_a, node_b] = NetworkNode::new_n_interconnected_nodes().await;
+    let message = |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::OpenChannel(
+            OpenChannelCommand {
+                peer_id: node_b.peer_id.clone(),
+                public: true,
+                shutdown_script: None,
+                funding_amount: 0xfffffffffffffffffffffffffffffff,
+                funding_udt_type_script: None,
+                commitment_fee_rate: None,
+                funding_fee_rate: None,
+                tlc_locktime_expiry_delta: None,
+                tlc_min_value: None,
+                tlc_max_value: None,
+                tlc_fee_proportional_millionths: None,
+                max_tlc_number_in_flight: None,
+                max_tlc_value_in_flight: None,
+            },
+            rpc_reply,
+        ))
+    };
+    let open_channel_result = call!(node_a.network_actor, message).expect("node_a alive");
+    assert!(open_channel_result
+        .err()
+        .unwrap()
+        .contains("The CKB amount of the channel should be less than 18446744073709551615"));
+}
+
+#[tokio::test]
 async fn test_revoke_old_commitment_transaction() {
     init_tracing();
 


### PR DESCRIPTION
For issue #252, upgrade ckb-rust-sdk will resolve the issue, but user can not get a proper error message since it's an error handled by auto accept code.

This pr add an extra check to make sure CKB amount is less than `u64::max`, since we use `u128` for all amount considering UDT amount.