### PR TITLE
Fix onion hop length limit issue

### DIFF
--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -790,13 +790,6 @@ where
         };
 
         if let Some(ref peeled_onion_packet) = peeled_onion_packet {
-            // check the payment hash and amount
-            if peeled_onion_packet.current.payment_hash != add_tlc.payment_hash {
-                return Err(ProcessingChannelError::InvalidParameter(
-                    "Payment hash mismatch".to_string(),
-                ));
-            }
-
             let received_amount = add_tlc.amount;
             let forward_amount = peeled_onion_packet.current.amount;
             debug!(
@@ -856,6 +849,7 @@ where
                 // if this is not the last hop, forward TLC to next hop
                 self.handle_forward_onion_packet(
                     state,
+                    add_tlc.payment_hash,
                     peeled_onion_packet.clone(),
                     add_tlc.tlc_id.into(),
                 )
@@ -964,6 +958,7 @@ where
     async fn handle_forward_onion_packet(
         &self,
         state: &mut ChannelActorState,
+        payment_hash: Hash256,
         peeled_onion_packet: PeeledPaymentOnionPacket,
         added_tlc_id: u64,
     ) -> Result<(), ProcessingChannelError> {
@@ -975,6 +970,7 @@ where
                     SendOnionPacketCommand {
                         peeled_onion_packet,
                         previous_tlc: Some((state.get_id(), added_tlc_id)),
+                        payment_hash,
                     },
                     rpc_reply,
                 ),

--- a/src/fiber/graph.rs
+++ b/src/fiber/graph.rs
@@ -610,6 +610,11 @@ where
                 (fee, expiry)
             };
 
+            let funding_tx_hash = if let Some(next_channel_outpoint) = next_channel_outpoint {
+                next_channel_outpoint.tx_hash().into()
+            } else {
+                Hash256::default()
+            };
             // make sure the final hop's amount is the same as the payment amount
             // the last hop will check the amount from TLC and the amount from the onion packet
             hops_data.push(PaymentHopData {
@@ -618,7 +623,7 @@ where
                 next_hop,
                 hash_algorithm: hash_algorithm,
                 expiry: current_expiry,
-                channel_outpoint: next_channel_outpoint,
+                funding_tx_hash,
                 payment_preimage: if is_last { preimage } else { None },
             });
             current_expiry += expiry;
@@ -631,7 +636,7 @@ where
             next_hop: Some(route[0].target),
             hash_algorithm: hash_algorithm,
             expiry: current_expiry,
-            channel_outpoint: Some(route[0].channel_outpoint.clone()),
+            funding_tx_hash: route[0].channel_outpoint.tx_hash().into(),
             payment_preimage: None,
         });
         hops_data.reverse();
@@ -936,7 +941,14 @@ impl SessionRoute {
             .zip(payment_hops)
             .map(|(pubkey, hop)| SessionRouteNode {
                 pubkey,
-                channel_outpoint: hop.channel_outpoint.clone().unwrap_or_default(),
+                channel_outpoint: OutPoint::new(
+                    if hop.funding_tx_hash != Hash256::default() {
+                        hop.funding_tx_hash.into()
+                    } else {
+                        Hash256::default().into()
+                    },
+                    0,
+                ),
                 amount: hop.amount,
             })
             .collect();

--- a/src/fiber/graph.rs
+++ b/src/fiber/graph.rs
@@ -619,7 +619,6 @@ where
             // the last hop will check the amount from TLC and the amount from the onion packet
             hops_data.push(PaymentHopData {
                 amount: current_amount,
-                payment_hash,
                 next_hop,
                 hash_algorithm: hash_algorithm,
                 expiry: current_expiry,
@@ -632,7 +631,6 @@ where
         // Add the first hop as the instruction for the current node, so the logic for send HTLC can be reused.
         hops_data.push(PaymentHopData {
             amount: current_amount,
-            payment_hash,
             next_hop: Some(route[0].target),
             hash_algorithm: hash_algorithm,
             expiry: current_expiry,

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -1283,6 +1283,99 @@ async fn test_send_payment_with_3_nodes() {
 }
 
 #[tokio::test]
+async fn test_send_payment_with_max_nodes() {
+    init_tracing();
+    let _span = tracing::info_span!("node", node = "test").entered();
+    let nodes_num = 15;
+    let last = nodes_num - 1;
+    let amounts = vec![(100000000000, 100000000000); nodes_num - 1];
+    let (nodes, channels) =
+        create_n_nodes_with_established_channel(&amounts, nodes_num, true).await;
+    let source_node = &nodes[0];
+    let target_pubkey = nodes[last].pubkey.clone();
+
+    let sender_local = nodes[0].get_local_balance_from_channel(channels[0]);
+    let receiver_local = nodes[last].get_local_balance_from_channel(channels[last - 1]);
+
+    // sleep for seconds to make sure the channel is established
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+    let sent_amount = 1000000 + 5;
+
+    let message = |rpc_reply| -> NetworkActorMessage {
+        NetworkActorMessage::Command(NetworkActorCommand::SendPayment(
+            SendPaymentCommand {
+                target_pubkey: Some(target_pubkey),
+                amount: Some(sent_amount),
+                payment_hash: None,
+                final_tlc_expiry_delta: None,
+                invoice: None,
+                timeout: None,
+                max_fee_amount: None,
+                tlc_expiry_limit: None,
+                max_parts: None,
+                keysend: Some(true),
+                udt_type_script: None,
+                allow_self_payment: false,
+                dry_run: true,
+            },
+            rpc_reply,
+        ))
+    };
+    let res = call!(source_node.network_actor, message).expect("node_a alive");
+    assert!(res.is_ok());
+
+    let message = |rpc_reply| -> NetworkActorMessage {
+        NetworkActorMessage::Command(NetworkActorCommand::SendPayment(
+            SendPaymentCommand {
+                target_pubkey: Some(target_pubkey),
+                amount: Some(sent_amount),
+                payment_hash: None,
+                final_tlc_expiry_delta: None,
+                invoice: None,
+                timeout: None,
+                max_fee_amount: None,
+                tlc_expiry_limit: None,
+                max_parts: None,
+                keysend: Some(true),
+                udt_type_script: None,
+                allow_self_payment: false,
+                dry_run: false,
+            },
+            rpc_reply,
+        ))
+    };
+    let source_node = &nodes[0];
+    let res = call!(source_node.network_actor, message).expect("node_a alive");
+    assert!(res.is_ok());
+    let res = res.unwrap();
+    assert_eq!(res.status, PaymentSessionStatus::Inflight);
+    assert!(res.fee > 0);
+    // sleep for 2 seconds to make sure the payment is sent
+    tokio::time::sleep(tokio::time::Duration::from_millis(3000)).await;
+    let message = |rpc_reply| -> NetworkActorMessage {
+        NetworkActorMessage::Command(NetworkActorCommand::GetPayment(res.payment_hash, rpc_reply))
+    };
+    let res = call!(nodes[0].network_actor, message)
+        .expect("node_a alive")
+        .unwrap();
+    assert_eq!(res.status, PaymentSessionStatus::Success);
+    assert_eq!(res.failed_error, None);
+
+    let sender_local_new = nodes[0].get_local_balance_from_channel(channels[0]);
+    let receiver_local_new = nodes[last].get_local_balance_from_channel(channels[last - 1]);
+
+    let sender_sent = sender_local - sender_local_new;
+    let receiver_received = receiver_local_new - receiver_local;
+
+    eprintln!(
+        "sender sent: {}, receiver received: {}",
+        sender_sent, receiver_received
+    );
+    assert_eq!(sender_sent, sent_amount + res.fee);
+    assert_eq!(receiver_received, sent_amount);
+}
+
+#[tokio::test]
 async fn test_send_payment_with_3_nodes_overflow() {
     // Fix issue #361
 
@@ -1960,36 +2053,57 @@ async fn create_3_nodes_with_established_channel(
     (channel_2_amount_b, channel_2_amount_c): (u128, u128),
     public: bool,
 ) -> (NetworkNode, NetworkNode, NetworkNode, Hash256, Hash256) {
-    let [mut node_a, mut node_b, mut node_c] = NetworkNode::new_n_interconnected_nodes().await;
-
-    let (channel_id_ab, funding_tx_ab) = establish_channel_between_nodes(
-        &mut node_a,
-        &mut node_b,
+    let (nodes, channels) = create_n_nodes_with_established_channel(
+        &[
+            (channel_1_amount_a, channel_1_amount_b),
+            (channel_2_amount_b, channel_2_amount_c),
+        ],
+        3,
         public,
-        channel_1_amount_a,
-        channel_1_amount_b,
-        None,
-        None,
     )
     .await;
+    let [node_a, node_b, node_c] = nodes.try_into().expect("3 nodes");
+    (node_a, node_b, node_c, channels[0], channels[1])
+}
 
-    let res = node_c.submit_tx(funding_tx_ab).await;
-    assert_eq!(res, Status::Committed);
+async fn create_n_nodes_with_established_channel(
+    amounts: &[(u128, u128)],
+    n: usize,
+    public: bool,
+) -> (Vec<NetworkNode>, Vec<Hash256>) {
+    assert!(n >= 2);
+    assert_eq!(amounts.len(), n - 1);
+    let mut nodes = NetworkNode::new_interconnected_nodes(n).await;
+    let mut channels = vec![];
 
-    let (channel_id_bc, funding_tx_bc) = establish_channel_between_nodes(
-        &mut node_b,
-        &mut node_c,
-        public,
-        channel_2_amount_b,
-        channel_2_amount_c,
-        None,
-        None,
-    )
-    .await;
-
-    let res = node_a.submit_tx(funding_tx_bc).await;
-    assert_eq!(res, Status::Committed);
-    (node_a, node_b, node_c, channel_id_ab, channel_id_bc)
+    for i in 0..n - 1 {
+        let (channel_id, funding_tx) = {
+            let (node_a, node_b) = {
+                // avoid borrow nodes as mutbale more than once
+                let (left, right) = nodes.split_at_mut(i + 1);
+                (&mut left[i], &mut right[0])
+            };
+            establish_channel_between_nodes(
+                node_a,
+                node_b,
+                public,
+                amounts[i].0,
+                amounts[i].1,
+                None,
+                None,
+            )
+            .await
+        };
+        channels.push(channel_id);
+        // all the other nodes submit_tx
+        for j in 0..n {
+            if j != i {
+                let res = nodes[j].submit_tx(funding_tx.clone()).await;
+                assert_eq!(res, Status::Committed);
+            }
+        }
+    }
+    (nodes, channels)
 }
 
 async fn do_test_remove_tlc_with_wrong_hash_algorithm(

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -26,7 +26,6 @@ use crate::{
     now_timestamp_as_millis_u64, NetworkServiceEvent,
 };
 use ckb_jsonrpc_types::Status;
-use ckb_types::packed::OutPointBuilder;
 use ckb_types::{
     core::{FeeRate, TransactionView},
     packed::{CellInput, Script, Transaction},
@@ -840,7 +839,7 @@ async fn test_network_send_previous_tlc_error() {
             amount: 2,
             expiry: 3,
             next_hop: Some(keys[0].pubkey().into()),
-            channel_outpoint: Some(OutPointBuilder::default().build().into()),
+            funding_tx_hash: Hash256::default(),
             hash_algorithm: HashAlgorithm::Sha256,
             payment_preimage: None,
         },
@@ -849,7 +848,7 @@ async fn test_network_send_previous_tlc_error() {
             amount: 8,
             expiry: 9,
             next_hop: None,
-            channel_outpoint: Some(OutPointBuilder::default().build().into()),
+            funding_tx_hash: Hash256::default(),
             hash_algorithm: HashAlgorithm::Sha256,
             payment_preimage: None,
         },

--- a/src/fiber/tests/graph.rs
+++ b/src/fiber/tests/graph.rs
@@ -739,8 +739,14 @@ fn test_graph_build_route_three_nodes() {
     assert!(route.is_ok());
     let route = route.unwrap();
     assert_eq!(route.len(), 3);
-    assert_eq!(route[0].channel_outpoint, Some(network.edges[0].2.clone()));
-    assert_eq!(route[1].channel_outpoint, Some(network.edges[1].2.clone()));
+    assert_eq!(
+        route[0].funding_tx_hash,
+        network.edges[0].2.tx_hash().into()
+    );
+    assert_eq!(
+        route[1].funding_tx_hash,
+        network.edges[1].2.tx_hash().into()
+    );
 
     assert_eq!(route[0].next_hop, Some(node2.into()));
     assert_eq!(route[1].next_hop, Some(node3.into()));

--- a/src/fiber/tests/test_utils.rs
+++ b/src/fiber/tests/test_utils.rs
@@ -165,6 +165,7 @@ pub fn generate_store() -> Store {
     store.expect("create store")
 }
 
+#[derive(Debug)]
 pub struct NetworkNode {
     /// The base directory of the node, will be deleted after this struct dropped.
     pub base_dir: Arc<TempDir>,
@@ -406,8 +407,16 @@ impl NetworkNode {
     }
 
     pub async fn new_n_interconnected_nodes<const N: usize>() -> [Self; N] {
-        let mut nodes: Vec<NetworkNode> = Vec::with_capacity(N);
-        for i in 0..N {
+        let nodes = Self::new_interconnected_nodes(N).await;
+        match nodes.try_into() {
+            Ok(nodes) => nodes,
+            Err(_) => unreachable!(),
+        }
+    }
+
+    pub async fn new_interconnected_nodes(n: usize) -> Vec<Self> {
+        let mut nodes: Vec<NetworkNode> = Vec::with_capacity(n);
+        for i in 0..n {
             let new = Self::new_with_config(
                 NetworkNodeConfigBuilder::new()
                     .node_name(Some(format!("node-{}", i)))

--- a/src/fiber/tests/types.rs
+++ b/src/fiber/tests/types.rs
@@ -4,12 +4,10 @@ use crate::fiber::{
     hash_algorithm::HashAlgorithm,
     tests::test_utils::generate_pubkey,
     types::{
-        secp256k1_instance, AddTlc, PaymentHopData, PeeledOnionPacket, Privkey, Pubkey, TlcErr,
-        TlcErrPacket, TlcErrorCode, NO_SHARED_SECRET,
+        secp256k1_instance, AddTlc, Hash256, PaymentHopData, PeeledOnionPacket, Privkey, Pubkey,
+        TlcErr, TlcErrPacket, TlcErrorCode, NO_SHARED_SECRET,
     },
 };
-use ckb_types::packed::OutPointBuilder;
-use ckb_types::prelude::Builder;
 use fiber_sphinx::OnionSharedSecretIter;
 use secp256k1::{PublicKey, Secp256k1, SecretKey};
 use std::str::FromStr;
@@ -56,7 +54,7 @@ fn test_peeled_onion_packet() {
             amount: 2,
             expiry: 3,
             next_hop: Some(keys[1].pubkey().into()),
-            channel_outpoint: Some(OutPointBuilder::default().build().into()),
+            funding_tx_hash: Hash256::default(),
             hash_algorithm: HashAlgorithm::Sha256,
             payment_preimage: None,
         },
@@ -65,7 +63,7 @@ fn test_peeled_onion_packet() {
             amount: 5,
             expiry: 6,
             next_hop: Some(keys[2].pubkey().into()),
-            channel_outpoint: Some(OutPointBuilder::default().build().into()),
+            funding_tx_hash: Hash256::default(),
             hash_algorithm: HashAlgorithm::Sha256,
             payment_preimage: None,
         },
@@ -74,7 +72,7 @@ fn test_peeled_onion_packet() {
             amount: 8,
             expiry: 9,
             next_hop: None,
-            channel_outpoint: Some(OutPointBuilder::default().build().into()),
+            funding_tx_hash: Hash256::default(),
             hash_algorithm: HashAlgorithm::Sha256,
             payment_preimage: None,
         },

--- a/src/fiber/tests/types.rs
+++ b/src/fiber/tests/types.rs
@@ -47,10 +47,8 @@ fn test_peeled_onion_packet() {
     let keys: Vec<Privkey> = std::iter::repeat_with(|| generate_seckey().into())
         .take(3)
         .collect();
-    let payment_hash = [1; 32].into();
     let hops_infos = vec![
         PaymentHopData {
-            payment_hash,
             amount: 2,
             expiry: 3,
             next_hop: Some(keys[1].pubkey().into()),
@@ -59,7 +57,6 @@ fn test_peeled_onion_packet() {
             payment_preimage: None,
         },
         PaymentHopData {
-            payment_hash,
             amount: 5,
             expiry: 6,
             next_hop: Some(keys[2].pubkey().into()),
@@ -68,7 +65,6 @@ fn test_peeled_onion_packet() {
             payment_preimage: None,
         },
         PaymentHopData {
-            payment_hash,
             amount: 8,
             expiry: 9,
             next_hop: None,
@@ -77,8 +73,9 @@ fn test_peeled_onion_packet() {
             payment_preimage: None,
         },
     ];
-    let packet = PeeledOnionPacket::create(generate_seckey().into(), hops_infos.clone(), &secp)
-        .expect("create peeled packet");
+    let packet =
+        PeeledOnionPacket::create(generate_seckey().into(), hops_infos.clone(), None, &secp)
+            .expect("create peeled packet");
 
     let serialized = packet.serialize();
     let deserialized = PeeledOnionPacket::deserialize(&serialized).expect("deserialize");

--- a/src/fiber/types.rs
+++ b/src/fiber/types.rs
@@ -3043,8 +3043,7 @@ pub struct PaymentHopData {
     // this is only specified in the last hop in the keysend mode
     pub payment_preimage: Option<Hash256>,
     pub hash_algorithm: HashAlgorithm,
-    #[serde_as(as = "Option<EntityHex>")]
-    pub channel_outpoint: Option<OutPoint>,
+    pub funding_tx_hash: Hash256,
     pub next_hop: Option<Pubkey>,
 }
 

--- a/src/fiber/types.rs
+++ b/src/fiber/types.rs
@@ -3058,7 +3058,7 @@ pub trait HopData: Sized {
 }
 
 impl HopData for PaymentHopData {
-    const PACKET_DATA_LEN: usize = 1300;
+    const PACKET_DATA_LEN: usize = 6500;
 
     fn next_hop(&self) -> Option<Pubkey> {
         self.next_hop.clone()

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -29,7 +29,7 @@ use std::{
 use tentacle::secio::PeerId;
 use tracing::{error, info};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Store {
     pub(crate) db: Arc<DB>,
 }


### PR DESCRIPTION
- Enlarge `PACKET_DATA_LEN` to make it send onion packet with at max 15 hops.
- Add unit test for max nodes scenario.
- Using funding_tx_hash replace channel_outpoint in PaymentHopData
- Remove payment_hash from PaymentHopData
