### PR TITLE
Check shutdown fee rate for shutdown peer message

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1124,6 +1124,12 @@ where
             }
         };
 
+        if !state.check_shutdown_fee_valid(shutdown.fee_rate.as_u64()) {
+            return Err(ProcessingChannelError::InvalidParameter(
+                "Shutdown fee is invalid".to_string(),
+            ));
+        }
+
         state.remote_shutdown_info = Some(ShutdownInfo {
             close_script: shutdown.close_script,
             fee_rate: shutdown.fee_rate.as_u64(),
@@ -1137,7 +1143,6 @@ where
         // e.g. our shutdown message is also sent, or we are trying to force shutdown,
         // we should not reply.
         let should_we_reply_shutdown = matches!(flags, ShuttingDownFlags::THEIR_SHUTDOWN_SENT);
-
         if state.check_valid_to_auto_accept_shutdown() && should_we_reply_shutdown {
             let close_script = state.get_local_shutdown_script();
             self.network
@@ -5359,14 +5364,8 @@ impl ChannelActorState {
         &self.get_remote_channel_public_keys().funding_pubkey
     }
 
-    fn check_valid_to_auto_accept_shutdown(&self) -> bool {
-        let Some(remote_fee_rate) = self.remote_shutdown_info.as_ref().map(|i| i.fee_rate) else {
-            return false;
-        };
-        if remote_fee_rate < self.commitment_fee_rate {
-            return false;
-        }
-        let fee = calculate_shutdown_tx_fee(
+    fn check_shutdown_fee_valid(&self, remote_fee_rate: u64) -> bool {
+        let remote_shutdown_fee = calculate_shutdown_tx_fee(
             remote_fee_rate,
             &self.funding_udt_type_script,
             (
@@ -5388,7 +5387,13 @@ impl ChannelActorState {
             self.remote_reserved_ckb_amount
                 .saturating_sub(occupied_capacity)
         };
-        return fee <= remote_available_max_fee;
+        return remote_shutdown_fee <= remote_available_max_fee;
+    }
+
+    fn check_valid_to_auto_accept_shutdown(&self) -> bool {
+        self.remote_shutdown_info
+            .as_ref()
+            .map_or(false, |i| i.fee_rate >= self.commitment_fee_rate)
     }
 
     fn check_tlc_expiry(&self, expiry: u64) -> ProcessingChannelResult {

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -3930,6 +3930,8 @@ async fn test_revoke_old_commitment_transaction() {
 
 #[tokio::test]
 async fn test_channel_with_simple_update_operation() {
+    init_tracing();
+
     for algorithm in HashAlgorithm::supported_algorithms() {
         do_test_channel_with_simple_update_operation(algorithm).await
     }
@@ -4739,6 +4741,34 @@ async fn test_shutdown_channel_with_large_size_shutdown_script_should_fail() {
         .err()
         .unwrap()
         .contains("Local balance is not enough to pay the fee"));
+}
+
+#[tokio::test]
+async fn test_shutdown_channel_with_invalid_feerate_peer_message() {
+    init_tracing();
+
+    let node_a_funding_amount = 100000000000;
+    let node_b_funding_amount = 6200000000;
+
+    let (node_a, mut node_b, new_channel_id) =
+        create_nodes_with_established_channel(node_a_funding_amount, node_b_funding_amount, false)
+            .await;
+
+    let command = ShutdownCommand {
+        close_script: Script::new_builder().args([0u8; 21].pack()).build(),
+        fee_rate: FeeRate::from_u64(u64::MAX),
+        force: false,
+    };
+
+    node_a
+        .handle_shutdown_command_without_check(new_channel_id, command)
+        .await;
+
+    node_b
+        .expect_debug_event("InvalidParameter(\"Shutdown fee is invalid\")")
+        .await;
+    let state = node_b.get_channel_actor_state(new_channel_id);
+    matches!(state.state, ChannelState::ChannelReady);
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/test_utils.rs
+++ b/crates/fiber-lib/src/fiber/tests/test_utils.rs
@@ -1,34 +1,20 @@
 use crate::ckb::tests::test_utils::get_tx_from_hash;
 use crate::ckb::tests::test_utils::MockChainActorMiddleware;
 use crate::ckb::GetTxResponse;
-use crate::fiber::channel::ChannelActorState;
-use crate::fiber::channel::ChannelActorStateStore;
-use crate::fiber::channel::ChannelCommand;
-use crate::fiber::channel::ChannelCommandWithId;
-use crate::fiber::channel::ReloadParams;
-use crate::fiber::channel::ShutdownCommand;
-use crate::fiber::channel::UpdateCommand;
+use crate::fiber::channel::*;
 use crate::fiber::gossip::get_gossip_actor_name;
 use crate::fiber::gossip::GossipActorMessage;
 use crate::fiber::graph::NetworkGraphStateStore;
 use crate::fiber::graph::PaymentSession;
 use crate::fiber::graph::PaymentSessionStatus;
-use crate::fiber::network::BuildRouterCommand;
-use crate::fiber::network::DebugEvent;
-use crate::fiber::network::GossipMessageWithPeerId;
-use crate::fiber::network::NodeInfoResponse;
-use crate::fiber::network::PaymentCustomRecords;
-use crate::fiber::network::PaymentRouter;
-use crate::fiber::network::SendPaymentCommand;
-use crate::fiber::network::SendPaymentResponse;
-use crate::fiber::network::SendPaymentWithRouterCommand;
+use crate::fiber::network::*;
 use crate::fiber::types::EcdsaSignature;
+use crate::fiber::types::FiberMessage;
 use crate::fiber::types::GossipMessage;
 use crate::fiber::types::Pubkey;
-use crate::invoice::CkbInvoice;
-use crate::invoice::CkbInvoiceStatus;
-use crate::invoice::InvoiceStore;
-use crate::invoice::PreimageStore;
+use crate::fiber::types::Shutdown;
+use crate::fiber::ASSUME_NETWORK_ACTOR_ALIVE;
+use crate::invoice::*;
 use crate::rpc::config::RpcConfig;
 use crate::rpc::server::start_rpc;
 use ckb_sdk::core::TransactionBuilder;
@@ -411,10 +397,6 @@ pub(crate) async fn establish_channel_between_nodes(
         })
         .await;
 
-    debug!(
-        "haha got ChannelPendingToBeAccepted: {:?}",
-        open_channel_result
-    );
     let message = |rpc_reply| {
         NetworkActorMessage::Command(NetworkActorCommand::AcceptChannel(
             AcceptChannelCommand {
@@ -1017,6 +999,26 @@ impl NetworkNode {
             }),
         )
         .await;
+    }
+
+    pub async fn handle_shutdown_command_without_check(
+        &self,
+        channel_id: Hash256,
+        command: ShutdownCommand,
+    ) {
+        let state = self.get_channel_actor_state(channel_id);
+        self.network_actor
+            .send_message(NetworkActorMessage::new_command(
+                NetworkActorCommand::SendFiberMessage(FiberMessageWithPeerId::new(
+                    state.get_remote_peer_id(),
+                    FiberMessage::shutdown(Shutdown {
+                        channel_id: state.get_id(),
+                        close_script: command.close_script.clone(),
+                        fee_rate: command.fee_rate,
+                    }),
+                )),
+            ))
+            .expect(ASSUME_NETWORK_ACTOR_ALIVE);
     }
 
     pub async fn update_channel_with_command(&self, channel_id: Hash256, command: UpdateCommand) {


### PR DESCRIPTION
If a malicious node sends `Shutdown` command with a too large `feerate`, previously peer node will only update ChannelState to `ShuttingDown` and will not auto accept shutdown, so the state will remain in the state of `ShuttingDown`.

This PR will check the fee rate from peer node, and if the calculated fee exceeded, it will report with proper error message and do not update channel state.
