### PR TITLE
Assume node support mpp when node is not synced into graph

### DIFF
--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1331,18 +1331,8 @@ where
     fn is_node_support_mpp(&self, node: &Pubkey) -> bool {
         self.nodes
             .get(node)
-            .is_some_and(|node_info| node_info.features.supports_basic_mpp())
-    }
-
-    fn check_node_exists(&self, node_id: &Pubkey) -> Result<(), PathFindError> {
-        if self.nodes.contains_key(node_id) {
-            Ok(())
-        } else {
-            Err(PathFindError::UnknownNode(format!(
-                "node {:?} not found in the graph",
-                node_id
-            )))
-        }
+            .map(|node_info| node_info.features.supports_basic_mpp())
+            .unwrap_or(true)
     }
 
     // A helper function to evaluate whether an edge should be added to the heap of nodes to visit.
@@ -1485,9 +1475,6 @@ where
                 max_fee_amount.unwrap_or(0)
             )));
         }
-
-        self.check_node_exists(&source)?;
-        self.check_node_exists(&target)?;
 
         if source == target && !allow_self {
             return Err(PathFindError::FeatureNotEnabled(

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -1250,7 +1250,7 @@ async fn test_network_send_payment_target_not_found() {
         })
         .await;
     assert!(res.is_err());
-    assert!(res.err().unwrap().contains("Node not found in graph"));
+    assert!(res.err().unwrap().contains("no path found"));
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/mpp.rs
+++ b/crates/fiber-lib/src/fiber/tests/mpp.rs
@@ -4018,5 +4018,5 @@ async fn test_send_payment_mpp_with_node_not_in_graph() {
         .await;
 
     let error = payment_hash.unwrap_err().to_string();
-    assert!(error.contains("Failed to build route, Node not found in graph"));
+    assert!(error.contains("no path found"));
 }


### PR DESCRIPTION
The config option `announce_private_addr` may filter out some nodes when receiving node announcements, it's more reasonable to assume a node support MPP, since we actually checked a node's feature when generating invoice in https://github.com/nervosnetwork/fiber/pull/895