### PR TITLE
cleanup AddTlcCommand

### DIFF
--- a/src/cch/actor.rs
+++ b/src/cch/actor.rs
@@ -588,10 +588,8 @@ impl CchActor {
                         command: ChannelCommand::AddTlc(
                             AddTlcCommand {
                                 amount: order.amount_sats - order.fee_sats,
-                                preimage: None,
-                                payment_hash: Some(
-                                    Hash256::from_str(&order.payment_hash).expect("parse Hash256"),
-                                ),
+                                payment_hash: Hash256::from_str(&order.payment_hash)
+                                    .expect("parse Hash256"),
                                 expiry: now_timestamp_as_millis_u64()
                                     + self.config.ckb_final_tlc_expiry_delta,
                                 hash_algorithm: HashAlgorithm::Sha256,

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -140,8 +140,7 @@ pub enum TxCollaborationCommand {
 #[derive(Debug)]
 pub struct AddTlcCommand {
     pub amount: u128,
-    pub preimage: Option<Hash256>,
-    pub payment_hash: Option<Hash256>,
+    pub payment_hash: Hash256,
     pub expiry: u64,
     pub hash_algorithm: HashAlgorithm,
     /// Peeled onion packet for the current node
@@ -169,12 +168,6 @@ pub struct UpdateCommand {
     pub tlc_minimum_value: Option<u128>,
     pub tlc_maximum_value: Option<u128>,
     pub tlc_fee_proportional_millionths: Option<u128>,
-}
-
-fn get_random_preimage() -> Hash256 {
-    let mut preimage = [0u8; 32];
-    preimage.copy_from_slice(&rand::random::<[u8; 32]>());
-    preimage.into()
 }
 
 #[derive(Debug)]
@@ -4177,17 +4170,12 @@ impl ChannelActorState {
             "Must not have the same id in pending offered tlcs"
         );
 
-        let preimage = command.preimage.unwrap_or(get_random_preimage());
-        let payment_hash = command
-            .payment_hash
-            .unwrap_or_else(|| command.hash_algorithm.hash(preimage).into());
-
         TLC {
             id: TLCId::Offered(id),
             amount: command.amount,
-            payment_hash,
+            payment_hash: command.payment_hash,
             expiry: command.expiry,
-            payment_preimage: Some(preimage),
+            payment_preimage: None,
             hash_algorithm: command.hash_algorithm,
             peeled_onion_packet: command.peeled_onion_packet,
             previous_tlc: command

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -2176,8 +2176,7 @@ where
         let command = ChannelCommand::AddTlc(
             AddTlcCommand {
                 amount: info.amount,
-                preimage: None,
-                payment_hash: Some(info.payment_hash),
+                payment_hash: info.payment_hash,
                 expiry: info.expiry,
                 hash_algorithm: info.hash_algorithm,
                 peeled_onion_packet: Some(peeled_onion_packet),

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -1005,9 +1005,8 @@ async fn do_test_channel_commitment_tx_after_add_tlc(algorithm: HashAlgorithm) {
                     AddTlcCommand {
                         amount: tlc_amount,
                         hash_algorithm: algorithm,
-                        payment_hash: Some(digest.into()),
+                        payment_hash: digest.into(),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
-                        preimage: None,
                         peeled_onion_packet: None,
                         previous_tlc: None,
                     },
@@ -1267,9 +1266,8 @@ async fn do_test_remove_tlc_with_wrong_hash_algorithm(
                     AddTlcCommand {
                         amount: tlc_amount,
                         hash_algorithm: correct_algorithm,
-                        payment_hash: Some(digest.into()),
+                        payment_hash: digest.into(),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
-                        preimage: None,
                         peeled_onion_packet: None,
                         previous_tlc: None,
                     },
@@ -1316,9 +1314,8 @@ async fn do_test_remove_tlc_with_wrong_hash_algorithm(
                     AddTlcCommand {
                         amount: tlc_amount,
                         hash_algorithm: wrong_algorithm,
-                        payment_hash: Some(digest.into()),
+                        payment_hash: digest.into(),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
-                        preimage: None,
                         peeled_onion_packet: None,
                         previous_tlc: None,
                     },
@@ -1374,9 +1371,8 @@ async fn do_test_remove_tlc_with_expiry_error() {
     let add_tlc_command = AddTlcCommand {
         amount: tlc_amount,
         hash_algorithm: HashAlgorithm::CkbHash,
-        payment_hash: Some(digest.into()),
+        payment_hash: digest.into(),
         expiry: now_timestamp_as_millis_u64() + 10,
-        preimage: None,
         peeled_onion_packet: None,
         previous_tlc: None,
     };
@@ -1397,9 +1393,8 @@ async fn do_test_remove_tlc_with_expiry_error() {
     let add_tlc_command = AddTlcCommand {
         amount: tlc_amount,
         hash_algorithm: HashAlgorithm::CkbHash,
-        payment_hash: Some(digest.into()),
+        payment_hash: digest.into(),
         expiry: now_timestamp_as_millis_u64() + MAX_PAYMENT_TLC_EXPIRY_LIMIT + 10,
-        preimage: None,
         peeled_onion_packet: None,
         previous_tlc: None,
     };
@@ -1450,9 +1445,8 @@ async fn do_test_channel_with_simple_update_operation(algorithm: HashAlgorithm) 
                     AddTlcCommand {
                         amount: tlc_amount,
                         hash_algorithm: algorithm,
-                        payment_hash: Some(digest.into()),
+                        payment_hash: digest.into(),
                         expiry: now_timestamp_as_millis_u64() + DEFAULT_EXPIRY_DELTA,
-                        preimage: None,
                         peeled_onion_packet: None,
                         previous_tlc: None,
                     },

--- a/src/rpc/channel.rs
+++ b/src/rpc/channel.rs
@@ -572,8 +572,7 @@ where
                     command: ChannelCommand::AddTlc(
                         AddTlcCommand {
                             amount: params.amount,
-                            preimage: None,
-                            payment_hash: Some(params.payment_hash),
+                            payment_hash: params.payment_hash,
                             expiry: params.expiry,
                             hash_algorithm: params.hash_algorithm.unwrap_or_default(),
                             peeled_onion_packet: None,


### PR DESCRIPTION
`preimage` should not given in AddTlcCommand, and `create_outbounding_tlc` should never create a random `payment_hash`, I believe it was added for testing purpose.
