### PR TITLE
Avoid channel event store invalid ChannelActorState

### DIFF
--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -1918,13 +1918,21 @@ where
                 }
             }
             ChannelActorMessage::Event(e) => {
+                if matches!(e, ChannelEvent::CheckTlcSetdown)
+                    && !matches!(
+                        state.state,
+                        ChannelState::ChannelReady() | ChannelState::ShuttingDown(_)
+                    )
+                {
+                    return Ok(());
+                }
                 if let Err(err) = self.handle_event(&myself, state, e).await {
                     error!("Error while processing channel event: {:?}", err);
                 }
             }
         }
-
         self.store.insert_channel_actor_state(state.clone());
+
         Ok(())
     }
 }

--- a/tests/bruno/e2e/udt/14-node2-list-channel-expect-two-channel.bru
+++ b/tests/bruno/e2e/udt/14-node2-list-channel-expect-two-channel.bru
@@ -37,8 +37,7 @@ script:post-response {
   // Sleep for sometime to make sure current operation finishes before next request starts.
   await new Promise(r => setTimeout(r, 2000));
   console.log("accept channel result: ", res.body.result.channels);
-  const readyChannels = res.body.result.channels.filter(channel => channel.state.state_name === "CHANNEL_READY");
-    if (readyChannels.length != 2) {
+    if (res.body.result.channels.length != 2) {
     throw new Error("Assertion failed: expect there are 2 channels");
   }
 }


### PR DESCRIPTION
The scheduled event such as `CheckTlcSetdown` should not execute for channel without Ready status, it may store a ChannelActorState with not ready state.

Fixes #371
Fixes #373

