### PR TITLE
fix: new tracer should have len 1

### DIFF
--- a/crates/fiber-lib/src/ckb/tx_tracing_actor.rs
+++ b/crates/fiber-lib/src/ckb/tx_tracing_actor.rs
@@ -172,7 +172,7 @@ impl CkbTxTracingState {
         let tx_tracers = self.tracers.entry(tx_hash).or_default();
         tx_tracers.tracers.push(tracer);
 
-        if tx_tracers.tracers.len() > 1 {
+        if tx_tracers.tracers.len() == 1 {
             // If there's no existing tracer for the tx, trigger the tracing task now
             self.run_tracers(myself, Some(vec![tx_hash])).await?
         }


### PR DESCRIPTION
Fix the condition to trigger new created CKB tx tracer. The new tracer should have one observer instead of more than one.
