### PR TITLE
Use `Vec<u8>` as middle man to deserialize various types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1661,7 @@ dependencies = [
  "bincode",
  "bitcoin",
  "bitflags 2.6.0",
+ "ciborium",
  "ckb-chain-spec",
  "ckb-gen-types",
  "ckb-hash 0.115.0",
@@ -1912,6 +1940,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ panic = "abort"
 [dev-dependencies]
 tempfile = "3.10.1"
 ckb-testtool = "0.13.2"
+ciborium = "0.2.2"
 
 [lints.clippy]
 needless-return = "allow"

--- a/src/fiber/serde_utils.rs
+++ b/src/fiber/serde_utils.rs
@@ -135,13 +135,11 @@ impl<'de> DeserializeAs<'de, CompactSignature> for CompactSignatureAsBytes {
     where
         D: Deserializer<'de>,
     {
-        let bytes: &[u8] = Deserialize::deserialize(deserializer)?;
+        let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
         if bytes.len() != SCHNORR_SIGNATURE_SIZE {
             return Err(serde::de::Error::custom("expected 64 bytes"));
         }
-        let mut array = [0u8; SCHNORR_SIGNATURE_SIZE];
-        array.copy_from_slice(bytes);
-        CompactSignature::from_bytes(&array).map_err(serde::de::Error::custom)
+        CompactSignature::from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }
 
@@ -161,12 +159,10 @@ impl<'de> DeserializeAs<'de, PubNonce> for PubNonceAsBytes {
     where
         D: Deserializer<'de>,
     {
-        let bytes: &[u8] = Deserialize::deserialize(deserializer)?;
+        let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
         if bytes.len() != 66 {
             return Err(serde::de::Error::custom("expected 66 bytes"));
         }
-        let mut array = [0u8; 66];
-        array.copy_from_slice(bytes);
-        PubNonce::from_bytes(&array).map_err(serde::de::Error::custom)
+        PubNonce::from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }

--- a/src/store/tests/store.rs
+++ b/src/store/tests/store.rs
@@ -410,6 +410,91 @@ fn test_channel_actor_state_store() {
 }
 
 #[test]
+fn test_serde_channel_actor_state_ciborium() {
+    let seed = [0u8; 32];
+    let signer = InMemorySigner::generate_from_seed(&seed);
+
+    let seckey = blake2b_hash_with_salt(
+        signer.musig2_base_nonce.as_ref(),
+        b"channel_announcement".as_slice(),
+    );
+    let sec_nonce = SecNonce::build(seckey).build();
+    let pub_nonce = sec_nonce.public_nonce();
+
+    let state = ChannelActorState {
+        state: ChannelState::NegotiatingFunding(NegotiatingFundingFlags::THEIR_INIT_SENT),
+        public_channel_info: Some(PublicChannelInfo {
+            local_channel_announcement_signature: Some((
+                mock_ecdsa_signature(),
+                MaybeScalar::two(),
+            )),
+            remote_channel_announcement_signature: Some((
+                mock_ecdsa_signature(),
+                MaybeScalar::two(),
+            )),
+            remote_channel_announcement_nonce: Some(pub_nonce.clone()),
+            channel_announcement: None,
+            channel_update: None,
+        }),
+        local_tlc_info: ChannelTlcInfo {
+            enabled: false,
+            timestamp: 0,
+            tlc_fee_proportional_millionths: 123,
+            tlc_expiry_delta: 3,
+            tlc_minimum_value: 10,
+            tlc_maximum_value: 0,
+        },
+        remote_tlc_info: None,
+        local_pubkey: gen_rand_fiber_public_key(),
+        remote_pubkey: gen_rand_fiber_public_key(),
+        funding_tx: Some(Transaction::default()),
+        funding_tx_confirmed_at: Some((H256::default(), 1, 1)),
+        is_acceptor: true,
+        funding_udt_type_script: Some(Script::default()),
+        to_local_amount: 100,
+        to_remote_amount: 100,
+        commitment_fee_rate: 100,
+        commitment_delay_epoch: 100,
+        funding_fee_rate: 100,
+        id: gen_rand_sha256_hash(),
+        tlc_state: Default::default(),
+        local_shutdown_script: Script::default(),
+        local_channel_public_keys: ChannelBasePublicKeys {
+            funding_pubkey: gen_rand_fiber_public_key(),
+            tlc_base_key: gen_rand_fiber_public_key(),
+        },
+        signer,
+        remote_channel_public_keys: Some(ChannelBasePublicKeys {
+            funding_pubkey: gen_rand_fiber_public_key(),
+            tlc_base_key: gen_rand_fiber_public_key(),
+        }),
+        commitment_numbers: Default::default(),
+        remote_shutdown_script: Some(Script::default()),
+        last_committed_remote_nonce: None,
+        last_revoke_and_ack_remote_nonce: None,
+        last_commitment_signed_remote_nonce: None,
+        remote_commitment_points: vec![
+            (0, gen_rand_fiber_public_key()),
+            (1, gen_rand_fiber_public_key()),
+        ],
+        local_shutdown_info: None,
+        remote_shutdown_info: None,
+        local_reserved_ckb_amount: 100,
+        remote_reserved_ckb_amount: 100,
+        latest_commitment_transaction: None,
+        local_constraints: ChannelConstraints::default(),
+        remote_constraints: ChannelConstraints::default(),
+        reestablishing: false,
+        created_at: SystemTime::now(),
+    };
+
+    let mut serialized = Vec::new();
+    ciborium::into_writer(&state, &mut serialized).unwrap();
+    let _new_channel_state: ChannelActorState =
+        ciborium::from_reader(serialized.as_slice()).expect("deserialize to new state");
+}
+
+#[test]
 fn test_store_payment_session() {
     let path = TempDir::new("payment-history-store-test");
     let store = Store::new(path).expect("created store failed");


### PR DESCRIPTION
While developing https://github.com/nervosnetwork/fiber/pull/474, we wanted an easy way to convert the old `ChannelActorState` struct to a new `ChannelActorState` struct (if the newer struct only adds a few fields with default value or removes a few obsolete fields). We tried `serde_json` which does not work because json can't serialize binary data natively.

We then tried cbor. To our surprise, current code can't even deserialize the serialized result of a `ChannelActorState`. This is shown in the [commit 6f9d1bffdb5a7b41cbc127835c194cb44c37dcb4](https://github.com/nervosnetwork/fiber/commit/6f9d1bffdb5a7b41cbc127835c194cb44c37dcb4). The test `test_serde_channel_actor_state_ciborium` will fail with error `Semantic(None, "invalid type: byte array, expected a borrowed byte array")` (see [github actions log](https://github.com/contrun/fiber/actions/runs/12783348900/job/35634321309#step:6:293)).

After some investigation, I found we need to deserialize the data to `Vec<u8>` instead of `&[u8]`. I don't know why bincode deserializtion succeeded. But there are many similar issues on github (e.g. https://github.com/jonasbb/serde_with/issues/372#issuecomment-932811411 and https://github.com/serde-rs/json/issues/530 ). With the change in [commit 99298012ef362ccfd0c9fa8832196cb09daad29e](https://github.com/nervosnetwork/fiber/commit/99298012ef362ccfd0c9fa8832196cb09daad29e), I can successfully deserialize data with cbor.

I have tried the patch in this PR to successfully convert from one `ChannelActorState` to another `ChannelActorState` with some additional `Option` fields (code: [chengyukang:refactor-migration-with-crate...contrun:fiber:refactor-migration-with-crate](https://github.com/chenyukang/fiber/compare/refactor-migration-with-crate...contrun:fiber:refactor-migration-with-crate)). I didn't add the simpler approach to https://github.com/nervosnetwork/fiber/pull/474 because we need to back port this PR to fiber v0.2.0, v0.2.1 and v0.3.0-rc1. There is also one field in v0.3.0-rc1 `local_tlc_info` which has no default value.