### PR TITLE
fix cch clap arg

### DIFF
--- a/src/cch/config.rs
+++ b/src/cch/config.rs
@@ -93,7 +93,7 @@ pub struct CchConfig {
     )]
     pub btc_final_tlc_expiry: u64,
 
-    ///  Tlc expiry time for CKB network in blocks.
+    /// Tlc expiry time for CKB network in blocks.
     #[default(DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA)]
     #[arg(
         name = "CCH_CKB_FINAL_TLC_EXPIRY_DELTA",
@@ -105,6 +105,7 @@ pub struct CchConfig {
 
     /// Ignore the failure when starting the cch service.
     #[default(false)]
+    #[arg(skip)]
     pub ignore_startup_failure: bool,
 }
 


### PR DESCRIPTION
When `#[arg]` is not added, the option will uses the positional args by default. This PR fixed it by skipping it for clap arg so it can only be configured via the config file.

The reason to skip is that when using `SetTrue` action, the option is set to false by default no mather what is configured in the config file.