### PR TITLE
chore: revert #401

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
           # Prebuild the program so that we can run the following script faster
-          export FNN="$(cargo build --message-format=json-render-diagnostics | jq -js '[.[] | select(.reason == "compiler-artifact") | select(.executable != null)] | last | .executable')"
+          cargo build
           cd tests/deploy/udt-init && cargo build && cd -
           if [ ${{ matrix.workflow }} = "router-pay" ]; then
             export START_BOOTNODE=y

--- a/tests/nodes/start.sh
+++ b/tests/nodes/start.sh
@@ -32,16 +32,13 @@ echo "Initializing finished, begin to start services ...."
 sleep 1
 
 ckb run -C "$deploy_dir/node-data" --indexer &
+cargo build
 
 # Start the dev node in the background.
 cd "$nodes_dir" || exit 1
 
 start() {
-    if [ -n "$FNN" ]; then
-        "$FNN" "$@"
-    else
-        cargo run -- "$@"
-    fi
+    ../../target/debug/fnn "$@"
 }
 
 if [ "$#" -ne 1 ]; then


### PR DESCRIPTION
#401 introduced unnecessary env variable, we can use simple relative path in the script.