### PR TITLE
chore: Remove unused fields tlc_max_value in rpc and state

### DIFF
--- a/src/fiber/config.rs
+++ b/src/fiber/config.rs
@@ -165,14 +165,6 @@ pub struct FiberConfig {
         help = "The minimal value of a tlc. [default: 0 (no minimal value)]"
     )]
     pub tlc_min_value: Option<u128>,
-    /// The maximal value of a tlc. [default: 0 (no maximal value)]
-    #[arg(
-        name = "FIBER_TLC_MAX_VALUE",
-        long = "fiber-tlc-max-value",
-        env,
-        help = "The maximal value of a tlc. [default: 0 (no maximal value)]"
-    )]
-    pub tlc_max_value: Option<u128>,
 
     /// The fee for forwarding peer tlcs. Proportional to the amount of the forwarded tlc. The unit is millionths of the amount. [default: 1000 (0.1%)]
     #[arg(
@@ -434,10 +426,6 @@ impl FiberConfig {
 
     pub fn tlc_min_value(&self) -> u128 {
         self.tlc_min_value.unwrap_or(DEFAULT_TLC_MIN_VALUE)
-    }
-
-    pub fn tlc_max_value(&self) -> u128 {
-        self.tlc_max_value.unwrap_or(DEFAULT_TLC_MAX_VALUE)
     }
 
     pub fn tlc_fee_proportional_millionths(&self) -> u128 {

--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -184,7 +184,6 @@ pub struct NodeInfoResponse {
     pub auto_accept_channel_ckb_funding_amount: u64,
     pub tlc_expiry_delta: u64,
     pub tlc_min_value: u128,
-    pub tlc_max_value: u128,
     pub tlc_fee_proportional_millionths: u128,
     pub channel_count: u32,
     pub pending_channel_count: u32,
@@ -1492,7 +1491,6 @@ where
                         .auto_accept_channel_ckb_funding_amount,
                     tlc_expiry_delta: state.tlc_expiry_delta,
                     tlc_min_value: state.tlc_min_value,
-                    tlc_max_value: state.tlc_max_value,
                     tlc_fee_proportional_millionths: state.tlc_fee_proportional_millionths,
                     channel_count: state.channels.len() as u32,
                     pending_channel_count: state.pending_channels.len() as u32,
@@ -2033,7 +2031,6 @@ pub struct NetworkActorState<S> {
     tlc_expiry_delta: u64,
     // The default tlc min and max value of tlcs to be accepted.
     tlc_min_value: u128,
-    tlc_max_value: u128,
     // The default tlc fee proportional millionths to be used when auto accepting a channel.
     tlc_fee_proportional_millionths: u128,
     // The gossip messages actor to process and send gossip messages.
@@ -3310,7 +3307,6 @@ where
             auto_accept_channel_ckb_funding_amount: config.auto_accept_channel_ckb_funding_amount(),
             tlc_expiry_delta: config.tlc_expiry_delta(),
             tlc_min_value: config.tlc_min_value(),
-            tlc_max_value: config.tlc_max_value(),
             tlc_fee_proportional_millionths: config.tlc_fee_proportional_millionths(),
             gossip_actor,
             channel_subscribers,

--- a/src/rpc/README.md
+++ b/src/rpc/README.md
@@ -493,7 +493,6 @@ Get the node information.
 * `default_funding_lock_script` - <em>`Script`</em>, The default funding lock script for the node.
 * `tlc_expiry_delta` - <em>`u64`</em>, The locktime expiry delta for Time-Locked Contracts (TLC), serialized as a hexadecimal string.
 * `tlc_min_value` - <em>`u128`</em>, The minimum value for Time-Locked Contracts (TLC) we can send, serialized as a hexadecimal string.
-* `tlc_max_value` - <em>`u128`</em>, The maximum value for Time-Locked Contracts (TLC) we can send, serialized as a hexadecimal string, `0` means no maximum value limit.
 * `tlc_fee_proportional_millionths` - <em>`u128`</em>, The fee (to forward payments) proportional to the value of Time-Locked Contracts (TLC), expressed in millionths and serialized as a hexadecimal string.
 * `channel_count` - <em>`u32`</em>, The number of channels associated with the node, serialized as a hexadecimal string.
 * `pending_channel_count` - <em>`u32`</em>, The number of pending channels associated with the node, serialized as a hexadecimal string.

--- a/src/rpc/info.rs
+++ b/src/rpc/info.rs
@@ -58,10 +58,6 @@ pub struct NodeInfoResult {
     #[serde_as(as = "U128Hex")]
     pub tlc_min_value: u128,
 
-    /// The maximum value for Time-Locked Contracts (TLC) we can send, serialized as a hexadecimal string, `0` means no maximum value limit.
-    #[serde_as(as = "U128Hex")]
-    pub tlc_max_value: u128,
-
     /// The fee (to forward payments) proportional to the value of Time-Locked Contracts (TLC), expressed in millionths and serialized as a hexadecimal string.
     #[serde_as(as = "U128Hex")]
     pub tlc_fee_proportional_millionths: u128,
@@ -130,7 +126,6 @@ impl InfoRpcServer for InfoRpcServerImpl {
             default_funding_lock_script: self.default_funding_lock_script.clone(),
             tlc_expiry_delta: response.tlc_expiry_delta,
             tlc_min_value: response.tlc_min_value,
-            tlc_max_value: response.tlc_max_value,
             tlc_fee_proportional_millionths: response.tlc_fee_proportional_millionths,
             channel_count: response.channel_count,
             pending_channel_count: response.pending_channel_count,


### PR DESCRIPTION
`tlc_max_value` is unused in code.

Fixes #631