### PR TITLE
Assuming channel is closed is it is disabled by both end

### DIFF
--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -925,7 +925,15 @@ where
                 ) => {
                     let mut channel_info = ChannelInfo::from((timestamp, channel_announcement));
                     self.load_channel_updates_from_store(&mut channel_info);
-                    Some(channel_info)
+
+                    // assuming channel is closed if disabled from the both side
+                    let is_closed = channel_info.update_of_node1.is_some_and(|u| !u.enabled)
+                        && channel_info.update_of_node2.is_some_and(|u| !u.enabled);
+                    if !is_closed {
+                        Some(channel_info)
+                    } else {
+                        None
+                    }
                 }
                 _ => None,
             })

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -4857,13 +4857,10 @@ async fn test_shutdown_channel_network_graph_with_sync_up() {
     assert_eq!(network_nodes.len(), 2);
 
     let network_channels = node_a.get_network_channels().await;
-    assert!(!network_channels[0].update_of_node1.unwrap().enabled);
-    assert!(!network_channels[0].update_of_node2.unwrap().enabled);
+    assert!(network_channels.is_empty());
 
     let network_channels = node_b.get_network_channels().await;
-    assert_eq!(network_channels.len(), 1);
-    assert!(!network_channels[0].update_of_node1.unwrap().enabled);
-    assert!(!network_channels[0].update_of_node2.unwrap().enabled);
+    assert!(network_channels.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
After a channel closed, the graph_channels still return the channel info. This PR remove these channel info from the RPC result.