### PR TITLE
chore: sync Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,7 @@ dependencies = [
  "anyhow",
  "arcode",
  "async-trait",
- "bech32 0.9.1",
+ "bech32 0.8.1",
  "bincode",
  "bitcoin",
  "bitflags 2.9.1",


### PR DESCRIPTION
bech32 has been downgraded in 04c1519714f5586bf088409345ff26d2fc3dc57d
