### PR TITLE
ci: add build matrix in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,22 @@ jobs:
           flags: unittests
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        profile: [dev, release]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
+      - uses: dsherret/rust-toolchain-file@v1
+      - name: Install Dependencies (Windows)
+        if: contains(matrix.os, 'windows')
+        run: |
+          vcpkg integrate install
+          vcpkg install openssl:x64-windows-static-md
+      - run: cargo build --verbose --profile ${{ matrix.profile }}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -46,6 +46,7 @@ fn build_server(addr: &str) -> Server {
             .set_nonblocking(true)
             .expect("set socket nonblocking");
         socket.set_reuse_address(true).expect("set reuse address");
+        #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
         socket.set_reuse_port(true).expect("set reuse port");
 
         socket.bind(&addr.into()).expect("bind socket to address");


### PR DESCRIPTION
Ensure fiber can be built in different operation systems and under different profiles.
