### PR TITLE
Add document and release CI for Fiber wasm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,25 @@ env:
 permissions:
   contents: write
 jobs:
+  release-npm:
+    name: Build & Release fiber-js
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the Repository
+      uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: |
+        npm install
+    - run: |
+        npm run build -ws
+    - run: |
+        cd fiber-js
+        npm publish --provenance --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   release:
     name: Build & Release
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ env:
   RUST_TOOLCHAIN: 1.84.0
 permissions:
   contents: write
+  id-token: write
 jobs:
   release-npm:
     name: Build & Release fiber-js

--- a/fiber-js/README.md
+++ b/fiber-js/README.md
@@ -1,0 +1,16 @@
+# Fiber JS
+
+This is a JavaScript wrapper over Fiber wasm, to make Fiber wasm usable in JavaScript projects.
+
+## Build
+
+In the root of fiber, run:
+```
+npm install
+npm build -ws
+```
+After that, `fiber-js` will be ready to use in npm.
+
+## APIs
+
+`fiber-js` provide the same API ad Fiber RPC, see `fiber-js/src/index.ts` for details. For documentation, please refer to the docs of Fiber RPC.

--- a/fiber-js/package.json
+++ b/fiber-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nervosnetwork/fiber-js",
+  "name": "@nervosnetwork/fiber-js__test",
   "version": "0.5.1",
   "main": "dist/index.js",
   "license": "MIT",

--- a/fiber-js/package.json
+++ b/fiber-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nervosnetwork/fiber-js__test",
+  "name": "@nervosnetwork/fiber-js",
   "version": "0.5.1",
   "main": "dist/index.js",
   "license": "MIT",
@@ -25,6 +25,6 @@
   },
   "type": "module",
   "repository": {
-    "url": "https://github.com/Officeyutong/fiber"
+    "url": "https://github.com/nervosnetwork/fiber"
   }
 }

--- a/fiber-js/package.json
+++ b/fiber-js/package.json
@@ -23,5 +23,8 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "type": "module"
+  "type": "module",
+  "repository": {
+    "url": "https://github.com/Officeyutong/fiber"
+  }
 }


### PR DESCRIPTION
This PR adds a README file for `fiber-js` folder and release CI to publish `fiber-js` to npm when there are new tags.