### PR TITLE
refactor: remove expect in ckb::funding

### DIFF
--- a/src/ckb/error.rs
+++ b/src/ckb/error.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 pub enum FundingError {
     #[error("Funding tx is absent")]
     AbsentTx,
+
     #[error("Failed to call CKB node RPC: {0}")]
     CkbRpcError(#[from] RpcError),
 


### PR DESCRIPTION
Step 2 of #65

There's an `expect` hard to remove, see the added comment in the code.