### PR TITLE
Change P2P keepalive interval to 15s

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -4402,17 +4402,23 @@ where
             .await
             .expect("subscribe to gossip store updates");
         let gossip_actor = gossip_handle.actor().clone();
+        let yamux_config = tentacle::yamux::config::Config {
+            keepalive_interval: Duration::from_secs(15),
+            ..Default::default()
+        };
         #[cfg(not(target_arch = "wasm32"))]
         let mut service = ServiceBuilder::default()
             .insert_protocol(fiber_handle.create_meta())
             .insert_protocol(gossip_handle.create_meta())
             .handshake_type(secio_kp.into())
+            .yamux_config(yamux_config)
             .build(handle);
         #[cfg(target_arch = "wasm32")]
         let mut service = ServiceBuilder::default()
             .insert_protocol(fiber_handle.create_meta())
             .insert_protocol(gossip_handle.create_meta())
             .handshake_type(secio_kp.into())
+            .yamux_config(yamux_config)
             // Sets forever to true so the network service won't be shutdown due to no incoming connections
             .forever(true)
             .build(handle);


### PR DESCRIPTION
The keepalive timeout in tentacle is hardcoded [30s](https://github.com/driftluo/tentacle/blob/1ccdc37a656e565c1d8b9ba2a50999d5a4793c2e/yamux/src/session.rs#L40)
The default keepalive interval is also 30s, which means if 1 keepalive packet is delayed(received more than 30s), the connection will be timeout, by reducing the keepalive interval to 15s, we expect to see less Timeout errors.