### PR TITLE
Htlc forwarding and htlc removing should be handled after commitment signed 

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -63,8 +63,8 @@ use super::types::{
     FiberQueryInformation, GetBroadcastMessages, GetBroadcastMessagesResult, Hash256,
     NodeAnnouncement, NodeAnnouncementQuery, OpenChannel, PaymentHopData, Privkey, Pubkey,
     QueryBroadcastMessagesWithinTimeRange, QueryBroadcastMessagesWithinTimeRangeResult,
-    QueryChannelsWithinBlockRange, QueryChannelsWithinBlockRangeResult, RemoveTlc, RemoveTlcReason,
-    TlcErr, TlcErrData, TlcErrPacket, TlcErrorCode,
+    QueryChannelsWithinBlockRange, QueryChannelsWithinBlockRangeResult, RemoveTlcReason, TlcErr,
+    TlcErrData, TlcErrPacket, TlcErrorCode,
 };
 use super::{FiberConfig, ASSUME_NETWORK_ACTOR_ALIVE};
 
@@ -558,7 +558,7 @@ pub enum NetworkActorEvent {
     GraphSyncerExited(PeerId, GraphSyncerExitStatus),
 
     // A tlc remove message is received. (payment_hash, remove_tlc)
-    TlcRemoveReceived(Hash256, RemoveTlc),
+    TlcRemoveReceived(Hash256, RemoveTlcReason),
 
     /// Network service events to be sent to outside observers.
     /// These events may be both present at `NetworkActorEvent` and
@@ -1255,9 +1255,9 @@ where
                 }
                 state.maybe_finish_sync();
             }
-            NetworkActorEvent::TlcRemoveReceived(payment_hash, remove_tlc) => {
+            NetworkActorEvent::TlcRemoveReceived(payment_hash, remove_tlc_reason) => {
                 // When a node is restarted, RemoveTLC will also be resent if necessary
-                self.on_remove_tlc_event(state, payment_hash, remove_tlc.reason)
+                self.on_remove_tlc_event(state, payment_hash, remove_tlc_reason)
                     .await;
             }
         }

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -334,7 +334,7 @@ async fn test_network_send_payment_normal_keysend_workflow() {
     assert_eq!(res.status, PaymentSessionStatus::Inflight);
     let payment_hash = res.payment_hash;
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(3000)).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
 
     let message = |rpc_reply| -> NetworkActorMessage {
         NetworkActorMessage::Command(NetworkActorCommand::GetPayment(payment_hash, rpc_reply))
@@ -342,6 +342,8 @@ async fn test_network_send_payment_normal_keysend_workflow() {
     let res = call!(node_a.network_actor, message)
         .expect("node_a alive")
         .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
     assert_eq!(res.status, PaymentSessionStatus::Success);
     assert_eq!(res.failed_error, None);
 }

--- a/src/fiber/tests/graph.rs
+++ b/src/fiber/tests/graph.rs
@@ -1007,7 +1007,6 @@ fn test_graph_payment_pay_self_with_one_node() {
     let payment_data = payment_data.unwrap();
 
     let route = network.graph.build_route(payment_data);
-    eprintln!("final result {:?}", route);
     assert!(route.is_ok());
     let route = route.unwrap();
     assert_eq!(route[1].next_hop, Some(node0.into()));


### PR DESCRIPTION
- htlc forwarding moved to `try_to_forward_pending_tlc`
- htlc removing relay moved to `try_to_send_remove_tlcs`