### PR TITLE
graph_channels read from memory instead of from DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,6 +2136,7 @@ dependencies = [
  "hex",
  "home",
  "hyper 1.6.0",
+ "indexmap 2.11.0",
  "indicatif",
  "jsonrpsee",
  "lightning-invoice",
@@ -2492,7 +2493,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2511,7 +2512,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3031,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -3982,7 +3983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
 ]
 
 [[package]]
@@ -5126,7 +5127,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -5154,7 +5155,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "ryu",
  "serde",
@@ -5831,7 +5832,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,6 @@ dependencies = [
  "hex",
  "home",
  "hyper 1.6.0",
- "indexmap 2.11.0",
  "indicatif",
  "jsonrpsee",
  "lightning-invoice",

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -57,6 +57,7 @@ thiserror = "1.0.58"
 tokio-util = {version = "0.7.10", features = ["rt"]}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
+indexmap = "2.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 biscuit-auth = "6.0.0-beta.3"

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -57,7 +57,6 @@ thiserror = "1.0.58"
 tokio-util = {version = "0.7.10", features = ["rt"]}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
-indexmap = "2.11.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 biscuit-auth = "6.0.0-beta.3"

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -463,6 +463,7 @@ Get the list of nodes in the network graph.
 
 * `nodes` - <em>Vec<[NodeInfo](#type-nodeinfo)></em>, The list of nodes.
 * `last_cursor` - <em>`JsonBytes`</em>, The last cursor.
+* `total_count` - <em>`Uint64`</em>, The total count of nodes
 
 ---
 
@@ -482,6 +483,7 @@ Get the list of channels in the network graph.
 
 * `channels` - <em>Vec<[ChannelInfo](#type-channelinfo)></em>, A list of channels.
 * `last_cursor` - <em>`JsonBytes`</em>, The last cursor for pagination.
+* `total_count` - <em>`Uint64`</em>, The total count of channels
 
 ---
 

--- a/crates/fiber-lib/src/rpc/graph.rs
+++ b/crates/fiber-lib/src/rpc/graph.rs
@@ -8,13 +8,15 @@ use crate::fiber::graph::{ChannelUpdateInfo, NetworkGraph, NetworkGraphStateStor
 use crate::fiber::network::get_chain_hash;
 use crate::fiber::serde_utils::EntityHex;
 use crate::fiber::serde_utils::{U128Hex, U64Hex};
-use crate::fiber::types::{Cursor, Hash256, Pubkey};
-use ckb_jsonrpc_types::{DepType, JsonBytes, OutPoint as OutPointWrapper, Script, ScriptHashType};
+use crate::fiber::types::{Hash256, Pubkey};
+use ckb_jsonrpc_types::{
+    DepType, JsonBytes, OutPoint as OutPointWrapper, Script, ScriptHashType, Uint64,
+};
 use ckb_types::packed::OutPoint;
 use ckb_types::H256;
 #[cfg(not(target_arch = "wasm32"))]
 use jsonrpsee::proc_macros::rpc;
-use jsonrpsee::{types::error::INVALID_PARAMS_CODE, types::ErrorObjectOwned};
+use jsonrpsee::types::ErrorObjectOwned;
 
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -182,6 +184,8 @@ pub struct GraphNodesResult {
     pub nodes: Vec<NodeInfo>,
     /// The last cursor.
     pub last_cursor: JsonBytes,
+    /// The total count of nodes
+    pub total_count: Uint64,
 }
 
 #[serde_as]
@@ -247,6 +251,8 @@ pub struct GraphChannelsResult {
     pub channels: Vec<ChannelInfo>,
     /// The last cursor for pagination.
     pub last_cursor: JsonBytes,
+    /// The total count of channels
+    pub total_count: Uint64,
 }
 
 /// RPC module for graph management.
@@ -332,22 +338,24 @@ where
         let network_graph = self.network_graph.read().await;
         let default_max_limit = 500;
         let limit = params.limit.unwrap_or(default_max_limit) as usize;
-        let cursor = params
-            .after
-            .as_ref()
-            .map(|cursor| Cursor::from_bytes(cursor.as_bytes()))
-            .transpose()
-            .map_err(|e| {
-                ErrorObjectOwned::owned(INVALID_PARAMS_CODE, e.to_string(), Some(params))
-            })?;
-        let nodes = network_graph.get_nodes_with_params(limit, cursor);
-        let last_cursor = nodes
-            .last()
-            .map(|node| JsonBytes::from_vec(node.cursor().to_bytes().into()))
-            .unwrap_or_default();
+        let after = params.after.as_ref().map(|after| {
+            let buf: [u8; 8] = after.as_bytes().try_into().unwrap_or_default();
+            u64::from_le_bytes(buf)
+        });
+        let nodes = network_graph.get_nodes_with_params(limit, after);
+        let last_cursor = JsonBytes::from_vec(
+            (after.unwrap_or_default() + nodes.len() as u64)
+                .to_le_bytes()
+                .to_vec(),
+        );
         let nodes = nodes.into_iter().map(Into::into).collect();
+        let total_count = (network_graph.nodes.len() as u64).into();
 
-        Ok(GraphNodesResult { nodes, last_cursor })
+        Ok(GraphNodesResult {
+            nodes,
+            last_cursor,
+            total_count,
+        })
     }
 
     pub async fn graph_channels(
@@ -370,9 +378,13 @@ where
         );
 
         let channels = channels.into_iter().map(Into::into).collect();
+        let public_channels_count =
+            network_graph.channels.len() - network_graph.private_channels_count;
+        let total_count = (public_channels_count as u64).into();
         Ok(GraphChannelsResult {
             channels,
             last_cursor,
+            total_count,
         })
     }
 }

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -1906,7 +1906,6 @@ dependencies = [
  "hex",
  "home",
  "hyper 1.6.0",
- "indexmap 2.11.0",
  "indicatif",
  "jsonrpsee",
  "lightning-invoice",

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -1906,6 +1906,7 @@ dependencies = [
  "hex",
  "home",
  "hyper 1.6.0",
+ "indexmap 2.11.0",
  "indicatif",
  "jsonrpsee",
  "lightning-invoice",
@@ -2277,7 +2278,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2296,7 +2297,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2786,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -3710,7 +3711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
 ]
 
 [[package]]
@@ -4795,7 +4796,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -4823,7 +4824,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "ryu",
  "serde",
@@ -5491,7 +5492,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "toml_datetime",
  "winnow",
 ]


### PR DESCRIPTION
1. Using indexmap struct to store graph channels,  thus, we can support paginate in graph_channels.
2. Remove Db access in graph_channels and graph_nodes Rpc
3. Add total_count to result

~~Drawback:~~

~~Since our paginate based on return count, the query result may contains duplicates or missing for multiple pages. It is acceptable since graph_channels is mainly used for statistics, one way to workaround this problems is to set limit large enough to return all channels in once.~~

Also fixes #534

--------------------------

Updated the new commit use BTreeMap to store graph channels and nodes avoid the paginate drawback