### PR TITLE
fix: resolve watchtower submit settlement tx error

### DIFF
--- a/src/fiber/tests/network.rs
+++ b/src/fiber/tests/network.rs
@@ -455,7 +455,7 @@ async fn test_query_missing_broadcast_message() {
     let node1_channel_info = node1.get_network_graph_channel(&out_point).await.unwrap();
     assert_ne!(node1_channel_info.update_of_node1, None);
 
-    let mut node2 = NetworkNode::new().await;
+    let node2 = NetworkNode::new().await;
     node1.connect_to(&node2).await;
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     // Verify that node2 still does not have channel info after active syncing done.

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/04-get-node1-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/04-get-node1-balance.bru
@@ -46,6 +46,7 @@ script:pre-request {
 
 script:post-response {
   let capacity = res.body.result.objects.reduce((acc, cell) => {
+    console.log("NODE1_BALANCE: ", cell.output_data);
     const hexBytes = cell.output_data.slice(2).match(/../g).reverse().join('');
     return acc + BigInt(`0x${hexBytes}`);
   }, BigInt(0));

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/05-get-node2-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/05-get-node2-balance.bru
@@ -46,6 +46,7 @@ script:pre-request {
 
 script:post-response {
   let capacity = res.body.result.objects.reduce((acc, cell) => {
+    console.log("NODE2_BALANCE: ", cell.output_data);
     const hexBytes = cell.output_data.slice(2).match(/../g).reverse().join('');
     return acc + BigInt(`0x${hexBytes}`);
   }, BigInt(0));

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/21-check-balance-node1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/21-check-balance-node1.bru
@@ -46,6 +46,7 @@ script:pre-request {
 
 script:post-response {
   let capacity = res.body.result.objects.reduce((acc, cell) => {
+    console.log("NODE1_NEW_BALANCE: ", cell.output_data);
     const hexBytes = cell.output_data.slice(2).match(/../g).reverse().join('');
     return acc + BigInt(`0x${hexBytes}`);
   }, BigInt(0));

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/22-check-balance-node2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/22-check-balance-node2.bru
@@ -46,6 +46,7 @@ script:pre-request {
 
 script:post-response {
   let capacity = res.body.result.objects.reduce((acc, cell) => {
+    console.log("NODE2_NEW_BALANCE: ", cell.output_data);
     const hexBytes = cell.output_data.slice(2).match(/../g).reverse().join('');
     return acc + BigInt(`0x${hexBytes}`);
   }, BigInt(0));


### PR DESCRIPTION
Add delay_epoch checking to ensure commitment transactions are ready to settle before proceeding and modify the params of `collect_live_cells` to use false to avoid lock cells.