### PR TITLE
Fix performance issue in sending payments benchmark testing

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1634,11 +1634,7 @@ where
         operation: RetryableTlcOperation,
     ) {
         if state.tlc_state.insert_retryable_tlc_operation(operation) {
-            myself
-                .send_message(ChannelActorMessage::Event(
-                    ChannelEvent::CheckTlcRetryOperation,
-                ))
-                .expect("myself alive");
+            state.trigger_retryable_tasks(myself, true);
         }
     }
 
@@ -1661,13 +1657,25 @@ where
         &self,
         myself: &ActorRef<ChannelActorMessage>,
         state: &mut ChannelActorState,
+        force: bool,
     ) {
         if state.reestablishing {
             myself.send_after(WAITING_REESTABLISH_FINISH_TIMEOUT, || {
-                ChannelActorMessage::Event(ChannelEvent::CheckTlcRetryOperation)
+                ChannelActorMessage::Event(ChannelEvent::CheckTlcRetryOperation(false))
             });
             return;
         }
+        if !force {
+            if let Some(last_time) = state.retryable_task_last_run_at {
+                if last_time + RETRYABLE_TLC_OPS_INTERVAL.as_millis() as u64
+                    > now_timestamp_as_millis_u64()
+                {
+                    // don't run retryable tasks too frequently
+                    return;
+                }
+            }
+        }
+        state.retryable_task_last_run_at = Some(now_timestamp_as_millis_u64());
         let mut pending_tlc_ops = state.tlc_state.get_pending_operations();
         pending_tlc_ops.retain_mut(|retryable_operation| {
             match retryable_operation {
@@ -1771,9 +1779,7 @@ where
 
         state.tlc_state.retryable_tlc_operations = pending_tlc_ops;
         if state.tlc_state.has_pending_operations() {
-            myself.send_after(RETRYABLE_TLC_OPS_INTERVAL, || {
-                ChannelActorMessage::Event(ChannelEvent::CheckTlcRetryOperation)
-            });
+            state.trigger_retryable_tasks(myself, false);
         }
     }
 
@@ -2079,8 +2085,9 @@ where
                 state.update_state(ChannelState::AwaitingChannelReady(flags));
                 state.maybe_channel_is_ready(myself).await;
             }
-            ChannelEvent::CheckTlcRetryOperation => {
-                self.apply_retryable_tlc_operations(myself, state).await;
+            ChannelEvent::CheckTlcRetryOperation(force) => {
+                self.apply_retryable_tlc_operations(myself, state, force)
+                    .await;
             }
             ChannelEvent::Stop(reason) => {
                 debug_event!(self.network, "ChannelActorStopped");
@@ -2145,7 +2152,7 @@ where
                     debug!(
                         "Channel {} from peer {:?} is inactive for a time, closing it",
                         state.get_id(),
-                        state.get_remote_peer_id()
+                        state.get_remote_peer_id(),
                     );
                     state
                         .network()
@@ -2566,11 +2573,7 @@ where
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         if state.tlc_state.has_pending_operations() && !state.reestablishing {
-            myself
-                .send_message(ChannelActorMessage::Event(
-                    ChannelEvent::CheckTlcRetryOperation,
-                ))
-                .expect("myself alive");
+            state.trigger_retryable_tasks(&myself, false);
         }
 
         Ok(())
@@ -3519,6 +3522,9 @@ pub struct ChannelActorState {
     // The arc here is only used to implement the clone trait for the ChannelActorState.
     #[serde(skip)]
     pub scheduled_channel_update_handle: ScheduledChannelUpdateHandle,
+
+    #[serde(skip)]
+    pub retryable_task_last_run_at: Option<u64>,
 }
 
 #[serde_as]
@@ -3613,7 +3619,7 @@ pub enum ChannelEvent {
     Stop(StopReason),
     FundingTransactionConfirmed(H256, u32, u64),
     ClosingTransactionConfirmed(bool),
-    CheckTlcRetryOperation,
+    CheckTlcRetryOperation(bool),
     CheckActiveChannel,
 }
 
@@ -4261,6 +4267,24 @@ impl ChannelActorState {
         }
     }
 
+    fn trigger_retryable_tasks(
+        &mut self,
+        myself: &ActorRef<ChannelActorMessage>,
+        first_register: bool,
+    ) {
+        if first_register {
+            myself
+                .send_message(ChannelActorMessage::Event(
+                    ChannelEvent::CheckTlcRetryOperation(true),
+                ))
+                .expect("myself alive");
+        } else {
+            myself.send_after(RETRYABLE_TLC_OPS_INTERVAL, || {
+                ChannelActorMessage::Event(ChannelEvent::CheckTlcRetryOperation(false))
+            });
+        }
+    }
+
     pub fn get_unsigned_channel_update_message(&self) -> Option<ChannelUpdate> {
         let message_flags = if self.local_is_node1() {
             ChannelUpdateMessageFlags::UPDATE_OF_NODE1
@@ -4370,6 +4394,7 @@ impl ChannelActorState {
             waiting_peer_response: None,
             network: Some(network),
             scheduled_channel_update_handle: None,
+            retryable_task_last_run_at: None,
         };
         if let Some(nonce) = remote_channel_announcement_nonce {
             state.update_remote_channel_announcement_nonce(&nonce);
@@ -4443,6 +4468,7 @@ impl ChannelActorState {
             waiting_peer_response: None,
             network: Some(network),
             scheduled_channel_update_handle: None,
+            retryable_task_last_run_at: None,
         }
     }
 
@@ -6225,7 +6251,7 @@ impl ChannelActorState {
         }
         if self.tlc_state.has_pending_operations() {
             myself.send_after(WAITING_REESTABLISH_FINISH_TIMEOUT, || {
-                ChannelActorMessage::Event(ChannelEvent::CheckTlcRetryOperation)
+                ChannelActorMessage::Event(ChannelEvent::CheckTlcRetryOperation(true))
             });
         }
         // If the channel is already ready, we should notify the network actor.

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -30,6 +30,7 @@ use std::panic;
 use std::time::SystemTime;
 use tracing::debug;
 use tracing::error;
+use tracing::info;
 
 #[tokio::test]
 async fn test_send_payment_custom_records() {
@@ -2231,42 +2232,50 @@ async fn test_send_payment_bench_test() {
         &[
             ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
             ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
+            ((2, 3), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
         ],
-        3,
+        4,
     )
     .await;
-    let [node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
+    let [node_0, node_1, node_2, node_3] = nodes.try_into().expect("3 nodes");
 
     let mut all_sent = HashSet::new();
 
-    for i in 1..=10 {
-        let payment = node_0
-            .send_payment_keysend(&node_2, 1000, false)
-            .await
-            .unwrap();
-        eprintln!("payment: {:?}", payment);
-        all_sent.insert(payment.payment_hash);
-        eprintln!("send: {} payment_hash: {:?} sent", i, payment.payment_hash);
+    for i in 1..=30 {
+        assert!(node_0.get_triggered_unexpected_events().await.is_empty());
+        assert!(node_1.get_triggered_unexpected_events().await.is_empty());
+        assert!(node_2.get_triggered_unexpected_events().await.is_empty());
+        assert!(node_3.get_triggered_unexpected_events().await.is_empty());
+
+        if let Ok(payment) = node_0.send_payment_keysend(&node_3, 100, false).await {
+            eprintln!("payment: {:?}", payment);
+            all_sent.insert(payment.payment_hash);
+            info!("send: {} payment_hash: {:?} sent", i, payment.payment_hash);
+        }
     }
 
+    let time = std::time::Instant::now();
     loop {
+        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
         for payment_hash in all_sent.clone().iter() {
             node_0.wait_until_final_status(*payment_hash).await;
             let status = node_0.get_payment_status(*payment_hash).await;
             eprintln!("got payment: {:?} status: {:?}", payment_hash, status);
             if status == PaymentSessionStatus::Success {
-                eprintln!("payment_hash: {:?} success", payment_hash);
                 all_sent.remove(payment_hash);
+                info!(
+                    "payment_hash: {:?} success, left: {:?}",
+                    payment_hash,
+                    all_sent.len()
+                );
             }
         }
-        let res = node_0.node_info().await;
-        eprintln!("node0 node_info: {:?}", res);
-        let res = node_1.node_info().await;
-        eprintln!("node1 node_info: {:?}", res);
-        let res = node_2.node_info().await;
-        eprintln!("node2 node_info: {:?}", res);
+
         if all_sent.is_empty() {
             break;
+        }
+        if time.elapsed().as_secs() >= 240 {
+            panic!("timeout, not all payments are settled");
         }
     }
 }
@@ -3582,7 +3591,7 @@ async fn test_send_payment_shutdown_with_force() {
             .duration_since(started)
             .expect("time passed")
             .as_secs();
-        if elapsed > 180 {
+        if elapsed > 180 || failed_count >= expect_failed_count {
             error!("timeout, failed_count: {:?}", failed_count);
             break;
         }

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -373,6 +373,7 @@ fn test_channel_actor_state_store() {
         waiting_peer_response: None,
         network: None,
         scheduled_channel_update_handle: None,
+        retryable_task_last_run_at: None,
     };
 
     let bincode_encoded = bincode::serialize(&state).unwrap();
@@ -487,6 +488,7 @@ fn test_serde_channel_actor_state_ciborium() {
         waiting_peer_response: None,
         network: None,
         scheduled_channel_update_handle: None,
+        retryable_task_last_run_at: None,
     };
 
     let mut serialized = Vec::new();

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -81,7 +81,7 @@ use crate::{
 static RETAIN_VAR: &str = "TEST_TEMP_RETAIN";
 pub const MIN_RESERVED_CKB: u128 = 4200000000;
 pub const HUGE_CKB_AMOUNT: u128 = MIN_RESERVED_CKB + 1000000000000_u128;
-const DEFAULT_WAIT_UNTIL_TIME: u64 = 60; // seconds
+const DEFAULT_WAIT_UNTIL_TIME: u64 = 60 * 4; // seconds
 
 #[derive(Debug)]
 pub struct TempDir(ManuallyDrop<OldTempDir>);

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -2025,7 +2025,7 @@ dependencies = [
  "nom",
  "num_enum",
  "once_cell",
- "ractor 0.15.3",
+ "ractor 0.15.6",
  "rand 0.8.5",
  "regex",
  "scrypt",
@@ -4083,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "ractor"
-version = "0.15.3"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7baf572559ad14ac3793c7c2fc3110f93d097d4d9b45aa626832933c78cb2445"
+checksum = "164cbdac94cb8f5c3bbb031f959643619e7e74f13d94381d69ba6161640f063e"
 dependencies = [
  "async-trait",
  "bon",


### PR DESCRIPTION
There are 3 performance improvements in this PR:
1. Avoid run retryable tasks too frequently in channel actor
2. Reuse old router when WaitingAck returned in first hop
3. Using `register_payment_retry` here https://github.com/nervosnetwork/fiber/pull/763/files#diff-14e04ef264a3a4c449eeb77f85a2a5db75b714848b0483b9122d03d516a3e769L2040-L2042 , the old code introduced performance regression.