### PR TITLE
Fix path finding bug for pay self with multiple direct channels

### DIFF
--- a/crates/fiber-lib/src/fiber/tests/mpp.rs
+++ b/crates/fiber-lib/src/fiber/tests/mpp.rs
@@ -3473,6 +3473,54 @@ async fn test_send_mpp_with_reverse_node_send_back() {
     node_0.wait_until_success(payment_hash).await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_send_3_nodes_pay_self() {
+    init_tracing();
+
+    let (nodes, _channels) = create_n_nodes_network(
+        &[
+            ((0, 1), (MIN_RESERVED_CKB + 66000, HUGE_CKB_AMOUNT)),
+            ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
+            ((2, 3), (MIN_RESERVED_CKB + 11000, MIN_RESERVED_CKB)),
+            ((2, 3), (MIN_RESERVED_CKB + 11000, MIN_RESERVED_CKB)),
+            ((2, 3), (MIN_RESERVED_CKB + 11000, MIN_RESERVED_CKB)),
+            // path_find will first try this direction, since it's with larger capacity
+            // but the middle hops for this direction don't have enough capacity
+            // so path finding should try another direction and succeed
+            ((3, 0), (MIN_RESERVED_CKB + 76000, HUGE_CKB_AMOUNT)),
+        ],
+        4,
+    )
+    .await;
+    let [mut node_0, _node_1, _node_2, _node_3] = nodes.try_into().expect("4 nodes");
+
+    let amount = 30000;
+    let target_pubkey = node_0.get_public_key();
+    let preimage = gen_rand_sha256_hash();
+    let ckb_invoice = InvoiceBuilder::new(Currency::Fibd)
+        .amount(Some(amount))
+        .payment_preimage(preimage)
+        .payee_pub_key(target_pubkey.into())
+        .allow_mpp(true)
+        .payment_secret(gen_rand_sha256_hash())
+        .build()
+        .expect("build invoice success");
+
+    node_0.insert_invoice(ckb_invoice.clone(), Some(preimage));
+    let command = SendPaymentCommand {
+        max_parts: Some(3),
+        invoice: Some(ckb_invoice.to_string()),
+        allow_self_payment: true,
+        ..Default::default()
+    };
+    let res = node_0.send_payment(command).await;
+
+    eprintln!("res: {:?}", res);
+    assert!(res.is_ok());
+    let payment_hash = res.unwrap().payment_hash;
+    node_0.wait_until_success(payment_hash).await;
+}
+
 #[tokio::test]
 async fn test_send_mpp_respect_min_tlc_value() {
     init_tracing();


### PR DESCRIPTION
When there are multiple direct channels, we choose a random direct channel for adjusting target node, suppose we first try `A -> D` direction and fail with capacity not enough error, if the following path finding in retry also choose `A -> D` direction, it will not find a router since we have recorded the failure for this payment try. 

The new unittest `test_send_3_nodes_pay_self` describes this scenario.

This fix will try all possible direct channels for payself payment.