### PR TITLE
fix: should force close channel when htlc is expired without response 

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -3299,7 +3299,7 @@ where
                     .expect(ASSUME_NETWORK_MYSELF_ALIVE);
             }
         }
-
+        // MAINTAINING_CONNECTIONS_INTERVAL is long, we need to trigger when start
         myself
             .send_message(NetworkActorMessage::new_command(
                 NetworkActorCommand::MaintainConnections,

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -109,6 +109,9 @@ const ASSUME_GOSSIP_ACTOR_ALIVE: &str = "gossip actor must be alive";
 const MAINTAINING_CONNECTIONS_INTERVAL: Duration = Duration::from_secs(3600);
 
 // The duration for which we will check if we should force close a channel.
+#[cfg(debug_assertions)]
+const CHECK_FORCE_CLOSE_INTERVAL: Duration = Duration::from_secs(3); // use a short interval for debugging build
+#[cfg(not(debug_assertions))]
 const CHECK_FORCE_CLOSE_INTERVAL: Duration = Duration::from_secs(60);
 
 // While creating a network graph from the gossip messages, we will load current gossip messages
@@ -1152,7 +1155,7 @@ where
                                             ShutdownCommand {
                                                 close_script: Script::default(),
                                                 fee_rate: FeeRate::default(),
-                                                force: false,
+                                                force: true,
                                             },
                                             rpc_reply,
                                         ),

--- a/src/fiber/tests/channel.rs
+++ b/src/fiber/tests/channel.rs
@@ -4066,7 +4066,7 @@ async fn do_test_channel_with_simple_update_operation(algorithm: HashAlgorithm) 
                 channel_id: new_channel_id,
                 command: ChannelCommand::Shutdown(
                     ShutdownCommand {
-                        close_script: Script::default().as_builder().build(),
+                        close_script: Script::default(),
                         fee_rate,
                         force: false,
                     },

--- a/src/rpc/README.md
+++ b/src/rpc/README.md
@@ -291,9 +291,10 @@ Shuts down a channel.
 ##### Params
 
 * `channel_id` - <em>[Hash256](#type-hash256)</em>, The channel ID of the channel to shut down
-* `close_script` - <em>`Script`</em>, The script used to receive the channel balance, only support secp256k1_blake160_sighash_all script for now
-* `force` - <em>`Option<bool>`</em>, Whether to force the channel to close
-* `fee_rate` - <em>`u64`</em>, The fee rate for the closing transaction, the fee will be deducted from the closing initiator's channel balance
+* `close_script` - <em>`Option<Script>`</em>, The script used to receive the channel balance, only support secp256k1_blake160_sighash_all script for now
+* `fee_rate` - <em>`Option<u64>`</em>, The fee rate for the closing transaction, the fee will be deducted from the closing initiator's channel balance
+* `force` - <em>`Option<bool>`</em>, Whether to force the channel to close, when set to false, `close_script` and `fee_rate` should be set, default is false.
+ When set to true, `close_script` and `fee_rate` will be ignored and will use the default value when opening the channel.
 
 ##### Returns
 

--- a/src/rpc/channel.rs
+++ b/src/rpc/channel.rs
@@ -488,14 +488,12 @@ where
                     Some(params),
                 ));
             }
-        } else {
-            if params.close_script.is_none() || params.fee_rate.is_none() {
-                return Err(ErrorObjectOwned::owned(
-                    CALL_EXECUTION_FAILED_CODE,
-                    "close_script and fee_rate should be set when force is false",
-                    Some(params),
-                ));
-            }
+        } else if params.close_script.is_none() || params.fee_rate.is_none() {
+            return Err(ErrorObjectOwned::owned(
+                CALL_EXECUTION_FAILED_CODE,
+                "close_script and fee_rate should be set when force is false",
+                Some(params),
+            ));
         }
 
         let message = |rpc_reply| -> NetworkActorMessage {

--- a/src/rpc/channel.rs
+++ b/src/rpc/channel.rs
@@ -279,12 +279,13 @@ pub struct ShutdownChannelParams {
     /// The channel ID of the channel to shut down
     pub channel_id: Hash256,
     /// The script used to receive the channel balance, only support secp256k1_blake160_sighash_all script for now
-    pub close_script: Script,
-    /// Whether to force the channel to close
-    pub force: Option<bool>,
+    pub close_script: Option<Script>,
     /// The fee rate for the closing transaction, the fee will be deducted from the closing initiator's channel balance
-    #[serde_as(as = "U64Hex")]
-    pub fee_rate: u64,
+    #[serde_as(as = "Option<U64Hex>")]
+    pub fee_rate: Option<u64>,
+    /// Whether to force the channel to close, when set to false, `close_script` and `fee_rate` should be set, default is false.
+    /// When set to true, `close_script` and `fee_rate` will be ignored and will use the default value when opening the channel.
+    pub force: Option<bool>,
 }
 
 #[serde_as]
@@ -479,15 +480,37 @@ where
         &self,
         params: ShutdownChannelParams,
     ) -> Result<(), ErrorObjectOwned> {
+        if params.force.unwrap_or_default() {
+            if params.close_script.is_some() || params.fee_rate.is_some() {
+                return Err(ErrorObjectOwned::owned(
+                    CALL_EXECUTION_FAILED_CODE,
+                    "close_script and fee_rate should not be set when force is true",
+                    Some(params),
+                ));
+            }
+        } else {
+            if params.close_script.is_none() || params.fee_rate.is_none() {
+                return Err(ErrorObjectOwned::owned(
+                    CALL_EXECUTION_FAILED_CODE,
+                    "close_script and fee_rate should be set when force is false",
+                    Some(params),
+                ));
+            }
+        }
+
         let message = |rpc_reply| -> NetworkActorMessage {
             NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
                 ChannelCommandWithId {
                     channel_id: params.channel_id,
                     command: ChannelCommand::Shutdown(
                         ShutdownCommand {
-                            close_script: params.close_script.clone().into(),
-                            fee_rate: FeeRate::from_u64(params.fee_rate),
-                            force: params.force.unwrap_or(false),
+                            close_script: params
+                                .close_script
+                                .clone()
+                                .map(Into::into)
+                                .unwrap_or_default(),
+                            fee_rate: params.fee_rate.map(FeeRate::from_u64).unwrap_or_default(),
+                            force: params.force.unwrap_or_default(),
                         },
                         rpc_reply,
                     ),

--- a/tests/bruno/e2e/period-check/force-close-expiry/01-node1-connect-node2.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/01-node1-connect-node2.bru
@@ -1,0 +1,38 @@
+meta {
+  name: connect peer
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "connect_peer",
+    "params": [
+      {"address": "{{NODE1_ADDR}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  // Dialing a peer is async in tentacle. Sleep for some time to make sure
+  // we're connected to the peer.
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/02-node2-connect-node3.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/02-node2-connect-node3.bru
@@ -1,0 +1,38 @@
+meta {
+  name: connect peer
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "connect_peer",
+    "params": [
+      {"address": "{{NODE2_ADDR}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  // Dialing a peer is async in tentacle. Sleep for some time to make sure
+  // we're connected to the peer.
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/03-node1-node2-open-channel.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/03-node1-node2-open-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Node1 open a channel to Node2
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "open_channel",
+    "params": [
+      {
+        "peer_id": "{{NODE2_PEERID}}",
+        "funding_amount": "0x377aab54d000"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 2000));
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/04-node2-get-auto-accepted-channel.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/04-node2-get-auto-accepted-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: get auto accepted channel id from Node2
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE1_PEERID}}"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body.result);
+  bru.setVar("N1N2_CHANNEL_ID", res.body.result.channels[0].channel_id);
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/05-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/05-ckb-generate-blocks.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for channel 1
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x2"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/06-node2-node3-open-channel.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/06-node2-node3-open-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Node2 open a channel to Node3
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "open_channel",
+    "params": [
+      {
+        "peer_id": "{{NODE3_PEERID}}",
+        "funding_amount": "0x377aab54d000"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 2000));
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/07-node3-get-auto-accepted-channel.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/07-node3-get-auto-accepted-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: get auto accepted channel id from Node3
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE2_PEERID}}"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body.result);
+  bru.setVar("N2N3_CHANNEL_ID", res.body.result.channels[0].channel_id);
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/08-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/08-ckb-generate-blocks.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for channel 2
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x2"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/09-node1-add-tlc.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/09-node1-add-tlc.bru
@@ -1,0 +1,49 @@
+meta {
+  name: Node1 add tlc
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "add_tlc",
+    "params": [
+      {
+        "channel_id": "{{N1N2_CHANNEL_ID}}",
+        "amount": "0x5f5e100",
+        "payment_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "expiry": "{{expiry}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.tlc_id: isDefined
+}
+
+script:pre-request {
+  // Set expiry to 30 seconds from now.
+  let expiry = "0x" + (Date.now() + 1000 * 30).toString(16);
+  bru.setVar("expiry", expiry);
+}
+
+script:post-response {
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 1000));
+  bru.setVar("N1N2_TLC_ID1", res.body.result.tlc_id);
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/10-node2-add-tlc.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/10-node2-add-tlc.bru
@@ -1,0 +1,49 @@
+meta {
+  name: Node2 add tlc
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "add_tlc",
+    "params": [
+      {
+        "channel_id": "{{N2N3_CHANNEL_ID}}",
+        "amount": "0x5f5e100",
+        "payment_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "expiry": "{{expiry}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.tlc_id: isDefined
+}
+
+script:pre-request {
+    // Set expiry to 15 seconds from now.
+  let expiry = "0x" + (Date.now() + 1000 * 15).toString(16);
+  bru.setVar("expiry", expiry);
+}
+
+script:post-response {
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 1000));
+  bru.setVar("N2N3_TLC_ID1", res.body.result.tlc_id);
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/11-node2-list-channels.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/11-node2-list-channels.bru
@@ -1,0 +1,38 @@
+meta {
+  name: get channels of node2 <=> node3
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE3_PEERID}}"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  // Wait for 20 seconds to make sure the periodic checkin is done.
+  await new Promise(r => setTimeout(r, 20000));
+}
+
+assert {
+  res.body.result.channels.length: eq 0
+}

--- a/tests/bruno/e2e/period-check/force-close-expiry/12-node1-list-channels.bru
+++ b/tests/bruno/e2e/period-check/force-close-expiry/12-node1-list-channels.bru
@@ -1,0 +1,38 @@
+meta {
+  name: get channels of node1 <=> node2
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE2_PEERID}}"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  // Wait for 20 seconds to make sure the periodic checkin is done.
+  await new Promise(r => setTimeout(r, 20000));
+}
+
+assert {
+  res.body.result.channels.length: eq 0
+}

--- a/tests/bruno/e2e/shutdown-force/05-shutdown-force-NODE1.bru
+++ b/tests/bruno/e2e/shutdown-force/05-shutdown-force-NODE1.bru
@@ -23,12 +23,6 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "close_script": {
-          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
-          "hash_type": "data",
-          "args": "0x0101010101010101010101010101010101010101"
-        },
-        "fee_rate": "0x3FC",
         "force": true
       }
     ]

--- a/tests/bruno/e2e/watchtower/force-close-after-multiple-payments/09-force-close.bru
+++ b/tests/bruno/e2e/watchtower/force-close-after-multiple-payments/09-force-close.bru
@@ -23,12 +23,6 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "close_script": {
-          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
-          "hash_type": "data",
-          "args": "0x0101010101010101010101010101010101010101"
-        },
-        "fee_rate": "0x3FC",
         "force": true
       }
     ]

--- a/tests/bruno/e2e/watchtower/force-close-after-open-channel/05-force-close.bru
+++ b/tests/bruno/e2e/watchtower/force-close-after-open-channel/05-force-close.bru
@@ -23,12 +23,6 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "close_script": {
-          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
-          "hash_type": "data",
-          "args": "0x0101010101010101010101010101010101010101"
-        },
-        "fee_rate": "0x3FC",
         "force": true
       }
     ]

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/12-force-close.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/12-force-close.bru
@@ -23,12 +23,6 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "close_script": {
-          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
-          "hash_type": "data",
-          "args": "0x0101010101010101010101010101010101010101"
-        },
-        "fee_rate": "0x3FC",
         "force": true
       }
     ]

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-stop-watchtower/12-force-close.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-stop-watchtower/12-force-close.bru
@@ -23,12 +23,6 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "close_script": {
-          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
-          "hash_type": "data",
-          "args": "0x0101010101010101010101010101010101010101"
-        },
-        "fee_rate": "0x3FC",
         "force": true
       }
     ]

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/12-force-close.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/12-force-close.bru
@@ -23,12 +23,6 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "close_script": {
-          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
-          "hash_type": "data",
-          "args": "0x0101010101010101010101010101010101010101"
-        },
-        "fee_rate": "0x3FC",
         "force": true
       }
     ]

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/12-force-close.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/12-force-close.bru
@@ -23,12 +23,6 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "close_script": {
-          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
-          "hash_type": "data",
-          "args": "0x0101010101010101010101010101010101010101"
-        },
-        "fee_rate": "0x3FC",
         "force": true
       }
     ]

--- a/tests/bruno/e2e/watchtower/force-close/07-force-close.bru
+++ b/tests/bruno/e2e/watchtower/force-close/07-force-close.bru
@@ -23,12 +23,6 @@ body:json {
     "params": [
       {
         "channel_id": "{{CHANNEL_ID}}",
-        "close_script": {
-          "code_hash": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
-          "hash_type": "data",
-          "args": "0x0101010101010101010101010101010101010101"
-        },
-        "fee_rate": "0x3FC",
         "force": true
       }
     ]


### PR DESCRIPTION
Consider a HTLC chain Peer A -> Peer B -> Offline Peer C

Peer B should force close the channel between B and C after htlc is expired without response, and A should force close the channel cascade too.

## Break change

* Modified `ShutdownChannelParams` to make `close_script` and `fee_rate` optional and added validation to ensure they are set correctly based on the `force` parameter. 