### PR TITLE
Add build lock for cargo build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,4 +116,4 @@ jobs:
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static-md
-      - run: cargo build --verbose --profile ${{ matrix.profile }}
+      - run: cargo build --locked --verbose --profile ${{ matrix.profile }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,8 +62,8 @@ jobs:
           fi
 
           # Prebuild the program so that we can run the following script faster
-          cargo build
-          cd ./tests/deploy/udt-init && cargo build && cd -
+          cargo build --locked
+          cd ./tests/deploy/udt-init && cargo build --locked && cd -
           if [ ${{ matrix.workflow }} = "router-pay" ]; then
             export START_BOOTNODE=y
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,23 +58,23 @@ jobs:
         export OPENSSL_LIB_DIR=${PWD_DIR}/openssl-1.1.1s
         export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
         export OPENSSL_STATIC=1
-        cargo build --release --features portable
+        cargo build --release --locked --features portable
         cd migrate
-        cargo build --release --features portable
+        cargo build --release --locked --features portable
         cd ..
     - if: matrix.os == 'ubuntu-24.04'
       name: Build linux
-      run: cargo build --release && cd migrate && cargo build --release && cd ..
+      run: cargo build --release --locked && cd migrate && cargo build --release --locked && cd ..
     - if: matrix.os == 'macos-13'
       name: Build macos portable
       run: |
         export OPENSSL_LIB_DIR=/usr/local/opt/openssl@1.1/lib
         export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl@1.1/include
         export OPENSSL_STATIC=1
-        cargo build --release --features portable && cd migrate && cargo build --release --features portable && cd ..
+        cargo build --release --locked --features portable && cd migrate && cargo build --release --locked --features portable && cd ..
     - if: matrix.os == 'windows-2019'
       name: Build windows
-      run: cargo build --release && cd migrate && cargo build --release && cd ..
+      run: cargo build --release --locked && cd migrate && cargo build --release --locked && cd ..
     - name: Get the Version
       id: get_version
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ test:
 
 .PHONY: check
 check:
-	cargo check
-	cargo check --release
+	cargo check --locked
+	cargo check --release --locked
 	cargo check --package fnn --no-default-features
-	cd migrate && cargo check
+	cd migrate && cargo check --locked
 
 .PHONY: clippy
 clippy:

--- a/tests/nodes/start.sh
+++ b/tests/nodes/start.sh
@@ -32,7 +32,7 @@ echo "Initializing finished, begin to start services ...."
 sleep 1
 
 ckb run -C "$deploy_dir/node-data" --indexer &
-cargo build
+cargo build --locked
 
 # Start the dev node in the background.
 cd "$nodes_dir" || exit 1


### PR DESCRIPTION
`--locked` is preferable when deterministic builds are desired, such as in CI pipelines.