### PR TITLE
chore: Fix release build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo check
+          cargo check --release
           make check-migrate
           make check-dirty-rpc-doc
           cd migrate && cargo check

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -713,7 +713,7 @@ where
         &self,
         myself: &ActorRef<ChannelActorMessage>,
         state: &mut ChannelActorState,
-        payment_hash: Hash256,
+        #[allow(unused_variables)] payment_hash: Hash256,
         tlc_id: TLCId,
         error: ProcessingChannelErrorWithSharedSecret,
     ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,7 @@ pub async fn main() -> Result<(), ExitMessage> {
         }
     });
 
+    #[allow(unused_variables)]
     let (network_actor, ckb_chain_actor, network_graph) = match config.fiber.clone() {
         Some(fiber_config) => {
             // TODO: this is not a super user friendly error message which has actionable information

--- a/src/rpc/payment.rs
+++ b/src/rpc/payment.rs
@@ -78,6 +78,7 @@ pub struct SessionRouteNode {
     pub channel_outpoint: OutPoint,
 }
 
+#[cfg(debug_assertions)]
 impl From<InternalSessionRouteNode> for SessionRouteNode {
     fn from(node: InternalSessionRouteNode) -> Self {
         SessionRouteNode {


### PR DESCRIPTION
Add `cargo check --release` to check build in release mode, in case we get error after PR is merged.