### PR TITLE
Fix invoice cancel bug caused by check channels

### DIFF
--- a/src/fiber/network.rs
+++ b/src/fiber/network.rs
@@ -82,7 +82,7 @@ use crate::fiber::types::{
     FiberChannelMessage, PaymentOnionPacket, PeeledPaymentOnionPacket, TxSignatures,
 };
 use crate::fiber::KeyPair;
-use crate::invoice::{CkbInvoice, InvoiceStore};
+use crate::invoice::{CkbInvoice, CkbInvoiceStatus, InvoiceStore};
 use crate::{now_timestamp_as_millis_u64, unwrap_or_return, Error};
 
 pub const FIBER_PROTOCOL_ID: ProtocolId = ProtocolId::new(42);
@@ -1143,6 +1143,18 @@ where
                                         channel_id,
                                         tlc.id()
                                     );
+                                    if self
+                                        .store
+                                        .get_invoice_status(&tlc.payment_hash)
+                                        .is_some_and(|s| {
+                                            !matches!(
+                                                s,
+                                                CkbInvoiceStatus::Open | CkbInvoiceStatus::Received
+                                            )
+                                        })
+                                    {
+                                        continue;
+                                    }
                                     let (send, _recv) = oneshot::channel();
                                     let rpc_reply = RpcReplyPort::from(send);
                                     if let Err(err) = state

--- a/src/fiber/tests/payment.rs
+++ b/src/fiber/tests/payment.rs
@@ -13,11 +13,15 @@ use crate::fiber::tests::test_utils::*;
 use crate::fiber::types::Hash256;
 use crate::fiber::NetworkActorCommand;
 use crate::fiber::NetworkActorMessage;
+use crate::gen_rand_sha256_hash;
+use crate::invoice::Currency;
+use crate::invoice::InvoiceBuilder;
 use crate::NetworkServiceEvent;
 use ckb_types::{core::tx_pool::TxStatus, packed::OutPoint};
 use ractor::call;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::time::Duration;
 
 #[tokio::test]
 async fn test_send_payment_custom_records() {
@@ -3084,6 +3088,85 @@ async fn test_send_payment_remove_tlc_with_preimage_will_retry() {
             if status == PaymentSessionStatus::Success {
                 payments.remove(payment_hash);
             }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+        if payments.is_empty() {
+            break;
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_send_payment_invoice_cancel_multiple_ops() {
+    init_tracing();
+    let _span = tracing::info_span!("node", node = "test").entered();
+    let (nodes, _channels) = create_n_nodes_network(
+        &[
+            ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
+            ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
+            ((2, 0), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
+        ],
+        3,
+    )
+    .await;
+    let [mut node_0, _node_1, _node_2] = nodes.try_into().expect("4 nodes");
+
+    let mut payments = HashSet::new();
+    let mut invoices = vec![];
+
+    let node_0_pubkey = node_0.pubkey;
+    for _i in 0..5 {
+        let preimage = gen_rand_sha256_hash();
+        let ckb_invoice = InvoiceBuilder::new(Currency::Fibd)
+            .amount(Some(100))
+            .payment_preimage(preimage)
+            .payee_pub_key(node_0_pubkey.into())
+            .expiry_time(Duration::from_secs(100))
+            .build()
+            .expect("build invoice success");
+
+        node_0.insert_invoice(ckb_invoice.clone(), Some(preimage));
+        invoices.push(ckb_invoice);
+    }
+
+    for i in 0..5 {
+        let invoice = &invoices[i];
+
+        node_0.cancel_invoice(invoice.payment_hash());
+        let res = node_0
+            .send_payment(SendPaymentCommand {
+                invoice: Some(invoice.to_string()),
+                amount: invoice.amount,
+                target_pubkey: None,
+                allow_self_payment: true,
+                payment_hash: None,
+                final_tlc_expiry_delta: None,
+                tlc_expiry_limit: None,
+                timeout: None,
+                max_fee_amount: None,
+                max_parts: None,
+                keysend: None,
+                udt_type_script: None,
+                dry_run: false,
+                hop_hints: None,
+                custom_records: None,
+            })
+            .await
+            .unwrap();
+        payments.insert(res.payment_hash);
+        node_0.wait_until_created(res.payment_hash).await;
+    }
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    loop {
+        for payment_hash in payments.clone().iter() {
+            let status = node_0.get_payment_status(*payment_hash).await;
+            eprintln!("payment_hash: {:?} got status : {:?}", payment_hash, status);
+            if status == PaymentSessionStatus::Failed {
+                payments.remove(payment_hash);
+            }
+            assert_ne!(status, PaymentSessionStatus::Success);
             tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         }
         if payments.is_empty() {

--- a/src/fiber/tests/payment.rs
+++ b/src/fiber/tests/payment.rs
@@ -3115,7 +3115,7 @@ async fn test_send_payment_invoice_cancel_multiple_ops() {
     let mut invoices: Vec<CkbInvoice> = vec![];
 
     let target_pubkey = node_0.pubkey;
-    let count = 30;
+    let count = 10;
     for _i in 0..count {
         let preimage = gen_rand_sha256_hash();
         let ckb_invoice = InvoiceBuilder::new(Currency::Fibd)
@@ -3126,10 +3126,6 @@ async fn test_send_payment_invoice_cancel_multiple_ops() {
             .expect("build invoice success");
 
         node_0.insert_invoice(ckb_invoice.clone(), Some(preimage));
-        assert!(invoices
-            .iter()
-            .find(|i| i.payment_hash() == ckb_invoice.payment_hash())
-            .is_none());
         invoices.push(ckb_invoice);
     }
 


### PR DESCRIPTION
This is a corner case for a node pay self, when there are many TLC opes, check channels cron job may try to RemoveTlc for invoice with preimage, but we didn't check invoice status.

Fixes #654
