### PR TITLE
Add migration for custom records, hop hints and channel timestamps

### DIFF
--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -1870,6 +1870,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnn"
+version = "0.4.0"
+source = "git+https://github.com/nervosnetwork/fiber.git?rev=2a481d582dcbbb0a9401f48751cd1132cbaed6a6#2a481d582dcbbb0a9401f48751cd1132cbaed6a6"
+dependencies = [
+ "anyhow",
+ "arcode",
+ "bech32 0.8.1",
+ "bincode",
+ "bitcoin",
+ "bitflags 2.7.0",
+ "ckb-chain-spec",
+ "ckb-gen-types",
+ "ckb-hash 0.115.0",
+ "ckb-jsonrpc-types",
+ "ckb-resource",
+ "ckb-rocksdb",
+ "ckb-sdk",
+ "ckb-types",
+ "clap",
+ "clap-serde-derive",
+ "console",
+ "fiber-sphinx",
+ "futures",
+ "git-version",
+ "hex",
+ "home",
+ "indicatif",
+ "jsonrpsee",
+ "lightning-invoice",
+ "lnd-grpc-tonic-client",
+ "molecule",
+ "musig2",
+ "nom",
+ "num_enum",
+ "once_cell",
+ "ractor 0.14.2",
+ "rand 0.8.5",
+ "regex",
+ "secp256k1 0.28.2",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "serde_yaml",
+ "socket2",
+ "strum",
+ "tentacle",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "fnn-migrate"
 version = "0.4.0"
 dependencies = [
@@ -1883,6 +1937,7 @@ dependencies = [
  "fnn 0.3.1 (git+https://github.com/nervosnetwork/fiber.git?tag=v0.3.1)",
  "fnn 0.3.1 (git+https://github.com/nervosnetwork/fiber.git?tag=v0.4.0-rc1)",
  "fnn 0.4.0",
+ "fnn 0.4.0 (git+https://github.com/nervosnetwork/fiber.git?rev=2a481d582dcbbb0a9401f48751cd1132cbaed6a6)",
  "hex",
  "indicatif",
  "serde",
@@ -3157,9 +3212,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.7.0",
  "cfg-if 1.0.0",
@@ -3198,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",

--- a/migrate/Cargo.toml
+++ b/migrate/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [dependencies]
 rocksdb = { package = "ckb-rocksdb", version = "=0.21.1", features = [
-    "lz4"
+    "lz4",
 ], default-features = false }
 
 tracing = "0.1"
@@ -26,6 +26,7 @@ fiber_v021 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.gi
 fiber_v030 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", tag = "v0.3.0" }
 fiber_v031 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", tag = "v0.3.1" }
 fiber_v040 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", tag = "v0.4.0-rc1" }
+fiber_v041 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", rev = "2a481d582dcbbb0a9401f48751cd1132cbaed6a6" }
 
 [features]
 default = []

--- a/migrate/src/migrations/mig_20250307.rs
+++ b/migrate/src/migrations/mig_20250307.rs
@@ -1,0 +1,99 @@
+use fiber::{store::migration::Migration, Error};
+use indicatif::ProgressBar;
+use rocksdb::ops::Iterate;
+use rocksdb::ops::Put;
+use rocksdb::DB;
+use std::sync::Arc;
+use tracing::info;
+
+use crate::util::convert;
+
+const MIGRATION_DB_VERSION: &str = "20250307160623";
+
+pub use fiber_v040::fiber::graph::PaymentSession as OldPaymentSession;
+pub use fiber_v040::fiber::network::SendPaymentData as OldSendPaymentData;
+pub use fiber_v041::fiber::graph::PaymentSession as NewPaymentSession;
+pub use fiber_v041::fiber::network::SendPaymentData as NewSendPaymentData;
+
+pub struct MigrationObj {
+    version: String,
+}
+
+impl MigrationObj {
+    pub fn new() -> Self {
+        Self {
+            version: MIGRATION_DB_VERSION.to_string(),
+        }
+    }
+}
+
+impl Migration for MigrationObj {
+    fn migrate(
+        &self,
+        db: Arc<DB>,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<Arc<DB>, Error> {
+        info!(
+            "MigrationObj::migrate to {} ...........",
+            MIGRATION_DB_VERSION
+        );
+
+        const PAYMENT_SESSION_PREFIX: u8 = 192;
+        let prefix = vec![PAYMENT_SESSION_PREFIX];
+
+        for (k, v) in db
+            .prefix_iterator(prefix.as_slice())
+            .take_while(move |(col_key, _)| col_key.starts_with(prefix.as_slice()))
+        {
+            let old_payment_session: OldPaymentSession =
+                bincode::deserialize(&v).expect("deserialize to old channel state");
+
+            let old_request = old_payment_session.request.clone();
+
+            let request = NewSendPaymentData {
+                target_pubkey: convert(old_request.target_pubkey),
+                amount: old_request.amount,
+                payment_hash: convert(old_request.payment_hash),
+                invoice: old_request.invoice,
+                final_tlc_expiry_delta: old_request.final_tlc_expiry_delta,
+                tlc_expiry_limit: old_request.tlc_expiry_limit,
+                timeout: old_request.timeout,
+                max_fee_amount: old_request.max_fee_amount,
+                max_parts: old_request.max_parts,
+                keysend: old_request.keysend,
+                udt_type_script: old_request.udt_type_script,
+                preimage: convert(old_request.preimage),
+                allow_self_payment: old_request.allow_self_payment,
+                dry_run: old_request.dry_run,
+                // TODO: custom records also requires a migration.
+                // Is this the right way to handle this?
+                custom_records: None,
+                // The meaning of hop_hints changed, we are dropping previous hop hints.
+                hop_hints: vec![],
+            };
+
+            let new_payment_session = NewPaymentSession {
+                request: request,
+                retried_times: old_payment_session.retried_times,
+                last_error: old_payment_session.last_error,
+                try_limit: old_payment_session.try_limit,
+                status: convert(old_payment_session.status),
+                created_at: old_payment_session.created_at,
+                last_updated_at: old_payment_session.last_updated_at,
+                route: convert(old_payment_session.route),
+                session_key: old_payment_session.session_key,
+            };
+
+            let new_payment_session_bytes =
+                bincode::serialize(&new_payment_session).expect("serialize to new channel state");
+
+            db.put(k, new_payment_session_bytes)
+                .expect("save new channel state");
+        }
+        Ok(db)
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+}

--- a/migrate/src/migrations/mig_20250307.rs
+++ b/migrate/src/migrations/mig_20250307.rs
@@ -45,6 +45,10 @@ impl Migration for MigrationObj {
             .prefix_iterator(prefix.as_slice())
             .take_while(move |(col_key, _)| col_key.starts_with(prefix.as_slice()))
         {
+            if let Ok(_) = bincode::deserialize::<NewSendPaymentData>(&v) {
+                // if we can deserialize the data correctly with new version, just skip it.
+                continue;
+            }
             let old_payment_session: OldPaymentSession =
                 bincode::deserialize(&v).expect("deserialize to old channel state");
 
@@ -65,8 +69,6 @@ impl Migration for MigrationObj {
                 preimage: convert(old_request.preimage),
                 allow_self_payment: old_request.allow_self_payment,
                 dry_run: old_request.dry_run,
-                // TODO: custom records also requires a migration.
-                // Is this the right way to handle this?
                 custom_records: None,
                 // The meaning of hop_hints changed, we are dropping previous hop hints.
                 hop_hints: vec![],

--- a/migrate/src/migrations/mig_20250308.rs
+++ b/migrate/src/migrations/mig_20250308.rs
@@ -1,0 +1,72 @@
+use fiber::{store::migration::Migration, Error};
+use indicatif::ProgressBar;
+use rocksdb::ops::{Delete, Get, Iterate, Put};
+use rocksdb::DB;
+use std::sync::Arc;
+use tracing::info;
+
+const MIGRATION_DB_VERSION: &str = "20250308000623";
+
+pub struct MigrationObj {
+    version: String,
+}
+
+impl MigrationObj {
+    pub fn new() -> Self {
+        Self {
+            version: MIGRATION_DB_VERSION.to_string(),
+        }
+    }
+}
+
+impl Migration for MigrationObj {
+    fn migrate(
+        &self,
+        db: Arc<DB>,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<Arc<DB>, Error> {
+        info!(
+            "MigrationObj::migrate to {} ...........",
+            MIGRATION_DB_VERSION
+        );
+
+        const BROADCAST_MESSAGE_TIMESTAMP_PREFIX: u8 = 97;
+        const CHANNEL_ANNOUNCEMENT_PREFIX: u8 = 0;
+        const CHANNEL_UPDATE_PREFIX: u8 = 1;
+        let channel_announcement_timestamp_prefix = [
+            BROADCAST_MESSAGE_TIMESTAMP_PREFIX,
+            CHANNEL_ANNOUNCEMENT_PREFIX,
+        ];
+        let channel_update_timestamp_prefix =
+            [BROADCAST_MESSAGE_TIMESTAMP_PREFIX, CHANNEL_UPDATE_PREFIX];
+
+        for (k, channel_update_timestamps) in db
+            .prefix_iterator(channel_update_timestamp_prefix.as_slice())
+            .take_while(move |(col_key, _)| {
+                col_key.starts_with(channel_update_timestamp_prefix.as_slice())
+            })
+        {
+            assert_eq!(channel_update_timestamps.len(), 24);
+            let outpoint = &k[2..];
+            let channel_announcement_key =
+                [channel_announcement_timestamp_prefix.as_slice(), outpoint].concat();
+            if let Some(channel_announcement_timestamps) = db
+                .get(channel_announcement_timestamp_prefix)
+                .expect("read channel announcement timestamps")
+            {
+                assert_eq!(channel_update_timestamps.len(), 24);
+                let mut timestamps = [0u8; 24];
+                timestamps[..8].copy_from_slice(&channel_announcement_timestamps[..8]);
+                timestamps[8..24].copy_from_slice(&channel_update_timestamps[8..24]);
+                db.put(channel_announcement_key, timestamps)
+                    .expect("save new channel state");
+                db.delete(k).expect("delete old channel state");
+            }
+        }
+        Ok(db)
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+}

--- a/migrate/src/migrations/mod.rs
+++ b/migrate/src/migrations/mod.rs
@@ -6,3 +6,4 @@ pub mod mig_20250115;
 pub mod mig_20250123;
 pub mod mig_20250227;
 pub mod mig_20250307;
+pub mod mig_20250308;

--- a/migrate/src/migrations/mod.rs
+++ b/migrate/src/migrations/mod.rs
@@ -5,3 +5,4 @@ pub mod mig_20250114;
 pub mod mig_20250115;
 pub mod mig_20250123;
 pub mod mig_20250227;
+pub mod mig_20250307;


### PR DESCRIPTION
From https://github.com/nervosnetwork/fiber/tree/v0.4.0 to https://github.com/nervosnetwork/fiber/commit/2a481d582dcbbb0a9401f48751cd1132cbaed6a6, we merged 3 PRs that requires migration. The [code changes](https://github.com/nervosnetwork/fiber/compare/v0.4.0...2a481d582dcbbb0a9401f48751cd1132cbaed6a6), AFAIK, contains 3 PRs need migration.

- [x] [Prune old gossip messages by contrun · Pull Request #541 · nervosnetwork/fiber](https://github.com/nervosnetwork/fiber/pull/541)
- [x] [Handle private channel hop hints by contrun · Pull Request #487 · nervosnetwork/fiber](https://github.com/nervosnetwork/fiber/pull/487)
- [x] [Add payment custom records by chenyukang · Pull Request #443 · nervosnetwork/fiber](https://github.com/nervosnetwork/fiber/pull/443)

It is not the best practice to add all migrations in one big PR. But I am unable to compile the migration code without also adding custom record (the code for custom record is merged before the merging of handle private channel hop hints). So the migration for custom record is also added here.
