### PR TITLE
fix: resolve pending tlc expiry time bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
  "ckb-crypto",
  "ckb-dao-utils",
  "ckb-error",
- "ckb-hash",
+ "ckb-hash 0.118.0",
  "ckb-jsonrpc-types",
  "ckb-logger",
  "ckb-pow",
@@ -796,10 +796,20 @@ dependencies = [
  "cfg-if 1.0.0",
  "ckb-error",
  "ckb-fixed-hash",
- "ckb-hash",
+ "ckb-hash 0.118.0",
  "ckb-occupied-capacity",
  "molecule",
  "numext-fixed-uint",
+]
+
+[[package]]
+name = "ckb-hash"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a80b274a236255963e7a9fe73eea35623a46de7f2d8548278f024b5eb0a7c7"
+dependencies = [
+ "blake2b-ref",
+ "blake2b-rs",
 ]
 
 [[package]]
@@ -906,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069c3db99adb9d350d186de8e02a43e77dff7be2a8b9b7cf61ba80a280e2dd00"
 dependencies = [
  "byteorder",
- "ckb-hash",
+ "ckb-hash 0.118.0",
  "ckb-types",
  "eaglesong",
  "log",
@@ -958,7 +968,7 @@ dependencies = [
  "byteorder",
  "ckb-chain-spec",
  "ckb-error",
- "ckb-hash",
+ "ckb-hash 0.118.0",
  "ckb-logger",
  "ckb-traits",
  "ckb-types",
@@ -981,7 +991,7 @@ dependencies = [
  "ckb-chain-spec",
  "ckb-crypto",
  "ckb-dao-utils",
- "ckb-hash",
+ "ckb-hash 0.118.0",
  "ckb-jsonrpc-types",
  "ckb-mock-tx-types",
  "ckb-resource",
@@ -1039,7 +1049,7 @@ dependencies = [
  "ckb-chain-spec",
  "ckb-crypto",
  "ckb-error",
- "ckb-hash",
+ "ckb-hash 0.118.0",
  "ckb-jsonrpc-types",
  "ckb-mock-tx-types",
  "ckb-resource",
@@ -1074,7 +1084,7 @@ dependencies = [
  "ckb-error",
  "ckb-fixed-hash",
  "ckb-gen-types",
- "ckb-hash",
+ "ckb-hash 0.118.0",
  "ckb-merkle-mountain-range",
  "ckb-occupied-capacity",
  "ckb-rational",
@@ -1647,14 +1657,14 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "arcode",
- "bech32 0.9.1",
+ "bech32 0.8.1",
  "bincode",
  "bitcoin",
  "bitflags 2.6.0",
  "ciborium",
  "ckb-chain-spec",
  "ckb-gen-types",
- "ckb-hash",
+ "ckb-hash 0.115.0",
  "ckb-jsonrpc-types",
  "ckb-resource",
  "ckb-rocksdb",

--- a/src/watchtower/actor.rs
+++ b/src/watchtower/actor.rs
@@ -860,7 +860,7 @@ fn build_settlement_tx_for_pending_tlcs<S: InvoiceStore>(
                     let pubkey_hash = blake2b_256(settlement_tlc.local_key.pubkey().serialize());
                     if settlement_tlc.tlc_id.is_offered() {
                         if pubkey_hash.starts_with(tlc.local_pubkey_hash())
-                            && tlc.expiry() < current_time
+                            && settlement_tlc.expiry < current_time
                         {
                             Some((index, settlement_tlc.clone(), None))
                         } else if pubkey_hash.starts_with(tlc.remote_pubkey_hash()) {
@@ -871,7 +871,7 @@ fn build_settlement_tx_for_pending_tlcs<S: InvoiceStore>(
                             None
                         }
                     } else if pubkey_hash.starts_with(tlc.remote_pubkey_hash())
-                        && tlc.expiry() < current_time
+                        && settlement_tlc.expiry < current_time
                     {
                         Some((index, settlement_tlc.clone(), None))
                     } else if pubkey_hash.starts_with(tlc.local_pubkey_hash()) {
@@ -1246,11 +1246,6 @@ impl<'a> Tlc<'a> {
 
     pub fn local_pubkey_hash(&self) -> &'a [u8] {
         &self.0[57..77]
-    }
-
-    pub fn expiry(&self) -> u64 {
-        let expiry = u64::from_le_bytes(self.0[77..85].try_into().unwrap());
-        Since::from_raw_value(expiry).extract_metric().unwrap().1
     }
 }
 

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/01-connect-peer.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/01-connect-peer.bru
@@ -1,0 +1,38 @@
+meta {
+  name: connect peer
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "connect_peer",
+    "params": [
+      {"address": "{{NODE1_ADDR}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  // Dialing a peer is async in tentacle. Sleep for some time to make sure
+  // we're connected to the peer.
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/02-get-node1-funding-script.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/02-get-node1-funding-script.bru
@@ -1,0 +1,29 @@
+meta {
+  name: get node1 funding script
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "node_info",
+    "params": []
+  }
+}
+
+script:post-response {
+  bru.setVar("NODE1_FUNDING_SCRIPT", res.body.result.default_funding_lock_script);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/03-get-node2-funding-script.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/03-get-node2-funding-script.bru
@@ -1,0 +1,29 @@
+meta {
+  name: get node2 funding script
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "node_info",
+    "params": []
+  }
+}
+
+script:post-response {
+  bru.setVar("NODE2_FUNDING_SCRIPT", res.body.result.default_funding_lock_script);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/04-get-node1-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/04-get-node1-balance.bru
@@ -1,0 +1,40 @@
+meta {
+  name: get node1 balance
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "get_cells_capacity",
+    "params": [
+      {
+        "script_type": "lock"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  let script = bru.getVar("NODE1_FUNDING_SCRIPT");
+  let body = req.getBody();
+  body.params[0].script = script;
+  req.setBody(body);
+}
+
+script:post-response {
+  bru.setVar("NODE1_BALANCE", res.body.result.capacity);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/05-get-node2-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/05-get-node2-balance.bru
@@ -1,0 +1,40 @@
+meta {
+  name: get node2 balance
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "get_cells_capacity",
+    "params": [
+      {
+        "script_type": "lock"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  let script = bru.getVar("NODE2_FUNDING_SCRIPT");
+  let body = req.getBody();
+  body.params[0].script = script;
+  req.setBody(body);
+}
+
+script:post-response {
+  bru.setVar("NODE2_BALANCE", res.body.result.capacity);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/06-open-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/06-open-channel.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Node1 open a channel to Node2 with amount 99 ckb
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "open_channel",
+    "params": [
+      {
+        "peer_id": "{{NODE2_PEERID}}",
+        "funding_amount": "0x24e160300"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.temporary_channel_id: isDefined
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 2000));
+    bru.setVar("N1N2_TEMP_CHANNEL_ID", res.body.result.temporary_channel_id);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/07-accept-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/07-accept-channel.bru
@@ -1,0 +1,41 @@
+meta {
+  name: node2 accept channel
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "accept_channel",
+    "params": [
+      {
+        "temporary_channel_id": "{{N1N2_TEMP_CHANNEL_ID}}",
+        "funding_amount": "0x1718c7e00"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+}
+
+script:post-response {
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 1000));
+  console.log("accept channel result: ", res.body);
+  bru.setVar("CHANNEL_ID", res.body.result.channel_id);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/08-generate-blocks-for-funding-tx.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/08-generate-blocks-for-funding-tx.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few blocks
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x1"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/09-node1-add-tlc1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/09-node1-add-tlc1.bru
@@ -1,0 +1,49 @@
+meta {
+  name: node1 add tlc1, 3000000 shannons
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "add_tlc",
+    "params": [
+      {
+        "channel_id": "{{CHANNEL_ID}}",
+        "amount": "0x2dc6c0",
+        "payment_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "expiry": "{{expiry}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isDefined
+}
+
+script:pre-request {
+  // a long expiry: 30 seconds
+  let expiry = "0x" + (Date.now() + 1000 * 30).toString(16);
+  bru.setVar("expiry", expiry);
+}
+
+script:post-response {
+  console.log("generated result: ", res.body.result);
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/10-node1-add-tlc2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/10-node1-add-tlc2.bru
@@ -1,0 +1,49 @@
+meta {
+  name: node1 add tlc2, 6000000 shannons
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "add_tlc",
+    "params": [
+      {
+        "channel_id": "{{CHANNEL_ID}}",
+        "amount": "0x5b8d80",
+        "payment_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "expiry": "{{expiry}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isDefined
+}
+
+script:pre-request {
+  // 10 seconds expiry
+  let expiry = "0x" + (Date.now() + 1000 * 10).toString(16);
+  bru.setVar("expiry", expiry);
+}
+
+script:post-response {
+  console.log("generated result: ", res.body.result);
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/11-node1-add-tlc3.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/11-node1-add-tlc3.bru
@@ -1,0 +1,49 @@
+meta {
+  name: node1 add tlc3, 9000000 shannons
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "add_tlc",
+    "params": [
+      {
+        "channel_id": "{{CHANNEL_ID}}",
+        "amount": "0x895440",
+        "payment_hash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+        "expiry": "{{expiry}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isDefined
+}
+
+script:pre-request {
+  // 10 seconds expiry
+  let expiry = "0x" + (Date.now() + 1000 * 10).toString(16);
+  bru.setVar("expiry", expiry);
+}
+
+script:post-response {
+  console.log("generated result: ", res.body.result);
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/12-force-close.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/12-force-close.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Node1 force close channel
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "shutdown_channel",
+    "params": [
+      {
+        "channel_id": "{{CHANNEL_ID}}",
+        "close_script": {
+          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
+          "hash_type": "data",
+          "args": "0x0101010101010101010101010101010101010101"
+        },
+        "fee_rate": "0x3FC",
+        "force": true
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/13-node2-stop-watchtower.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/13-node2-stop-watchtower.bru
@@ -1,0 +1,34 @@
+meta {
+  name: remove watched channel from node2 watchtower
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "remove_watch_channel",
+    "params": [
+      {
+        "channel_id": "{{CHANNEL_ID}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isDefined
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/14-get-force-closed-commitment-tx-hash.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/14-get-force-closed-commitment-tx-hash.bru
@@ -1,0 +1,40 @@
+meta {
+  name: get force closed commitment tx hash
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE2_PEERID}}",
+        "include_closed": true
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.channels: isDefined
+}
+
+script:post-response {
+  console.log(res.body.result);
+  bru.setVar("TX_HASH", res.body.result.channels[0].latest_commitment_transaction_hash);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/15-generate-blocks-for-commitment-tx.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/15-generate-blocks-for-commitment-tx.bru
@@ -1,0 +1,34 @@
+meta {
+  name: generate a few blocks for commitment tx
+  type: http
+  seq: 15
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x1"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  // Wait for the commitment tx to be included in a block
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/16-generate-blocks-for-onchain-timestamp-updates.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/16-generate-blocks-for-onchain-timestamp-updates.bru
@@ -1,0 +1,39 @@
+meta {
+  name: generate a few blocks for onchain timestamp updates
+  type: http
+  seq: 16
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x4"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:pre-request {
+  // wait 10 seconds for the onchain timestamp to be updated
+  await new Promise(r => setTimeout(r, 10000));
+}
+
+script:post-response {
+  // Wait for the settlement tlc2 to be generated
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/17-generate-blocks-for-settlement-tlc2-committed.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/17-generate-blocks-for-settlement-tlc2-committed.bru
@@ -1,0 +1,34 @@
+meta {
+  name: generate a few blocks for settlement tlc2 committed
+  type: http
+  seq: 17
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x5"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  // Wait for the settlement tlc3 to be generated
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/18-generate-blocks-for-settlement-tlc3-committed.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/18-generate-blocks-for-settlement-tlc3-committed.bru
@@ -1,0 +1,34 @@
+meta {
+  name: generate a few blocks for settlement tlc3 committed
+  type: http
+  seq: 18
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x5"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  // Wait for the settlement tlc1 expiry time to be reached
+  await new Promise(r => setTimeout(r, 30000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/19-generate-blocks-for-onchain-timestamp-updates.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/19-generate-blocks-for-onchain-timestamp-updates.bru
@@ -1,0 +1,34 @@
+meta {
+  name: generate a few blocks for onchain timestamp updates
+  type: http
+  seq: 19
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x4"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  // Wait for the settlement tlc3 to be generated
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/20-generate-blocks-for-settlement-tlc1-committed.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/20-generate-blocks-for-settlement-tlc1-committed.bru
@@ -1,0 +1,34 @@
+meta {
+  name: generate a few blocks for settlement tlc1 to be committed
+  type: http
+  seq: 20
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x10"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  // Wait for the final settlement tx to be generated
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/21-generate-blocks-for-final-settlement-tx-committed.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/21-generate-blocks-for-final-settlement-tx-committed.bru
@@ -1,0 +1,29 @@
+meta {
+  name: generate a few blocks for final settlement tx to be committed
+  type: http
+  seq: 21
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x1"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/22-check-commitment-tx.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/22-check-commitment-tx.bru
@@ -1,0 +1,39 @@
+meta {
+  name: check submitted commitment tx should be settled
+  type: http
+  seq: 22
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "get_live_cell",
+    "params": [
+      {
+        "index": "0x0",
+        "tx_hash": "{{TX_HASH}}"
+      },
+      false
+    ]
+  }
+}
+
+assert {
+  res.body.result.status: eq "unknown"
+}
+
+script:post-response {
+  console.log("generated result: ", res.body);
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/23-check-balance-node1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/23-check-balance-node1.bru
@@ -1,0 +1,40 @@
+meta {
+  name: check balance, the difference should be the fee (it may vary, max 5000)
+  type: http
+  seq: 23
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "get_cells_capacity",
+    "params": [
+      {
+        "script_type": "lock"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  let script = bru.getVar("NODE1_FUNDING_SCRIPT");
+  let body = req.getBody();
+  body.params[0].script = script;
+  req.setBody(body);
+}
+
+assert {
+  Number(BigInt(bru.getVar("NODE1_BALANCE")) - BigInt(res.body.result.capacity)): lt 5000
+}

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/24-check-balance-node2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/24-check-balance-node2.bru
@@ -1,0 +1,40 @@
+meta {
+  name: check balance, the difference should be the fee (it may vary, max 5000)
+  type: http
+  seq: 24
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "get_cells_capacity",
+    "params": [
+      {
+        "script_type": "lock"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  let script = bru.getVar("NODE2_FUNDING_SCRIPT");
+  let body = req.getBody();
+  body.params[0].script = script;
+  req.setBody(body);
+}
+
+assert {
+  Number(BigInt(bru.getVar("NODE2_BALANCE")) - BigInt(res.body.result.capacity)): lt 5000
+}


### PR DESCRIPTION
The bug is that the code incorrectly compares `tlc.expiry` with current_time, which is divided by 1000 in witness, we should use the settlement data's expiry time.