### PR TITLE
Add rpc unit test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.31",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
 dependencies = [
  "jsonrpsee-core",
+ "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
@@ -2603,6 +2620,26 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
+dependencies = [
+ "async-trait",
+ "hyper 0.14.31",
+ "hyper-rustls",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3658,7 +3695,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3752,6 +3789,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,6 +3835,16 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -3820,6 +3900,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -4533,6 +4623,16 @@ checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
 dependencies = [
  "openssl",
  "openssl-sys",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ debug = false
 tempfile = "3.10.1"
 ckb-testtool = "0.15.1"
 ciborium = "0.2.2"
+jsonrpsee = { version = "0.22", features = ["server", "macros", "http-client"] }
+
 
 [lints.clippy]
 needless-return = "allow"

--- a/src/fiber/graph.rs
+++ b/src/fiber/graph.rs
@@ -13,6 +13,7 @@ use crate::ckb::config::UdtCfgInfos;
 use crate::fiber::fee::calculate_tlc_forward_fee;
 use crate::fiber::path::NodeHeapElement;
 use crate::fiber::serde_utils::EntityHex;
+use crate::fiber::serde_utils::U128Hex;
 use crate::fiber::types::PaymentHopData;
 use crate::invoice::CkbInvoice;
 use crate::now_timestamp_as_millis_u64;
@@ -1352,6 +1353,7 @@ pub struct SessionRouteNode {
     /// the public key of the node
     pub pubkey: Pubkey,
     /// the amount for this hop
+    #[serde_as(as = "U128Hex")]
     pub amount: u128,
     /// the channel outpoint for this hop
     #[serde_as(as = "EntityHex")]

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -1707,7 +1707,6 @@ async fn test_send_payment_with_3_nodes() {
         create_3_nodes_with_established_channel(
             (100000000000, 100000000000),
             (100000000000, 100000000000),
-            true,
         )
         .await;
     let node_a_local = node_a.get_local_balance_from_channel(channel_1);
@@ -1777,14 +1776,13 @@ async fn test_send_payment_with_3_nodes() {
 async fn test_send_payment_with_rev_3_nodes() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         vec![
             ((2, 1), (100000000000, 100000000000)),
             ((1, 0), (100000000000, 100000000000)),
         ]
         .as_slice(),
         3,
-        true,
     )
     .await;
 
@@ -1858,8 +1856,7 @@ async fn test_send_payment_with_max_nodes() {
     let nodes_num = 15;
     let last = nodes_num - 1;
     let amounts = vec![(100000000000, 100000000000); nodes_num - 1];
-    let (nodes, channels) =
-        create_n_nodes_with_established_channel(&amounts, nodes_num, true).await;
+    let (nodes, channels) = create_n_nodes_with_established_channel(&amounts, nodes_num).await;
     let target_pubkey = nodes[last].pubkey;
 
     let sender_local = nodes[0].get_local_balance_from_channel(channels[0]);
@@ -1930,7 +1927,6 @@ async fn test_send_payment_with_3_nodes_overflow() {
     let (node_a, _node_b, node_c, ..) = create_3_nodes_with_established_channel(
         (1000000000 * 100000000, 1000000000 * 100000000),
         (1000000000 * 100000000, 1000000000 * 100000000),
-        true,
     )
     .await;
 
@@ -1976,7 +1972,6 @@ async fn test_send_payment_fail_with_3_nodes_invalid_hash() {
     let (node_a, node_b, node_c, channel_1, channel_2) = create_3_nodes_with_established_channel(
         (100000000000, 100000000000),
         (100000000000, 100000000000),
-        true,
     )
     .await;
 
@@ -2054,7 +2049,6 @@ async fn test_send_payment_fail_with_3_nodes_final_tlc_expiry_delta() {
     let (node_a, _node_b, node_c, ..) = create_3_nodes_with_established_channel(
         (100000000000, 100000000000),
         (100000000000, 100000000000),
-        true,
     )
     .await;
 
@@ -2153,7 +2147,6 @@ async fn test_send_payment_fail_with_3_nodes_dry_run_fee() {
     let (node_a, _node_b, node_c, ..) = create_3_nodes_with_established_channel(
         (100000000000, 100000000000),
         (100000000000, 100000000000),
-        true,
     )
     .await;
 
@@ -3609,13 +3602,12 @@ async fn test_channel_update_tlc_expiry() {
 
 #[tokio::test]
 async fn test_forward_payment_channel_disabled() {
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
     let [node_a, node_b, node_c] = nodes.try_into().expect("3 nodes");
@@ -3705,13 +3697,12 @@ async fn test_forward_payment_channel_disabled() {
 
 #[tokio::test]
 async fn test_forward_payment_tlc_minimum_value() {
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
     let [node_a, node_b, node_c] = nodes.try_into().expect("3 nodes");
@@ -3923,13 +3914,12 @@ async fn test_forward_payment_tlc_minimum_value() {
 #[tokio::test]
 async fn test_send_payment_with_outdated_fee_rate() {
     init_tracing();
-    let (nodes, _) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
     let [node_a, node_b, node_c] = nodes.try_into().expect("3 nodes");
@@ -5200,8 +5190,7 @@ async fn test_send_payment_with_channel_balance_error() {
     let _span = tracing::info_span!("node", node = "test").entered();
     let nodes_num = 4;
     let amounts = vec![(100000000000, 100000000000); nodes_num - 1];
-    let (nodes, channels) =
-        create_n_nodes_with_established_channel(&amounts, nodes_num, true).await;
+    let (nodes, channels) = create_n_nodes_with_established_channel(&amounts, nodes_num).await;
     let [node_0, _node_1, node_2, node_3] = nodes.try_into().expect("4 nodes");
     let source_node = &node_0;
     let target_pubkey = node_3.pubkey;
@@ -5286,8 +5275,7 @@ async fn test_send_payment_with_disable_channel() {
     let _span = tracing::info_span!("node", node = "test").entered();
     let nodes_num = 4;
     let amounts = vec![(100000000000, 100000000000); nodes_num - 1];
-    let (nodes, channels) =
-        create_n_nodes_with_established_channel(&amounts, nodes_num, true).await;
+    let (nodes, channels) = create_n_nodes_with_established_channel(&amounts, nodes_num).await;
     let [node_0, _node_1, node_2, node_3] = nodes.try_into().expect("4 nodes");
 
     // begin to set channel disable, but do not notify the network
@@ -5324,7 +5312,7 @@ async fn test_send_payment_with_multiple_edges_in_middle_hops() {
     // we have two chaneels between node_1 and node_2, they are all with the same meta information except the later one has more capacity
     // path finding will try the channel with larger capacity first, so we assert the payment retry times is 1
     // the send payment should be succeed
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (MIN_RESERVED_CKB + 900, 5200000000)),
@@ -5332,7 +5320,6 @@ async fn test_send_payment_with_multiple_edges_in_middle_hops() {
             ((2, 3), (100000000000, 100000000000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5381,7 +5368,7 @@ async fn test_send_payment_with_all_failed_middle_hops() {
     // we have two chaneels between node_1 and node_2
     // they liquid capacity is enough for send payment, but actual balance are both not enough
     // path finding will all try them but all failed, so we assert the payment retry times is 3
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (MIN_RESERVED_CKB + 900, MIN_RESERVED_CKB + 1000)),
@@ -5389,7 +5376,6 @@ async fn test_send_payment_with_all_failed_middle_hops() {
             ((2, 3), (100000000000, 100000000000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5440,7 +5426,7 @@ async fn test_send_payment_with_multiple_edges_can_succeed_in_retry() {
     // but even channel_2's capacity is larger, the to_local_amount is not enough for the payment
     // path finding will retry the first channel and the send payment should be succeed
     // the payment retry times should be 2
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (MIN_RESERVED_CKB + 1000, 5200000000)),
@@ -5448,7 +5434,6 @@ async fn test_send_payment_with_multiple_edges_can_succeed_in_retry() {
             ((2, 3), (100000000000, 100000000000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5497,7 +5482,7 @@ async fn test_send_payment_with_final_hop_multiple_edges_in_middle_hops() {
     // we have two chaneels between node_2 and node_3, they are all with the same meta information except the later one has more capacity
     // path finding will try the channel with larger capacity first, so we assert the payment retry times is 1
     // the send payment should be succeed
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -5505,7 +5490,6 @@ async fn test_send_payment_with_final_hop_multiple_edges_in_middle_hops() {
             ((2, 3), (MIN_RESERVED_CKB + 1000, 5200000000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5554,7 +5538,7 @@ async fn test_send_payment_with_final_all_failed_middle_hops() {
     // we have two chaneels between node_2 and node_3
     // they liquid capacity is enough for send payment, but actual balance are both not enough
     // path finding will all try them but all failed, so we assert the payment retry times is 3
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -5562,7 +5546,6 @@ async fn test_send_payment_with_final_all_failed_middle_hops() {
             ((2, 3), (MIN_RESERVED_CKB + 910, MIN_RESERVED_CKB + 1000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5611,7 +5594,7 @@ async fn test_send_payment_with_final_multiple_edges_can_succeed_in_retry() {
     // but even channel_2's capacity is larger, the to_local_amount is not enough for the payment
     // path finding will retry the first channel and the send payment should be succeed
     // the payment retry times should be 2
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -5619,7 +5602,6 @@ async fn test_send_payment_with_final_multiple_edges_can_succeed_in_retry() {
             ((2, 3), (MIN_RESERVED_CKB + 900, 6200000000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5664,7 +5646,7 @@ async fn test_send_payment_with_final_multiple_edges_can_succeed_in_retry() {
 async fn test_send_payment_with_first_hop_failed_with_fee() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             // even 1000 > 999, but it's not enough for fee, and this is the direct channel
             // so we can check the actual balance of channel
@@ -5674,7 +5656,6 @@ async fn test_send_payment_with_first_hop_failed_with_fee() {
             ((2, 3), (100000000000, 100000000000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5717,7 +5698,7 @@ async fn test_send_payment_succeed_with_multiple_edges_in_first_hop() {
     // we have two chaneels between node_0 and node_1, they are all with the same meta information except the later one has more capacity
     // path finding will try the channel with larger capacity first, so we assert the payment retry times is 1
     // the send payment should be succeed
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 900, 5200000000)),
             ((0, 1), (MIN_RESERVED_CKB + 1001, 5200000000)),
@@ -5725,7 +5706,6 @@ async fn test_send_payment_succeed_with_multiple_edges_in_first_hop() {
             ((2, 3), (100000000000, 100000000000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5773,7 +5753,7 @@ async fn test_send_payment_with_first_hop_all_failed() {
     // we have two chaneels between node_0 and node_1
     // they liquid capacity is enough for send payment, but actual balance are both not enough
     // path finding will fail in the first time of send payment
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 900, MIN_RESERVED_CKB + 1000)),
             ((0, 1), (MIN_RESERVED_CKB + 910, MIN_RESERVED_CKB + 1000)),
@@ -5781,7 +5761,6 @@ async fn test_send_payment_with_first_hop_all_failed() {
             ((2, 3), (100000000000, 100000000000)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5826,7 +5805,7 @@ async fn test_send_payment_will_succeed_with_direct_channel_info_first_hop() {
     // but we manually set the to_local_amount to smaller value for testing
     // path finding will get the direct channel info with actual balance of channel,
     // so it will try the channel with smaller capacity and the payment will succeed
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 2000, MIN_RESERVED_CKB + 1000)),
             ((0, 1), (MIN_RESERVED_CKB + 1005, MIN_RESERVED_CKB + 1000)),
@@ -5834,7 +5813,6 @@ async fn test_send_payment_will_succeed_with_direct_channel_info_first_hop() {
             ((2, 3), (100000000000, 100000000000)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5890,7 +5868,7 @@ async fn test_send_payment_will_succeed_with_retry_in_middle_hops() {
     // but we manually set the to_local_amount to smaller value for testing
     // path finding will get a temporary failure in the first try and retry the second channel
     // so it will try the channel with smaller capacity and the payment will succeed
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -5898,7 +5876,6 @@ async fn test_send_payment_will_succeed_with_retry_in_middle_hops() {
             ((2, 3), (MIN_RESERVED_CKB + 1005, MIN_RESERVED_CKB + 1000)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, _node_1, node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -5961,7 +5938,7 @@ async fn test_send_payment_will_fail_with_last_hop_info_in_add_tlc_peer() {
     // but we manually set the to_remote_amount for node_3 to a larger amount,
     // this will make node3 trigger error in add_tlc_peer and got an Musig2VerifyError(BadSignature)
     // the send_payment will failed with retry times of 1
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -5969,7 +5946,6 @@ async fn test_send_payment_will_fail_with_last_hop_info_in_add_tlc_peer() {
             ((2, 3), (MIN_RESERVED_CKB + 1005, MIN_RESERVED_CKB + 1000)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, _node_1, _node_2, mut node_3] = nodes.try_into().expect("4 nodes");
@@ -6028,7 +6004,7 @@ async fn test_send_payment_will_fail_with_invoice_not_generated_by_target() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
 
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -6036,7 +6012,6 @@ async fn test_send_payment_will_fail_with_invoice_not_generated_by_target() {
             ((2, 3), (MIN_RESERVED_CKB + 1005, MIN_RESERVED_CKB + 1000)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -6087,7 +6062,7 @@ async fn test_send_payment_will_succeed_with_valid_invoice() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
 
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -6095,7 +6070,6 @@ async fn test_send_payment_will_succeed_with_valid_invoice() {
             ((2, 3), (MIN_RESERVED_CKB + 1005, MIN_RESERVED_CKB + 1000)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, _node_1, _node_2, mut node_3] = nodes.try_into().expect("4 nodes");
@@ -6159,7 +6133,7 @@ async fn test_send_payment_will_succeed_with_valid_invoice() {
 async fn test_send_payment_will_fail_with_no_invoice_preimage() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -6167,7 +6141,6 @@ async fn test_send_payment_will_fail_with_no_invoice_preimage() {
             ((2, 3), (MIN_RESERVED_CKB + 1005, MIN_RESERVED_CKB + 1000)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, _node_1, _node_2, mut node_3] = nodes.try_into().expect("4 nodes");
@@ -6232,7 +6205,7 @@ async fn test_send_payment_will_fail_with_cancelled_invoice() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
 
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (100000000000, 100000000000)),
             ((1, 2), (100000000000, 100000000000)),
@@ -6240,7 +6213,6 @@ async fn test_send_payment_will_fail_with_cancelled_invoice() {
             ((2, 3), (MIN_RESERVED_CKB + 1005, MIN_RESERVED_CKB + 1000)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, _node_1, _node_2, mut node_3] = nodes.try_into().expect("4 nodes");
@@ -6307,14 +6279,13 @@ async fn test_send_payment_will_succeed_with_large_tlc_expiry_limit() {
     let _span = tracing::info_span!("node", node = "test").entered();
     // from https://github.com/nervosnetwork/fiber/issues/367
 
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 2000, MIN_RESERVED_CKB + 1000)),
             ((1, 2), (100000000000, 100000000000)),
             ((2, 3), (100000000000, 100000000000)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("4 nodes");

--- a/src/fiber/tests/mod.rs
+++ b/src/fiber/tests/mod.rs
@@ -6,6 +6,7 @@ mod history;
 mod network;
 mod path;
 mod payment;
+mod rpc;
 mod serde_utils;
 pub mod test_utils;
 mod tlc_op;

--- a/src/fiber/tests/payment.rs
+++ b/src/fiber/tests/payment.rs
@@ -20,13 +20,12 @@ use std::collections::HashSet;
 
 #[tokio::test]
 async fn test_send_payment_custom_records() {
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
             ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
         ],
         2,
-        true,
     )
     .await;
     let [mut node_0, node_1] = nodes.try_into().expect("2 nodes");
@@ -91,10 +90,9 @@ async fn test_send_payment_for_direct_channel_and_dry_run() {
     let _span = tracing::info_span!("node", node = "test").entered();
     // from https://github.com/nervosnetwork/fiber/issues/359
 
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB))],
         2,
-        true,
     )
     .await;
     let [node_0, node_1] = nodes.try_into().expect("2 nodes");
@@ -130,13 +128,12 @@ async fn test_send_payment_prefer_newer_channels() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
 
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
             ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
         ],
         2,
-        true,
     )
     .await;
     let [mut node_0, node_1] = nodes.try_into().expect("2 nodes");
@@ -186,7 +183,7 @@ async fn test_send_payment_prefer_channels_with_larger_balance() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
 
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             // These two channels have the same overall capacity, but the second channel has more balance for node_0.
             (
@@ -196,7 +193,6 @@ async fn test_send_payment_prefer_channels_with_larger_balance() {
             ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
         ],
         2,
-        true,
     )
     .await;
     let [mut node_0, node_1] = nodes.try_into().expect("2 nodes");
@@ -330,10 +326,9 @@ async fn test_send_payment_fee_rate() {
 #[tokio::test]
 async fn test_send_payment_over_private_channel() {
     async fn test(amount_to_send: u128, is_payment_ok: bool) {
-        let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+        let (nodes, _channels) = create_n_nodes_network(
             &[((1, 2), (MIN_RESERVED_CKB + 20000000000, MIN_RESERVED_CKB))],
             3,
-            true,
         )
         .await;
         let [mut node1, mut node2, node3] = nodes.try_into().expect("3 nodes");
@@ -404,14 +399,13 @@ async fn test_send_payment_for_pay_self() {
     let _span = tracing::info_span!("node", node = "test").entered();
     // from https://github.com/nervosnetwork/fiber/issues/362
 
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
             ((1, 2), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
             ((2, 0), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
         ],
         3,
-        true,
     )
     .await;
     let [node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
@@ -479,13 +473,12 @@ async fn test_send_payment_for_pay_self_with_two_nodes() {
     let _span = tracing::info_span!("node", node = "test").entered();
     // from https://github.com/nervosnetwork/fiber/issues/355
 
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
             ((1, 0), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
         ],
         2,
-        true,
     )
     .await;
     let [node_0, node_1] = nodes.try_into().expect("2 nodes");
@@ -527,7 +520,7 @@ async fn test_send_payment_with_more_capacity_for_payself() {
     let _span = tracing::info_span!("node", node = "test").entered();
     // from https://github.com/nervosnetwork/fiber/issues/362
 
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             (
                 (0, 1),
@@ -552,7 +545,6 @@ async fn test_send_payment_with_more_capacity_for_payself() {
             ),
         ],
         3,
-        true,
     )
     .await;
     let [node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
@@ -620,10 +612,9 @@ async fn test_send_payment_with_more_capacity_for_payself() {
 #[tokio::test]
 async fn test_send_payment_with_private_channel_hints() {
     async fn test(amount_to_send: u128, is_payment_ok: bool) {
-        let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+        let (nodes, _channels) = create_n_nodes_network(
             &[((0, 1), (MIN_RESERVED_CKB + 40000000000, MIN_RESERVED_CKB))],
             3,
-            true,
         )
         .await;
         let [mut node1, mut node2, mut node3] = nodes.try_into().expect("3 nodes");
@@ -701,13 +692,12 @@ async fn test_send_payment_with_private_channel_hints() {
 async fn test_send_payment_with_private_channel_hints_fallback() {
     init_tracing();
 
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 40000000000, MIN_RESERVED_CKB)),
             ((1, 2), (MIN_RESERVED_CKB + 40000000000, MIN_RESERVED_CKB)),
         ],
         3,
-        true,
     )
     .await;
     let [mut node1, mut node2, mut node3] = nodes.try_into().expect("3 nodes");
@@ -779,13 +769,12 @@ async fn test_send_payment_with_private_channel_hints_fallback() {
 #[tokio::test]
 async fn test_send_payment_with_private_multiple_channel_hints_fallback() {
     init_tracing();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 40000000000, MIN_RESERVED_CKB)),
             ((1, 2), (MIN_RESERVED_CKB + 40000000000, MIN_RESERVED_CKB)),
         ],
         3,
-        true,
     )
     .await;
     let [mut node1, mut node2, mut node3] = nodes.try_into().expect("3 nodes");
@@ -1490,13 +1479,12 @@ async fn test_network_three_nodes_two_channels_send_each_other() {
     init_tracing();
 
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
     let [node_a, node_b, node_c] = nodes.try_into().expect("3 nodes");
@@ -1545,7 +1533,7 @@ async fn test_network_three_nodes_send_each_other() {
     init_tracing();
 
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
@@ -1553,7 +1541,6 @@ async fn test_network_three_nodes_send_each_other() {
             ((1, 0), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
     let [node_a, node_b, node_c] = nodes.try_into().expect("3 nodes");
@@ -1664,13 +1651,12 @@ async fn test_network_three_nodes_send_each_other() {
 async fn test_send_payment_bench_test() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
     let [node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
@@ -1718,13 +1704,12 @@ async fn test_send_payment_bench_test() {
 async fn test_send_payment_three_nodes_wait_succ_bench_test() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
     let [node_0, _node_1, node_2] = nodes.try_into().expect("3 nodes");
@@ -1754,13 +1739,12 @@ async fn test_send_payment_three_nodes_wait_succ_bench_test() {
 async fn test_send_payment_three_nodes_send_each_other_bench_test() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
     let [node_0, _node_1, node_2] = nodes.try_into().expect("3 nodes");
@@ -1794,13 +1778,12 @@ async fn test_send_payment_three_nodes_send_each_other_bench_test() {
 async fn test_send_payment_three_nodes_send_each_other_no_wait() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
 
@@ -1876,13 +1859,12 @@ async fn test_send_payment_three_nodes_send_each_other_no_wait() {
 async fn test_send_payment_three_nodes_bench_test() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         3,
-        true,
     )
     .await;
 
@@ -2000,7 +1982,7 @@ async fn test_send_payment_three_nodes_bench_test() {
 async fn test_send_payment_middle_hop_stopped() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
@@ -2009,7 +1991,6 @@ async fn test_send_payment_middle_hop_stopped() {
             ((4, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         5,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3, mut node_4] = nodes.try_into().expect("5 nodes");
@@ -2042,7 +2023,7 @@ async fn test_send_payment_middle_hop_stopped() {
 async fn test_send_payment_middle_hop_stopped_retry_longer_path() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
@@ -2053,7 +2034,6 @@ async fn test_send_payment_middle_hop_stopped_retry_longer_path() {
             ((6, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         7,
-        true,
     )
     .await;
     let [node_0, _node_1, mut node_2, mut node_3, _node_4, _node_5, _node_6] =
@@ -2118,7 +2098,7 @@ async fn test_send_payment_max_value_in_flight_in_first_hop() {
 
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let nodes = NetworkNode::new_interconnected_nodes(2).await;
+    let nodes = NetworkNode::new_interconnected_nodes(2, false).await;
     let [mut node_0, mut node_1] = nodes.try_into().expect("2 nodes");
     let (_channel_id, _funding_tx_hash) = {
         establish_channel_between_nodes(
@@ -2202,7 +2182,7 @@ async fn test_send_payment_max_value_in_flight_in_first_hop() {
 async fn test_send_payment_target_hop_stopped() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
@@ -2210,7 +2190,6 @@ async fn test_send_payment_target_hop_stopped() {
             ((3, 4), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         5,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, _node_3, mut node_4] = nodes.try_into().expect("5 nodes");
@@ -2244,14 +2223,13 @@ async fn test_send_payment_middle_hop_balance_is_not_enough() {
     // https://github.com/nervosnetwork/fiber/issues/286
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((2, 3), (MIN_RESERVED_CKB, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, _node_2, node_3] = nodes.try_into().expect("3 nodes");
@@ -2277,14 +2255,13 @@ async fn test_send_payment_middle_hop_balance_is_not_enough() {
 async fn test_send_payment_middle_hop_update_fee_send_payment_failed() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((2, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
     let [node_0, _node_1, node_2, node_3] = nodes.try_into().expect("4 nodes");
@@ -2317,14 +2294,13 @@ async fn test_send_payment_middle_hop_update_fee_multiple_payments() {
     // https://github.com/nervosnetwork/fiber/issues/480
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((2, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
 
@@ -2385,7 +2361,7 @@ async fn test_send_payment_middle_hop_update_fee_should_recovery() {
     // in the end, all the payments should success
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
@@ -2393,7 +2369,6 @@ async fn test_send_payment_middle_hop_update_fee_should_recovery() {
             ((2, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
     let mut all_sent = HashSet::new();
@@ -2456,7 +2431,7 @@ async fn run_complex_network_with_params(
 ) -> Vec<(Hash256, PaymentSessionStatus)> {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (funding_amount, funding_amount)),
             ((1, 2), (funding_amount, funding_amount)),
@@ -2467,7 +2442,6 @@ async fn run_complex_network_with_params(
             ((2, 5), (funding_amount, funding_amount)),
         ],
         6,
-        true,
     )
     .await;
 
@@ -2564,14 +2538,13 @@ async fn test_send_payment_with_one_node_stop() {
     // TLC forwarding will fail and proper error will be returned
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (mut nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (mut nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((2, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
 
@@ -2615,14 +2588,13 @@ async fn test_send_payment_with_one_node_stop() {
 async fn test_send_payment_shutdown_with_force() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((2, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
 
@@ -2696,14 +2668,13 @@ async fn test_send_payment_shutdown_with_force() {
 async fn test_send_payment_shutdown_cooperative() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((2, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
 
@@ -2779,14 +2750,13 @@ async fn test_send_payment_shutdown_cooperative() {
 async fn test_send_payment_shutdown_under_send_each_other() {
     init_tracing();
     let _span = tracing::info_span!("node", node = "test").entered();
-    let (nodes, channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((2, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
 
@@ -2851,14 +2821,13 @@ async fn test_send_payment_middle_hop_restart_will_be_ok() {
         init_tracing();
         let _span = tracing::info_span!("node", node = "test").entered();
         let funding_amount = MIN_RESERVED_CKB + 1000 * 100_000_000;
-        let (mut nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+        let (mut nodes, _channels) = create_n_nodes_network(
             &[
                 ((0, 1), (funding_amount, funding_amount)),
                 ((1, 2), (funding_amount, funding_amount)),
                 ((2, 3), (funding_amount, funding_amount)),
             ],
             4,
-            true,
         )
         .await;
 
@@ -2899,14 +2868,13 @@ async fn test_send_payment_middle_hop_stop_send_payment_then_start() {
         init_tracing();
         let _span = tracing::info_span!("node", node = "test").entered();
         let funding_amount = MIN_RESERVED_CKB + 1000 * 100_000_000;
-        let (mut nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+        let (mut nodes, _channels) = create_n_nodes_network(
             &[
                 ((0, 1), (funding_amount, funding_amount)),
                 ((1, 2), (funding_amount, funding_amount)),
                 ((2, 3), (funding_amount, funding_amount)),
             ],
             4,
-            true,
         )
         .await;
 
@@ -2990,13 +2958,12 @@ async fn test_send_payment_sync_up_new_channel_is_added() {
     let _span = tracing::info_span!("node", node = "test").entered();
     // create a network with 4 nodes, but only connect with 2 channels
     // node0 -> node1 -> node2  node3
-    let (nodes, _channels) = create_n_nodes_and_channels_with_index_amounts(
+    let (nodes, _channels) = create_n_nodes_network(
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
         4,
-        true,
     )
     .await;
     let [mut node_0, mut node_1, mut node_2, mut node_3] = nodes.try_into().expect("4 nodes");

--- a/src/fiber/tests/rpc.rs
+++ b/src/fiber/tests/rpc.rs
@@ -1,0 +1,30 @@
+#![allow(clippy::needless_range_loop)]
+
+use crate::{fiber::tests::test_utils::*, rpc::channel::ListChannelsParams};
+
+#[tokio::test]
+async fn test_rpc_basic() {
+    let (nodes, _channels) = create_n_nodes_network_with_rpc_option(
+        &[
+            ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
+            ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
+        ],
+        2,
+        true,
+    )
+    .await;
+    let [node_0, _node_1] = nodes.try_into().expect("2 nodes");
+
+    let res = node_0
+        .send_rpc_request(
+            "list_channels",
+            ListChannelsParams {
+                peer_id: None,
+                include_closed: None,
+            },
+        )
+        .await
+        .unwrap();
+    eprintln!("get_info: {:?}", res);
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+}

--- a/src/fiber/tests/rpc.rs
+++ b/src/fiber/tests/rpc.rs
@@ -1,6 +1,16 @@
 #![allow(clippy::needless_range_loop)]
 
-use crate::{fiber::tests::test_utils::*, rpc::channel::ListChannelsParams};
+use ckb_types::packed::Script;
+
+use crate::{
+    fiber::{tests::test_utils::*, types::Hash256},
+    invoice::Currency,
+    rpc::{
+        channel::{ListChannelsParams, ListChannelsResult},
+        invoice::{InvoiceParams, InvoiceResult, NewInvoiceParams},
+        payment::{GetPaymentCommandParams, GetPaymentCommandResult},
+    },
+};
 
 #[tokio::test]
 async fn test_rpc_basic() {
@@ -13,9 +23,9 @@ async fn test_rpc_basic() {
         true,
     )
     .await;
-    let [node_0, _node_1] = nodes.try_into().expect("2 nodes");
+    let [node_0, node_1] = nodes.try_into().expect("2 nodes");
 
-    let res = node_0
+    let res: ListChannelsResult = node_0
         .send_rpc_request(
             "list_channels",
             ListChannelsParams {
@@ -25,6 +35,52 @@ async fn test_rpc_basic() {
         )
         .await
         .unwrap();
-    eprintln!("get_info: {:?}", res);
+    assert_eq!(res.channels.len(), 2);
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
+    let payment = node_0
+        .send_payment_keysend(&node_1, 1000, false)
+        .await
+        .unwrap();
+
+    let payment_hash = payment.payment_hash;
+    node_0.wait_until_success(payment_hash).await;
+
+    let payment: GetPaymentCommandResult = node_0
+        .send_rpc_request("get_payment", GetPaymentCommandParams { payment_hash })
+        .await
+        .unwrap();
+    assert_eq!(payment.payment_hash, payment_hash);
+
+    // node0 generate a invoice
+    let invoice_res: InvoiceResult = node_0
+        .send_rpc_request(
+            "new_invoice",
+            NewInvoiceParams {
+                amount: 1000,
+                description: Some("test".to_string()),
+                currency: Currency::Fibd,
+                expiry: Some(322),
+                fallback_address: None,
+                final_expiry_delta: Some(900000 + 1234),
+                udt_type_script: Some(Script::default().into()),
+                payment_preimage: Hash256::default(),
+                hash_algorithm: Some(crate::fiber::hash_algorithm::HashAlgorithm::CkbHash),
+            },
+        )
+        .await
+        .unwrap();
+
+    let invoice_payment_hash = invoice_res.invoice.payment_hash();
+    let get_invoice_res: InvoiceResult = node_0
+        .send_rpc_request(
+            "get_invoice",
+            InvoiceParams {
+                payment_hash: *invoice_payment_hash,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(get_invoice_res.invoice.payment_hash(), invoice_payment_hash);
 }

--- a/src/fiber/tests/test_utils.rs
+++ b/src/fiber/tests/test_utils.rs
@@ -23,18 +23,27 @@ use crate::fiber::types::Pubkey;
 use crate::invoice::CkbInvoice;
 use crate::invoice::CkbInvoiceStatus;
 use crate::invoice::InvoiceStore;
+use crate::start_rpc;
+use crate::RpcConfig;
 use ckb_sdk::core::TransactionBuilder;
 use ckb_types::{
     core::{tx_pool::TxStatus, TransactionView},
     packed::{OutPoint, Script},
 };
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::transport::HttpBackend;
+use jsonrpsee::http_client::HttpClient;
+use jsonrpsee::rpc_params;
+use jsonrpsee::server::ServerHandle;
 use ractor::{call, Actor, ActorRef};
 use rand::distributions::Alphanumeric;
 use rand::rngs::OsRng;
 use rand::Rng;
 use secp256k1::{Message, Secp256k1};
+use serde::Serialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::net::SocketAddr;
 use std::{
     env,
     ffi::OsStr,
@@ -184,6 +193,7 @@ pub struct NetworkNode {
     pub store: Store,
     pub channels_tx_map: HashMap<Hash256, Hash256>,
     pub fiber_config: FiberConfig,
+    pub rpc_config: Option<RpcConfig>,
     pub listening_addrs: Vec<MultiAddr>,
     pub network_actor: ActorRef<NetworkActorMessage>,
     pub ckb_chain_actor: ActorRef<CkbChainMessage>,
@@ -196,6 +206,7 @@ pub struct NetworkNode {
     pub pubkey: Pubkey,
     pub unexpected_events: Arc<TokioRwLock<HashSet<String>>>,
     pub triggered_unexpected_events: Arc<TokioRwLock<Vec<String>>>,
+    pub rpc_server: Option<(ServerHandle, SocketAddr)>,
 }
 
 pub struct NetworkNodeConfig {
@@ -203,6 +214,7 @@ pub struct NetworkNodeConfig {
     node_name: Option<String>,
     store: Store,
     fiber_config: FiberConfig,
+    rpc_config: Option<RpcConfig>,
 }
 
 impl NetworkNodeConfig {
@@ -214,6 +226,7 @@ impl NetworkNodeConfig {
 pub struct NetworkNodeConfigBuilder {
     base_dir: Option<Arc<TempDir>>,
     node_name: Option<String>,
+    enable_rpc_server: bool,
     // We may generate a FiberConfig based on the base_dir and node_name,
     // but allow user to override it.
     #[allow(clippy::type_complexity)]
@@ -231,6 +244,7 @@ impl NetworkNodeConfigBuilder {
         Self {
             base_dir: None,
             node_name: None,
+            enable_rpc_server: false,
             fiber_config_updater: None,
         }
     }
@@ -246,6 +260,11 @@ impl NetworkNodeConfigBuilder {
 
     pub fn node_name(mut self, node_name: Option<String>) -> Self {
         self.node_name = node_name;
+        self
+    }
+
+    pub fn enable_rpc_server(mut self, enable: bool) -> Self {
+        self.enable_rpc_server = enable;
         self
     }
 
@@ -274,12 +293,28 @@ impl NetworkNodeConfigBuilder {
         let rand_db_dir = Path::new(base_dir.to_str()).join(rand_name);
         let store = Store::new(rand_db_dir).expect("create store");
         let fiber_config = get_fiber_config(base_dir.as_ref(), node_name.as_deref());
+        let rpc_config = if self.enable_rpc_server {
+            Some(RpcConfig {
+                listening_addr: None,
+                enabled_modules: vec![
+                    "channel".to_string(),
+                    "graph".to_string(),
+                    "payment".to_string(),
+                    "invoice".to_string(),
+                    "peer".to_string(),
+                ],
+            })
+        } else {
+            None
+        };
         let mut config = NetworkNodeConfig {
             base_dir,
             node_name,
             store,
             fiber_config,
+            rpc_config,
         };
+
         if let Some(updater) = self.fiber_config_updater {
             updater(&mut config.fiber_config);
         }
@@ -428,7 +463,6 @@ pub(crate) async fn create_nodes_with_established_channel(
 pub(crate) async fn create_3_nodes_with_established_channel(
     (channel_1_amount_a, channel_1_amount_b): (u128, u128),
     (channel_2_amount_b, channel_2_amount_c): (u128, u128),
-    public: bool,
 ) -> (NetworkNode, NetworkNode, NetworkNode, Hash256, Hash256) {
     let (nodes, channels) = create_n_nodes_with_established_channel(
         &[
@@ -436,7 +470,6 @@ pub(crate) async fn create_3_nodes_with_established_channel(
             (channel_2_amount_b, channel_2_amount_c),
         ],
         3,
-        public,
     )
     .await;
     let [node_a, node_b, node_c] = nodes.try_into().expect("3 nodes");
@@ -447,7 +480,6 @@ pub(crate) async fn create_3_nodes_with_established_channel(
 pub(crate) async fn create_n_nodes_with_established_channel(
     amounts: &[(u128, u128)],
     n: usize,
-    public: bool,
 ) -> (Vec<NetworkNode>, Vec<Hash256>) {
     assert!(n >= 2);
     assert_eq!(amounts.len(), n - 1);
@@ -456,17 +488,18 @@ pub(crate) async fn create_n_nodes_with_established_channel(
         .map(|i| ((i, i + 1), (amounts[i].0, amounts[i].1)))
         .collect();
 
-    create_n_nodes_and_channels_with_index_amounts(&nodes_index_map, n, public).await
+    create_n_nodes_network(&nodes_index_map, n).await
 }
 
 #[allow(clippy::type_complexity)]
-pub(crate) async fn create_n_nodes_and_channels_with_index_amounts(
+
+pub(crate) async fn create_n_nodes_network_with_rpc_option(
     amounts: &[((usize, usize), (u128, u128))],
     n: usize,
-    public: bool,
+    enable_rpc: bool,
 ) -> (Vec<NetworkNode>, Vec<Hash256>) {
     assert!(n >= 2);
-    let mut nodes = NetworkNode::new_interconnected_nodes(n).await;
+    let mut nodes = NetworkNode::new_interconnected_nodes(n, enable_rpc).await;
     let mut channels = vec![];
 
     for &((i, j), (node_a_amount, node_b_amount)) in amounts.iter() {
@@ -485,7 +518,7 @@ pub(crate) async fn create_n_nodes_and_channels_with_index_amounts(
             let (channel_id, funding_tx_hash) = establish_channel_between_nodes(
                 node_a,
                 node_b,
-                public,
+                true,
                 node_a_amount,
                 node_b_amount,
                 None,
@@ -535,6 +568,15 @@ pub(crate) async fn create_n_nodes_and_channels_with_index_amounts(
         }
     }
     (nodes, channels)
+}
+
+#[allow(clippy::type_complexity)]
+
+pub(crate) async fn create_n_nodes_network(
+    amounts: &[((usize, usize), (u128, u128))],
+    n: usize,
+) -> (Vec<NetworkNode>, Vec<Hash256>) {
+    create_n_nodes_network_with_rpc_option(amounts, n, false).await
 }
 
 impl NetworkNode {
@@ -689,6 +731,53 @@ impl NetworkNode {
             custom_records: None,
         })
         .await
+    }
+
+    pub async fn send_rpc_request<P: Serialize>(
+        &self,
+        method: &str,
+        params: P,
+    ) -> Result<serde_json::Value, String> {
+        if let Some((_server, socket_addr)) = &self.rpc_server {
+            let client = HttpClient::<HttpBackend>::builder()
+                .build(format!("http://{}", socket_addr))
+                .expect("build client");
+            let params = rpc_params![params];
+            let response: serde_json::Value = client
+                .request(method, params)
+                .await
+                .expect("request failed");
+            Self::verify_serde_json_value(response.clone()).expect("verify response");
+            Ok(response)
+        } else {
+            Err("RPC server not started".to_string())
+        }
+    }
+
+    // verify serde_json::Value do not contains any Number,
+    // we expect all number values are hex encoded
+    pub fn verify_serde_json_value(value: serde_json::Value) -> Result<(), String> {
+        if value.is_array() {
+            for val in value.as_array().unwrap() {
+                if val.is_object() || val.is_array() {
+                    Self::verify_serde_json_value(val.clone())?;
+                }
+            }
+        }
+        if value.is_object() {
+            for (key, val) in value.as_object().unwrap() {
+                if val.is_number() {
+                    return Err(format!(
+                        "field should be in hex encoded: {}, but it is with value: {}",
+                        key, val,
+                    ));
+                }
+                if val.is_object() || val.is_array() {
+                    Self::verify_serde_json_value(val.clone())?;
+                }
+            }
+        }
+        Ok(())
     }
 
     pub async fn send_payment_keysend_to_self(
@@ -913,6 +1002,7 @@ impl NetworkNode {
             node_name,
             store,
             fiber_config,
+            rpc_config,
         } = config;
 
         let _span = tracing::info_span!("NetworkNode", node_name = &node_name).entered();
@@ -1017,11 +1107,31 @@ impl NetworkNode {
             .expect("gossip actor should have been started")
             .into();
 
+        let rpc_handler = if let Some(rpc_config) = rpc_config.clone() {
+            Some(
+                start_rpc(
+                    rpc_config,
+                    None,
+                    Some(fiber_config.clone()),
+                    Some(network_actor.clone()),
+                    None,
+                    store.clone(),
+                    network_graph.clone(),
+                    None,
+                    None,
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+
         Self {
             base_dir,
             node_name,
             store,
             fiber_config,
+            rpc_config,
             channels_tx_map: Default::default(),
             listening_addrs: announced_addrs,
             network_actor,
@@ -1035,6 +1145,7 @@ impl NetworkNode {
             pubkey: public_key,
             unexpected_events,
             triggered_unexpected_events,
+            rpc_server: rpc_handler,
         }
     }
 
@@ -1044,6 +1155,7 @@ impl NetworkNode {
             node_name: self.node_name.clone(),
             store: self.store.clone(),
             fiber_config: self.fiber_config.clone(),
+            rpc_config: self.rpc_config.clone(),
         }
     }
 
@@ -1106,20 +1218,21 @@ impl NetworkNode {
     }
 
     pub async fn new_n_interconnected_nodes<const N: usize>() -> [Self; N] {
-        let nodes = Self::new_interconnected_nodes(N).await;
+        let nodes = Self::new_interconnected_nodes(N, false).await;
         match nodes.try_into() {
             Ok(nodes) => nodes,
             Err(_) => unreachable!(),
         }
     }
 
-    pub async fn new_interconnected_nodes(n: usize) -> Vec<Self> {
+    pub async fn new_interconnected_nodes(n: usize, enable_rpc: bool) -> Vec<Self> {
         let mut nodes: Vec<NetworkNode> = Vec::with_capacity(n);
         for i in 0..n {
             let new = Self::new_with_config(
                 NetworkNodeConfigBuilder::new()
                     .node_name(Some(format!("node-{}", i)))
                     .base_dir_prefix(&format!("test-fnn-node-{}-", i))
+                    .enable_rpc_server(enable_rpc)
                     .build(),
             )
             .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ pub async fn main() -> Result<(), ExitMessage> {
     };
 
     signal_listener().await;
-    if let Some(handle) = rpc_server_handle {
+    if let Some((handle, _)) = rpc_server_handle {
         handle
             .stop()
             .map_err(|err| ExitMessage(format!("failed to stop rpc server: {}", err)))?;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -44,6 +44,7 @@ use peer::{PeerRpcServer, PeerRpcServerImpl};
 use ractor::ActorRef;
 #[cfg(debug_assertions)]
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -104,9 +105,11 @@ pub async fn start_rpc<
     #[cfg(debug_assertions)] rpc_dev_module_commitment_txs: Option<
         Arc<RwLock<HashMap<(Hash256, u64), TransactionView>>>,
     >,
-) -> ServerHandle {
+) -> (ServerHandle, SocketAddr) {
     let listening_addr = config.listening_addr.as_deref().unwrap_or("[::]:0");
     let server = build_server(listening_addr).await;
+    let sockaddr = server.local_addr().expect("local addr");
+
     let mut modules = RpcModule::new(());
     if config.is_module_enabled("invoice") {
         modules
@@ -172,5 +175,5 @@ pub async fn start_rpc<
                 .unwrap();
         }
     }
-    server.start(modules)
+    (server.start(modules), sockaddr)
 }


### PR DESCRIPTION
This PR add a `enable_rpc` option for NetworkNode, so we can add assertions for rpc, such as all number value should be hex encoded, and also other RPC functional check in unit test.

Fixes #234