### PR TITLE
Fix udt overflow issue caused by u64

### DIFF
--- a/src/ckb/funding/funding_tx.rs
+++ b/src/ckb/funding/funding_tx.rs
@@ -58,11 +58,11 @@ pub struct FundingRequest {
     #[serde_as(as = "Option<EntityHex>")]
     pub udt_type_script: Option<packed::Script>,
     /// Assets amount to be provided by the local party
-    pub local_amount: u64,
+    pub local_amount: u128,
     /// Fee to be provided by the local party
     pub funding_fee_rate: u64,
     /// Assets amount to be provided by the remote party
-    pub remote_amount: u64,
+    pub remote_amount: u128,
     /// CKB amount to be provided by the local party.
     pub local_reserved_ckb_amount: u64,
     /// CKB amount to be provided by the remote party.
@@ -180,16 +180,17 @@ impl FundingTxBuilder {
             }
             None => {
                 let mut ckb_amount =
-                    self.request.local_amount + self.request.local_reserved_ckb_amount;
+                    self.request.local_amount as u64 + self.request.local_reserved_ckb_amount;
                 if remote_funded {
                     ckb_amount = ckb_amount
                         .checked_add(
-                            self.request.remote_amount + self.request.remote_reserved_ckb_amount,
+                            self.request.remote_amount as u64
+                                + self.request.remote_reserved_ckb_amount,
                         )
                         .ok_or(FundingError::InvalidChannel)?;
                 }
                 let ckb_output = packed::CellOutput::new_builder()
-                    .capacity(Capacity::shannons(ckb_amount).pack())
+                    .capacity(Capacity::shannons(ckb_amount as u64).pack())
                     .lock(self.context.funding_cell_lock_script.clone())
                     .build();
                 debug!("build_funding_cell debug ckb_output: {:?}", ckb_output);

--- a/src/ckb/tests/test_utils.rs
+++ b/src/ckb/tests/test_utils.rs
@@ -326,7 +326,7 @@ impl Actor for MockChainActor {
                             return Ok(());
                         }
                         let current_capacity: u64 = output.capacity().unpack();
-                        let capacity = request.local_amount
+                        let capacity = request.local_amount as u64
                             + request.local_reserved_ckb_amount
                             + current_capacity;
                         let mut outputs_builder = outputs.as_builder();
@@ -336,7 +336,10 @@ impl Actor for MockChainActor {
                         outputs_builder.build()
                     }
                     None => [CellOutput::new_builder()
-                        .capacity((request.local_amount + request.local_reserved_ckb_amount).pack())
+                        .capacity(
+                            (request.local_amount as u64 + request.local_reserved_ckb_amount)
+                                .pack(),
+                        )
                         .lock(request.script.clone())
                         .build()]
                     .pack(),

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -4455,9 +4455,9 @@ impl ChannelActorState {
         FundingRequest {
             script: self.get_funding_lock_script(),
             udt_type_script: self.funding_udt_type_script.clone(),
-            local_amount: self.to_local_amount as u64,
+            local_amount: self.to_local_amount,
             funding_fee_rate: self.funding_fee_rate,
-            remote_amount: self.to_remote_amount as u64,
+            remote_amount: self.to_remote_amount,
             local_reserved_ckb_amount: self.local_reserved_ckb_amount,
             remote_reserved_ckb_amount: self.remote_reserved_ckb_amount,
         }

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -1172,9 +1172,9 @@ where
                                     FundingRequest {
                                         script,
                                         udt_type_script: udt_funding_script,
-                                        local_amount: local as u64,
+                                        local_amount: local,
                                         funding_fee_rate,
-                                        remote_amount: remote as u64,
+                                        remote_amount: remote,
                                         local_reserved_ckb_amount,
                                         remote_reserved_ckb_amount,
                                     },

--- a/tests/bruno/e2e/udt/04-node1-node2-open-channel.bru
+++ b/tests/bruno/e2e/udt/04-node1-node2-open-channel.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Node1 open a channel to Node2
+  name: Node1 open a channel to Node2, make funding_amount is larger to check overflow issue
   type: http
   seq: 4
 }
@@ -24,7 +24,7 @@ body:json {
     "params": [
       {
         "peer_id": "{{NODE2_PEERID}}",
-          "funding_amount": "0x4b0",
+          "funding_amount": "0xfffffffffffffffffffffffffffff",
           "funding_udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
             "hash_type": "data1",

--- a/tests/deploy/udt-init/src/main.rs
+++ b/tests/deploy/udt-init/src/main.rs
@@ -331,8 +331,15 @@ fn genrate_nodes_config() {
 fn init_udt_accounts() -> Result<(), Box<dyn StdErr>> {
     let udt_owner = get_nodes_info("deployer");
     for udt in UDT_KINDS {
-        init_or_send_udt(udt, &udt_owner.0, &udt_owner, None, 1000000000000, true)
-            .expect("init udt");
+        init_or_send_udt(
+            udt,
+            &udt_owner.0,
+            &udt_owner,
+            None,
+            0xfffffffffffffffffffffffffffffff,
+            true,
+        )
+        .expect("init udt");
         generate_blocks(8).expect("ok");
         std::thread::sleep(std::time::Duration::from_millis(1000));
         for i in 0..3 {
@@ -342,7 +349,7 @@ fn init_udt_accounts() -> Result<(), Box<dyn StdErr>> {
                 &udt_owner.0,
                 &udt_owner,
                 Some(&wallet.0),
-                200000000000,
+                0xffffffffffffffffffffffffffffff,
                 true,
             )?;
             generate_blocks(8).expect("ok");


### PR DESCRIPTION
Fixes #346

The code here https://github.com/nervosnetwork/fiber/pull/398/files#diff-69ae8d1e23722c7deb83f0097b5e72b6120e824443741bf08c3c6b8e902979f4L4458 converted `u128` to `u64`, if the udt amount is larger than `u64::max`, it will make the [is_tx_final](https://github.com/nervosnetwork/fiber/blob/6fff5119ccf9d9eb661bec17cbaca800be648d1a/src/fiber/channel.rs#L5752) check fail forever, so the two peers are always negotiating funding tx.