### PR TITLE
feat: use type safe onion packet

### DIFF
--- a/src/cch/actor.rs
+++ b/src/cch/actor.rs
@@ -595,7 +595,7 @@ impl CchActor {
                                 expiry: now_timestamp_as_millis_u64()
                                     + self.config.ckb_final_tlc_expiry_delta,
                                 hash_algorithm: HashAlgorithm::Sha256,
-                                onion_packet: vec![],
+                                peeled_onion_packet: None,
                                 previous_tlc: None,
                             },
                             rpc_reply,

--- a/src/fiber/graph.rs
+++ b/src/fiber/graph.rs
@@ -615,10 +615,10 @@ where
                 amount: current_amount,
                 payment_hash,
                 next_hop,
-                tlc_hash_algorithm: hash_algorithm,
+                hash_algorithm: hash_algorithm,
                 expiry: current_expiry,
                 channel_outpoint: next_channel_outpoint,
-                preimage: if is_last { preimage } else { None },
+                payment_preimage: if is_last { preimage } else { None },
             });
             current_expiry += expiry;
             current_amount += fee;
@@ -628,10 +628,10 @@ where
             amount: current_amount,
             payment_hash,
             next_hop: Some(route[0].target),
-            tlc_hash_algorithm: hash_algorithm,
+            hash_algorithm: hash_algorithm,
             expiry: current_expiry,
             channel_outpoint: Some(route[0].channel_outpoint.clone()),
-            preimage: None,
+            payment_preimage: None,
         });
         hops_data.reverse();
         assert_eq!(hops_data.len(), route.len() + 1);

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -1008,7 +1008,7 @@ async fn do_test_channel_commitment_tx_after_add_tlc(algorithm: HashAlgorithm) {
                         payment_hash: Some(digest.into()),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
                         preimage: None,
-                        onion_packet: vec![],
+                        peeled_onion_packet: None,
                         previous_tlc: None,
                     },
                     rpc_reply,
@@ -1270,7 +1270,7 @@ async fn do_test_remove_tlc_with_wrong_hash_algorithm(
                         payment_hash: Some(digest.into()),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
                         preimage: None,
-                        onion_packet: vec![],
+                        peeled_onion_packet: None,
                         previous_tlc: None,
                     },
                     rpc_reply,
@@ -1319,7 +1319,7 @@ async fn do_test_remove_tlc_with_wrong_hash_algorithm(
                         payment_hash: Some(digest.into()),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
                         preimage: None,
-                        onion_packet: vec![],
+                        peeled_onion_packet: None,
                         previous_tlc: None,
                     },
                     rpc_reply,
@@ -1377,7 +1377,7 @@ async fn do_test_remove_tlc_with_expiry_error() {
         payment_hash: Some(digest.into()),
         expiry: now_timestamp_as_millis_u64() + 10,
         preimage: None,
-        onion_packet: vec![],
+        peeled_onion_packet: None,
         previous_tlc: None,
     };
 
@@ -1400,7 +1400,7 @@ async fn do_test_remove_tlc_with_expiry_error() {
         payment_hash: Some(digest.into()),
         expiry: now_timestamp_as_millis_u64() + MAX_PAYMENT_TLC_EXPIRY_LIMIT + 10,
         preimage: None,
-        onion_packet: vec![],
+        peeled_onion_packet: None,
         previous_tlc: None,
     };
 
@@ -1453,7 +1453,7 @@ async fn do_test_channel_with_simple_update_operation(algorithm: HashAlgorithm) 
                         payment_hash: Some(digest.into()),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
                         preimage: None,
-                        onion_packet: vec![],
+                        peeled_onion_packet: None,
                         previous_tlc: None,
                     },
                     rpc_reply,

--- a/src/fiber/tests/types.rs
+++ b/src/fiber/tests/types.rs
@@ -35,7 +35,7 @@ fn test_add_tlc_serialization() {
         payment_hash: [42; 32].into(),
         expiry: 42,
         hash_algorithm: HashAlgorithm::Sha256,
-        onion_packet: vec![],
+        onion_packet: None,
     };
     let add_tlc_mol: molecule_fiber::AddTlc = add_tlc.clone().into();
     let add_tlc2 = add_tlc_mol.try_into().expect("decode");
@@ -56,8 +56,8 @@ fn test_peeled_onion_packet() {
             expiry: 3,
             next_hop: Some(keys[1].pubkey().into()),
             channel_outpoint: Some(OutPointBuilder::default().build().into()),
-            tlc_hash_algorithm: HashAlgorithm::Sha256,
-            preimage: None,
+            hash_algorithm: HashAlgorithm::Sha256,
+            payment_preimage: None,
         },
         PaymentHopData {
             payment_hash,
@@ -65,8 +65,8 @@ fn test_peeled_onion_packet() {
             expiry: 6,
             next_hop: Some(keys[2].pubkey().into()),
             channel_outpoint: Some(OutPointBuilder::default().build().into()),
-            tlc_hash_algorithm: HashAlgorithm::Sha256,
-            preimage: None,
+            hash_algorithm: HashAlgorithm::Sha256,
+            payment_preimage: None,
         },
         PaymentHopData {
             payment_hash,
@@ -74,8 +74,8 @@ fn test_peeled_onion_packet() {
             expiry: 9,
             next_hop: None,
             channel_outpoint: Some(OutPointBuilder::default().build().into()),
-            tlc_hash_algorithm: HashAlgorithm::Sha256,
-            preimage: None,
+            hash_algorithm: HashAlgorithm::Sha256,
+            payment_preimage: None,
         },
     ];
     let packet = PeeledOnionPacket::create(generate_seckey().into(), hops_infos.clone(), &secp)

--- a/src/rpc/channel.rs
+++ b/src/rpc/channel.rs
@@ -576,7 +576,7 @@ where
                             payment_hash: Some(params.payment_hash),
                             expiry: params.expiry,
                             hash_algorithm: params.hash_algorithm.unwrap_or_default(),
-                            onion_packet: vec![],
+                            peeled_onion_packet: None,
                             previous_tlc: None,
                         },
                         rpc_reply,


### PR DESCRIPTION
Use type safe onion pack instead of `Vec<u8>`, which is error-prone since at some places we store `PaymentOnionPacket`, and at other places we may store `PeeledPaymentOnionPacket`.