### PR TITLE
Fix tentacle version issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,8 +2159,7 @@ dependencies = [
  "serde_yaml",
  "strum",
  "tempfile",
- "tentacle 0.6.7",
- "tentacle 0.7.2",
+ "tentacle",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -5461,13 +5460,15 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.6.7"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3374cb0b9cf25499dcb2e9ecf199af2f778b8d40dd01c413536de5b1574a2b"
+checksum = "f506abf5f90f9a082c8368b34bc62026bfc9138c6e6e706c3ea3e9906dc34564"
 dependencies = [
  "async-trait",
  "bytes",
+ "fast-socks5",
  "futures",
+ "futures-timer",
  "httparse",
  "igd-next",
  "js-sys",
@@ -5483,35 +5484,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
- "tokio-util",
- "tokio-yamux",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "winapi",
-]
-
-[[package]]
-name = "tentacle"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f506abf5f90f9a082c8368b34bc62026bfc9138c6e6e706c3ea3e9906dc34564"
-dependencies = [
- "async-trait",
- "bytes",
- "fast-socks5",
- "futures",
- "futures-timer",
- "js-sys",
- "libc",
- "log",
- "molecule",
- "nohash-hasher",
- "rand 0.8.5",
- "socket2 0.5.10",
- "tentacle-multiaddr",
- "tentacle-secio",
- "thiserror 1.0.69",
- "tokio",
  "tokio-util",
  "tokio-yamux",
  "url",
@@ -5773,9 +5745,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
@@ -6114,9 +6086,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -71,7 +71,7 @@ lnd-grpc-tonic-client = "0.3.0"
 rocksdb = {package = "ckb-rocksdb", version = "=0.21.1", features = [
   "lz4",
 ], default-features = false}
-tentacle = {version = "0.6.6", default-features = false, features = [
+tentacle = {version = "0.7", default-features = false, features = [
   "upnp",
   "parking_lot",
   "openssl-vendored",

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -1927,8 +1927,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "strum",
- "tentacle 0.6.7",
- "tentacle 0.7.2",
+ "tentacle",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -5130,13 +5129,15 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.6.7"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3374cb0b9cf25499dcb2e9ecf199af2f778b8d40dd01c413536de5b1574a2b"
+checksum = "f506abf5f90f9a082c8368b34bc62026bfc9138c6e6e706c3ea3e9906dc34564"
 dependencies = [
  "async-trait",
  "bytes",
+ "fast-socks5",
  "futures",
+ "futures-timer",
  "httparse",
  "igd-next",
  "js-sys",
@@ -5152,35 +5153,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
- "tokio-util",
- "tokio-yamux",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "winapi",
-]
-
-[[package]]
-name = "tentacle"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f506abf5f90f9a082c8368b34bc62026bfc9138c6e6e706c3ea3e9906dc34564"
-dependencies = [
- "async-trait",
- "bytes",
- "fast-socks5",
- "futures",
- "futures-timer",
- "js-sys",
- "libc",
- "log",
- "molecule",
- "nohash-hasher",
- "rand 0.8.5",
- "socket2 0.5.10",
- "tentacle-multiaddr",
- "tentacle-secio",
- "thiserror 1.0.69",
- "tokio",
  "tokio-util",
  "tokio-yamux",
  "url",
@@ -5432,9 +5404,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
@@ -5774,9 +5746,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",


### PR DESCRIPTION
This issue is introduced from: https://github.com/nervosnetwork/fiber/pull/806/files

which reverted https://github.com/nervosnetwork/fiber/pull/807 because of code merge error.