### PR TITLE
chore: reduce cch log noise in test

### DIFF
--- a/tests/nodes/start.sh
+++ b/tests/nodes/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 export SHELLOPTS
-export RUST_BACKTRACE=full RUST_LOG=info,fnn=debug
+export RUST_BACKTRACE=full RUST_LOG=info,fnn=debug,fnn::cch::actor::tracker=off
 
 should_remove_old_state="${REMOVE_OLD_STATE:-}"
 should_clean_fiber_state="${REMOVE_OLD_FIBER:-}"


### PR DESCRIPTION
- Use log target `fnn::cch::actor::tracker` for cch trackers
- Disable logs generated by cch trackers in integration tests by setting `fnn::cch::actor::tracker=off` in `RUST_LOG`
