### PR TITLE
Fix connect to peer with multi addresses

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -11,6 +11,7 @@ use ractor::concurrency::Duration;
 use ractor::{
     call_t, Actor, ActorCell, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent,
 };
+use rand::seq::SliceRandom;
 use rand::Rng;
 use secp256k1::Secp256k1;
 use serde::{Deserialize, Serialize};
@@ -1405,6 +1406,8 @@ where
                         .into_iter()
                         .chain(graph_nodes_to_connect.into_iter())
                 };
+
+                let mut rng = rand::thread_rng();
                 for (peer_id, addresses) in peers_to_connect {
                     debug!("Peer to connect: {:?}, {:?}", peer_id, addresses);
                     if let Some(session) = state.get_peer_session(&peer_id) {
@@ -1414,7 +1417,9 @@ where
                                 );
                         continue;
                     }
-                    for addr in addresses {
+
+                    // Randomly pick one address to connect
+                    if let Some(addr) = addresses.choose(&mut rng) {
                         state
                             .network
                             .send_message(NetworkActorMessage::new_command(


### PR DESCRIPTION
If a node has multiple addresses, fiber will try to connect these address 1 by 1. However, tentacle ignores duplicate dial based on peer id(I am not sure is it intended or a bug). So the result is only first dial is send, and the following dial is ignored.

This Pr provides a workaround: randomly pick one address to dial.

In this line tentacle insert the dialing address

https://github.com/driftluo/tentacle/blob/1ccdc37a656e565c1d8b9ba2a50999d5a4793c2e/tentacle/src/service.rs#L389

In this line tentacle ignored the address with same peer_id

https://github.com/driftluo/tentacle/blob/1ccdc37a656e565c1d8b9ba2a50999d5a4793c2e/tentacle/src/service.rs#L1164