### PR TITLE
Fix update close transaction when actor exit; remove network signing command

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -345,6 +345,7 @@ pub enum ChannelInitializationOperation {
 pub struct ChannelInitializationParameter {
     pub operation: ChannelInitializationOperation,
     pub ephemeral_config: ChannelEphemeralConfig,
+    pub private_key: Privkey,
 }
 
 #[derive(Clone)]
@@ -368,7 +369,6 @@ pub struct ChannelActor<S> {
     network: ActorRef<NetworkActorMessage>,
     store: S,
     subscribers: ChannelSubscribers,
-    private_key: Privkey,
 }
 
 impl<S> ChannelActor<S>
@@ -381,7 +381,6 @@ where
         network: ActorRef<NetworkActorMessage>,
         store: S,
         subscribers: ChannelSubscribers,
-        private_key: Privkey,
     ) -> Self {
         Self {
             local_pubkey,
@@ -389,7 +388,6 @@ where
             network,
             store,
             subscribers,
-            private_key,
         }
     }
 
@@ -969,7 +967,7 @@ where
             Some(onion_packet) => {
                 let peeled = onion_packet
                     .peel(
-                        &self.private_key,
+                        state.private_key(),
                         Some(add_tlc.payment_hash.as_ref()),
                         &Secp256k1::new(),
                     )
@@ -2151,11 +2149,13 @@ where
             }
             #[cfg(any(test, feature = "bench"))]
             ChannelCommand::ReloadState(reload_params) => {
+                let private_key = state.private_key.clone();
                 *state = self
                     .store
                     .get_channel_actor_state(&state.get_id())
                     .expect("load channel state failed");
                 state.network = Some(self.network.clone());
+                state.private_key = private_key.clone();
                 let ReloadParams { notify_changes } = reload_params;
                 if notify_changes {
                     state.on_owned_channel_updated(myself, false).await;
@@ -2405,6 +2405,7 @@ where
                     max_tlc_value_in_flight,
                     tlc_info,
                     self.network.clone(),
+                    args.private_key.clone(),
                 );
                 state.check_accept_channel_parameters()?;
 
@@ -2502,6 +2503,7 @@ where
                     max_tlc_number_in_flight,
                     tlc_info,
                     self.network.clone(),
+                    args.private_key.clone(),
                 );
 
                 check_open_channel_parameters(
@@ -2587,6 +2589,7 @@ where
                     .expect("channel should exist");
                 channel.reestablishing = true;
                 channel.network = Some(self.network.clone());
+                channel.private_key = Some(args.private_key.clone());
 
                 let reestablish_channel = ReestablishChannel {
                     channel_id,
@@ -3662,6 +3665,10 @@ pub struct ChannelActorState {
 
     #[serde(skip)]
     pub ephemeral_config: ChannelEphemeralConfig,
+
+    // signing key
+    #[serde(skip)]
+    pub private_key: Option<Privkey>,
 }
 
 #[serde_as]
@@ -4089,6 +4096,12 @@ impl ChannelActorState {
             .clone()
     }
 
+    fn private_key(&self) -> &Privkey {
+        self.private_key
+            .as_ref()
+            .expect("ChannelActorState should have signing key")
+    }
+
     pub fn is_public(&self) -> bool {
         self.public_channel_info.is_some()
     }
@@ -4193,9 +4206,8 @@ impl ChannelActorState {
 
         let message = channel_announcement.message_to_sign();
 
-        let (local_node_signature, local_partial_signature) = self
-            .get_or_create_local_channel_announcement_signature(remote_nonce.clone(), message)
-            .await;
+        let (local_node_signature, local_partial_signature) =
+            self.get_or_create_local_channel_announcement_signature(remote_nonce.clone(), message);
 
         let (remote_node_signature, remote_partial_signature) =
             self.get_remote_channel_announcement_signature()?;
@@ -4228,7 +4240,7 @@ impl ChannelActorState {
         }
     }
 
-    async fn do_generate_channel_update(
+    fn do_generate_channel_update(
         &mut self,
         // The function that would change the channel update parameters.
         f: impl FnOnce(&mut ChannelUpdate),
@@ -4243,17 +4255,16 @@ impl ChannelActorState {
             &self.get_id(),
             &channel_update
         );
-        let node_signature = sign_network_message(self.network(), channel_update.message_to_sign())
-            .await
-            .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+        let node_signature =
+            sign_network_message(self.private_key(), channel_update.message_to_sign());
 
         channel_update.signature = Some(node_signature);
         self.public_channel_state_mut().channel_update = Some(channel_update.clone());
         channel_update
     }
 
-    async fn generate_channel_update(&mut self) -> ChannelUpdate {
-        self.do_generate_channel_update(|_update| {}).await
+    fn generate_channel_update(&mut self) -> ChannelUpdate {
+        self.do_generate_channel_update(|_update| {})
     }
 
     fn create_update_tlc_info_message(&mut self) -> UpdateTlcInfo {
@@ -4268,11 +4279,10 @@ impl ChannelActorState {
         }
     }
 
-    async fn generate_disabled_channel_update(&mut self) -> ChannelUpdate {
+    fn generate_disabled_channel_update(&mut self) -> ChannelUpdate {
         self.do_generate_channel_update(|update| {
             update.channel_flags |= ChannelUpdateChannelFlags::DISABLED;
         })
-        .await
     }
 
     // Notify the network, network graph and channel counterparty about the channel update,
@@ -4302,7 +4312,7 @@ impl ChannelActorState {
 
     async fn broadcast_channel_update(&mut self, myself: &ActorRef<ChannelActorMessage>) {
         if self.is_public() {
-            let channel_update = self.generate_channel_update().await;
+            let channel_update = self.generate_channel_update();
             self.network()
                 .send_message(NetworkActorMessage::new_command(
                     NetworkActorCommand::BroadcastMessages(vec![
@@ -4404,7 +4414,7 @@ impl ChannelActorState {
             return Some(x);
         };
 
-        Some(self.generate_channel_update().await)
+        Some(self.generate_channel_update())
     }
 
     fn get_channel_update_channel_flags(&self) -> ChannelUpdateChannelFlags {
@@ -4497,6 +4507,7 @@ impl ChannelActorState {
         local_max_tlc_value_in_flight: u128,
         local_tlc_info: ChannelTlcInfo,
         network: ActorRef<NetworkActorMessage>,
+        private_key: Privkey,
     ) -> Self {
         let signer = InMemorySigner::generate_from_seed(seed);
         let local_base_pubkeys = signer.get_base_public_keys();
@@ -4566,6 +4577,7 @@ impl ChannelActorState {
             scheduled_channel_update_handle: None,
             pending_notify_mpp_tcls: vec![],
             ephemeral_config: Default::default(),
+            private_key: Some(private_key),
         };
         if let Some(nonce) = remote_channel_announcement_nonce {
             state.update_remote_channel_announcement_nonce(&nonce);
@@ -4590,6 +4602,7 @@ impl ChannelActorState {
         local_max_tlc_number_in_flight: u64,
         local_tlc_info: ChannelTlcInfo,
         network: ActorRef<NetworkActorMessage>,
+        private_key: Privkey,
     ) -> Self {
         let signer = InMemorySigner::generate_from_seed(seed);
         let local_pubkeys = signer.get_base_public_keys();
@@ -4644,6 +4657,7 @@ impl ChannelActorState {
             scheduled_channel_update_handle: None,
             pending_notify_mpp_tcls: vec![],
             ephemeral_config: Default::default(),
+            private_key: Some(private_key),
         }
     }
 
@@ -4780,7 +4794,7 @@ impl ChannelActorState {
         self.local_pubkey < self.remote_pubkey
     }
 
-    async fn get_or_create_local_channel_announcement_signature(
+    fn get_or_create_local_channel_announcement_signature(
         &mut self,
         remote_nonce: PubNonce,
         message: [u8; 32],
@@ -4810,9 +4824,7 @@ impl ChannelActorState {
         )
         .expect("Partial sign channel announcement");
 
-        let node_signature = sign_network_message(self.network(), message)
-            .await
-            .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+        let node_signature = sign_network_message(self.private_key(), message);
         self.network()
             .send_message(NetworkActorMessage::new_command(
                 NetworkActorCommand::SendFiberMessage(FiberMessageWithPeerId::new(
@@ -7910,7 +7922,7 @@ impl ChannelActorState {
         self.shutdown_transaction_hash.replace(tx_hash);
         // Broadcast the channel update message which disables the channel.
         if self.is_public() {
-            let update = self.generate_disabled_channel_update().await;
+            let update = self.generate_disabled_channel_update();
 
             self.network()
                 .send_message(NetworkActorMessage::new_command(
@@ -7920,6 +7932,7 @@ impl ChannelActorState {
                 ))
                 .expect(ASSUME_NETWORK_ACTOR_ALIVE);
         }
+
         Ok(())
     }
 

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -537,6 +537,7 @@ fn test_channel_actor_state_store() {
         scheduled_channel_update_handle: None,
         pending_notify_mpp_tcls: vec![],
         ephemeral_config: Default::default(),
+        private_key: None,
     };
 
     let bincode_encoded = bincode::serialize(&state).unwrap();
@@ -657,6 +658,7 @@ fn test_serde_channel_actor_state_ciborium() {
         scheduled_channel_update_handle: None,
         pending_notify_mpp_tcls: vec![],
         ephemeral_config: Default::default(),
+        private_key: None,
     };
 
     let mut serialized = Vec::new();

--- a/tests/bruno/e2e/shutdown-force/05-disconnect-peer.bru
+++ b/tests/bruno/e2e/shutdown-force/05-disconnect-peer.bru
@@ -19,11 +19,10 @@ body:json {
   {
     "id": "42",
     "jsonrpc": "2.0",
-    "method": "shutdown_channel",
+    "method": "disconnect_peer",
     "params": [
       {
-        "channel_id": "{{CHANNEL_ID}}",
-        "force": true
+        "peer_id": "{{NODE3_PEERID}}"
       }
     ]
   }

--- a/tests/bruno/e2e/shutdown-force/06-shutdown-force-NODE1.bru
+++ b/tests/bruno/e2e/shutdown-force/06-shutdown-force-NODE1.bru
@@ -1,0 +1,41 @@
+meta {
+  name: send shutdown from NODE1
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "shutdown_channel",
+    "params": [
+      {
+        "channel_id": "{{CHANNEL_ID}}",
+        "force": true
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  console.log("res.body: ", res.body);
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 100));
+}

--- a/tests/bruno/e2e/shutdown-force/07-generate-a-few-blocks.bru
+++ b/tests/bruno/e2e/shutdown-force/07-generate-a-few-blocks.bru
@@ -1,7 +1,7 @@
 meta {
   name: generate a few blocks after shutdown
   type: http
-  seq: 6
+  seq: 7
 }
 
 post {

--- a/tests/bruno/e2e/shutdown-force/08-list-channel-NODE1.bru
+++ b/tests/bruno/e2e/shutdown-force/08-list-channel-NODE1.bru
@@ -1,0 +1,44 @@
+meta {
+  name: List all channels after shutdown force
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "peer_id": "{{NODE3_PEERID}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.channels: isDefined
+}
+
+script:post-response {
+  console.log(res.body.result);
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 2000));
+  if (res.body.result.channels.length != 0) {
+    console.log("channel first: ", res.body.result.channels[0]);
+    throw new Error("Assertion failed: expect thel channel is closed");
+  }
+}

--- a/tests/bruno/e2e/shutdown-force/09-list-closed-channel-NODE1.bru
+++ b/tests/bruno/e2e/shutdown-force/09-list-closed-channel-NODE1.bru
@@ -1,7 +1,7 @@
 meta {
   name: List all channels after shutdown force
   type: http
-  seq: 7
+  seq: 9
 }
 
 post {
@@ -22,7 +22,8 @@ body:json {
     "method": "list_channels",
     "params": [
       {
-        "peer_id": "{{NODE3_PEERID}}"
+        "peer_id": "{{NODE3_PEERID}}",
+        "include_closed": true
       }
     ]
   }
@@ -37,9 +38,11 @@ script:post-response {
   console.log(res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
   await new Promise(r => setTimeout(r, 2000));
-  bru.setVar("CHANNEL_ID", res.body.result.channels.length);
-  if (res.body.result.channels.length != 0) {
-    console.log("channel first: ", res.body.result.channels[0]);
+  console.log("channel first: ", res.body.result.channels[0]);
+  if (res.body.result.channels[0].state.state_name != 'CLOSED') {
     throw new Error("Assertion failed: expect thel channel is closed");
+  }
+  if (res.body.result.channels[0].shutdown_transaction_hash == null) {
+    throw new Error("Assertion failed: expect shutdown_transaction_hash is not null");
   }
 }

--- a/tests/bruno/e2e/shutdown-force/10-set-channel-id.bru
+++ b/tests/bruno/e2e/shutdown-force/10-set-channel-id.bru
@@ -1,5 +1,5 @@
 meta {
-  name: List all channels after shutdown force
+  name: Set shutdown channel id
   type: http
   seq: 10
 }
@@ -34,12 +34,7 @@ assert {
 }
 
 script:post-response {
-  console.log(res.body.result);
-  // Sleep for sometime to make sure current operation finishes before next request starts.
   await new Promise(r => setTimeout(r, 2000));
-  bru.setVar("CHANNEL_ID", res.body.result.channels.length);
-  if (res.body.result.channels.length != 0) {
-    console.log("channel first: ", res.body.result.channels[0]);
-    throw new Error("Assertion failed: expect thel channel is closed");
-  }
+  console.log(res.body.result);
+  bru.setVar("CHANNEL_ID", res.body.result.channels[0].channel_id);
 }

--- a/tests/bruno/e2e/shutdown-force/11-trigger-check-shutdown.bru
+++ b/tests/bruno/e2e/shutdown-force/11-trigger-check-shutdown.bru
@@ -1,7 +1,7 @@
 meta {
   name: Check channel shutdown
   type: http
-  seq: 9
+  seq: 11
 }
 
 post {

--- a/tests/bruno/e2e/shutdown-force/12-list-channel-NODE3.bru
+++ b/tests/bruno/e2e/shutdown-force/12-list-channel-NODE3.bru
@@ -1,7 +1,7 @@
 meta {
-  name: Set shutdown channel id
+  name: List all channels after shutdown force
   type: http
-  seq: 8
+  seq: 12
 }
 
 post {
@@ -34,7 +34,12 @@ assert {
 }
 
 script:post-response {
-  await new Promise(r => setTimeout(r, 2000));
   console.log(res.body.result);
-  bru.setVar("CHANNEL_ID", res.body.result.channels[0].channel_id);
+  // Sleep for sometime to make sure current operation finishes before next request starts.
+  await new Promise(r => setTimeout(r, 2000));
+  bru.setVar("CHANNEL_ID", res.body.result.channels.length);
+  if (res.body.result.channels.length != 0) {
+    console.log("channel first: ", res.body.result.channels[0]);
+    throw new Error("Assertion failed: expect thel channel is closed");
+  }
 }


### PR DESCRIPTION
1. Move `ChannelActor` field `private_key` to `ChannelActorState`.
2. Remove `NetworkActorCommand::SignMessage` and `call!` on network.
3. Fix `update_close_transaction_confirmed` hanging issue.
4. Fix force close disconnected peer's channel do not update the state.
5. Update e2e test case