### PR TITLE
fix: readme of test cross chain hub

### DIFF
--- a/tests/bruno/e2e/cross-chain-hub/README.md
+++ b/tests/bruno/e2e/cross-chain-hub/README.md
@@ -10,5 +10,5 @@
 
 1. Install [bitcoind](https://bitcoin.org/en/download), [lnd](https://github.com/lightningnetwork/lnd), and [jq](https://jqlang.github.io/jq/download/). Ensure that the executables are in your PATH.
 2. Start Bitcoin and LND nodes using `tests/deploy/lnd-init/setup-lnd.sh`.
-3. Start CKB and FNN using `tests/nodes/start.sh`.
+3. Start CKB and FNN using `REMOVE_OLD_STATE=y tests/nodes/start.sh`.
 4. Go to `tests/bruno` and run the command `npm exec -- @usebruno/cli run e2e/cross-chain-hub -r --env test`.

--- a/tests/deploy/init-dev-chain.sh
+++ b/tests/deploy/init-dev-chain.sh
@@ -77,7 +77,8 @@ if ! [[ -d "$data_dir" ]]; then
     echo "begin to generate blocks for wallet updating..."
     "$script_dir/generate-blocks.sh" 6
 
-    # Aslo deploy the contracts.
+    # Also deploy the contracts.
+    echo "deploy.sh..."
     "$script_dir/deploy.sh"
 
     pkill -P $$


### PR DESCRIPTION
* [`tests/bruno/e2e/cross-chain-hub/README.md`](diffhunk://#diff-c52add0b27876d8512fe1fec3973ec0a24d21fdf1b730e012ddebfac7e1a0f86L13-R13): Modified the command to start CKB and FNN nodes to include the `REMOVE_OLD_STATE` environment variable, ensuring old state is removed before starting. Otherwise, the `fnn` node's `config.yml` cannot be generated, and an error will be raised.

Script improvement:

* [`tests/deploy/init-dev-chain.sh`](diffhunk://#diff-657a32390e50fe1d628df910e8659b850db5b7470084330a2aa8ea7ad89b81bcL80-R81): Corrected a typo in a comment.