### PR TITLE
fix: add cfg for watchtower only import

### DIFF
--- a/crates/fiber-lib/src/rpc/mod.rs
+++ b/crates/fiber-lib/src/rpc/mod.rs
@@ -16,6 +16,7 @@ pub mod server {
 
     use crate::ckb::CkbConfig;
     use crate::fiber::gossip::GossipMessageStore;
+    #[cfg(feature = "watchtower")]
     use crate::invoice::PreimageStore;
     use crate::rpc::cch::{CchRpcServer, CchRpcServerImpl};
     use crate::rpc::channel::{ChannelRpcServer, ChannelRpcServerImpl};


### PR DESCRIPTION
How to verify:

```
cargo check --package fnn --no-default-features
```

Before, it will generate following error:

```
warning: unused import: `crate::invoice::PreimageStore`
  --> crates/fiber-lib/src/rpc/mod.rs:19:9
   |
19 |     use crate::invoice::PreimageStore;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```
