### PR TITLE
feat: verify TxUpdate from peer

### DIFF
--- a/crates/fiber-lib/src/ckb/funding/funding_tx.rs
+++ b/crates/fiber-lib/src/ckb/funding/funding_tx.rs
@@ -453,7 +453,7 @@ impl FundingTxBuilder {
         let tx_builder = tx.as_advanced_builder();
         debug!("final tx_builder: {:?}", tx_builder);
 
-        funding_tx.update_for_self(tx)?;
+        funding_tx.update_for_self(tx);
 
         // Replace the old tx with the new one in the exclusion map
         if let Some(tx_hash) = old_tx_hash {
@@ -527,14 +527,12 @@ impl FundingTx {
         let tx_dep_provider = DefaultTransactionDependencyProvider::new(&rpc_url, 10);
 
         let (tx, _) = unlock_tx_async(tx, &tx_dep_provider, &unlockers).await?;
-        self.update_for_self(tx)?;
+        self.update_for_self(tx);
         Ok(self)
     }
 
-    // TODO: verify the transaction
-    pub fn update_for_self(&mut self, tx: TransactionView) -> Result<(), FundingError> {
+    pub fn update_for_self(&mut self, tx: TransactionView) {
         self.tx = Some(tx);
-        Ok(())
     }
 
     // TODO: verify the transaction

--- a/crates/fiber-lib/src/ckb/tests/test_utils.rs
+++ b/crates/fiber-lib/src/ckb/tests/test_utils.rs
@@ -472,14 +472,12 @@ impl Actor for MockChainActor {
                     .map(|x| x.as_advanced_builder())
                     .unwrap_or_default();
 
-                fulfilled_tx
-                    .update_for_self(
-                        tx_builder
-                            .set_outputs(outputs.into_iter().collect())
-                            .set_outputs_data(outputs_data.into_iter().collect())
-                            .build(),
-                    )
-                    .expect("update tx");
+                fulfilled_tx.update_for_self(
+                    tx_builder
+                        .set_outputs(outputs.into_iter().collect())
+                        .set_outputs_data(outputs_data.into_iter().collect())
+                        .build(),
+                );
 
                 debug!(
                     "Fulfilling funding request: request: {:?}, original tx: {:?}, fulfilled tx: {:?}",
@@ -493,6 +491,9 @@ impl Actor for MockChainActor {
                         e
                     );
                 }
+            }
+            VerifyFundingTx { reply, .. } => {
+                let _ = reply.send(Ok(()));
             }
             AddFundingTx(_) | RemoveFundingTx(_) | CommitFundingTx(..) => {
                 // ignore

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -269,6 +269,11 @@ pub enum NetworkActorCommand {
         RpcReplyPort<Result<PeeledPaymentOnionPacket, String>>,
     ),
     UpdateChannelFunding(Hash256, Transaction, FundingRequest),
+    VerifyFundingTx {
+        local_tx: Transaction,
+        remote_tx: Transaction,
+        reply: RpcReplyPort<Result<(), FundingError>>,
+    },
     SignFundingTx(PeerId, Hash256, Transaction, Option<Vec<Vec<u8>>>),
     NotifyFundingTx(Transaction),
     // Broadcast our BroadcastMessage to the network.
@@ -1521,7 +1526,7 @@ where
             NetworkActorCommand::UpdateChannelFunding(channel_id, transaction, request) => {
                 let old_tx = transaction.into_view();
                 let mut tx = FundingTx::new();
-                tx.update_for_self(old_tx)?;
+                tx.update_for_self(old_tx);
                 let tx = match self.fund(state, tx, request).await {
                     Ok(tx) => match tx.into_inner() {
                         Some(tx) => tx,
@@ -1554,6 +1559,19 @@ where
                         )),
                     )
                     .await?
+            }
+            NetworkActorCommand::VerifyFundingTx {
+                local_tx,
+                remote_tx,
+                reply,
+            } => {
+                let _ = self
+                    .chain_actor
+                    .send_message(CkbChainMessage::VerifyFundingTx {
+                        local_tx,
+                        remote_tx,
+                        reply,
+                    });
             }
             NetworkActorCommand::NotifyFundingTx(tx) => {
                 let _ = self


### PR DESCRIPTION
Based on #785

Call `FundingTx::update_for_peer` on TxUpdate message from peer.

`update_for_peer` has no verification code yet, which will be added in
another PR.

The verification step is added when Channel Actor receives TxUpdate
message from the peer. Channel Actor calls method `VerifyFundingTx` of
the Network Actor, which forwards the request to the CKB Chain actor.
The verification involves three actors because:

- The verification must resolve inputs using CKB client, thus CKB Chain
  actor is required.
- The verification must use the latest local version of the funding tx,
  which is held by the Channel Actor.
- The Channel Actor has no reference to the CKB Chain actor, so it asks
  Network Actor to forward the request.

See detailed workflow here: https://link.excalidraw.com/readonly/AwEhe2OSQN3swC8LEPCW
