### PR TITLE
Add retryable_remove_tlcs for relaying remove tlc

### DIFF
--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -1328,11 +1328,11 @@ where
         state: &mut ChannelActorState,
     ) {
         let pending_removes = state.tlc_state.get_pending_remove();
-        for retryable_remove in pending_removes.iter() {
+        for retryable_remove in pending_removes.into_iter() {
             match retryable_remove {
-                RetryableRemoveTlc::RemoveTlc(tlc_id, reason) => {
+                RetryableRemoveTlc::RemoveTlc(tlc_id, ref reason) => {
                     let command = RemoveTlcCommand {
-                        id: (*tlc_id).into(),
+                        id: tlc_id.into(),
                         reason: reason.clone(),
                     };
 
@@ -1355,16 +1355,16 @@ where
                         }
                     }
                 }
-                RetryableRemoveTlc::RelayRemoveTlc(channel_id, tlc_id, reason) => {
+                RetryableRemoveTlc::RelayRemoveTlc(channel_id, tlc_id, ref reason) => {
                     let (send, recv) = oneshot::channel::<Result<(), String>>();
                     let port = RpcReplyPort::from(send);
                     self.network
                         .send_message(NetworkActorMessage::new_command(
                             NetworkActorCommand::ControlFiberChannel(ChannelCommandWithId {
-                                channel_id: *channel_id,
+                                channel_id: channel_id,
                                 command: ChannelCommand::RemoveTlc(
                                     RemoveTlcCommand {
-                                        id: *tlc_id,
+                                        id: tlc_id,
                                         reason: reason.clone(),
                                     },
                                     port,

--- a/tests/bruno/e2e/udt/14-node2-list-channel-expect-two-channel.bru
+++ b/tests/bruno/e2e/udt/14-node2-list-channel-expect-two-channel.bru
@@ -37,8 +37,7 @@ script:post-response {
   // Sleep for sometime to make sure current operation finishes before next request starts.
   await new Promise(r => setTimeout(r, 2000));
   console.log("accept channel result: ", res.body.result.channels);
-  const readyChannels = res.body.result.channels.filter(channel => channel.state.state_name === "CHANNEL_READY");
-    if (readyChannels.length != 2) {
+    if (res.body.result.channels.length != 2) {
     throw new Error("Assertion failed: expect there are 2 channels");
   }
 }


### PR DESCRIPTION
If an error like WaitingAck is met in relaying remove tlc, the previous hop may lose the choice to fulfill TLC, it's better to add error handling for it.

Fixes https://github.com/nervosnetwork/fiber/issues/371
Fixes https://github.com/nervosnetwork/fiber/issues/373
