### PR TITLE
Setup onion error packet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,9 +1510,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiber-sphinx"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94381300373be2ca1021ecb906c34d1d71c7e4baf28ef5f4b8414fe0cd84ea2"
+checksum = "937d84d3b6b78b462457376163a1461c20ba76852734d25c6ba3a03ea27b15a0"
 dependencies = [
  "chacha20",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 socket2 = "0.5.7"
 lnd-grpc-tonic-client = "0.3.0"
 git-version = "0.3.9"
-fiber-sphinx = "1.0.1"
+fiber-sphinx = "2.1.0"
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -739,7 +739,7 @@ where
                         RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(TlcErr::new(error_code)));
                 }
                 CkbInvoiceStatus::Paid => {
-                    unreachable!("Paid invoice shold not be paid again");
+                    unreachable!("Paid invoice should not be paid again");
                 }
                 _ => {
                     self.store

--- a/src/fiber/graph.rs
+++ b/src/fiber/graph.rs
@@ -956,6 +956,8 @@ pub struct PaymentSession {
     pub first_hop_channel_outpoint: Option<OutPoint>,
     pub first_hop_tlc_id: Option<u64>,
     pub route: SessionRoute,
+    // Session key for onion packet. Save it for decoding the error packet.
+    pub session_key: [u8; 32],
 }
 
 impl PaymentSession {
@@ -972,6 +974,7 @@ impl PaymentSession {
             first_hop_channel_outpoint: None,
             first_hop_tlc_id: None,
             route: SessionRoute::default(),
+            session_key: Default::default(),
         }
     }
 
@@ -1006,6 +1009,10 @@ impl PaymentSession {
 
     pub fn fee(&self) -> u128 {
         self.route.fee()
+    }
+
+    pub fn hops_public_keys(&self) -> Vec<Pubkey> {
+        self.route.nodes.iter().map(|x| x.pubkey).collect()
     }
 }
 

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -7,7 +7,7 @@ use crate::fiber::network::SendPaymentCommand;
 use crate::fiber::tests::test_utils::{
     gen_rand_public_key, gen_sha256_hash, generate_seckey, NetworkNodeConfigBuilder,
 };
-use crate::fiber::types::{PaymentHopData, PeeledOnionPacket, TlcErrorCode};
+use crate::fiber::types::{PaymentHopData, PeeledOnionPacket, TlcErrorCode, NO_SHARED_SECRET};
 use crate::{
     ckb::contracts::{get_cell_deps, Contract},
     fiber::{
@@ -2024,7 +2024,10 @@ async fn do_test_add_tlc_waiting_ack() {
         if i == 2 {
             // we are sending AddTlc constantly, so we should get a TemporaryChannelFailure
             assert!(add_tlc_result.is_err());
-            let code = add_tlc_result.unwrap_err().decode().unwrap();
+            let code = add_tlc_result
+                .unwrap_err()
+                .decode(&NO_SHARED_SECRET, vec![])
+                .unwrap();
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             assert!(add_tlc_result.is_ok());
@@ -2075,7 +2078,10 @@ async fn do_test_add_tlc_number_limit() {
         tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
         if i == max_tlc_number + 1 {
             assert!(add_tlc_result.is_err());
-            let code = add_tlc_result.unwrap_err().decode().unwrap();
+            let code = add_tlc_result
+                .unwrap_err()
+                .decode(&NO_SHARED_SECRET, vec![])
+                .unwrap();
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             dbg!(&add_tlc_result);
@@ -2128,7 +2134,10 @@ async fn do_test_add_tlc_value_limit() {
         tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
         if i == max_tlc_number + 1 {
             assert!(add_tlc_result.is_err());
-            let code = add_tlc_result.unwrap_err().decode().unwrap();
+            let code = add_tlc_result
+                .unwrap_err()
+                .decode(&NO_SHARED_SECRET, vec![])
+                .unwrap();
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             assert!(add_tlc_result.is_ok());

--- a/src/rpc/channel.rs
+++ b/src/rpc/channel.rs
@@ -10,7 +10,9 @@ use crate::fiber::{
     hash_algorithm::HashAlgorithm,
     network::{AcceptChannelCommand, OpenChannelCommand, SendPaymentCommand},
     serde_utils::{EntityHex, U128Hex, U64Hex},
-    types::{Hash256, Pubkey, RemoveTlcFulfill, TlcErr, TlcErrPacket, TlcErrorCode},
+    types::{
+        Hash256, Pubkey, RemoveTlcFulfill, TlcErr, TlcErrPacket, TlcErrorCode, NO_SHARED_SECRET,
+    },
     NetworkActorCommand, NetworkActorMessage,
 };
 use crate::{handle_actor_call, handle_actor_cast, log_and_error};
@@ -616,9 +618,11 @@ where
                                 RemoveTlcReason::RemoveTlcFail { .. } => {
                                     // TODO: maybe we should remove this PRC or move add_tlc and remove_tlc to `test` module?
                                     crate::fiber::types::RemoveTlcReason::RemoveTlcFail(
-                                        TlcErrPacket::new(TlcErr::new(
-                                            err_code.expect("expect error code"),
-                                        )),
+                                        TlcErrPacket::new(
+                                            TlcErr::new(err_code.expect("expect error code")),
+                                            // TODO: get shared secret to create the error packet
+                                            &NO_SHARED_SECRET,
+                                        ),
                                     )
                                 }
                             },


### PR DESCRIPTION
Setup the framework to return payment error via onion error packet.

The spec can be found here: https://github.com/cryptape/fiber-sphinx/blob/develop/docs/spec.md#returning-errors

The encryption has not been enabled yet so I can split the changes into several PRs. The encryption can be enabled later without breaking the network protocol because the decryption phrase will check whether the error has been encrypted or not.

Refs #198 