### PR TITLE
fix: remove error prone union packet method

### DIFF
--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -190,11 +190,19 @@ fn test_peeled_onion_packet() {
     assert_eq!(packet.current, hops_infos[0].clone().into());
     assert!(!packet.is_last());
 
-    let packet = packet.peel(&keys[1], &secp).expect("peel");
+    let packet = packet
+        .next
+        .expect("next hop")
+        .peel(&keys[1], None, &secp)
+        .expect("peel");
     assert_eq!(packet.current, hops_infos[1].clone().into());
     assert!(!packet.is_last());
 
-    let packet = packet.peel(&keys[2], &secp).expect("peel");
+    let packet = packet
+        .next
+        .expect("next hop")
+        .peel(&keys[2], None, &secp)
+        .expect("peel");
     assert_eq!(packet.current, hops_infos[2].clone().into());
     assert!(packet.is_last());
 }
@@ -245,7 +253,12 @@ fn test_peeled_large_onion_packet() {
 
         let mut now = Some(packet);
         for i in 0..hops_infos.len() - 1 {
-            let packet = now.unwrap().peel(&keys[i], &secp).expect("peel");
+            let packet = now
+                .unwrap()
+                .next
+                .expect("next hop")
+                .peel(&keys[i], None, &secp)
+                .expect("peel");
             assert_eq!(packet.current, hops_infos[i + 1].clone().into());
             now = Some(packet.clone());
         }

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -420,9 +420,6 @@ pub enum Error {
 
 #[derive(Error, Debug)]
 pub enum OnionPacketError {
-    #[error("Try to peel the last hop")]
-    PeelingLastHop,
-
     #[error("Fail to deserialize the hop data")]
     InvalidHopData,
 
@@ -4073,23 +4070,6 @@ impl PeeledPaymentOnionPacket {
     /// Returns true if this is the peeled packet for the last destination.
     pub fn is_last(&self) -> bool {
         self.next.is_none()
-    }
-
-    /// Peels the next layer of the onion packet using the privkey of the current node.
-    ///
-    /// Returns errors when:
-    /// - This is the packet for the last hop.
-    /// - Fail to peel the packet using the given private key.
-    pub fn peel<C: Verification>(
-        self,
-        peeler: &Privkey,
-        secp_ctx: &Secp256k1<C>,
-    ) -> Result<Self, Error> {
-        let next = self
-            .next
-            .ok_or_else(|| Error::OnionPacket(OnionPacketError::PeelingLastHop))?;
-
-        next.peel(peeler, None, secp_ctx)
     }
 
     pub fn serialize(&self) -> Vec<u8> {


### PR DESCRIPTION
`PeeledPaymentOnionPacket::peel` uses `None` as assoc data, but
the payment onion packet must use payment hash as assoc data.

This method is never used and is error prone, so remove it.

Another option is adding payment hash as a required argument to this
function.
