### PR TITLE
Onion error encryption

### DIFF
--- a/src/cch/actor.rs
+++ b/src/cch/actor.rs
@@ -19,7 +19,7 @@ use crate::fiber::channel::{
     AddTlcCommand, ChannelCommand, ChannelCommandWithId, RemoveTlcCommand, TlcNotification,
 };
 use crate::fiber::hash_algorithm::HashAlgorithm;
-use crate::fiber::types::{Hash256, RemoveTlcFulfill, RemoveTlcReason};
+use crate::fiber::types::{Hash256, RemoveTlcFulfill, RemoveTlcReason, NO_SHARED_SECRET};
 use crate::fiber::{NetworkActorCommand, NetworkActorMessage};
 use crate::invoice::Currency;
 use crate::now_timestamp_as_millis_u64;
@@ -594,6 +594,7 @@ impl CchActor {
                                     + self.config.ckb_final_tlc_expiry_delta,
                                 hash_algorithm: HashAlgorithm::Sha256,
                                 onion_packet: None,
+                                shared_secret: NO_SHARED_SECRET.clone(),
                                 previous_tlc: None,
                             },
                             rpc_reply,

--- a/src/fiber/graph.rs
+++ b/src/fiber/graph.rs
@@ -1040,7 +1040,8 @@ impl PaymentSession {
     }
 
     pub fn hops_public_keys(&self) -> Vec<Pubkey> {
-        self.route.nodes.iter().map(|x| x.pubkey).collect()
+        // Skip the first node, which is the sender.
+        self.route.nodes.iter().skip(1).map(|x| x.pubkey).collect()
     }
 }
 

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -2188,6 +2188,7 @@ where
                 expiry: info.expiry,
                 hash_algorithm: info.hash_algorithm,
                 onion_packet: peeled_onion_packet.next.clone(),
+                shared_secret: shared_secret.clone(),
                 previous_tlc,
             },
             rpc_reply,
@@ -2347,6 +2348,9 @@ where
         assert_ne!(hops[0].funding_tx_hash, Hash256::default());
         let first_channel_outpoint = OutPoint::new(hops[0].funding_tx_hash.into(), 0);
 
+        payment_session
+            .session_key
+            .copy_from_slice(session_key.as_ref());
         payment_session.route =
             SessionRoute::new(state.get_public_key(), payment_data.target_pubkey, &hops);
 

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -69,6 +69,7 @@ fn test_pending_tlcs() {
         expiry: now_timestamp_as_millis_u64() + 1000,
         hash_algorithm: HashAlgorithm::Sha256,
         onion_packet: None,
+        shared_secret: NO_SHARED_SECRET.clone(),
         tlc_id: TLCId::Offered(0),
         created_at: CommitmentNumbers::default(),
         removed_at: None,
@@ -82,6 +83,7 @@ fn test_pending_tlcs() {
         expiry: now_timestamp_as_millis_u64() + 2000,
         hash_algorithm: HashAlgorithm::Sha256,
         onion_packet: None,
+        shared_secret: NO_SHARED_SECRET.clone(),
         tlc_id: TLCId::Offered(1),
         created_at: CommitmentNumbers::default(),
         removed_at: None,
@@ -148,6 +150,7 @@ fn test_pending_tlcs_duplicated_tlcs() {
         expiry: now_timestamp_as_millis_u64() + 1000,
         hash_algorithm: HashAlgorithm::Sha256,
         onion_packet: None,
+        shared_secret: NO_SHARED_SECRET.clone(),
         tlc_id: TLCId::Offered(0),
         created_at: CommitmentNumbers::default(),
         removed_at: None,
@@ -185,6 +188,7 @@ fn test_pending_tlcs_duplicated_tlcs() {
         expiry: now_timestamp_as_millis_u64() + 2000,
         hash_algorithm: HashAlgorithm::Sha256,
         onion_packet: None,
+        shared_secret: NO_SHARED_SECRET.clone(),
         tlc_id: TLCId::Offered(1),
         created_at: CommitmentNumbers::default(),
         removed_at: None,
@@ -226,6 +230,7 @@ fn test_pending_tlcs_with_remove_tlc() {
         expiry: now_timestamp_as_millis_u64() + 1000,
         hash_algorithm: HashAlgorithm::Sha256,
         onion_packet: None,
+        shared_secret: NO_SHARED_SECRET.clone(),
         tlc_id: TLCId::Offered(0),
         created_at: CommitmentNumbers::default(),
         removed_at: None,
@@ -239,6 +244,7 @@ fn test_pending_tlcs_with_remove_tlc() {
         expiry: now_timestamp_as_millis_u64() + 2000,
         hash_algorithm: HashAlgorithm::Sha256,
         onion_packet: None,
+        shared_secret: NO_SHARED_SECRET.clone(),
         tlc_id: TLCId::Offered(1),
         created_at: CommitmentNumbers::default(),
         removed_at: None,
@@ -874,6 +880,7 @@ async fn test_network_send_previous_tlc_error() {
                         hash_algorithm: HashAlgorithm::Sha256,
                         // invalid onion packet
                         onion_packet: packet.next.clone(),
+                        shared_secret: packet.shared_secret.clone(),
                         previous_tlc: None,
                     },
                     rpc_reply,
@@ -1963,6 +1970,7 @@ async fn do_test_channel_commitment_tx_after_add_tlc(algorithm: HashAlgorithm) {
                         payment_hash: digest.into(),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
                         onion_packet: None,
+                        shared_secret: NO_SHARED_SECRET.clone(),
                         previous_tlc: None,
                     },
                     rpc_reply,
@@ -2253,6 +2261,7 @@ async fn do_test_remove_tlc_with_wrong_hash_algorithm(
                         payment_hash: digest.into(),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
                         onion_packet: None,
+                        shared_secret: NO_SHARED_SECRET.clone(),
                         previous_tlc: None,
                     },
                     rpc_reply,
@@ -2304,6 +2313,7 @@ async fn do_test_remove_tlc_with_wrong_hash_algorithm(
                         payment_hash: digest.into(),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
                         onion_packet: None,
+                        shared_secret: NO_SHARED_SECRET.clone(),
                         previous_tlc: None,
                     },
                     rpc_reply,
@@ -2361,6 +2371,7 @@ async fn do_test_remove_tlc_with_expiry_error() {
         payment_hash: digest.into(),
         expiry: now_timestamp_as_millis_u64() + 10,
         onion_packet: None,
+        shared_secret: NO_SHARED_SECRET.clone(),
         previous_tlc: None,
     };
 
@@ -2383,6 +2394,7 @@ async fn do_test_remove_tlc_with_expiry_error() {
         payment_hash: digest.into(),
         expiry: now_timestamp_as_millis_u64() + MAX_PAYMENT_TLC_EXPIRY_LIMIT + 10,
         onion_packet: None,
+        shared_secret: NO_SHARED_SECRET.clone(),
         previous_tlc: None,
     };
 
@@ -2421,6 +2433,7 @@ async fn do_test_add_tlc_duplicated() {
             payment_hash: digest.into(),
             expiry: now_timestamp_as_millis_u64() + 10,
             onion_packet: None,
+            shared_secret: NO_SHARED_SECRET.clone(),
             previous_tlc: None,
         };
         let add_tlc_result = call!(node_a.network_actor, |rpc_reply| {
@@ -2460,6 +2473,7 @@ async fn do_test_add_tlc_waiting_ack() {
             payment_hash: gen_sha256_hash().into(),
             expiry: now_timestamp_as_millis_u64() + 100000000,
             onion_packet: None,
+            shared_secret: NO_SHARED_SECRET.clone(),
             previous_tlc: None,
         };
         let add_tlc_result = call!(node_a.network_actor, |rpc_reply| {
@@ -2514,6 +2528,7 @@ async fn do_test_add_tlc_number_limit() {
             payment_hash: gen_sha256_hash().into(),
             expiry: now_timestamp_as_millis_u64() + 100000000,
             onion_packet: None,
+            shared_secret: NO_SHARED_SECRET.clone(),
             previous_tlc: None,
         };
         let add_tlc_result = call!(node_a.network_actor, |rpc_reply| {
@@ -2569,6 +2584,7 @@ async fn do_test_add_tlc_value_limit() {
             payment_hash: gen_sha256_hash().into(),
             expiry: now_timestamp_as_millis_u64() + 100000000,
             onion_packet: None,
+            shared_secret: NO_SHARED_SECRET.clone(),
             previous_tlc: None,
         };
         let add_tlc_result = call!(node_a.network_actor, |rpc_reply| {
@@ -2631,6 +2647,7 @@ async fn do_test_channel_with_simple_update_operation(algorithm: HashAlgorithm) 
                         payment_hash: digest.into(),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
                         onion_packet: None,
+                        shared_secret: NO_SHARED_SECRET.clone(),
                         previous_tlc: None,
                     },
                     rpc_reply,

--- a/src/fiber/tests/types.rs
+++ b/src/fiber/tests/types.rs
@@ -138,7 +138,7 @@ fn test_tlc_err_packet_encryption() {
     let tlc_fail_detail = TlcErr::new(TlcErrorCode::InvalidOnionVersion);
     {
         // Error from the first hop
-        let tlc_fail = TlcErrPacket::new_with_encryption(tlc_fail_detail.clone(), &hops_ss[0]);
+        let tlc_fail = TlcErrPacket::new(tlc_fail_detail.clone(), &hops_ss[0]);
         let decrypted_tlc_fail_detail = tlc_fail
             .decode(session_key.as_ref(), hops_path.clone())
             .expect("decrypted");
@@ -147,7 +147,7 @@ fn test_tlc_err_packet_encryption() {
 
     {
         // Error from the the last hop
-        let mut tlc_fail = TlcErrPacket::new_with_encryption(tlc_fail_detail.clone(), &hops_ss[2]);
+        let mut tlc_fail = TlcErrPacket::new(tlc_fail_detail.clone(), &hops_ss[2]);
         tlc_fail = tlc_fail.backward(&hops_ss[1]);
         tlc_fail = tlc_fail.backward(&hops_ss[0]);
         let decrypted_tlc_fail_detail = tlc_fail

--- a/src/fiber/types.rs
+++ b/src/fiber/types.rs
@@ -35,7 +35,7 @@ use strum::{AsRefStr, EnumString};
 use tentacle::multiaddr::MultiAddr;
 use tentacle::secio::PeerId;
 use thiserror::Error;
-use tracing::{debug, trace};
+use tracing::{debug, error, trace};
 
 pub fn secp256k1_instance() -> &'static Secp256k1<All> {
     static INSTANCE: OnceCell<Secp256k1<All>> = OnceCell::new();
@@ -1247,37 +1247,24 @@ const ERROR_DECODING_PASSES: usize = 27;
 impl TlcErrPacket {
     /// Erring node creates the error packet using the shared secret used in forwarding onion packet.
     /// Use all zeros for the origin node.
-    pub fn new(tlc_fail: TlcErr, _shared_secret: &[u8; 32]) -> Self {
+    pub fn new(tlc_fail: TlcErr, shared_secret: &[u8; 32]) -> Self {
         dbg!(&tlc_fail);
         let payload = tlc_fail.serialize();
 
-        let onion_packet =
-            OnionErrorPacket::concat(NO_ERROR_PACKET_HMAC.clone(), payload).into_bytes();
-        return TlcErrPacket { onion_packet };
-    }
-
-    // TODO: Enable error encryption by replacing `new` with this method.
-    // The encryption has been disabled so we can split the PR into small pieces and apply future
-    // upgrades without breaking the network protocol.
-    #[cfg(test)]
-    pub fn new_with_encryption(tlc_fail: TlcErr, shared_secret: &[u8; 32]) -> Self {
-        dbg!(&tlc_fail);
-        let payload = tlc_fail.serialize();
-
-        let onion_packet = (if shared_secret != &NO_SHARED_SECRET {
+        let onion_packet = if shared_secret != &NO_SHARED_SECRET {
             OnionErrorPacket::create(shared_secret, payload)
         } else {
             OnionErrorPacket::concat(NO_ERROR_PACKET_HMAC.clone(), payload)
-        })
+        }
         .into_bytes();
-        return TlcErrPacket { onion_packet };
+        TlcErrPacket { onion_packet }
     }
 
     pub fn is_plaintext(&self) -> bool {
         self.onion_packet.len() >= 32 && self.onion_packet[0..32] == NO_ERROR_PACKET_HMAC
     }
 
-    /// Intermediate node forwards the error to the previous hop using the shared secret used in forwarding
+    /// Intermediate node backwards the error to the previous hop using the shared secret used in forwarding
     /// the onion packet.
     pub fn backward(self, shared_secret: &[u8; 32]) -> Self {
         if !self.is_plaintext() {
@@ -1299,8 +1286,11 @@ impl TlcErrPacket {
             }
         }
 
-        let hops_public_keys = hops_public_keys.iter().map(|k| k.0.clone()).collect();
-        let session_key = SecretKey::from_slice(session_key).ok()?;
+        let hops_public_keys: Vec<PublicKey> =
+            hops_public_keys.iter().map(|k| k.0.clone()).collect();
+        let session_key = SecretKey::from_slice(session_key).inspect_err(|err|
+            error!(target: "fnn::fiber::types::TlcErrPacket", "decode session_key error={} key={}", err, hex::encode(session_key))
+        ).ok()?;
         OnionErrorPacket::from_bytes(self.onion_packet.clone())
             .parse(hops_public_keys, session_key, TlcErr::deserialize)
             .map(|(error, hop_index)| {
@@ -1415,6 +1405,21 @@ impl TlcErrorCode {
 pub enum RemoveTlcReason {
     RemoveTlcFulfill(RemoveTlcFulfill),
     RemoveTlcFail(TlcErrPacket),
+}
+
+impl RemoveTlcReason {
+    /// Intermediate node backwards the error to the previous hop using the shared secret used in forwarding
+    /// the onion packet.
+    pub fn backward(self, shared_secret: &[u8; 32]) -> Self {
+        match self {
+            RemoveTlcReason::RemoveTlcFulfill(remove_tlc_fulfill) => {
+                RemoveTlcReason::RemoveTlcFulfill(remove_tlc_fulfill)
+            }
+            RemoveTlcReason::RemoveTlcFail(remove_tlc_fail) => {
+                RemoveTlcReason::RemoveTlcFail(remove_tlc_fail.backward(shared_secret))
+            }
+        }
+    }
 }
 
 impl From<RemoveTlcReason> for molecule_fiber::RemoveTlcReasonUnion {
@@ -3104,6 +3109,11 @@ impl<T> OnionPacket<T> {
         }
     }
 
+    pub fn into_sphinx_onion_packet(self) -> Result<fiber_sphinx::OnionPacket, Error> {
+        fiber_sphinx::OnionPacket::from_bytes(self.data)
+            .map_err(|err| Error::OnionPacket(err.into()))
+    }
+
     pub fn into_bytes(self) -> Vec<u8> {
         self.data
     }
@@ -3125,8 +3135,7 @@ impl<T: HopData> OnionPacket<T> {
         assoc_data: Option<&[u8]>,
         secp_ctx: &Secp256k1<C>,
     ) -> Result<PeeledOnionPacket<T>, Error> {
-        let sphinx_packet = fiber_sphinx::OnionPacket::from_bytes(self.data)
-            .map_err(|err| Error::OnionPacket(err.into()))?;
+        let sphinx_packet = self.into_sphinx_onion_packet()?;
         let shared_secret = sphinx_packet.shared_secret(&privkey.0);
 
         let (new_current, new_next) = sphinx_packet

--- a/src/rpc/channel.rs
+++ b/src/rpc/channel.rs
@@ -578,6 +578,7 @@ where
                             expiry: params.expiry,
                             hash_algorithm: params.hash_algorithm.unwrap_or_default(),
                             onion_packet: None,
+                            shared_secret: NO_SHARED_SECRET.clone(),
                             previous_tlc: None,
                         },
                         rpc_reply,
@@ -620,7 +621,8 @@ where
                                     crate::fiber::types::RemoveTlcReason::RemoveTlcFail(
                                         TlcErrPacket::new(
                                             TlcErr::new(err_code.expect("expect error code")),
-                                            // TODO: get shared secret to create the error packet
+                                            // Do not encrypt the error message when removing the TLC via RPC.
+                                            // TODO: use tlc id to look up the shared secret in the store
                                             &NO_SHARED_SECRET,
                                         ),
                                     )


### PR DESCRIPTION
Save shared secret for forwarding the onion packet, and use it to encrypt the backwarding error packets.

Depends on #354 
Refs #198