### PR TITLE
Refactor tlc forwarding and add more unit tests fro error handling

### DIFF
--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -566,7 +566,7 @@ where
         }
     }
 
-    async fn get_tlc_detail_error(
+    async fn get_tlc_error(
         &self,
         state: &mut ChannelActorState,
         error: &ProcessingChannelError,
@@ -668,8 +668,7 @@ where
                             // If we already have TlcErr, we can directly use it to send back to the peer.
                             ProcessingChannelError::TlcForwardingError(tlc_err) => tlc_err,
                             _ => {
-                                let error_detail =
-                                    self.get_tlc_detail_error(state, &e.source).await;
+                                let error_detail = self.get_tlc_error(state, &e.source).await;
                                 self.network
                                     .clone()
                                     .send_message(NetworkActorMessage::new_notification(
@@ -1596,7 +1595,7 @@ where
                     }
                     Err(err) => {
                         debug!("Error processing AddTlc command: {:?}", &err);
-                        let tlc_err = self.get_tlc_detail_error(state, &err).await;
+                        let tlc_err = self.get_tlc_error(state, &err).await;
                         let _ = reply.send(Err(tlc_err));
                         Err(err)
                     }

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -2025,9 +2025,10 @@ where
         trace!(
             "Channel actor processing message: id: {:?}, state: {:?}, message: {:?}",
             &state.get_id(),
-            &message,
-            &state.state
+            &state.state,
+            message,
         );
+
         match message {
             ChannelActorMessage::PeerMessage(message) => {
                 if let Err(error) = self.handle_peer_message(&myself, state, message).await {

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -732,8 +732,6 @@ where
         );
 
         let remove_reason = remove_reason.clone().backward(&tlc_info.shared_secret);
-
-        // TODO: encrypt the error to backward
         self.register_retryable_relay_tlc_remove(
             myself,
             state,

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -1415,7 +1415,6 @@ where
                     .await?
             }
 
-            // TODO: we should check the OnionPacket is valid or not, only the current node can decrypt it.
             NetworkActorCommand::SendPaymentOnionPacket(command, reply) => {
                 self.handle_send_onion_packet_command(state, command, reply)
                     .await;

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -66,7 +66,7 @@ use super::types::{
     NodeAnnouncement, NodeAnnouncementQuery, OpenChannel, PaymentHopData, Privkey, Pubkey,
     QueryBroadcastMessagesWithinTimeRange, QueryBroadcastMessagesWithinTimeRangeResult,
     QueryChannelsWithinBlockRange, QueryChannelsWithinBlockRangeResult, RemoveTlcReason, TlcErr,
-    TlcErrData, TlcErrPacket, TlcErrorCode,
+    TlcErrData, TlcErrorCode,
 };
 use super::{FiberConfig, ASSUME_NETWORK_ACTOR_ALIVE};
 
@@ -204,10 +204,7 @@ pub enum NetworkActorCommand {
     ControlFiberChannel(ChannelCommandWithId),
     // The first parameter is the peeled onion in binary via `PeeledOnionPacket::serialize`. `PeeledOnionPacket::current`
     // is for the current node.
-    SendPaymentOnionPacket(
-        SendOnionPacketCommand,
-        RpcReplyPort<Result<u64, TlcErrPacket>>,
-    ),
+    SendPaymentOnionPacket(SendOnionPacketCommand, RpcReplyPort<Result<u64, TlcErr>>),
     PeelPaymentOnionPacket(
         PaymentOnionPacket, // onion_packet
         Hash256,            // payment_hash
@@ -2154,7 +2151,7 @@ where
         &self,
         state: &mut NetworkActorState<S>,
         command: SendOnionPacketCommand,
-        reply: RpcReplyPort<Result<u64, TlcErrPacket>>,
+        reply: RpcReplyPort<Result<u64, TlcErr>>,
     ) {
         let SendOnionPacketCommand {
             peeled_onion_packet,
@@ -2167,14 +2164,14 @@ where
         debug!("Processing onion packet info: {:?}", info);
 
         let channel_outpoint = OutPoint::new(info.funding_tx_hash.into(), 0);
-        let unknown_next_peer = |reply: RpcReplyPort<Result<u64, TlcErrPacket>>| {
+        let unknown_next_peer = |reply: RpcReplyPort<Result<u64, TlcErr>>| {
             let error_detail = TlcErr::new_channel_fail(
                 TlcErrorCode::UnknownNextPeer,
                 channel_outpoint.clone(),
                 None,
             );
             reply
-                .send(Err(TlcErrPacket::new(error_detail, &shared_secret)))
+                .send(Err(error_detail))
                 .expect("send add tlc response");
         };
 
@@ -2188,7 +2185,7 @@ where
                 return unknown_next_peer(reply);
             }
         };
-        let (send, recv) = oneshot::channel::<Result<AddTlcResponse, TlcErrPacket>>();
+        let (send, recv) = oneshot::channel::<Result<AddTlcResponse, TlcErr>>();
         let rpc_reply = RpcReplyPort::from(send);
         let command = ChannelCommand::AddTlc(
             AddTlcCommand {
@@ -2217,7 +2214,7 @@ where
                 );
                 let error_detail = TlcErr::new(TlcErrorCode::TemporaryNodeFailure);
                 return reply
-                    .send(Err(TlcErrPacket::new(error_detail, &shared_secret)))
+                    .send(Err(error_detail))
                     .expect("send add tlc response");
             }
         }
@@ -2363,7 +2360,7 @@ where
         payment_session.route =
             SessionRoute::new(state.get_public_key(), payment_data.target_pubkey, &hops);
 
-        let (send, recv) = oneshot::channel::<Result<u64, TlcErrPacket>>();
+        let (send, recv) = oneshot::channel::<Result<u64, TlcErr>>();
         let rpc_reply = RpcReplyPort::from(send);
         let peeled_onion_packet = match PeeledPaymentOnionPacket::create(
             session_key,
@@ -2390,31 +2387,19 @@ where
         self.handle_send_onion_packet_command(state, command, rpc_reply)
             .await;
         match recv.await.expect("msg recv error") {
-            Err(e) => {
-                if let Some(error_detail) = e.decode(
-                    &payment_session.session_key,
-                    payment_session.hops_public_keys(),
-                ) {
-                    // This is the error implies we send payment request to the first hop failed
-                    // graph or payment history need to update and then have a retry
-                    self.update_graph_with_tlc_fail(&error_detail).await;
-                    let need_to_retry = self
-                        .network_graph
-                        .write()
-                        .await
-                        .record_payment_fail(&payment_session, error_detail.clone());
-                    let err = format!(
-                        "Failed to send onion packet with error {}",
-                        error_detail.error_code_as_str()
-                    );
-                    self.set_payment_fail_with_error(payment_session, &err);
-                    return Err(Error::SendPaymentFirstHopError(err, need_to_retry));
-                } else {
-                    // This expected never to be happended, to be safe, we will set the payment session to failed
-                    let err = format!("Failed to send onion packet, got malioucious error message");
-                    self.set_payment_fail_with_error(payment_session, &err);
-                    return Err(Error::SendPaymentError(err));
-                }
+            Err(error_detail) => {
+                self.update_graph_with_tlc_fail(&error_detail).await;
+                let need_to_retry = self
+                    .network_graph
+                    .write()
+                    .await
+                    .record_payment_fail(&payment_session, error_detail.clone());
+                let err = format!(
+                    "Failed to send onion packet with error {}",
+                    error_detail.error_code_as_str()
+                );
+                self.set_payment_fail_with_error(payment_session, &err);
+                return Err(Error::SendPaymentFirstHopError(err, need_to_retry));
             }
             Ok(tlc_id) => {
                 payment_session.set_inflight_status(first_channel_outpoint, tlc_id);

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -4045,3 +4045,70 @@ async fn test_send_payment_with_channel_balance_error() {
     let payment_session = source_node.get_payment_session(payment_hash).unwrap();
     assert_eq!(payment_session.retried_times, 2);
 }
+
+#[tokio::test]
+async fn test_send_payment_with_disable_channel() {
+    init_tracing();
+    let _span = tracing::info_span!("node", node = "test").entered();
+    let nodes_num = 4;
+    let amounts = vec![(100000000000, 100000000000); nodes_num - 1];
+    let (nodes, channels) =
+        create_n_nodes_with_established_channel(&amounts, nodes_num, true).await;
+    let [node_0, _node_1, mut node_2, node_3] = nodes.try_into().expect("4 nodes");
+    let source_node = &node_0;
+    let target_pubkey = node_3.pubkey.clone();
+
+    // sleep for a while
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    // begin to set channel disable
+    node_2.disable_channel(channels[1]).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    let message = |rpc_reply| -> NetworkActorMessage {
+        NetworkActorMessage::Command(NetworkActorCommand::SendPayment(
+            SendPaymentCommand {
+                target_pubkey: Some(target_pubkey.clone()),
+                amount: Some(3000),
+                payment_hash: None,
+                final_tlc_expiry_delta: None,
+                tlc_expiry_limit: None,
+                invoice: None,
+                timeout: None,
+                max_fee_amount: None,
+                max_parts: None,
+                keysend: Some(true),
+                udt_type_script: None,
+                allow_self_payment: false,
+                dry_run: false,
+            },
+            rpc_reply,
+        ))
+    };
+
+    // expect send payment failed
+    let res = call!(source_node.network_actor, message).expect("source_node alive");
+    assert!(res.is_ok());
+    let payment_hash = res.unwrap().payment_hash;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    let message = |rpc_reply| -> NetworkActorMessage {
+        NetworkActorMessage::Command(NetworkActorCommand::GetPayment(payment_hash, rpc_reply))
+    };
+    let res = call!(source_node.network_actor, message)
+        .expect("node_a alive")
+        .unwrap();
+
+    assert_eq!(res.status, PaymentSessionStatus::Failed);
+    eprintln!("failed_error: {:?}", res.failed_error);
+    assert!(res
+        .failed_error
+        .unwrap()
+        .contains("TemporaryChannelFailure"));
+
+    // because there is only one path for the payment, the payment will fail in the second try
+    // this assertion make sure we didn't do meaningless retry
+    let payment_session = source_node.get_payment_session(payment_hash).unwrap();
+    // TODO: we should only try once
+    assert_eq!(payment_session.retried_times, 5);
+}

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -2518,10 +2518,7 @@ async fn do_test_add_tlc_waiting_ack() {
         if i == 2 {
             // we are sending AddTlc constantly, so we should get a TemporaryChannelFailure
             assert!(add_tlc_result.is_err());
-            let code = add_tlc_result
-                .unwrap_err()
-                .decode(&NO_SHARED_SECRET, vec![])
-                .unwrap();
+            let code = add_tlc_result.unwrap_err();
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             assert!(add_tlc_result.is_ok());
@@ -2551,10 +2548,7 @@ async fn do_test_add_tlc_waiting_ack() {
         if i == 2 {
             // we are sending AddTlc constantly, so we should get a TemporaryChannelFailure
             assert!(add_tlc_result.is_err());
-            let code = add_tlc_result
-                .unwrap_err()
-                .decode(&NO_SHARED_SECRET, vec![])
-                .unwrap();
+            let code = add_tlc_result.unwrap_err();
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             assert!(add_tlc_result.is_ok());
@@ -2614,10 +2608,7 @@ async fn do_test_add_tlc_number_limit() {
         tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
         if i == node_a_max_tlc_number + 1 {
             assert!(add_tlc_result.is_err());
-            let code = add_tlc_result
-                .unwrap_err()
-                .decode(&NO_SHARED_SECRET, vec![])
-                .unwrap();
+            let code = add_tlc_result.unwrap_err();
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             dbg!(&add_tlc_result);
@@ -2702,10 +2693,7 @@ async fn do_test_add_tlc_number_limit_reverse() {
         tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
         if i == node_b_max_tlc_number + 1 {
             assert!(add_tlc_result.is_err());
-            let code = add_tlc_result
-                .unwrap_err()
-                .decode(&NO_SHARED_SECRET, vec![])
-                .unwrap();
+            let code = add_tlc_result.unwrap_err();
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             dbg!(&add_tlc_result);
@@ -2792,10 +2780,8 @@ async fn do_test_add_tlc_value_limit() {
         tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
         if i == max_tlc_number + 1 {
             assert!(add_tlc_result.is_err());
-            let code = add_tlc_result
-                .unwrap_err()
-                .decode(&NO_SHARED_SECRET, vec![])
-                .unwrap();
+            let code = add_tlc_result.unwrap_err();
+
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             assert!(add_tlc_result.is_ok());

--- a/src/fiber/tests/graph.rs
+++ b/src/fiber/tests/graph.rs
@@ -1335,7 +1335,6 @@ fn test_graph_payment_expiry_is_in_right_order() {
         dry_run: false,
     };
     let payment_data = SendPaymentData::new(command);
-    eprintln!("{:?}", payment_data);
     assert!(payment_data.is_ok());
 
     let current_time = now_timestamp_as_millis_u64();

--- a/src/fiber/tests/test_utils.rs
+++ b/src/fiber/tests/test_utils.rs
@@ -311,6 +311,14 @@ impl NetworkNode {
         self.update_channel_actor_state(channel_actor_state).await;
     }
 
+    pub async fn disable_channel(&mut self, channel_id: Hash256) {
+        let mut channel_actor_state = self.get_channel_actor_state(channel_id);
+        let mut public_info = channel_actor_state.public_channel_info.unwrap();
+        public_info.enabled = false;
+        channel_actor_state.public_channel_info = Some(public_info);
+        self.update_channel_actor_state(channel_actor_state).await;
+    }
+
     pub fn get_payment_session(&self, payment_hash: Hash256) -> Option<PaymentSession> {
         self.store.get_payment_session(payment_hash)
     }

--- a/src/fiber/tests/test_utils.rs
+++ b/src/fiber/tests/test_utils.rs
@@ -2,6 +2,8 @@ use crate::fiber::channel::ChannelActorState;
 use crate::fiber::channel::ChannelActorStateStore;
 use crate::fiber::channel::ChannelCommand;
 use crate::fiber::channel::ChannelCommandWithId;
+use crate::fiber::graph::NetworkGraphStateStore;
+use crate::fiber::graph::PaymentSession;
 use crate::fiber::types::EcdsaSignature;
 use crate::fiber::types::Pubkey;
 use ckb_types::{core::TransactionView, packed::Byte32};
@@ -307,6 +309,10 @@ impl NetworkNode {
         let mut channel_actor_state = self.get_channel_actor_state(channel_id);
         channel_actor_state.to_local_amount = new_to_local_amount;
         self.update_channel_actor_state(channel_actor_state).await;
+    }
+
+    pub fn get_payment_session(&self, payment_hash: Hash256) -> Option<PaymentSession> {
+        self.store.get_payment_session(payment_hash)
     }
 
     pub async fn new_with_node_name(node_name: &str) -> Self {

--- a/src/fiber/types.rs
+++ b/src/fiber/types.rs
@@ -29,6 +29,7 @@ use secp256k1::{
 use secp256k1::{Verification, XOnlyPublicKey};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::fmt::Display;
 use std::marker::PhantomData;
 use std::str::FromStr;
 use strum::{AsRefStr, EnumString};
@@ -1152,6 +1153,12 @@ pub enum TlcErrData {
 pub struct TlcErr {
     pub error_code: TlcErrorCode,
     pub extra_data: Option<TlcErrData>,
+}
+
+impl Display for TlcErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error_code_as_str().fmt(f)
+    }
 }
 
 impl TlcErr {

--- a/src/store/tests/store.rs
+++ b/src/store/tests/store.rs
@@ -317,7 +317,17 @@ fn test_channel_actor_state_store() {
     let store = Store::new(tempdir().unwrap().path().join("store")).expect("create store failed");
     assert!(store.get_channel_actor_state(&state.id).is_none());
     store.insert_channel_actor_state(state.clone());
-    assert!(store.get_channel_actor_state(&state.id).is_some());
+    let get_state = store.get_channel_actor_state(&state.id);
+    assert!(get_state.is_some());
+    assert_eq!(
+        get_state
+            .unwrap()
+            .public_channel_info
+            .as_ref()
+            .unwrap()
+            .enabled,
+        false
+    );
     store.delete_channel_actor_state(&state.id);
     assert!(store.get_channel_actor_state(&state.id).is_none());
 }


### PR DESCRIPTION
Make it easier for testing tlc error handling, we now can update ChannelActorState with error data and then trigger send payment.

From comment https://github.com/nervosnetwork/fiber/issues/386#issuecomment-2535625480