### PR TITLE
Fix inconsistency in bootnodes args

### DIFF
--- a/src/fiber/config.rs
+++ b/src/fiber/config.rs
@@ -102,7 +102,7 @@ pub struct FiberConfig {
     pub(crate) announced_addrs: Vec<String>,
 
     /// bootstrap node addresses to be connected at startup (separated by `,`)
-    #[arg(name = "FIBER_BOOTNODES_ADDRS", long = "fiber-bootnodes-addrs", env, value_parser, num_args = 0.., value_delimiter = ',')]
+    #[arg(name = "FIBER_BOOTNODE_ADDRS", long = "fiber-bootnode-addrs", env, value_parser, num_args = 0.., value_delimiter = ',')]
     pub bootnode_addrs: Vec<String>,
 
     /// node name to be announced to fiber network

--- a/tests/nodes/start.sh
+++ b/tests/nodes/start.sh
@@ -48,7 +48,7 @@ if [ "$#" -ne 1 ]; then
         # while other nodes try to connect to it.
         sleep 5
         # export the environment variable so that other nodes can connect to the bootnode.
-        export FIBER_BOOTNODES_ADDRS=/ip4/127.0.0.1/tcp/8343/p2p/Qmbyc4rhwEwxxSQXd5B4Ej4XkKZL6XLipa3iJrnPL9cjGR
+        export FIBER_BOOTNODE_ADDRS=/ip4/127.0.0.1/tcp/8343/p2p/Qmbyc4rhwEwxxSQXd5B4Ej4XkKZL6XLipa3iJrnPL9cjGR
     fi
     LOG_PREFIX=$'[node 1]' start -d 1 &
     LOG_PREFIX=$'[node 2]' start -d 2 &


### PR DESCRIPTION
The additional "s" in the command line arguments and environment variable name may surprise people.