### PR TITLE
chore: trivial refactor for mpp payment records

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -418,6 +418,8 @@ pub struct SendPaymentWithRouterCommand {
     pub dry_run: bool,
 }
 
+// 0 ~ 65535 is reserved for endpoint usage, index aboving 65535 is reserved for internal usage
+pub const USER_CUSTOM_RECORDS_MAX_INDEX: u32 = 65535;
 /// The custom records to be included in the payment.
 /// The key is hex encoded of `u32`, and the value is hex encoded of `Vec<u8>` with `0x` as prefix.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
@@ -666,11 +668,11 @@ impl SendPaymentData {
             if custom_records
                 .data
                 .keys()
-                .any(|k| *k >= BasicMppPaymentData::CUSTOM_RECORD_KEY)
+                .any(|k| *k > USER_CUSTOM_RECORDS_MAX_INDEX)
             {
                 return Err(format!(
                     "custom_records key should in range 0 ~ {:?}",
-                    BasicMppPaymentData::CUSTOM_RECORD_KEY - 1
+                    USER_CUSTOM_RECORDS_MAX_INDEX
                 ));
             }
         }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -59,9 +59,9 @@ use super::gossip::{GossipActorMessage, GossipMessageStore, GossipMessageUpdates
 use super::graph::{NetworkGraph, NetworkGraphStateStore, OwnedChannelUpdateEvent, RouterHop};
 use super::key::blake2b_hash_with_salt;
 use super::types::{
-    BroadcastMessageWithTimestamp, EcdsaSignature, FiberMessage, ForwardTlcResult, GossipMessage,
-    Hash256, Init, NodeAnnouncement, OpenChannel, PaymentDataRecord, PaymentHopData, Privkey,
-    Pubkey, RemoveTlcFulfill, RemoveTlcReason, TlcErr, TlcErrData, TlcErrorCode,
+    BasicMppPaymentData, BroadcastMessageWithTimestamp, EcdsaSignature, FiberMessage,
+    ForwardTlcResult, GossipMessage, Hash256, Init, NodeAnnouncement, OpenChannel, PaymentHopData,
+    Privkey, Pubkey, RemoveTlcFulfill, RemoveTlcReason, TlcErr, TlcErrData, TlcErrorCode,
 };
 use super::{
     FiberConfig, InFlightCkbTxActor, InFlightCkbTxActorArguments, InFlightCkbTxActorMessage,
@@ -666,11 +666,11 @@ impl SendPaymentData {
             if custom_records
                 .data
                 .keys()
-                .any(|k| *k >= PaymentDataRecord::CUSTOM_RECORD_KEY)
+                .any(|k| *k >= BasicMppPaymentData::CUSTOM_RECORD_KEY)
             {
                 return Err(format!(
                     "custom_records key should in range 0 ~ {:?}",
-                    PaymentDataRecord::CUSTOM_RECORD_KEY - 1
+                    BasicMppPaymentData::CUSTOM_RECORD_KEY - 1
                 ));
             }
         }
@@ -679,7 +679,7 @@ impl SendPaymentData {
         // bolt04 write payment data record to custom records if payment secret is set
         if let Some(payment_secret) = payment_secret {
             let records = custom_records.get_or_insert_with(PaymentCustomRecords::default);
-            PaymentDataRecord::new(payment_secret, amount).write(records);
+            BasicMppPaymentData::new(payment_secret, amount).write(records);
         }
 
         Ok(SendPaymentData {

--- a/crates/fiber-lib/src/fiber/tests/mpp.rs
+++ b/crates/fiber-lib/src/fiber/tests/mpp.rs
@@ -11,7 +11,7 @@ use crate::{
         config::{CKB_SHANNONS, DEFAULT_TLC_EXPIRY_DELTA, PAYMENT_MAX_PARTS_LIMIT},
         features::FeatureVector,
         hash_algorithm::HashAlgorithm,
-        network::{DebugEvent, SendPaymentCommand},
+        network::{DebugEvent, SendPaymentCommand, USER_CUSTOM_RECORDS_MAX_INDEX},
         payment::AttemptStatus,
         types::{BasicMppPaymentData, Hash256, PaymentHopData, PeeledOnionPacket, RemoveTlcReason},
         NetworkActorCommand, NetworkActorMessage, PaymentCustomRecords,
@@ -3146,7 +3146,7 @@ async fn test_send_payment_custom_records_not_in_range() {
     assert!(error.contains("custom_records key should in range 0 ~ 65535"));
 
     let data: HashMap<_, _> = vec![(
-        BasicMppPaymentData::CUSTOM_RECORD_KEY - 1,
+        USER_CUSTOM_RECORDS_MAX_INDEX,
         "hello".to_string().into_bytes(),
     )]
     .into_iter()

--- a/crates/fiber-lib/src/fiber/tests/mpp.rs
+++ b/crates/fiber-lib/src/fiber/tests/mpp.rs
@@ -13,7 +13,7 @@ use crate::{
         hash_algorithm::HashAlgorithm,
         network::{DebugEvent, SendPaymentCommand},
         payment::AttemptStatus,
-        types::{Hash256, PaymentDataRecord, PaymentHopData, PeeledOnionPacket, RemoveTlcReason},
+        types::{BasicMppPaymentData, Hash256, PaymentHopData, PeeledOnionPacket, RemoveTlcReason},
         NetworkActorCommand, NetworkActorMessage, PaymentCustomRecords,
     },
     gen_rand_sha256_hash, gen_rpc_config,
@@ -510,7 +510,7 @@ async fn test_mpp_tlc_set() {
 
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 20000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -650,7 +650,7 @@ async fn test_mpp_tlc_set_with_insufficient_total_amount() {
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     // set total amount to 20000000000, but pay only 10000000000
-    let record = PaymentDataRecord::new(payment_secret, 20000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -787,7 +787,7 @@ async fn test_mpp_tlc_set_with_only_1_tlc() {
 
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 10000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 10000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -993,7 +993,7 @@ async fn test_mpp_tlc_set_total_amount_mismatch() {
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     // the total amount should be 20000000000, but we set 10000000000 here
-    let record = PaymentDataRecord::new(payment_secret, 10000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 10000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -1147,12 +1147,12 @@ async fn test_mpp_tlc_set_total_amount_should_be_consistent() {
     // but payment will fail because the total_amount is inconsistent
     // tlc1 records
     let mut custom_records_1 = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 20000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records_1);
 
     // tlc2 records
     let mut custom_records_2 = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 20000000001);
+    let record = BasicMppPaymentData::new(payment_secret, 20000000001);
     record.write(&mut custom_records_2);
 
     let build_packet = |custom_records: PaymentCustomRecords| {
@@ -1320,7 +1320,7 @@ async fn test_mpp_tlc_set_payment_secret_mismatch() {
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     // set the payment secret to a random value
-    let record = PaymentDataRecord::new(gen_rand_sha256_hash(), 20000000000);
+    let record = BasicMppPaymentData::new(gen_rand_sha256_hash(), 20000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -1472,7 +1472,7 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
 
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 30000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 30000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -1685,7 +1685,7 @@ async fn test_mpp_tlc_set_timeout() {
 
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 20000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -2521,7 +2521,7 @@ async fn test_mpp_tlc_set_without_invoice_should_not_be_accepted() {
 
         let secp = Secp256k1::new();
         let mut custom_records = PaymentCustomRecords::default();
-        let record = PaymentDataRecord::new(payment_secret, 20000000000);
+        let record = BasicMppPaymentData::new(payment_secret, 20000000000);
         record.write(&mut custom_records);
         let hops_infos = vec![
             PaymentHopData {
@@ -2687,7 +2687,7 @@ async fn test_mpp_tlc_with_invoice_not_allow_mpp_should_not_be_accepted() {
 
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 20000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -3126,7 +3126,7 @@ async fn test_send_payment_custom_records_not_in_range() {
     let target_pubkey = node_1.pubkey;
 
     let data: HashMap<_, _> = vec![(
-        PaymentDataRecord::CUSTOM_RECORD_KEY,
+        BasicMppPaymentData::CUSTOM_RECORD_KEY,
         "hello".to_string().into_bytes(),
     )]
     .into_iter()
@@ -3146,7 +3146,7 @@ async fn test_send_payment_custom_records_not_in_range() {
     assert!(error.contains("custom_records key should in range 0 ~ 65535"));
 
     let data: HashMap<_, _> = vec![(
-        PaymentDataRecord::CUSTOM_RECORD_KEY - 1,
+        BasicMppPaymentData::CUSTOM_RECORD_KEY - 1,
         "hello".to_string().into_bytes(),
     )]
     .into_iter()

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -5521,7 +5521,7 @@ async fn test_payment_with_payment_data_record() {
 
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 10000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 10000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -5623,7 +5623,7 @@ async fn test_payment_with_insufficient_total_amount() {
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     // set total amount to 20000000000, but pay only 10000000000
-    let record = PaymentDataRecord::new(payment_secret, 20000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -5749,7 +5749,7 @@ async fn test_payment_with_wrong_payment_secret() {
     let wrong_payment_secret = gen_rand_sha256_hash();
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(wrong_payment_secret, 10000000000);
+    let record = BasicMppPaymentData::new(wrong_payment_secret, 10000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {
@@ -5862,7 +5862,7 @@ async fn test_payment_with_insufficient_amount_with_payment_data() {
 
     let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
-    let record = PaymentDataRecord::new(payment_secret, 9000000000);
+    let record = BasicMppPaymentData::new(payment_secret, 9000000000);
     record.write(&mut custom_records);
     let hops_infos = vec![
         PaymentHopData {

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -6,14 +6,15 @@ use crate::{
         gen::{fiber as molecule_fiber, gossip},
         hash_algorithm::HashAlgorithm,
         types::{
-            pack_hop_data, secp256k1_instance, unpack_hop_data, AddTlc, BroadcastMessageID, Cursor,
-            Hash256, NodeAnnouncement, NodeId, PaymentHopData, PeeledOnionPacket, Privkey, Pubkey,
-            TlcErr, TlcErrPacket, TlcErrorCode, NO_SHARED_SECRET,
+            pack_hop_data, secp256k1_instance, unpack_hop_data, AddTlc, BasicMppPaymentData,
+            BroadcastMessageID, Cursor, Hash256, NodeAnnouncement, NodeId, PaymentHopData,
+            PeeledOnionPacket, Privkey, Pubkey, TlcErr, TlcErrPacket, TlcErrorCode,
+            NO_SHARED_SECRET,
         },
         PaymentCustomRecords,
     },
     gen_deterministic_fiber_private_key, gen_rand_channel_outpoint, gen_rand_fiber_private_key,
-    gen_rand_fiber_public_key, now_timestamp_as_millis_u64,
+    gen_rand_fiber_public_key, gen_rand_sha256_hash, now_timestamp_as_millis_u64,
 };
 use ckb_hash::blake2b_256;
 use ckb_jsonrpc_types::OutPoint;
@@ -700,4 +701,15 @@ fn test_serde_node_id() {
         serde_json::from_str(&node_id_str).unwrap(),
         "to NodeId"
     );
+}
+
+#[test]
+fn test_basic_mpp_custom_records() {
+    let mut payment_custom_records = PaymentCustomRecords::default();
+    let payment_secret = gen_rand_sha256_hash();
+    let record = BasicMppPaymentData::new(payment_secret, 100);
+    record.write(&mut payment_custom_records);
+
+    let new_record = BasicMppPaymentData::read(&payment_custom_records).unwrap();
+    assert_eq!(new_record, record);
 }

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -3739,13 +3739,13 @@ pub(crate) fn deterministically_hash<T: Entity>(v: &T) -> [u8; 32] {
     ckb_hash::blake2b_256(v.as_slice())
 }
 
-/// Bolt04 payment data record
-pub struct PaymentDataRecord {
+/// Bolt04 basic MPP payment data record
+pub struct BasicMppPaymentData {
     pub payment_secret: Hash256,
     pub total_amount: u128,
 }
 
-impl PaymentDataRecord {
+impl BasicMppPaymentData {
     // record type for payment data record in bolt04
     // custom records key from 65536 is reserved for internal usage
     pub const CUSTOM_RECORD_KEY: u32 = 65536;
@@ -3935,11 +3935,11 @@ pub type PaymentOnionPacket = OnionPacket<PaymentHopData>;
 pub type PeeledPaymentOnionPacket = PeeledOnionPacket<PaymentHopData>;
 
 impl PeeledOnionPacket<PaymentHopData> {
-    pub fn mpp_custom_records(&self) -> Option<PaymentDataRecord> {
+    pub fn mpp_custom_records(&self) -> Option<BasicMppPaymentData> {
         self.current
             .custom_records
             .as_ref()
-            .and_then(PaymentDataRecord::read)
+            .and_then(BasicMppPaymentData::read)
     }
 }
 

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -12,6 +12,7 @@ use super::r#gen::fiber::PubNonceOpt;
 use super::serde_utils::{EntityHex, PubNonceAsBytes, SliceBase58, SliceHex};
 use crate::ckb::config::{UdtArgInfo, UdtCellDep, UdtCfgInfos, UdtDep, UdtScript};
 use crate::ckb::contracts::get_udt_whitelist;
+use crate::fiber::network::USER_CUSTOM_RECORDS_MAX_INDEX;
 use ckb_jsonrpc_types::CellOutput;
 use ckb_types::H256;
 use num_enum::IntoPrimitive;
@@ -3749,7 +3750,7 @@ pub struct BasicMppPaymentData {
 impl BasicMppPaymentData {
     // record type for payment data record in bolt04
     // custom records key from 65536 is reserved for internal usage
-    pub const CUSTOM_RECORD_KEY: u32 = 65536;
+    pub const CUSTOM_RECORD_KEY: u32 = USER_CUSTOM_RECORDS_MAX_INDEX + 1;
 
     pub fn new(payment_secret: Hash256, total_amount: u128) -> Self {
         Self {

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -3739,6 +3739,7 @@ pub(crate) fn deterministically_hash<T: Entity>(v: &T) -> [u8; 32] {
     ckb_hash::blake2b_256(v.as_slice())
 }
 
+#[derive(Eq, PartialEq, Debug)]
 /// Bolt04 basic MPP payment data record
 pub struct BasicMppPaymentData {
     pub payment_secret: Hash256,

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -3764,7 +3764,7 @@ impl BasicMppPaymentData {
         vec
     }
 
-    pub fn write(self, custom_records: &mut PaymentCustomRecords) {
+    pub fn write(&self, custom_records: &mut PaymentCustomRecords) {
         custom_records
             .data
             .insert(Self::CUSTOM_RECORD_KEY, self.to_vec());


### PR DESCRIPTION
`PaymentDataRecord` is only used for basic mpp, and it's a too general struct name, when I continue to work on atomic mpp, the code seems confused, so change it to a more descriptive name.