### PR TITLE
fix: watchtower should claim upstream tlc with onchain preimage

### DIFF
--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -2690,10 +2690,7 @@ impl TlcInfo {
     }
 
     pub fn id(&self) -> u64 {
-        match self.tlc_id {
-            TLCId::Offered(id) => id,
-            TLCId::Received(id) => id,
-        }
+        self.tlc_id.into()
     }
 
     pub fn is_offered(&self) -> bool {

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -2689,6 +2689,13 @@ impl TlcInfo {
         )
     }
 
+    pub fn id(&self) -> u64 {
+        match self.tlc_id {
+            TLCId::Offered(id) => id,
+            TLCId::Received(id) => id,
+        }
+    }
+
     pub fn is_offered(&self) -> bool {
         self.tlc_id.is_offered()
     }

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -48,10 +48,10 @@ use super::channel::{
     AwaitingTxSignaturesFlags, ChannelActor, ChannelActorMessage, ChannelActorStateStore,
     ChannelCommand, ChannelCommandWithId, ChannelEvent, ChannelInitializationParameter,
     ChannelState, ChannelSubscribers, ChannelTlcInfo, OpenChannelParameter, PrevTlcInfo,
-    ProcessingChannelError, ProcessingChannelResult, PublicChannelInfo, RevocationData,
-    SettlementData, ShuttingDownFlags, StopReason, DEFAULT_COMMITMENT_FEE_RATE, DEFAULT_FEE_RATE,
-    DEFAULT_MAX_TLC_VALUE_IN_FLIGHT, MAX_COMMITMENT_DELAY_EPOCHS, MAX_TLC_NUMBER_IN_FLIGHT,
-    MIN_COMMITMENT_DELAY_EPOCHS, SYS_MAX_TLC_NUMBER_IN_FLIGHT,
+    ProcessingChannelError, ProcessingChannelResult, PublicChannelInfo, RemoveTlcCommand,
+    RevocationData, SettlementData, ShuttingDownFlags, StopReason, DEFAULT_COMMITMENT_FEE_RATE,
+    DEFAULT_FEE_RATE, DEFAULT_MAX_TLC_VALUE_IN_FLIGHT, MAX_COMMITMENT_DELAY_EPOCHS,
+    MAX_TLC_NUMBER_IN_FLIGHT, MIN_COMMITMENT_DELAY_EPOCHS, SYS_MAX_TLC_NUMBER_IN_FLIGHT,
 };
 use super::config::{AnnouncedNodeName, MIN_TLC_EXPIRY_DELTA};
 use super::fee::calculate_commitment_tx_fee;
@@ -60,8 +60,8 @@ use super::graph::{NetworkGraph, NetworkGraphStateStore, OwnedChannelUpdateEvent
 use super::key::blake2b_hash_with_salt;
 use super::types::{
     BroadcastMessageWithTimestamp, EcdsaSignature, FiberMessage, ForwardTlcResult, GossipMessage,
-    Hash256, NodeAnnouncement, OpenChannel, PaymentHopData, Privkey, Pubkey, RemoveTlcReason,
-    TlcErr, TlcErrData, TlcErrorCode,
+    Hash256, NodeAnnouncement, OpenChannel, PaymentHopData, Privkey, Pubkey, RemoveTlcFulfill,
+    RemoveTlcReason, TlcErr, TlcErrData, TlcErrorCode,
 };
 use super::{
     FiberConfig, InFlightCkbTxActor, InFlightCkbTxActorArguments, InFlightCkbTxActorMessage,
@@ -108,11 +108,11 @@ const ASSUME_GOSSIP_ACTOR_ALIVE: &str = "gossip actor must be alive";
 // The duration for which we will try to maintain the number of peers in connection.
 const MAINTAINING_CONNECTIONS_INTERVAL: Duration = Duration::from_secs(3600);
 
-// The duration for which we will check if we should force close a channel.
+// The duration for which we will check all channels.
 #[cfg(debug_assertions)]
-const CHECK_FORCE_CLOSE_INTERVAL: Duration = Duration::from_secs(3); // use a short interval for debugging build
+const CHECK_CHANNELS_INTERVAL: Duration = Duration::from_secs(3); // use a short interval for debugging build
 #[cfg(not(debug_assertions))]
-const CHECK_FORCE_CLOSE_INTERVAL: Duration = Duration::from_secs(60);
+const CHECK_CHANNELS_INTERVAL: Duration = Duration::from_secs(60);
 
 // While creating a network graph from the gossip messages, we will load current gossip messages
 // in the store and process them. We will load all current messages and get the latest cursor.
@@ -223,8 +223,8 @@ pub enum NetworkActorCommand {
     SavePeerAddress(Multiaddr),
     // We need to maintain a certain number of peers connections to keep the network running.
     MaintainConnections,
-    // Check if we should force close a channel.
-    CheckForceClose,
+    // Check all channels and see if we need to force close any of them or settle down tlc with preimage.
+    CheckChannels,
     // For internal use and debugging only. Most of the messages requires some
     // changes to local state. Even if we can send a message to a peer, some
     // part of the local state is not changed.
@@ -1130,7 +1130,7 @@ where
                     }
                 }
             }
-            NetworkActorCommand::CheckForceClose => {
+            NetworkActorCommand::CheckChannels => {
                 let now = now_timestamp_as_millis_u64();
                 for (_peer_id, channel_id, channel_state) in self.store.get_channel_states(None) {
                     if matches!(channel_state, ChannelState::ChannelReady) {
@@ -1146,7 +1146,7 @@ where
                                     "Force closing channel {:?} due to expired offered tlc",
                                     channel_id
                                 );
-                                let (send, _recv) = oneshot::channel::<Result<(), String>>();
+                                let (send, _recv) = oneshot::channel();
                                 let rpc_reply = RpcReplyPort::from(send);
                                 state
                                     .send_command_to_channel(
@@ -1161,6 +1161,33 @@ where
                                         ),
                                     )
                                     .await?;
+                            }
+                            for tlc in actor_state.tlc_state.received_tlcs.get_committed_tlcs() {
+                                if let Some(payment_preimage) =
+                                    self.store.get_invoice_preimage(&tlc.payment_hash)
+                                {
+                                    debug!(
+                                        "Found payment preimage for channel {:?} tlc {:?}",
+                                        channel_id,
+                                        tlc.id()
+                                    );
+                                    let (send, _recv) = oneshot::channel();
+                                    let rpc_reply = RpcReplyPort::from(send);
+                                    state
+                                        .send_command_to_channel(
+                                            channel_id,
+                                            ChannelCommand::RemoveTlc(
+                                                RemoveTlcCommand {
+                                                    id: tlc.id(),
+                                                    reason: RemoveTlcReason::RemoveTlcFulfill(
+                                                        RemoveTlcFulfill { payment_preimage },
+                                                    ),
+                                                },
+                                                rpc_reply,
+                                            ),
+                                        )
+                                        .await?;
+                                }
                             }
                         }
                     }
@@ -3320,8 +3347,8 @@ where
         myself.send_interval(MAINTAINING_CONNECTIONS_INTERVAL, || {
             NetworkActorMessage::new_command(NetworkActorCommand::MaintainConnections)
         });
-        myself.send_interval(CHECK_FORCE_CLOSE_INTERVAL, || {
-            NetworkActorMessage::new_command(NetworkActorCommand::CheckForceClose)
+        myself.send_interval(CHECK_CHANNELS_INTERVAL, || {
+            NetworkActorMessage::new_command(NetworkActorCommand::CheckChannels)
         });
         Ok(())
     }

--- a/src/watchtower/actor.rs
+++ b/src/watchtower/actor.rs
@@ -30,6 +30,7 @@ use crate::{
             create_witness_for_commitment_cell_with_pending_tlcs, RevocationData, SettlementData,
             SettlementTlc, XUDT_COMPATIBLE_WITNESS,
         },
+        hash_algorithm::HashAlgorithm,
         types::Hash256,
     },
     invoice::InvoiceStore,
@@ -505,13 +506,12 @@ fn try_settle_commitment_tx<S: InvoiceStore>(
                             continue;
                         }
                     };
+                let commitment_tx_hash = cell.out_point.tx_hash.clone();
                 if lock_script_args.len() > 36 {
                     info!(
                         "Found a force closed commitment tx with pending tlcs: {:#x}",
-                        cell.out_point.tx_hash
+                        commitment_tx_hash
                     );
-
-                    let commitment_tx_hash = cell.out_point.tx_hash.clone();
                     match ckb_client.get_transaction(commitment_tx_hash.clone()) {
                         Ok(Some(tx_with_status)) => {
                             if tx_with_status.tx_status.status != Status::Committed {
@@ -533,6 +533,22 @@ fn try_settle_commitment_tx<S: InvoiceStore>(
                                                         && witness.len()
                                                             > 18 + 85 * pending_tlc_count as usize
                                                     {
+                                                        // store the payment preimage if needed
+                                                        let tlc = Tlc(
+                                                            &witness[(18 + 85 * unlock_type as usize)..(18 + 85 * (unlock_type + 1) as usize)]
+                                                        );
+                                                        let preimage: [u8; 32] = witness[witness.len() - 32..].try_into().expect("checked length");
+                                                        let payment_hash = tlc.hash_algorithm().hash(preimage);
+                                                        if payment_hash.starts_with(tlc.payment_hash()) {
+                                                            info!("Found a preimage for payment hash: {:?}", payment_hash);
+                                                            store.insert_payment_preimage(
+                                                                payment_hash.into(),
+                                                                preimage.into(),
+                                                            ).expect("insert payment preimage should be ok");
+                                                        } else {
+                                                            warn!("Found a preimage for payment hash: {:?}, but not match the tlc", payment_hash);
+                                                        }
+                                                        // use remaining tlcs as new pending tlcs
                                                         let remain = [
                                                             &witness[18..(18
                                                                 + 85 * unlock_type as usize)],
@@ -604,8 +620,63 @@ fn try_settle_commitment_tx<S: InvoiceStore>(
                 } else {
                     info!(
                         "Found a force closed commitment tx without pending tlcs: {:#x}",
-                        cell.out_point.tx_hash
+                        commitment_tx_hash
                     );
+                    // we need to find and store the payment preimage if needed
+                    match ckb_client.get_transaction(commitment_tx_hash.clone()) {
+                        Ok(Some(tx_with_status)) => {
+                            if tx_with_status.tx_status.status != Status::Committed {
+                                error!("Cannot find the commitment tx: {:?}, status is {:?}, maybe ckb indexer bug?", tx_with_status.tx_status.status, commitment_tx_hash);
+                            } else if let Some(tx) = tx_with_status.transaction {
+                                match tx.inner {
+                                    Either::Left(tx) => {
+                                        let tx: Transaction = tx.inner.into();
+                                        tx.witnesses().into_iter().for_each(|witness| {
+                                            let witness = witness.raw_data();
+                                            if witness.len() > 18
+                                                && witness[0..16] == XUDT_COMPATIBLE_WITNESS
+                                            {
+                                                let unlock_type = witness[16];
+                                                let pending_tlc_count = witness[17];
+                                                if unlock_type < 0xFE
+                                                    && unlock_type < pending_tlc_count
+                                                    && witness.len()
+                                                        > 18 + 85 * pending_tlc_count as usize
+                                                {
+                                                    let tlc = Tlc(
+                                                        &witness[(18 + 85 * unlock_type as usize)..(18 + 85 * (unlock_type + 1) as usize)]
+                                                    );
+                                                    let preimage: [u8; 32] = witness[witness.len() - 32..].try_into().expect("checked length");
+                                                    let payment_hash = tlc.hash_algorithm().hash(preimage);
+                                                    if payment_hash.starts_with(tlc.payment_hash()) {
+                                                        info!("Found a preimage for payment hash: {:?}", payment_hash);
+                                                        store.insert_payment_preimage(
+                                                            payment_hash.into(),
+                                                            preimage.into(),
+                                                        ).expect("insert payment preimage should be ok");
+                                                    } else {
+                                                        warn!("Found a preimage for payment hash: {:?}, but not match the tlc", payment_hash);
+                                                    }
+                                                }
+                                            }
+                                        })
+                                    }
+                                    Either::Right(_) => {
+                                        // unreachable, ignore
+                                    }
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            error!(
+                                "Cannot find the commitment tx: {:?}, maybe ckb indexer bug?",
+                                commitment_tx_hash
+                            );
+                        }
+                        Err(err) => {
+                            error!("Failed to get commitment tx: {:?}", err);
+                        }
+                    }
                     if cell_header.epoch().to_rational() + delay_epoch.unwrap().to_rational()
                         > current_epoch.to_rational()
                     {
@@ -804,14 +875,8 @@ fn sign_tx_with_settlement(
         .expect("get witness at index 0")
         .raw_data()
         .to_vec();
-    // a trick to avoid the signature place holder offset check
-    let witness_len = settlement_witness.len();
-    let signature_start = witness_len
-        - if settlement_witness[witness_len - 65..witness_len] == vec![0u8; 65] {
-            65
-        } else {
-            65 + 32
-        };
+    let pending_tlc_count = settlement_witness[17] as usize;
+    let signature_start = 18 + 85 * pending_tlc_count;
     settlement_witness.splice(signature_start..signature_start + 65, signature_bytes);
 
     let witness = tx.witnesses().get(1).expect("get witness at index 1");
@@ -1239,6 +1304,14 @@ fn build_settlement_tx_for_pending_tlcs<S: InvoiceStore>(
 struct Tlc<'a>(&'a [u8]);
 
 impl<'a> Tlc<'a> {
+    pub fn hash_algorithm(&self) -> HashAlgorithm {
+        if (self.0[0] >> 1) & 0b0000001 == 0 {
+            HashAlgorithm::CkbHash
+        } else {
+            HashAlgorithm::Sha256
+        }
+    }
+
     pub fn payment_hash(&self) -> &'a [u8] {
         &self.0[17..37]
     }

--- a/src/watchtower/actor.rs
+++ b/src/watchtower/actor.rs
@@ -460,8 +460,93 @@ fn try_settle_commitment_tx<S: InvoiceStore>(
         script_search_mode: Some(SearchMode::Prefix),
         with_data: None,
         filter: None,
-        group_by_transaction: None,
+        group_by_transaction: Some(true),
     };
+    // find all on-chain transactions with the preimage and store them
+    let mut after = None;
+    loop {
+        match ckb_client.get_transactions(
+            search_key.clone(),
+            Order::Desc,
+            100u32.into(),
+            after.clone(),
+        ) {
+            Ok(txs) => {
+                if txs.objects.is_empty() {
+                    break;
+                } else {
+                    after = Some(txs.last_cursor.clone());
+                    for tx in txs.objects {
+                        match ckb_client.get_transaction(tx.tx_hash()) {
+                            Ok(Some(tx_with_status)) => {
+                                if tx_with_status.tx_status.status != Status::Committed {
+                                    error!("Cannot find the tx: {:?}, status is {:?}, maybe ckb indexer bug?", tx_with_status.tx_status.status, tx.tx_hash());
+                                } else if let Some(tx) = tx_with_status.transaction {
+                                    match tx.inner {
+                                        Either::Left(tx) => {
+                                            let tx: Transaction = tx.inner.into();
+                                            for witness in tx.witnesses().into_iter() {
+                                                let witness = witness.raw_data();
+                                                if witness.len() > 18
+                                                    && witness[0..16] == XUDT_COMPATIBLE_WITNESS
+                                                {
+                                                    let unlock_type = witness[16];
+                                                    let pending_tlc_count = witness[17];
+                                                    if unlock_type < 0xFE
+                                                        && unlock_type < pending_tlc_count
+                                                        && witness.len()
+                                                            > 18 + 85 * pending_tlc_count as usize
+                                                    {
+                                                        let tlc = Tlc(&witness[(18
+                                                            + 85 * unlock_type as usize)
+                                                            ..(18
+                                                                + 85 * (unlock_type + 1)
+                                                                    as usize)]);
+                                                        let preimage: [u8; 32] = witness
+                                                            [witness.len() - 32..]
+                                                            .try_into()
+                                                            .expect("checked length");
+                                                        let payment_hash =
+                                                            tlc.hash_algorithm().hash(preimage);
+                                                        if payment_hash
+                                                            .starts_with(tlc.payment_hash())
+                                                        {
+                                                            info!("Found a preimage for payment hash: {:?}", payment_hash);
+                                                            store.insert_payment_preimage(
+                                                            payment_hash.into(),
+                                                            preimage.into(),
+                                                        ).expect("insert payment preimage should be ok");
+                                                        } else {
+                                                            warn!("Found a preimage for payment hash: {:?}, but not match the tlc", payment_hash);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        Either::Right(_) => {
+                                            // unreachable, ignore
+                                        }
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                error!(
+                                    "Cannot find the tx: {:?}, maybe ckb indexer bug?",
+                                    tx.tx_hash()
+                                );
+                            }
+                            Err(err) => {
+                                error!("Failed to get tx: {:?}", err);
+                            }
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                error!("Failed to get transactions: {:?}", err);
+            }
+        }
+    }
     // the live cells number should be 1 or 0 for normal case, however, an attacker may create a lot of cells to implement a tx pinning attack.
     match ckb_client.get_cells(search_key, Order::Desc, 100u32.into(), None) {
         Ok(cells) => {
@@ -533,21 +618,6 @@ fn try_settle_commitment_tx<S: InvoiceStore>(
                                                         && witness.len()
                                                             > 18 + 85 * pending_tlc_count as usize
                                                     {
-                                                        // store the payment preimage if needed
-                                                        let tlc = Tlc(
-                                                            &witness[(18 + 85 * unlock_type as usize)..(18 + 85 * (unlock_type + 1) as usize)]
-                                                        );
-                                                        let preimage: [u8; 32] = witness[witness.len() - 32..].try_into().expect("checked length");
-                                                        let payment_hash = tlc.hash_algorithm().hash(preimage);
-                                                        if payment_hash.starts_with(tlc.payment_hash()) {
-                                                            info!("Found a preimage for payment hash: {:?}", payment_hash);
-                                                            store.insert_payment_preimage(
-                                                                payment_hash.into(),
-                                                                preimage.into(),
-                                                            ).expect("insert payment preimage should be ok");
-                                                        } else {
-                                                            warn!("Found a preimage for payment hash: {:?}, but not match the tlc", payment_hash);
-                                                        }
                                                         // use remaining tlcs as new pending tlcs
                                                         let remain = [
                                                             &witness[18..(18
@@ -622,61 +692,6 @@ fn try_settle_commitment_tx<S: InvoiceStore>(
                         "Found a force closed commitment tx without pending tlcs: {:#x}",
                         commitment_tx_hash
                     );
-                    // we need to find and store the payment preimage if needed
-                    match ckb_client.get_transaction(commitment_tx_hash.clone()) {
-                        Ok(Some(tx_with_status)) => {
-                            if tx_with_status.tx_status.status != Status::Committed {
-                                error!("Cannot find the commitment tx: {:?}, status is {:?}, maybe ckb indexer bug?", tx_with_status.tx_status.status, commitment_tx_hash);
-                            } else if let Some(tx) = tx_with_status.transaction {
-                                match tx.inner {
-                                    Either::Left(tx) => {
-                                        let tx: Transaction = tx.inner.into();
-                                        tx.witnesses().into_iter().for_each(|witness| {
-                                            let witness = witness.raw_data();
-                                            if witness.len() > 18
-                                                && witness[0..16] == XUDT_COMPATIBLE_WITNESS
-                                            {
-                                                let unlock_type = witness[16];
-                                                let pending_tlc_count = witness[17];
-                                                if unlock_type < 0xFE
-                                                    && unlock_type < pending_tlc_count
-                                                    && witness.len()
-                                                        > 18 + 85 * pending_tlc_count as usize
-                                                {
-                                                    let tlc = Tlc(
-                                                        &witness[(18 + 85 * unlock_type as usize)..(18 + 85 * (unlock_type + 1) as usize)]
-                                                    );
-                                                    let preimage: [u8; 32] = witness[witness.len() - 32..].try_into().expect("checked length");
-                                                    let payment_hash = tlc.hash_algorithm().hash(preimage);
-                                                    if payment_hash.starts_with(tlc.payment_hash()) {
-                                                        info!("Found a preimage for payment hash: {:?}", payment_hash);
-                                                        store.insert_payment_preimage(
-                                                            payment_hash.into(),
-                                                            preimage.into(),
-                                                        ).expect("insert payment preimage should be ok");
-                                                    } else {
-                                                        warn!("Found a preimage for payment hash: {:?}, but not match the tlc", payment_hash);
-                                                    }
-                                                }
-                                            }
-                                        })
-                                    }
-                                    Either::Right(_) => {
-                                        // unreachable, ignore
-                                    }
-                                }
-                            }
-                        }
-                        Ok(None) => {
-                            error!(
-                                "Cannot find the commitment tx: {:?}, maybe ckb indexer bug?",
-                                commitment_tx_hash
-                            );
-                        }
-                        Err(err) => {
-                            error!("Failed to get commitment tx: {:?}", err);
-                        }
-                    }
                     if cell_header.epoch().to_rational() + delay_epoch.unwrap().to_rational()
                         > current_epoch.to_rational()
                     {

--- a/tests/bruno/e2e/watchtower/force-close-preimage/01-node1-connect-node2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/01-node1-connect-node2.bru
@@ -1,0 +1,38 @@
+meta {
+  name: connect peer
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "connect_peer",
+    "params": [
+      {"address": "{{NODE1_ADDR}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  // Dialing a peer is async in tentacle. Sleep for some time to make sure
+  // we're connected to the peer.
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/02-node2-connect-node3.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/02-node2-connect-node3.bru
@@ -1,0 +1,38 @@
+meta {
+  name: connect peer
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "connect_peer",
+    "params": [
+      {"address": "{{NODE2_ADDR}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  // Dialing a peer is async in tentacle. Sleep for some time to make sure
+  // we're connected to the peer.
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/03-node1-node2-open-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/03-node1-node2-open-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Node1 open a channel to Node2
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "open_channel",
+    "params": [
+      {
+        "peer_id": "{{NODE2_PEERID}}",
+        "funding_amount": "0x377aab54d000"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 2000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/04-node2-get-auto-accepted-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/04-node2-get-auto-accepted-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: get auto accepted channel id from Node2
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE1_PEERID}}"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body.result);
+  bru.setVar("N1N2_CHANNEL_ID", res.body.result.channels[0].channel_id);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/05-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/05-ckb-generate-blocks.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for channel 1
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x2"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/06-node2-node3-open-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/06-node2-node3-open-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Node2 open a channel to Node3
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "open_channel",
+    "params": [
+      {
+        "peer_id": "{{NODE3_PEERID}}",
+        "funding_amount": "0x377aab54d000"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 2000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/07-node3-get-auto-accepted-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/07-node3-get-auto-accepted-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: get auto accepted channel id from Node3
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE2_PEERID}}"
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body.result);
+  bru.setVar("N2N3_CHANNEL_ID", res.body.result.channels[0].channel_id);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/08-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/08-ckb-generate-blocks.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for channel 2
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x2"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/09-node1-add-tlc.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/09-node1-add-tlc.bru
@@ -1,0 +1,49 @@
+meta {
+  name: Node1 add tlc, 0x266cec97cbede2cfbce73666f08deed9560bdf7841a7a5a51b3a3f09da249e21 is the hash of 32 bytes zeroes
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "add_tlc",
+    "params": [
+      {
+        "channel_id": "{{N1N2_CHANNEL_ID}}",
+        "amount": "0x5f5e100",
+        "payment_hash": "0x266cec97cbede2cfbce73666f08deed9560bdf7841a7a5a51b3a3f09da249e21",
+        "expiry": "{{expiry}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.tlc_id: isDefined
+}
+
+script:pre-request {
+  // Set expiry to 2 hours from now.
+  let expiry = "0x" + (Date.now() + 1000 * 60 * 60 * 2).toString(16);
+  bru.setVar("expiry", expiry);
+}
+
+script:post-response {
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 1000));
+  bru.setVar("N1N2_TLC_ID1", res.body.result.tlc_id);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/10-node2-add-tlc.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/10-node2-add-tlc.bru
@@ -1,0 +1,49 @@
+meta {
+  name: Node2 add tlc, 0x266cec97cbede2cfbce73666f08deed9560bdf7841a7a5a51b3a3f09da249e21 is the hash of 32 bytes zeroes
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "add_tlc",
+    "params": [
+      {
+        "channel_id": "{{N2N3_CHANNEL_ID}}",
+        "amount": "0x5f5e100",
+        "payment_hash": "0x266cec97cbede2cfbce73666f08deed9560bdf7841a7a5a51b3a3f09da249e21",
+        "expiry": "{{expiry}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.tlc_id: isDefined
+}
+
+script:pre-request {
+  // Set expiry to 1 hour from now.
+  let expiry = "0x" + (Date.now() + 1000 * 60 * 60 * 1).toString(16);
+  bru.setVar("expiry", expiry);
+}
+
+script:post-response {
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 1000));
+  bru.setVar("N2N3_TLC_ID1", res.body.result.tlc_id);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/11-node2-force-close-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/11-node2-force-close-channel.bru
@@ -1,0 +1,34 @@
+meta {
+  name: node2 force close channel
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "shutdown_channel",
+    "params": [
+      {
+        "channel_id": "{{N2N3_CHANNEL_ID}}",
+        "force": true
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/12-ckb-generate-blocks-for-force-close-tx.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/12-ckb-generate-blocks-for-force-close-tx.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate one epoch for two force close transactions
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x1"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/13-node3-remove-tlc.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/13-node3-remove-tlc.bru
@@ -1,0 +1,37 @@
+meta {
+  name: remove tlc from node3, the preimage should be stored and node3 should be able to use it to claim the tlc from the force close tx
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "remove_tlc",
+    "params": [
+      {
+        "channel_id": "{{N2N3_CHANNEL_ID}}",
+        "tlc_id": "{{N2N3_TLC_ID1}}",
+        "reason": {
+          "payment_preimage": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        }
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/14-ckb-generate-blocks-for-settlement-tx-preimage.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/14-ckb-generate-blocks-for-settlement-tx-preimage.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for settlement transaction
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x3"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/15-ckb-generate-blocks-for-final-settlement-tx.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/15-ckb-generate-blocks-for-final-settlement-tx.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for final settlement transaction
+  type: http
+  seq: 15
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x7"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/16-ckb-generate-blocks-for-final-settlement-tx-commit.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/16-ckb-generate-blocks-for-final-settlement-tx-commit.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate one epoch for final settlement transaction commit
+  type: http
+  seq: 16
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x1"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 10000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage/17-check-channel1-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage/17-check-channel1-balance.bru
@@ -1,0 +1,38 @@
+meta {
+  name: check channel1 balance
+  type: http
+  seq: 17
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE1_PEERID}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.result.channels[0].local_balance: eq "0x5f5e100"
+  res.body.result.channels[0].received_tlc_balance: eq "0x0"
+}
+
+script:post-response {
+  console.log(res.body.result.channels[0]);
+}


### PR DESCRIPTION
Consider a HTLC chain Peer A -> Peer B -> Peer C

Peer C  force close the channel between B and C, then claim the tlc amount by preimage on-chain. B should be able to found this preimage and claim the tlc amount between B and A.