### PR TITLE
feat: auto close funding channel on timeout

### DIFF
--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -318,6 +318,16 @@ pub struct FiberConfig {
         help = "Max allowed bytes of channels to be accepted from one peer. [default: 50KB]"
     )]
     pub to_be_accepted_channels_bytes_limit: Option<usize>,
+
+    /// Default timeout to auto close a funding channel. [default: 1 day]
+    #[arg(
+        name = "FIBER_FUNDING_TIMEOUT_SECONDS",
+        long = "fiber-funding-timeout-seconds",
+        env,
+        help = "Default timeout to auto close a funding channel. [default: 1 day]"
+    )]
+    #[default(DEFAULT_FUNDING_TIMEOUT_SECONDS)]
+    pub funding_timeout_seconds: u64,
 }
 
 /// Must be a valid utf-8 string of length maximal length 32 bytes.

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -62,6 +62,9 @@ pub const DEFAULT_MAX_INBOUND_PEERS: usize = 16;
 /// Minimal number of outbound connections.
 pub const DEFAULT_MIN_OUTBOUND_PEERS: usize = 8;
 
+/// Funding timeout in seconds since the channel is created.
+pub const DEFAULT_FUNDING_TIMEOUT_SECONDS: u64 = 60 * 60 * 24; // 1 day
+
 /// The interval to maintain the gossip network, in milli-seconds.
 #[cfg(not(any(test, feature = "bench")))]
 pub const DEFAULT_GOSSIP_STORE_MAINTENANCE_INTERVAL_MS: u64 = 20 * 1000;

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -5565,3 +5565,49 @@ async fn test_channel_with_malicious_peer_send_channel_msg() {
     test_with_node(&node_0).await;
     test_with_node(&node_1).await;
 }
+
+#[tokio::test]
+async fn test_funding_timeout() {
+    let funding_amount: u128 = 100000000000;
+    let mut nodes = NetworkNode::new_n_interconnected_nodes_with_config(2, |i| {
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some(format!("node-{}", i)))
+            .base_dir_prefix(&format!("test-fnn-node-{}-", i))
+            .fiber_config_updater(|config| {
+                // funding amount + 1
+                config.open_channel_auto_accept_min_ckb_funding_amount = Some(100000000001);
+                config.funding_timeout_seconds = 1;
+            })
+            .build()
+    })
+    .await;
+
+    let message = |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::OpenChannel(
+            OpenChannelCommand {
+                peer_id: nodes[1].peer_id.clone(),
+                public: false,
+                shutdown_script: None,
+                funding_amount,
+                funding_udt_type_script: None,
+                commitment_fee_rate: None,
+                commitment_delay_epoch: None,
+                funding_fee_rate: None,
+                tlc_expiry_delta: None,
+                tlc_min_value: None,
+                tlc_fee_proportional_millionths: None,
+                max_tlc_number_in_flight: None,
+                max_tlc_value_in_flight: None,
+            },
+            rpc_reply,
+        ))
+    };
+    call!(nodes[0].network_actor, message)
+        .expect("node_a alive")
+        .expect("open channel success");
+
+    // Auto closed because of timeout
+    nodes[0]
+        .expect_event(|event| matches!(event, NetworkServiceEvent::ChannelFundingAborted(_)))
+        .await;
+}

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -374,6 +374,7 @@ fn test_channel_actor_state_store() {
         network: None,
         scheduled_channel_update_handle: None,
         retryable_task_last_run_at: None,
+        ephemeral_config: Default::default(),
     };
 
     let bincode_encoded = bincode::serialize(&state).unwrap();
@@ -489,6 +490,7 @@ fn test_serde_channel_actor_state_ciborium() {
         network: None,
         scheduled_channel_update_handle: None,
         retryable_task_last_run_at: None,
+        ephemeral_config: Default::default(),
     };
 
     let mut serialized = Vec::new();


### PR DESCRIPTION
When there's no signature sent yet, it's safe to abort the funding channel and forget it.

The default timeout in this PR is 1 day.

It is configurable via config file, command line argument or environment variable.

Channel does not read config before, so I changed the channel startup args a bit to include a ephemeral config struct which is not persisted along with the channel state. Suggestions are recommended for a better way to pass config options to channel actors.