### PR TITLE
Payment session will retry to send if channel is reestablished

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           tool: nextest
       - run: |
-          RUST_BACKTRACE=full RUST_LOG=trace cargo nextest run --no-fail-fast
+          RUST_BACKTRACE=full RUST_LOG=trace,fnn=trace,fnn::cch::actor::tracker=off,fnn::fiber::gossip=off,tentacle=off,tokio_yamux=off,tentacle_secio=off cargo nextest run --no-fail-fast
 
   fmt:
     name: Rustfmt

--- a/src/fiber/channel.rs
+++ b/src/fiber/channel.rs
@@ -99,6 +99,7 @@ pub const COMMITMENT_CELL_WITNESS_LEN: usize = 16 + 1 + 32 + 64;
 pub const INITIAL_COMMITMENT_NUMBER: u64 = 0;
 
 const RETRYABLE_TLC_OPS_INTERVAL: Duration = Duration::from_millis(1000);
+const WAITING_REESTABLISH_FINISH_TIMEOUT: Duration = Duration::from_millis(4000);
 
 // if a important TLC operation is not acked in 30 seconds, we will try to disconnect the peer.
 #[cfg(not(test))]
@@ -1647,7 +1648,7 @@ where
         state: &mut ChannelActorState,
     ) {
         if state.reestablishing {
-            myself.send_after(RETRYABLE_TLC_OPS_INTERVAL * 4, || {
+            myself.send_after(WAITING_REESTABLISH_FINISH_TIMEOUT, || {
                 ChannelActorMessage::Event(ChannelEvent::CheckTlcRetryOperation)
             });
             return;
@@ -2474,19 +2475,6 @@ where
                     ))
                     .expect(ASSUME_NETWORK_ACTOR_ALIVE);
 
-                // If the channel is already ready, we should notify the network actor.
-                // so that we update the network.outpoint_channel_map
-                if matches!(channel.state, ChannelState::ChannelReady) {
-                    self.network
-                        .send_message(NetworkActorMessage::new_event(
-                            NetworkActorEvent::ChannelReady(
-                                channel.get_id(),
-                                channel.get_remote_peer_id(),
-                                channel.must_get_funding_transaction_outpoint(),
-                            ),
-                        ))
-                        .expect(ASSUME_NETWORK_ACTOR_ALIVE);
-                }
                 Ok(channel)
             }
         }
@@ -6256,10 +6244,21 @@ impl ChannelActorState {
             }
         }
         if self.tlc_state.has_pending_operations() {
-            myself.send_after(4 * RETRYABLE_TLC_OPS_INTERVAL, || {
+            myself.send_after(WAITING_REESTABLISH_FINISH_TIMEOUT, || {
                 ChannelActorMessage::Event(ChannelEvent::CheckTlcRetryOperation)
             });
         }
+        // If the channel is already ready, we should notify the network actor.
+        // so that we update the network.outpoint_channel_map
+        let channel_id = self.get_id();
+        let outpoint = self.must_get_funding_transaction_outpoint();
+        let peer_id = self.get_remote_peer_id();
+        self.network()
+            .send_after(WAITING_REESTABLISH_FINISH_TIMEOUT, move || {
+                NetworkActorMessage::new_event(NetworkActorEvent::ChannelReady(
+                    channel_id, peer_id, outpoint,
+                ))
+            });
         self.on_owned_channel_updated(myself, false).await;
     }
 

--- a/src/fiber/graph.rs
+++ b/src/fiber/graph.rs
@@ -1487,6 +1487,8 @@ where
 
 pub trait NetworkGraphStateStore {
     fn get_payment_session(&self, payment_hash: Hash256) -> Option<PaymentSession>;
+    fn get_payment_sessions_with_status(&self, status: PaymentSessionStatus)
+        -> Vec<PaymentSession>;
     fn insert_payment_session(&self, session: PaymentSession);
     fn insert_payment_history_result(
         &mut self,
@@ -1610,6 +1612,14 @@ impl PaymentSession {
 
     pub fn is_send_payment_with_router(&self) -> bool {
         !self.request.router.is_empty()
+    }
+
+    pub fn first_hop_channel_outpoint_eq(&self, out_point: &OutPoint) -> bool {
+        self.route
+            .nodes
+            .first()
+            .map(|x| x.channel_outpoint.eq(out_point))
+            .unwrap_or_default()
     }
 
     fn set_status(&mut self, status: PaymentSessionStatus) {

--- a/src/fiber/tests/payment.rs
+++ b/src/fiber/tests/payment.rs
@@ -3959,7 +3959,9 @@ async fn test_send_payment_middle_hop_restart_will_be_ok() {
         assert_eq!(status, PaymentSessionStatus::Success);
 
         nodes[restart_node_index].restart().await;
-        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
+        // wait for the node to be ready after reestablish channel
+        tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
 
         let res = nodes[0]
             .send_payment_keysend(&nodes[3], payment_amount, false)
@@ -4023,7 +4025,7 @@ async fn test_send_payment_middle_hop_stop_send_payment_then_start() {
 
         // now we start nodes[2], expect the payment will success
         nodes[restart_node_index].start().await;
-        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
 
         // because the probability of the path is not 100% after the node is restarted
         // send normal payment amount will fail at the beginning
@@ -4437,4 +4439,81 @@ async fn test_send_payment_with_mixed_channel_hops() {
     );
     let payment_session = node0.get_payment_session(payment_hash).unwrap();
     assert_eq!(payment_session.retried_times, 1);
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_send_payment_with_reconnect_two_times() {
+    init_tracing();
+    let _span = tracing::info_span!("node", node = "test").entered();
+    let (nodes, _channels) =
+        create_n_nodes_network(&[((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT))], 2).await;
+    let [mut node0, mut node1] = nodes.try_into().expect("2 nodes");
+
+    for _i in 0..2 {
+        let mut payments = HashSet::new();
+        for _j in 0..5 {
+            let res = node0
+                .send_payment_keysend(&node1, 1000, false)
+                .await
+                .unwrap();
+            let payment_hash = res.payment_hash;
+            payments.insert(payment_hash);
+        }
+
+        // disconnect peer
+        let node1_id = node1.peer_id.clone();
+        let node0_id = node0.peer_id.clone();
+        node0
+            .network_actor
+            .send_message(NetworkActorMessage::new_command(
+                NetworkActorCommand::DisconnectPeer(node1_id.clone()),
+            ))
+            .expect("node_a alive");
+
+        node1
+            .expect_event(|event| match event {
+                NetworkServiceEvent::PeerDisConnected(peer_id, _) => {
+                    assert_eq!(peer_id, &node0_id);
+                    true
+                }
+                _ => false,
+            })
+            .await;
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
+
+        // reconnect peer
+        node0.connect_to_nonblocking(&node1).await;
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        // wait for the payment to be retried
+        for _i in 0..20 {
+            assert!(node0.get_triggered_unexpected_events().await.is_empty());
+            assert!(node1.get_triggered_unexpected_events().await.is_empty());
+            for payment_hash in payments.clone().iter() {
+                let status = node0.get_payment_status(*payment_hash).await;
+                eprintln!("payment_hash: {:?} got status : {:?}", payment_hash, status);
+                if status == PaymentSessionStatus::Success || status == PaymentSessionStatus::Failed
+                {
+                    payments.remove(payment_hash);
+                } else if status == PaymentSessionStatus::Created {
+                    // wait for the payment to be retried
+                    let payment_session = node0.get_payment_session(*payment_hash).unwrap();
+                    eprintln!(
+                        "payment_session can_retry: {:?} retry_times: {:?}",
+                        payment_session.can_retry(),
+                        payment_session.retried_times
+                    );
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            }
+            if payments.is_empty() {
+                break;
+            }
+        }
+        if !payments.is_empty() {
+            panic!("some payments are not finished: {:?}", payments);
+        }
+    }
 }

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -6,7 +6,7 @@ use crate::{
             ChannelActorState, ChannelActorStateStore, ChannelState, RevocationData, SettlementData,
         },
         gossip::GossipMessageStore,
-        graph::{NetworkGraphStateStore, PaymentSession},
+        graph::{NetworkGraphStateStore, PaymentSession, PaymentSessionStatus},
         history::{Direction, TimedResult},
         network::{NetworkActorStateStore, PaymentCustomRecords, PersistentNetworkActorState},
         types::{BroadcastMessage, BroadcastMessageID, Cursor, Hash256, CURSOR_SIZE},
@@ -475,6 +475,23 @@ impl NetworkGraphStateStore for Store {
         let prefix = [&[PAYMENT_SESSION_PREFIX], payment_hash.as_ref()].concat();
         self.get(prefix)
             .map(|v| deserialize_from(v.as_ref(), "PaymentSession"))
+    }
+
+    fn get_payment_sessions_with_status(
+        &self,
+        status: PaymentSessionStatus,
+    ) -> Vec<PaymentSession> {
+        let prefix = [PAYMENT_SESSION_PREFIX];
+        self.prefix_iterator(&prefix)
+            .filter_map(|(_key, value)| {
+                let session: PaymentSession = deserialize_from(value.as_ref(), "PaymentSession");
+                if session.status == status {
+                    Some(session)
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     fn insert_payment_session(&self, session: PaymentSession) {


### PR DESCRIPTION
When peer is disconnected, some payments may be left in `Created` status (which means we haven't sent out TLC for the first hop), after channel is reestablished, we need retry these payments if needed.
