### PR TITLE
Change service error log level

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -3378,13 +3378,13 @@ impl From<&MyServiceHandle> for FiberProtocolHandle {
 #[async_trait]
 impl ServiceHandle for MyServiceHandle {
     async fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
-        trace!("Service error: {:?}", error);
+        error!("Tentacle service error: {:?}", error);
         // TODO
         // ServiceError::DialerError => remove address from peer store
         // ServiceError::ProtocolError => ban peer
     }
     async fn handle_event(&mut self, _context: &mut ServiceContext, event: ServiceEvent) {
-        trace!("Service event: {:?}", event);
+        trace!("Tentacle service event: {:?}", event);
     }
 }
 


### PR DESCRIPTION
Some important connection error message will not be shown to users if we are using `trace!` by default. For example, even the user specified an invalid boot node address, he/she may not know that there is an error while connecting to boot node.