### PR TITLE
feat: throttle to be accepted channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,7 @@ dependencies = [
  "anyhow",
  "arcode",
  "async-trait",
- "bech32 0.9.1",
+ "bech32 0.8.1",
  "bincode",
  "bitcoin",
  "bitflags 2.9.1",

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -658,6 +658,9 @@ where
             ProcessingChannelError::TlcForwardingError(_) => {
                 unreachable!("TlcForwardingError should be handled before this point")
             }
+            ProcessingChannelError::ToBeAcceptedChannelsExceedLimit(_) => {
+                unreachable!("ToBeAcceptedChannelsExceedLimit should be handled before this point")
+            }
         };
 
         let channel_update = if error_code.is_update() {
@@ -3671,6 +3674,8 @@ pub enum ProcessingChannelError {
     TlcExpiryTooFar,
     #[error("Tlc forwarding error")]
     TlcForwardingError(TlcErr),
+    #[error("Total number or bytes of to-be-accepted channels exceed the limit: {0}")]
+    ToBeAcceptedChannelsExceedLimit(String),
 }
 
 /// ProcessingChannelError which brings the shared secret used in forwarding onion packet.

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -298,6 +298,24 @@ pub struct FiberConfig {
         help = "Disable built-in watchtower actor. [default: false]"
     )]
     pub disable_built_in_watchtower: Option<bool>,
+
+    /// Max allowed number of channels to be accepted from one peer. [default: 20]
+    #[arg(
+        name = "FIBER_TO_BE_ACCEPTED_CHANNELS_NUMBER_LIMIT",
+        long = "fiber-to-be-accepted-channels-number-limit",
+        env,
+        help = "Max allowed number of channels to be accepted from one peer. [default: 20]"
+    )]
+    pub to_be_accepted_channels_number_limit: Option<usize>,
+
+    /// Max allowed storage bytes of channels to be accepted from one peer. [default: 50KB]
+    #[arg(
+        name = "FIBER_TO_BE_ACCEPTED_CHANNELS_BYTESS_LIMIT",
+        long = "fiber-to-be-accepted-channels-bytes-limit",
+        env,
+        help = "Max allowed bytes of channels to be accepted from one peer. [default: 50KB]"
+    )]
+    pub to_be_accepted_channels_bytes_limit: Option<usize>,
 }
 
 /// Must be a valid utf-8 string of length maximal length 32 bytes.

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -573,6 +573,17 @@ impl OpenChannel {
     pub fn is_public(&self) -> bool {
         self.channel_flags.contains(ChannelFlags::PUBLIC)
     }
+
+    pub fn mem_size(&self) -> usize {
+        let static_size = std::mem::size_of_val(self);
+        let funding_udt_type_script_size = self
+            .funding_udt_type_script
+            .as_ref()
+            .map(|script| script.total_size())
+            .unwrap_or_default();
+        let shutdown_script_size = self.shutdown_script.total_size();
+        static_size + funding_udt_type_script_size + shutdown_script_size
+    }
 }
 
 impl From<OpenChannel> for molecule_fiber::OpenChannel {


### PR DESCRIPTION
Limit the total number and bytes of open channel requests that a peer can send us.

- The default number limit is 20
- The default storage size limit is 50KB

When a peer reaches the limit, following open channel requests are rejected.