### PR TITLE
chore: split preimage store

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -35,7 +35,7 @@ use crate::{
         },
         NetworkActorCommand, NetworkActorEvent, NetworkActorMessage, ASSUME_NETWORK_ACTOR_ALIVE,
     },
-    invoice::{CkbInvoice, CkbInvoiceStatus, InvoiceStore},
+    invoice::{CkbInvoice, CkbInvoiceStatus, InvoiceStore, PreimageStore},
     now_timestamp_as_millis_u64, NetworkServiceEvent,
 };
 use ckb_hash::{blake2b_256, new_blake2b};
@@ -333,7 +333,7 @@ pub struct ChannelActor<S> {
 
 impl<S> ChannelActor<S>
 where
-    S: InvoiceStore + ChannelActorStateStore,
+    S: ChannelActorStateStore + InvoiceStore + PreimageStore,
 {
     pub fn new(
         local_pubkey: Pubkey,
@@ -839,7 +839,7 @@ where
         tlc_id: TLCId,
     ) {
         let tlc_info = state.get_received_tlc(tlc_id).expect("expect tlc");
-        let preimage = self.store.get_invoice_preimage(&tlc_info.payment_hash);
+        let preimage = self.store.get_preimage(&tlc_info.payment_hash);
 
         let preimage = if let Some(preimage) = preimage {
             preimage
@@ -983,7 +983,7 @@ where
             let preimage = peeled_onion_packet
                 .current
                 .payment_preimage
-                .or_else(|| self.store.get_invoice_preimage(&add_tlc.payment_hash));
+                .or_else(|| self.store.get_preimage(&add_tlc.payment_hash));
 
             if let Some(preimage) = preimage {
                 let filled_payment_hash: Hash256 = add_tlc.hash_algorithm.hash(preimage).into();
@@ -1002,11 +1002,7 @@ where
                         .insert_payment_custom_records(&payment_hash, custom_records);
                 }
 
-                self.store
-                    .insert_payment_preimage(payment_hash, preimage)
-                    .map_err(|_| {
-                        ProcessingChannelError::InternalError("insert preimage failed".to_string())
-                    })?;
+                self.store.insert_preimage(payment_hash, preimage);
             } else {
                 return Err(ProcessingChannelError::FinalIncorrectPaymentHash);
             }
@@ -1079,11 +1075,7 @@ where
             // incase the peer has already shutdown the channel,
             // so we can send setttlement transaction to get money when necessary
             // the preimage must be valid since we have checked it in check_remove_tlc_with_reason
-            self.store
-                .insert_payment_preimage(payment_hash, payment_preimage)
-                .map_err(|_| {
-                    ProcessingChannelError::InternalError("insert preimage failed".to_string())
-                })?;
+            self.store.insert_preimage(payment_hash, payment_preimage);
             debug_event!(
                 self.network,
                 &format!("store payment_preimage for: {:?}", payment_hash)
@@ -1199,9 +1191,7 @@ where
             // when a hop is a forwarding hop, we need to keep preimage after relay RemoveTlc finished
             // incase watchtower may need preimage to settledown
             if tlc_info.previous_tlc.is_none() {
-                self.store
-                    .remove_payment_preimage(&tlc_info.payment_hash)
-                    .expect("remove preimage failed");
+                self.store.remove_preimage(&tlc_info.payment_hash);
             }
         }
 
@@ -1396,11 +1386,7 @@ where
         if let RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill { payment_preimage }) =
             command.reason
         {
-            self.store
-                .insert_payment_preimage(payment_hash, payment_preimage)
-                .map_err(|_| {
-                    ProcessingChannelError::InternalError("insert preimage failed".to_string())
-                })?;
+            self.store.insert_preimage(payment_hash, payment_preimage);
         }
         let msg = FiberMessageWithPeerId::new(
             state.get_remote_peer_id(),
@@ -2195,7 +2181,7 @@ where
 #[rasync_trait]
 impl<S> Actor for ChannelActor<S>
 where
-    S: ChannelActorStateStore + InvoiceStore + Send + Sync + 'static,
+    S: ChannelActorStateStore + InvoiceStore + PreimageStore + Send + Sync + 'static,
 {
     type Msg = ChannelActorMessage;
     type State = ChannelActorState;

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -85,7 +85,7 @@ use crate::fiber::types::{
     FiberChannelMessage, PaymentOnionPacket, PeeledPaymentOnionPacket, TxSignatures,
 };
 use crate::fiber::KeyPair;
-use crate::invoice::{CkbInvoice, CkbInvoiceStatus, InvoiceStore};
+use crate::invoice::{CkbInvoice, CkbInvoiceStatus, InvoiceStore, PreimageStore};
 use crate::{now_timestamp_as_millis_u64, unwrap_or_return, Error};
 
 pub const FIBER_PROTOCOL_ID: ProtocolId = ProtocolId::new(42);
@@ -815,6 +815,7 @@ where
         + ChannelActorStateStore
         + NetworkGraphStateStore
         + GossipMessageStore
+        + PreimageStore
         + InvoiceStore
         + Clone
         + Send
@@ -1242,7 +1243,7 @@ where
                             }
                             for tlc in actor_state.tlc_state.received_tlcs.get_committed_tlcs() {
                                 if let Some(payment_preimage) =
-                                    self.store.get_invoice_preimage(&tlc.payment_hash)
+                                    self.store.get_preimage(&tlc.payment_hash)
                                 {
                                     debug!(
                                         "Found payment preimage for channel {:?} tlc {:?}",
@@ -2356,6 +2357,7 @@ where
         + ChannelActorStateStore
         + NetworkGraphStateStore
         + GossipMessageStore
+        + PreimageStore
         + InvoiceStore
         + Clone
         + Send
@@ -3375,6 +3377,7 @@ where
         + ChannelActorStateStore
         + NetworkGraphStateStore
         + GossipMessageStore
+        + PreimageStore
         + InvoiceStore
         + Clone
         + Send
@@ -3796,6 +3799,7 @@ pub async fn start_network<
         + ChannelActorStateStore
         + NetworkGraphStateStore
         + GossipMessageStore
+        + PreimageStore
         + InvoiceStore
         + Clone
         + Send

--- a/crates/fiber-lib/src/fiber/tests/test_utils.rs
+++ b/crates/fiber-lib/src/fiber/tests/test_utils.rs
@@ -28,6 +28,7 @@ use crate::fiber::types::Pubkey;
 use crate::invoice::CkbInvoice;
 use crate::invoice::CkbInvoiceStatus;
 use crate::invoice::InvoiceStore;
+use crate::invoice::PreimageStore;
 use crate::rpc::config::RpcConfig;
 use crate::rpc::server::start_rpc;
 use ckb_sdk::core::TransactionBuilder;
@@ -662,7 +663,7 @@ impl NetworkNode {
     }
 
     pub fn get_payment_preimage(&self, payment_hash: &Hash256) -> Option<Hash256> {
-        self.store.get_invoice_preimage(payment_hash)
+        self.store.get_preimage(payment_hash)
     }
 
     pub async fn send_payment(

--- a/crates/fiber-lib/src/invoice/store.rs
+++ b/crates/fiber-lib/src/invoice/store.rs
@@ -8,19 +8,24 @@ pub trait InvoiceStore {
         invoice: CkbInvoice,
         preimage: Option<Hash256>,
     ) -> Result<(), InvoiceError>;
-    fn get_invoice_preimage(&self, id: &Hash256) -> Option<Hash256>;
     fn update_invoice_status(
         &self,
         id: &Hash256,
         status: CkbInvoiceStatus,
     ) -> Result<(), InvoiceError>;
     fn get_invoice_status(&self, id: &Hash256) -> Option<CkbInvoiceStatus>;
-    fn insert_payment_preimage(
-        &self,
-        payment_hash: Hash256,
-        preimage: Hash256,
-    ) -> Result<(), InvoiceError>;
-    /// Search for the stored preimage with the given payment hash prefix, usually the first 20 bytes of the payment hash.
-    fn search_payment_preimage(&self, payment_hash_prefix: &[u8]) -> Option<Hash256>;
-    fn remove_payment_preimage(&self, payment_hash: &Hash256) -> Result<(), InvoiceError>;
+}
+
+pub trait PreimageStore {
+    /// Insert a preimage into the store, the payment hash should be a 32 bytes hash result of the preimage after `HashAlgorithm` is applied.
+    fn insert_preimage(&self, payment_hash: Hash256, preimage: Hash256);
+
+    /// Remove a preimage from the store.
+    fn remove_preimage(&self, payment_hash: &Hash256);
+
+    /// Get a preimage from the store.
+    fn get_preimage(&self, payment_hash: &Hash256) -> Option<Hash256>;
+
+    /// Search for the stored preimage with the given payment hash prefix, should be the first 20 bytes of the payment hash.
+    fn search_preimage(&self, payment_hash_prefix: &[u8]) -> Option<Hash256>;
 }

--- a/crates/fiber-lib/src/store/schema.rs
+++ b/crates/fiber-lib/src/store/schema.rs
@@ -20,7 +20,7 @@
 pub(crate) const CHANNEL_ACTOR_STATE_PREFIX: u8 = 0;
 pub(crate) const PEER_ID_NETWORK_ACTOR_STATE_PREFIX: u8 = 16;
 pub(crate) const CKB_INVOICE_PREFIX: u8 = 32;
-pub(crate) const CKB_INVOICE_PREIMAGE_PREFIX: u8 = 33;
+pub(crate) const PREIMAGE_PREFIX: u8 = 33;
 pub(crate) const CKB_INVOICE_STATUS_PREFIX: u8 = 34;
 pub(crate) const PEER_ID_CHANNEL_ID_PREFIX: u8 = 64;
 pub(crate) const CHANNEL_OUTPOINT_CHANNEL_ID_PREFIX: u8 = 65;

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -92,14 +92,11 @@ fn test_store_invoice() {
         .insert_invoice(invoice.clone(), Some(preimage))
         .unwrap();
     assert_eq!(store.get_invoice(hash), Some(invoice.clone()));
-    assert_eq!(store.get_invoice_preimage(hash), Some(preimage));
-    assert_eq!(
-        store.search_payment_preimage(&hash.as_ref()[0..20]),
-        Some(preimage)
-    );
+    assert_eq!(store.get_preimage(hash), Some(preimage));
+    assert_eq!(store.search_preimage(&hash.as_ref()[0..20]), Some(preimage));
 
     let invalid_hash = gen_rand_sha256_hash();
-    assert_eq!(store.get_invoice_preimage(&invalid_hash), None);
+    assert_eq!(store.get_preimage(&invalid_hash), None);
 
     assert_eq!(store.get_invoice_status(hash), Some(CkbInvoiceStatus::Open));
     assert_eq!(store.get_invoice_status(&gen_rand_sha256_hash()), None);

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -33,7 +33,7 @@ use crate::{
         hash_algorithm::HashAlgorithm,
         types::Hash256,
     },
-    invoice::InvoiceStore,
+    invoice::PreimageStore,
     utils::tx::compute_tx_message,
     NetworkServiceEvent,
 };
@@ -46,7 +46,7 @@ pub struct WatchtowerActor<S> {
     store: S,
 }
 
-impl<S: InvoiceStore + WatchtowerStore> WatchtowerActor<S> {
+impl<S: PreimageStore + WatchtowerStore> WatchtowerActor<S> {
     pub fn new(store: S) -> Self {
         Self { store }
     }
@@ -65,7 +65,7 @@ pub struct WatchtowerState {
 #[ractor::async_trait]
 impl<S> Actor for WatchtowerActor<S>
 where
-    S: InvoiceStore + WatchtowerStore + Send + Sync + 'static,
+    S: PreimageStore + WatchtowerStore + Send + Sync + 'static,
 {
     type Msg = WatchtowerMessage;
     type State = WatchtowerState;
@@ -139,7 +139,7 @@ where
 
 impl<S> WatchtowerActor<S>
 where
-    S: InvoiceStore + WatchtowerStore,
+    S: PreimageStore + WatchtowerStore,
 {
     fn periodic_check(&self, state: &WatchtowerState) {
         let secret_key = state.secret_key;
@@ -416,7 +416,7 @@ fn build_revocation_tx(
     Err(Box::new(RpcError::Other(anyhow!("Not enough capacity"))))
 }
 
-fn try_settle_commitment_tx<S: InvoiceStore>(
+fn try_settle_commitment_tx<S: PreimageStore>(
     commitment_lock: Script,
     ckb_client: CkbRpcClient,
     settlement_data: SettlementData,
@@ -670,7 +670,7 @@ fn try_settle_commitment_tx<S: InvoiceStore>(
 }
 
 // find all on-chain transactions with the preimage and store them
-fn find_preimages<S: InvoiceStore>(search_key: SearchKey, ckb_client: &CkbRpcClient, store: &S) {
+fn find_preimages<S: PreimageStore>(search_key: SearchKey, ckb_client: &CkbRpcClient, store: &S) {
     let mut after = None;
     loop {
         match ckb_client.get_transactions(
@@ -717,10 +717,10 @@ fn find_preimages<S: InvoiceStore>(search_key: SearchKey, ckb_client: &CkbRpcCli
                                                     if payment_hash.starts_with(tlc.payment_hash())
                                                     {
                                                         info!("Found a preimage for payment hash: {:?}", payment_hash);
-                                                        store.insert_payment_preimage(
+                                                        store.insert_preimage(
                                                             payment_hash.into(),
                                                             preimage.into(),
-                                                        ).expect("insert payment preimage should be ok");
+                                                        );
                                                     } else {
                                                         warn!("Found a preimage for payment hash: {:?}, but not match the tlc", payment_hash);
                                                     }
@@ -940,7 +940,7 @@ fn sign_tx_with_settlement(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn build_settlement_tx_for_pending_tlcs<S: InvoiceStore>(
+fn build_settlement_tx_for_pending_tlcs<S: PreimageStore>(
     commitment_tx_cell: Cell,
     cell_header: HeaderView,
     delay_epoch: EpochNumberWithFraction,
@@ -969,7 +969,7 @@ fn build_settlement_tx_for_pending_tlcs<S: InvoiceStore>(
                             Some((index, settlement_tlc.clone(), None))
                         } else if pubkey_hash.starts_with(tlc.remote_pubkey_hash()) {
                             store
-                                .search_payment_preimage(tlc.payment_hash())
+                                .search_preimage(tlc.payment_hash())
                                 .map(|preimage| (index, settlement_tlc.clone(), Some(preimage)))
                         } else {
                             None
@@ -980,7 +980,7 @@ fn build_settlement_tx_for_pending_tlcs<S: InvoiceStore>(
                         Some((index, settlement_tlc.clone(), None))
                     } else if pubkey_hash.starts_with(tlc.local_pubkey_hash()) {
                         store
-                            .search_payment_preimage(tlc.payment_hash())
+                            .search_preimage(tlc.payment_hash())
                             .map(|preimage| (index, settlement_tlc.clone(), Some(preimage)))
                     } else {
                         None
@@ -1003,7 +1003,7 @@ fn build_settlement_tx_for_pending_tlcs<S: InvoiceStore>(
                         None
                     } else {
                         store
-                            .get_invoice_preimage(&settlement_tlc.payment_hash)
+                            .get_preimage(&settlement_tlc.payment_hash)
                             .map(|preimage| (index, settlement_tlc.clone(), Some(preimage)))
                     }
                 } else if settlement_tlc.expiry < current_time {
@@ -1014,7 +1014,7 @@ fn build_settlement_tx_for_pending_tlcs<S: InvoiceStore>(
                     }
                 } else if for_remote {
                     store
-                        .get_invoice_preimage(&settlement_tlc.payment_hash)
+                        .get_preimage(&settlement_tlc.payment_hash)
                         .map(|preimage| (index, settlement_tlc.clone(), Some(preimage)))
                 } else {
                     None


### PR DESCRIPTION
This PR separated preimage-related operations into a new `PreimageStore` trait, replacing the previous methods in `InvoiceStore`, it is a prerequisite for a standalone watchtower service, I create a separate PR to make subsequent code review easier.