### PR TITLE
Fix channel balance issue caused by remove tlc failure

### DIFF
--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -1216,20 +1216,26 @@ async fn test_network_send_payment_with_dry_run() {
 async fn test_send_payment_with_3_nodes() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (node_a, _node_b, node_c, _, _) = create_3_nodes_with_established_channel(
+    let (node_a, node_b, node_c, channel_1, channel_2) = create_3_nodes_with_established_channel(
         (100000000000, 100000000000),
         (100000000000, 100000000000),
         true,
     )
     .await;
+    let node_a_local = node_a.get_local_balance_from_channel(channel_1);
+    let node_b_local_left = node_b.get_local_balance_from_channel(channel_1);
+    let node_b_local_right = node_b.get_local_balance_from_channel(channel_2);
+    let node_c_local = node_c.get_local_balance_from_channel(channel_2);
+
     // sleep for 2 seconds to make sure the channel is established
     tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
+    let sent_amount = 1000000 + 5;
     let node_c_pubkey = node_c.pubkey.clone();
     let message = |rpc_reply| -> NetworkActorMessage {
         NetworkActorMessage::Command(NetworkActorCommand::SendPayment(
             SendPaymentCommand {
                 target_pubkey: Some(node_c_pubkey),
-                amount: Some(1000000 + 5),
+                amount: Some(sent_amount),
                 payment_hash: None,
                 final_tlc_expiry_delta: None,
                 invoice: None,
@@ -1260,6 +1266,20 @@ async fn test_send_payment_with_3_nodes() {
         .unwrap();
     assert_eq!(res.status, PaymentSessionStatus::Success);
     assert_eq!(res.failed_error, None);
+
+    let new_node_a_local = node_a.get_local_balance_from_channel(channel_1);
+    let new_node_b_left = node_b.get_local_balance_from_channel(channel_1);
+    let new_node_b_right = node_b.get_local_balance_from_channel(channel_2);
+    let new_node_c_local = node_c.get_local_balance_from_channel(channel_2);
+
+    let node_a_sent = node_a_local - new_node_a_local;
+    assert_eq!(node_a_sent, sent_amount + res.fee);
+    let node_b_sent = node_b_local_right - new_node_b_right;
+    let node_b_received = new_node_b_left - node_b_local_left;
+    let node_b_got = node_b_received - node_b_sent;
+    assert_eq!(node_b_got, res.fee);
+    let node_c_got = new_node_c_local - node_c_local;
+    assert_eq!(node_c_got, sent_amount);
 }
 
 #[tokio::test]
@@ -1267,12 +1287,18 @@ async fn test_send_payment_fail_with_3_nodes_invalid_hash() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
 
-    let (node_a, _node_b, node_c, _, _) = create_3_nodes_with_established_channel(
+    let (node_a, node_b, node_c, channel_1, channel_2) = create_3_nodes_with_established_channel(
         (100000000000, 100000000000),
         (100000000000, 100000000000),
         true,
     )
     .await;
+
+    let node_a_local = node_a.get_local_balance_from_channel(channel_1);
+    let node_b_local_left = node_b.get_local_balance_from_channel(channel_1);
+    let node_b_local_right = node_b.get_local_balance_from_channel(channel_2);
+    let node_c_local = node_c.get_local_balance_from_channel(channel_2);
+
     // sleep for 2 seconds to make sure the channel is established
     tokio::time::sleep(tokio::time::Duration::from_millis(3000)).await;
     let node_c_pubkey = node_c.pubkey.clone();
@@ -1314,6 +1340,20 @@ async fn test_send_payment_fail_with_3_nodes_invalid_hash() {
         res.failed_error,
         Some("IncorrectOrUnknownPaymentDetails".to_string())
     );
+
+    let new_node_a_local = node_a.get_local_balance_from_channel(channel_1);
+    let new_node_b_left = node_b.get_local_balance_from_channel(channel_1);
+    let new_node_b_right = node_b.get_local_balance_from_channel(channel_2);
+    let new_node_c_local = node_c.get_local_balance_from_channel(channel_2);
+
+    let node_a_sent = node_a_local - new_node_a_local;
+    assert_eq!(node_a_sent, 0);
+    let node_b_sent = node_b_local_right - new_node_b_right;
+    let node_b_received = new_node_b_left - node_b_local_left;
+    let node_b_got = node_b_received - node_b_sent;
+    assert_eq!(node_b_got, 0);
+    let node_c_got = new_node_c_local - node_c_local;
+    assert_eq!(node_c_got, 0);
 }
 
 #[tokio::test]

--- a/src/fiber/tests/test_utils.rs
+++ b/src/fiber/tests/test_utils.rs
@@ -1,3 +1,4 @@
+use crate::fiber::channel::ChannelActorStateStore;
 use crate::fiber::types::EcdsaSignature;
 use crate::fiber::types::Pubkey;
 use ckb_types::{core::TransactionView, packed::Byte32};
@@ -181,6 +182,20 @@ pub struct NetworkNode {
 impl NetworkNode {
     pub fn get_node_address(&self) -> &MultiAddr {
         &self.listening_addrs[0]
+    }
+
+    pub fn get_local_balance_from_channel(&self, channel_id: Hash256) -> u128 {
+        self.store
+            .get_channel_actor_state(&channel_id)
+            .expect("get channel")
+            .to_local_amount
+    }
+
+    pub fn get_remote_balance_from_channel(&self, channel_id: Hash256) -> u128 {
+        self.store
+            .get_channel_actor_state(&channel_id)
+            .expect("get channel")
+            .to_remote_amount
     }
 }
 


### PR DESCRIPTION
Balance should not be updated for removing tlc failure.

We should add more unit tests for channel balance.