### PR TITLE
chore: Add dependent abot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    timezone: Asia/Shanghai
+  open-pull-requests-limit: 10
+  versioning-strategy: lockfile-only


### PR DESCRIPTION
Need to enable `Dependabot alerts` in settings.