### PR TITLE
Refactor channel state with storing network actor ref 

### DIFF
--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -2272,8 +2272,6 @@ where
                 channel.reestablishing = true;
                 channel.network = Some(self.network.clone());
 
-                eprintln!("finished reestablishing channel ..........");
-
                 let reestablish_channel = ReestablishChannel {
                     channel_id,
                     local_commitment_number: channel.get_current_commitment_number(true),

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -348,7 +348,7 @@ where
             match message {
                 FiberChannelMessage::ReestablishChannel(ref reestablish_channel) => {
                     state
-                        .handle_reestablish_channel_message(reestablish_channel, &self.network)
+                        .handle_reestablish_channel_message(reestablish_channel)
                         .await?;
                 }
                 _ => {
@@ -388,7 +388,7 @@ where
                     node_signature,
                     partial_signature,
                 );
-                state.maybe_public_channel_is_ready(&self.network).await;
+                state.maybe_public_channel_is_ready().await;
                 Ok(())
             }
             FiberChannelMessage::AcceptChannel(accept_channel) => {
@@ -414,13 +414,10 @@ where
                 Ok(())
             }
             FiberChannelMessage::TxUpdate(tx) => {
-                state.handle_tx_collaboration_msg(TxCollaborationMsg::TxUpdate(tx), &self.network)
+                state.handle_tx_collaboration_msg(TxCollaborationMsg::TxUpdate(tx))
             }
             FiberChannelMessage::TxComplete(tx) => {
-                state.handle_tx_collaboration_msg(
-                    TxCollaborationMsg::TxComplete(tx),
-                    &self.network,
-                )?;
+                state.handle_tx_collaboration_msg(TxCollaborationMsg::TxComplete(tx))?;
                 if let ChannelState::CollaboratingFundingTx(flags) = state.state {
                     if flags.contains(CollaboratingFundingTxFlags::COLLABORATION_COMPLETED) {
                         self.handle_commitment_signed_command(state)?;
@@ -471,12 +468,12 @@ where
                     return Ok(());
                 };
 
-                state.handle_tx_signatures(&self.network, Some(tx_signatures.witnesses))?;
+                state.handle_tx_signatures(Some(tx_signatures.witnesses))?;
                 Ok(())
             }
             FiberChannelMessage::RevokeAndAck(revoke_and_ack) => {
                 let need_commitment_signed =
-                    state.handle_revoke_and_ack_peer_message(&self.network, revoke_and_ack)?;
+                    state.handle_revoke_and_ack_peer_message(revoke_and_ack)?;
                 self.update_tlc_status_on_ack(myself, state).await;
                 if need_commitment_signed {
                     self.handle_commitment_signed_command(state)?;
@@ -504,12 +501,12 @@ where
                 };
                 let flags = flags | AwaitingChannelReadyFlags::THEIR_CHANNEL_READY;
                 state.update_state(ChannelState::AwaitingChannelReady(flags));
-                state.maybe_channel_is_ready(&self.network).await;
+                state.maybe_channel_is_ready().await;
                 Ok(())
             }
             FiberChannelMessage::UpdateTlcInfo(update_tlc_info) => {
                 state.remote_tlc_info = Some(update_tlc_info.into());
-                state.update_graph_for_remote_channel_change(&self.network);
+                state.update_graph_for_remote_channel_change();
                 Ok(())
             }
             FiberChannelMessage::AddTlc(add_tlc) => {
@@ -577,7 +574,7 @@ where
                     debug!("Auto accept shutdown ...");
                 }
                 state.update_state(ChannelState::ShuttingDown(flags));
-                state.maybe_transition_to_shutdown(&self.network)?;
+                state.maybe_transition_to_shutdown()?;
                 Ok(())
             }
             FiberChannelMessage::ClosingSigned(closing) => {
@@ -602,12 +599,12 @@ where
                     shutdown_info.signature = Some(partial_signature);
                 }
 
-                state.maybe_transition_to_shutdown(&self.network)?;
+                state.maybe_transition_to_shutdown()?;
                 Ok(())
             }
             FiberChannelMessage::ReestablishChannel(ref reestablish_channel) => {
                 state
-                    .handle_reestablish_channel_message(reestablish_channel, &self.network)
+                    .handle_reestablish_channel_message(reestablish_channel)
                     .await?;
                 Ok(())
             }
@@ -689,7 +686,7 @@ where
         };
 
         let channel_update = if error_code.is_update() {
-            state.try_create_channel_update_message(&self.network).await
+            state.try_create_channel_update_message().await
         } else {
             None
         };
@@ -708,7 +705,7 @@ where
         commitment_signed: CommitmentSigned,
     ) -> Result<(), ProcessingChannelError> {
         // build commitment tx and verify signature from remote, if passed send ACK for partner
-        state.verify_commitment_signed_and_send_ack(commitment_signed.clone(), &self.network)?;
+        state.verify_commitment_signed_and_send_ack(commitment_signed.clone())?;
         let need_commitment_signed = state.tlc_state.update_for_commitment_signed();
 
         // flush remove tlc for received tlcs after replying ack for peer
@@ -753,8 +750,8 @@ where
         }
 
         if state.get_local_balance() != previous_balance {
-            state.update_graph_for_local_channel_change(&self.network);
-            state.update_graph_for_remote_channel_change(&self.network);
+            state.update_graph_for_local_channel_change();
+            state.update_graph_for_remote_channel_change();
         }
     }
 
@@ -1235,14 +1232,14 @@ where
             CommitmentSignedFlags::SigningCommitment(flags) => {
                 let flags = flags | SigningCommitmentFlags::OUR_COMMITMENT_SIGNED_SENT;
                 state.update_state(ChannelState::SigningCommitment(flags));
-                state.maybe_transition_to_tx_signatures(flags, &self.network)?;
+                state.maybe_transition_to_tx_signatures(flags)?;
             }
             CommitmentSignedFlags::ChannelReady() => {
                 state.tlc_state.set_waiting_ack(true);
             }
             CommitmentSignedFlags::PendingShutdown() => {
                 state.tlc_state.set_waiting_ack(true);
-                state.maybe_transition_to_shutdown(&self.network)?;
+                state.maybe_transition_to_shutdown()?;
             }
         }
         state.update_last_commitment_signed_remote_nonce();
@@ -1331,7 +1328,7 @@ where
             ))
             .expect(ASSUME_NETWORK_ACTOR_ALIVE);
 
-        state.maybe_transition_to_shutdown(&self.network)?;
+        state.maybe_transition_to_shutdown()?;
         self.handle_commitment_signed_command(state)?;
         Ok(())
     }
@@ -1419,7 +1416,7 @@ where
             &state.state
         );
 
-        state.maybe_transition_to_shutdown(&self.network)
+        state.maybe_transition_to_shutdown()
     }
 
     pub async fn handle_update_command(
@@ -1465,9 +1462,7 @@ where
         }
 
         if updated {
-            state
-                .notify_owned_channel_updated(&self.network, true)
-                .await;
+            state.notify_owned_channel_updated(true).await;
         }
 
         Ok(())
@@ -1767,7 +1762,7 @@ where
                     CollaboratingFundingTxFlags::AWAITING_REMOTE_TX_COLLABORATION_MSG,
                 ));
                 state.funding_tx = Some(tx_update.transaction.clone());
-                state.maybe_complete_tx_collaboration(tx_update.transaction, &self.network)?;
+                state.maybe_complete_tx_collaboration(tx_update.transaction)?;
             }
             TxCollaborationCommand::TxComplete() => {
                 state.check_tx_complete_preconditions()?;
@@ -1895,11 +1890,10 @@ where
                     .store
                     .get_channel_actor_state(&state.get_id())
                     .expect("load channel state failed");
+                state.network = Some(self.network.clone());
                 let ReloadParams { notify_changes } = reload_params;
                 if notify_changes {
-                    state
-                        .notify_owned_channel_updated(&self.network, false)
-                        .await;
+                    state.notify_owned_channel_updated(false).await;
                 }
                 Ok(())
             }
@@ -1940,7 +1934,7 @@ where
                     .expect(ASSUME_NETWORK_ACTOR_ALIVE);
                 let flags = flags | AwaitingChannelReadyFlags::OUR_CHANNEL_READY;
                 state.update_state(ChannelState::AwaitingChannelReady(flags));
-                state.maybe_channel_is_ready(&self.network).await;
+                state.maybe_channel_is_ready().await;
             }
             ChannelEvent::CommitmentTransactionConfirmed => {
                 match state.state {
@@ -1964,7 +1958,7 @@ where
             ChannelEvent::ClosingTransactionConfirmed => {
                 // Broadcast the channel update message which disables the channel.
                 if state.is_public() {
-                    let update = state.generate_disabled_channel_update(&self.network).await;
+                    let update = state.generate_disabled_channel_update().await;
 
                     self.network
                         .send_message(NetworkActorMessage::new_command(
@@ -2102,6 +2096,7 @@ where
                     max_tlc_number_in_flight,
                     max_tlc_value_in_flight,
                     tlc_info,
+                    self.network.clone(),
                 );
                 state.check_accept_channel_parameters()?;
 
@@ -2199,6 +2194,7 @@ where
                     max_tlc_value_in_flight,
                     max_tlc_number_in_flight,
                     tlc_info,
+                    self.network.clone(),
                 );
 
                 channel.check_open_channel_parameters()?;
@@ -2274,6 +2270,9 @@ where
                     .get_channel_actor_state(&channel_id)
                     .expect("channel should exist");
                 channel.reestablishing = true;
+                channel.network = Some(self.network.clone());
+
+                eprintln!("finished reestablishing channel ..........");
 
                 let reestablish_channel = ReestablishChannel {
                     channel_id,
@@ -3237,6 +3236,9 @@ pub struct ChannelActorState {
     pub reestablishing: bool,
 
     pub created_at: SystemTime,
+
+    #[serde(skip)]
+    pub network: Option<ActorRef<NetworkActorMessage>>,
 }
 
 #[serde_as]
@@ -3617,6 +3619,13 @@ pub(crate) fn occupied_capacity(
 // Constructors for the channel actor state.
 #[allow(clippy::too_many_arguments)]
 impl ChannelActorState {
+    pub fn network(&self) -> ActorRef<NetworkActorMessage> {
+        self.network
+            .as_ref()
+            .expect("ChannelActorState should have network actor reference")
+            .clone()
+    }
+
     pub fn is_public(&self) -> bool {
         self.public_channel_info.is_some()
     }
@@ -3631,19 +3640,13 @@ impl ChannelActorState {
 
     pub async fn try_create_channel_messages(
         &mut self,
-        network: &ActorRef<NetworkActorMessage>,
     ) -> Option<(ChannelAnnouncement, ChannelUpdate)> {
-        let channel_announcement = self
-            .try_create_channel_announcement_message(network)
-            .await?;
-        let channel_update = self.try_create_channel_update_message(network).await?;
+        let channel_announcement = self.try_create_channel_announcement_message().await?;
+        let channel_update = self.try_create_channel_update_message().await?;
         Some((channel_announcement, channel_update))
     }
 
-    pub async fn try_create_channel_announcement_message(
-        &mut self,
-        network: &ActorRef<NetworkActorMessage>,
-    ) -> Option<ChannelAnnouncement> {
+    pub async fn try_create_channel_announcement_message(&mut self) -> Option<ChannelAnnouncement> {
         if !self.is_public() {
             debug!("Ignoring non-public channel announcement");
             return None;
@@ -3692,11 +3695,7 @@ impl ChannelActorState {
         let message = channel_announcement.message_to_sign();
 
         let (local_node_signature, local_partial_signature) = self
-            .get_or_create_local_channel_announcement_signature(
-                remote_nonce.clone(),
-                message,
-                network,
-            )
+            .get_or_create_local_channel_announcement_signature(remote_nonce.clone(), message)
             .await;
 
         let (remote_node_signature, remote_partial_signature) =
@@ -3726,7 +3725,6 @@ impl ChannelActorState {
 
     async fn do_generate_channel_update(
         &mut self,
-        network: &ActorRef<NetworkActorMessage>,
         // The function that would change the channel update parameters.
         f: impl FnOnce(&mut ChannelUpdate),
     ) -> ChannelUpdate {
@@ -3740,21 +3738,17 @@ impl ChannelActorState {
             &self.get_id(),
             &channel_update
         );
-        let node_signature =
-            sign_network_message(network.clone(), channel_update.message_to_sign())
-                .await
-                .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+        let node_signature = sign_network_message(self.network(), channel_update.message_to_sign())
+            .await
+            .expect(ASSUME_NETWORK_ACTOR_ALIVE);
 
         channel_update.signature = Some(node_signature);
         self.public_channel_state_mut().channel_update = Some(channel_update.clone());
         channel_update
     }
 
-    async fn generate_channel_update(
-        &mut self,
-        network: &ActorRef<NetworkActorMessage>,
-    ) -> ChannelUpdate {
-        self.do_generate_channel_update(network, |_update| {}).await
+    async fn generate_channel_update(&mut self) -> ChannelUpdate {
+        self.do_generate_channel_update(|_update| {}).await
     }
 
     fn create_update_tlc_info_message(&mut self) -> UpdateTlcInfo {
@@ -3770,11 +3764,8 @@ impl ChannelActorState {
         }
     }
 
-    async fn generate_disabled_channel_update(
-        &mut self,
-        network: &ActorRef<NetworkActorMessage>,
-    ) -> ChannelUpdate {
-        self.do_generate_channel_update(network, |update| {
+    async fn generate_disabled_channel_update(&mut self) -> ChannelUpdate {
+        self.do_generate_channel_update(|update| {
             update.channel_flags |= ChannelUpdateChannelFlags::DISABLED;
         })
         .await
@@ -3786,19 +3777,15 @@ impl ChannelActorState {
     // (e.g. channel ready and channel reestablishment) and some require us to send a
     // OwnedChannelUpdateEvent::Updated (e.g. user channel parameters update) to the network actor.
     // update_only is used to distinguish between the two cases.
-    async fn notify_owned_channel_updated(
-        &mut self,
-        network: &ActorRef<NetworkActorMessage>,
-        update_only: bool,
-    ) {
+    async fn notify_owned_channel_updated(&mut self, update_only: bool) {
         if update_only {
-            self.update_graph_for_local_channel_change(network);
+            self.update_graph_for_local_channel_change();
         } else {
-            self.update_graph_for_local_channel_ready(network);
+            self.update_graph_for_local_channel_ready();
         }
         if self.is_public() {
-            let channel_update = self.generate_channel_update(network).await;
-            network
+            let channel_update = self.generate_channel_update().await;
+            self.network()
                 .send_message(NetworkActorMessage::new_command(
                     NetworkActorCommand::BroadcastMessages(vec![
                         BroadcastMessageWithTimestamp::ChannelUpdate(channel_update),
@@ -3806,14 +3793,14 @@ impl ChannelActorState {
                 ))
                 .expect(ASSUME_NETWORK_ACTOR_ALIVE);
         }
-        self.send_update_tlc_info_message(network);
+        self.send_update_tlc_info_message();
     }
 
-    fn update_graph_for_remote_channel_change(&mut self, network: &ActorRef<NetworkActorMessage>) {
+    fn update_graph_for_remote_channel_change(&mut self) {
         if let Some(channel_update_info) = self.get_remote_channel_update_info() {
             let channel_outpoint = self.must_get_funding_transaction_outpoint();
             let peer_id = self.get_remote_pubkey();
-            network
+            self.network()
                 .send_message(NetworkActorMessage::new_event(
                     NetworkActorEvent::OwnedChannelUpdateEvent(
                         super::graph::OwnedChannelUpdateEvent::Updated(
@@ -3827,9 +3814,9 @@ impl ChannelActorState {
         }
     }
 
-    fn update_graph_for_local_channel_ready(&mut self, network: &ActorRef<NetworkActorMessage>) {
+    fn update_graph_for_local_channel_ready(&mut self) {
         if let Ok(channel_info) = (&*self).try_into() {
-            network
+            self.network()
                 .send_message(NetworkActorMessage::new_event(
                     NetworkActorEvent::OwnedChannelUpdateEvent(
                         super::graph::OwnedChannelUpdateEvent::Up(channel_info),
@@ -3839,11 +3826,11 @@ impl ChannelActorState {
         }
     }
 
-    fn update_graph_for_local_channel_change(&mut self, network: &ActorRef<NetworkActorMessage>) {
+    fn update_graph_for_local_channel_change(&mut self) {
         let channel_outpoint = self.must_get_funding_transaction_outpoint();
         let peer_id = self.get_local_pubkey();
         let channel_update_info = self.get_local_channel_update_info();
-        network
+        self.network()
             .send_message(NetworkActorMessage::new_event(
                 NetworkActorEvent::OwnedChannelUpdateEvent(
                     super::graph::OwnedChannelUpdateEvent::Updated(
@@ -3856,9 +3843,9 @@ impl ChannelActorState {
             .expect(ASSUME_NETWORK_ACTOR_ALIVE);
     }
 
-    fn send_update_tlc_info_message(&mut self, network: &ActorRef<NetworkActorMessage>) {
+    fn send_update_tlc_info_message(&mut self) {
         let update_tlc_info = self.create_update_tlc_info_message();
-        network
+        self.network()
             .send_message(NetworkActorMessage::new_command(
                 NetworkActorCommand::SendFiberMessage(FiberMessageWithPeerId {
                     peer_id: self.get_remote_peer_id(),
@@ -3870,10 +3857,7 @@ impl ChannelActorState {
             .expect(ASSUME_NETWORK_ACTOR_ALIVE);
     }
 
-    async fn try_create_channel_update_message(
-        &mut self,
-        network: &ActorRef<NetworkActorMessage>,
-    ) -> Option<ChannelUpdate> {
+    async fn try_create_channel_update_message(&mut self) -> Option<ChannelUpdate> {
         if !self.is_public() {
             debug!("Ignoring non-public channel update");
             return None;
@@ -3887,7 +3871,7 @@ impl ChannelActorState {
             return Some(x);
         };
 
-        Some(self.generate_channel_update(network).await)
+        Some(self.generate_channel_update().await)
     }
 
     fn get_channel_update_channel_flags(&self) -> ChannelUpdateChannelFlags {
@@ -3942,6 +3926,7 @@ impl ChannelActorState {
         local_max_tlc_number_in_flight: u64,
         local_max_tlc_value_in_flight: u128,
         local_tlc_info: ChannelTlcInfo,
+        network: ActorRef<NetworkActorMessage>,
     ) -> Self {
         let signer = InMemorySigner::generate_from_seed(seed);
         let local_base_pubkeys = signer.get_base_public_keys();
@@ -4002,6 +3987,7 @@ impl ChannelActorState {
             latest_commitment_transaction: None,
             reestablishing: false,
             created_at: SystemTime::now(),
+            network: Some(network),
         };
         if let Some(nonce) = remote_channel_announcement_nonce {
             state.update_remote_channel_announcement_nonce(&nonce);
@@ -4025,6 +4011,7 @@ impl ChannelActorState {
         local_max_tlc_value_in_flight: u128,
         local_max_tlc_number_in_flight: u64,
         local_tlc_info: ChannelTlcInfo,
+        network: ActorRef<NetworkActorMessage>,
     ) -> Self {
         let signer = InMemorySigner::generate_from_seed(seed);
         let local_pubkeys = signer.get_base_public_keys();
@@ -4070,6 +4057,7 @@ impl ChannelActorState {
             latest_commitment_transaction: None,
             reestablishing: false,
             created_at: SystemTime::now(),
+            network: Some(network),
         }
     }
 
@@ -4266,7 +4254,6 @@ impl ChannelActorState {
         &mut self,
         remote_nonce: PubNonce,
         message: [u8; 32],
-        network: &ActorRef<NetworkActorMessage>,
     ) -> (EcdsaSignature, PartialSignature) {
         if let Some(local_channel_announcement_signature) = self
             .public_channel_info
@@ -4293,10 +4280,10 @@ impl ChannelActorState {
         )
         .expect("Partial sign channel announcement");
 
-        let node_signature = sign_network_message(network.clone(), message)
+        let node_signature = sign_network_message(self.network(), message)
             .await
             .expect(ASSUME_NETWORK_ACTOR_ALIVE);
-        network
+        self.network()
             .send_message(NetworkActorMessage::new_command(
                 NetworkActorCommand::SendFiberMessage(FiberMessageWithPeerId::new(
                     peer_id,
@@ -4411,10 +4398,7 @@ impl ChannelActorState {
 
     // Send RevokeAndAck message to the counterparty, and update the
     // channel state accordingly.
-    fn send_revoke_and_ack_message(
-        &mut self,
-        network: &ActorRef<NetworkActorMessage>,
-    ) -> ProcessingChannelResult {
+    fn send_revoke_and_ack_message(&mut self) -> ProcessingChannelResult {
         let sign_ctx = self.get_sign_context(false);
         let x_only_aggregated_pubkey = sign_ctx.common_ctx.x_only_aggregated_pubkey();
 
@@ -4495,7 +4479,7 @@ impl ChannelActorState {
         self.increment_remote_commitment_number();
         let point = self.get_current_local_commitment_point();
 
-        network
+        self.network()
             .send_message(NetworkActorMessage::new_command(
                 NetworkActorCommand::SendFiberMessage(FiberMessageWithPeerId::new(
                     self.get_remote_peer_id(),
@@ -5394,10 +5378,7 @@ impl ChannelActorState {
         Ok((completed_commitment_tx, settlement_data))
     }
 
-    fn maybe_transition_to_shutdown(
-        &mut self,
-        network: &ActorRef<NetworkActorMessage>,
-    ) -> ProcessingChannelResult {
+    fn maybe_transition_to_shutdown(&mut self) -> ProcessingChannelResult {
         // This function will also be called when we resolve all pending tlcs.
         // If we are not in the ShuttingDown state, we should not do anything.
         let flags = match self.state {
@@ -5443,7 +5424,7 @@ impl ChannelActorState {
                     let signature = deterministic_sign_ctx.sign(shutdown_tx.hash().as_slice())?;
                     local_shutdown_info.signature = Some(signature);
 
-                    network
+                    self.network()
                         .send_message(NetworkActorMessage::new_command(
                             NetworkActorCommand::SendFiberMessage(FiberMessageWithPeerId::new(
                                 self.get_remote_peer_id(),
@@ -5473,7 +5454,7 @@ impl ChannelActorState {
 
                 self.update_state(ChannelState::Closed(CloseFlags::COOPERATIVE));
 
-                network
+                self.network()
                     .send_message(NetworkActorMessage::new_event(
                         NetworkActorEvent::ClosingTransactionPending(
                             self.get_id(),
@@ -5548,12 +5529,9 @@ impl ChannelActorState {
 
     // This is the dual of `handle_tx_collaboration_command`. Any logic error here is likely
     // to present in the other function as well.
-    fn handle_tx_collaboration_msg(
-        &mut self,
-        msg: TxCollaborationMsg,
-        network: &ActorRef<NetworkActorMessage>,
-    ) -> ProcessingChannelResult {
+    fn handle_tx_collaboration_msg(&mut self, msg: TxCollaborationMsg) -> ProcessingChannelResult {
         debug!("Processing tx collaboration message: {:?}", &msg);
+        let network = self.network();
         let is_complete_message = matches!(msg, TxCollaborationMsg::TxComplete(_));
         let is_waiting_for_remote = match self.state {
             ChannelState::CollaboratingFundingTx(flags) => {
@@ -5609,7 +5587,7 @@ impl ChannelActorState {
                 // TODO check if the tx is valid.
                 self.funding_tx = Some(msg.tx.clone());
                 if self.is_tx_final(&msg.tx)? {
-                    self.maybe_complete_tx_collaboration(msg.tx, network)?;
+                    self.maybe_complete_tx_collaboration(msg.tx)?;
                 } else {
                     network
                         .send_message(NetworkActorMessage::new_command(
@@ -5650,8 +5628,8 @@ impl ChannelActorState {
     fn verify_commitment_signed_and_send_ack(
         &mut self,
         commitment_signed: CommitmentSigned,
-        network: &ActorRef<NetworkActorMessage>,
     ) -> ProcessingChannelResult {
+        let network = self.network();
         let flags = match self.state {
             ChannelState::CollaboratingFundingTx(flags)
                 if !flags.contains(CollaboratingFundingTxFlags::COLLABORATION_COMPLETED) =>
@@ -5720,16 +5698,16 @@ impl ChannelActorState {
             CommitmentSignedFlags::SigningCommitment(flags) => {
                 let flags = flags | SigningCommitmentFlags::THEIR_COMMITMENT_SIGNED_SENT;
                 self.update_state(ChannelState::SigningCommitment(flags));
-                self.maybe_transition_to_tx_signatures(flags, network)?;
+                self.maybe_transition_to_tx_signatures(flags)?;
             }
             CommitmentSignedFlags::ChannelReady() | CommitmentSignedFlags::PendingShutdown() => {
-                self.send_revoke_and_ack_message(network)?;
+                self.send_revoke_and_ack_message()?;
                 match flags {
                     CommitmentSignedFlags::ChannelReady() => {}
                     CommitmentSignedFlags::PendingShutdown() => {
                         // TODO: Handle error in the below function call.
                         // We've already updated our state, we should never fail here.
-                        self.maybe_transition_to_shutdown(network)?;
+                        self.maybe_transition_to_shutdown()?;
                     }
                     _ => {
                         unreachable!(
@@ -5748,7 +5726,6 @@ impl ChannelActorState {
     fn maybe_transition_to_tx_signatures(
         &mut self,
         flags: SigningCommitmentFlags,
-        network: &ActorRef<NetworkActorMessage>,
     ) -> ProcessingChannelResult {
         if flags.contains(SigningCommitmentFlags::COMMITMENT_SIGNED_SENT) {
             debug!("Commitment signed message sent by both sides, transitioning to AwaitingTxSignatures state");
@@ -5757,7 +5734,7 @@ impl ChannelActorState {
             ));
             if self.should_local_send_tx_signatures_first() {
                 debug!("It is our turn to send tx_signatures, so we will do it now.");
-                self.handle_tx_signatures(network, None)?;
+                self.handle_tx_signatures(None)?;
             }
         }
         Ok(())
@@ -5768,7 +5745,6 @@ impl ChannelActorState {
     // set of witnesses.
     fn handle_tx_signatures(
         &mut self,
-        network: &ActorRef<NetworkActorMessage>,
         // If partial_witnesses is given, then it is the counterparty that send a message
         // to us, and we must combine them to make a full list of witnesses.
         // Otherwise, we are the one who is to start send the tx_signatures.
@@ -5821,7 +5797,7 @@ impl ChannelActorState {
                 "Funding transaction is not present".to_string(),
             ))?;
 
-        network
+        self.network()
             .send_message(NetworkActorMessage::new_command(
                 NetworkActorCommand::SignTx(
                     self.get_remote_peer_id(),
@@ -5837,22 +5813,22 @@ impl ChannelActorState {
         Ok(())
     }
 
-    async fn maybe_public_channel_is_ready(&mut self, network: &ActorRef<NetworkActorMessage>) {
+    async fn maybe_public_channel_is_ready(&mut self) {
         debug!("Trying to create channel announcement message for public channel");
         if let Some((channel_announcement, channel_update)) =
-            self.try_create_channel_messages(network).await
+            self.try_create_channel_messages().await
         {
             debug!(
                 "Channel announcement/update message for {:?} created, public channel is ready",
                 self.get_id(),
             );
-            self.on_channel_ready(network).await;
+            self.on_channel_ready().await;
 
             debug!(
                 "Broadcasting channel announcement {:?} and channel update {:?}",
                 &channel_announcement, &channel_update
             );
-            network
+            self.network()
                 .send_message(NetworkActorMessage::new_command(
                     NetworkActorCommand::BroadcastMessages(vec![
                         BroadcastMessageWithTimestamp::ChannelAnnouncement(
@@ -5866,14 +5842,14 @@ impl ChannelActorState {
         }
     }
 
-    async fn maybe_channel_is_ready(&mut self, network: &ActorRef<NetworkActorMessage>) {
+    async fn maybe_channel_is_ready(&mut self) {
         match self.state {
             ChannelState::AwaitingChannelReady(flags) => {
                 if flags.contains(AwaitingChannelReadyFlags::CHANNEL_READY) {
                     if !self.is_public() {
-                        self.on_channel_ready(network).await;
+                        self.on_channel_ready().await;
                     } else {
-                        self.maybe_public_channel_is_ready(network).await;
+                        self.maybe_public_channel_is_ready().await;
                     }
                 }
             }
@@ -5886,13 +5862,13 @@ impl ChannelActorState {
         }
     }
 
-    async fn on_channel_ready(&mut self, network: &ActorRef<NetworkActorMessage>) {
+    async fn on_channel_ready(&mut self) {
         self.update_state(ChannelState::ChannelReady());
         self.increment_local_commitment_number();
         self.increment_remote_commitment_number();
         let peer_id = self.get_remote_peer_id();
-        self.notify_owned_channel_updated(network, false).await;
-        network
+        self.notify_owned_channel_updated(false).await;
+        self.network()
             .send_message(NetworkActorMessage::new_event(
                 NetworkActorEvent::ChannelReady(
                     self.get_id(),
@@ -5924,7 +5900,6 @@ impl ChannelActorState {
 
     fn handle_revoke_and_ack_peer_message(
         &mut self,
-        network: &ActorRef<NetworkActorMessage>,
         revoke_and_ack: RevokeAndAck,
     ) -> Result<bool, ProcessingChannelError> {
         if !self.tlc_state.waiting_ack {
@@ -6039,7 +6014,7 @@ impl ChannelActorState {
         let need_commitment_signed = self
             .tlc_state
             .update_for_revoke_and_ack(self.commitment_numbers);
-        network
+        self.network()
             .send_message(NetworkActorMessage::new_notification(
                 NetworkServiceEvent::RevokeAndAckReceived(
                     self.get_remote_peer_id(),
@@ -6055,13 +6030,13 @@ impl ChannelActorState {
     async fn handle_reestablish_channel_message(
         &mut self,
         reestablish_channel: &ReestablishChannel,
-        network: &ActorRef<NetworkActorMessage>,
     ) -> ProcessingChannelResult {
         debug!(
             "Handling reestablish channel message: {:?}, our commitment_numbers {:?} in channel state {:?}",
             reestablish_channel, self.commitment_numbers, self.state
         );
         self.reestablishing = false;
+        let network = self.network();
         match self.state {
             ChannelState::NegotiatingFunding(_flags) => {
                 // TODO: in current implementation, we don't store the channel when we are in NegotiatingFunding state.
@@ -6170,7 +6145,7 @@ impl ChannelActorState {
                         .expect("must have set last_revoke_and_ack_remote_nonce")
                         .clone();
                     self.commit_remote_nonce(used_nonce);
-                    self.send_revoke_and_ack_message(network)?;
+                    self.send_revoke_and_ack_message()?;
                     // Now we can reset the remote nonce to the "real" last committed nonce
                     self.commit_remote_nonce(last_committed_nonce);
                     let need_commitment_signed = self.tlc_state.update_for_commitment_signed();
@@ -6192,7 +6167,7 @@ impl ChannelActorState {
                     );
                 }
 
-                self.notify_owned_channel_updated(network, false).await;
+                self.notify_owned_channel_updated(false).await;
 
                 debug_event!(network, "Reestablished channel in ChannelReady");
             }
@@ -6257,11 +6232,7 @@ impl ChannelActorState {
         }
     }
 
-    fn maybe_complete_tx_collaboration(
-        &mut self,
-        tx: Transaction,
-        network: &ActorRef<NetworkActorMessage>,
-    ) -> ProcessingChannelResult {
+    fn maybe_complete_tx_collaboration(&mut self, tx: Transaction) -> ProcessingChannelResult {
         let is_complete = self.is_tx_final(&tx)?;
 
         debug!(
@@ -6276,7 +6247,7 @@ impl ChannelActorState {
             // it receives another SendFiberMessage command, and that message (e.g. CommitmentSigned)
             // is processed first, thus breaking the order of messages.
             let commitment_tx_partial_signature = self.build_init_commitment_tx_signature()?;
-            network
+            self.network()
                 .send_message(NetworkActorMessage::new_command(
                     NetworkActorCommand::SendFiberMessage(FiberMessageWithPeerId::new(
                         self.get_remote_peer_id(),

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -306,7 +306,7 @@ impl ChannelActorStateStore for Store {
 
     fn insert_channel_actor_state(&self, state: ChannelActorState) {
         let mut batch = self.batch();
-        batch.put_kv(KeyValue::ChannelActorState(state.id, state.clone()));
+
         batch.put_kv(KeyValue::PeerIdChannelId(
             (state.get_remote_peer_id(), state.id),
             state.state,
@@ -314,6 +314,7 @@ impl ChannelActorStateStore for Store {
         if let Some(outpoint) = state.get_funding_transaction_outpoint() {
             batch.put_kv(KeyValue::OutPointChannelId(outpoint, state.id));
         }
+        batch.put_kv(KeyValue::ChannelActorState(state.id, state));
         batch.commit();
     }
 

--- a/src/store/tests/store.rs
+++ b/src/store/tests/store.rs
@@ -385,6 +385,7 @@ fn test_channel_actor_state_store() {
         remote_constraints: ChannelConstraints::default(),
         reestablishing: false,
         created_at: SystemTime::now(),
+        network: None,
     };
 
     let bincode_encoded = bincode::serialize(&state).unwrap();
@@ -496,6 +497,7 @@ fn test_serde_channel_actor_state_ciborium() {
         remote_constraints: ChannelConstraints::default(),
         reestablishing: false,
         created_at: SystemTime::now(),
+        network: None,
     };
 
     let mut serialized = Vec::new();


### PR DESCRIPTION
So we don't need to pass network actor ref in all the associated fn.