### PR TITLE
fix: remove expect from molecule type conversion

### DIFF
--- a/src/fiber/types.rs
+++ b/src/fiber/types.rs
@@ -1930,7 +1930,6 @@ impl From<molecule_fiber::UdtDep> for UdtDep {
 
 impl From<UdtArgInfo> for molecule_fiber::UdtArgInfo {
     fn from(udt_arg_info: UdtArgInfo) -> Self {
-        tracing::info!("udt_arg_info: {:?}", udt_arg_info);
         molecule_fiber::UdtArgInfo::new_builder()
             .name(udt_arg_info.name.pack())
             .script(udt_arg_info.script.into())
@@ -1957,7 +1956,7 @@ impl From<UdtArgInfo> for molecule_fiber::UdtArgInfo {
 impl From<molecule_fiber::UdtArgInfo> for UdtArgInfo {
     fn from(udt_arg_info: molecule_fiber::UdtArgInfo) -> Self {
         UdtArgInfo {
-            name: String::from_utf8(udt_arg_info.name().unpack()).expect("invalid name"),
+            name: String::from_utf8(udt_arg_info.name().unpack()).unwrap_or_default(),
             script: udt_arg_info.script().into(),
             auto_accept_amount: udt_arg_info
                 .auto_accept_amount()
@@ -3758,12 +3757,13 @@ impl From<molecule_fiber::PaymentHopData> for PaymentHopData {
             hash_algorithm: payment_hop_data
                 .hash_algorithm()
                 .try_into()
-                .expect("valid hash algorithm"),
+                .unwrap_or_default(),
             funding_tx_hash: payment_hop_data.funding_tx_hash().into(),
             next_hop: payment_hop_data
                 .next_hop()
                 .to_opt()
-                .map(|x| x.try_into().expect("invalid pubkey")),
+                .map(|x| x.try_into())
+                .and_then(Result::ok),
             custom_records: payment_hop_data.custom_records().to_opt().map(|x| x.into()),
         }
     }


### PR DESCRIPTION
The molecule data coming from p2p messages is not trusted and should not be transformed by using `expect`, otherwise an attacker can construct malicious data to crash the node.