### PR TITLE
Fix the issue of shrink remote_commitment_points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
           git checkout ${{ github.sha }}
 
           export ON_GITHUB_ACTION=y
+          sed -i 's/sleep 5/sleep 10/g' ./tests/nodes/wait.sh
           CKB_LOG=warn TEST_ENV=release ./tests/nodes/start.sh > baseline.log 2>&1 &
           ./tests/nodes/wait.sh
 

--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -246,8 +246,9 @@ pub async fn main() -> Result<(), ExitMessage> {
                                     break;
                                 }
                                 Some(event) => {
-                                    // we may forward more events to the rpc dev module in the future for integration testing
-                                    // for now, we only forward RemoteCommitmentSigned events, which are used for submitting outdated commitment transactions
+                                    // we may forward more events to the rpc dev module in the future for
+                                    // integration testing for now, we only forward RemoteCommitmentSigned events,
+                                    // which are used for submitting outdated commitment transactions
                                     #[cfg(debug_assertions)]
                                     if let Some(rpc_dev_module_commitment_txs) = rpc_dev_module_commitment_txs_clone.as_ref() {
                                         if let NetworkServiceEvent::RemoteCommitmentSigned(_, channel_id, commitment_tx, _) = event.clone() {
@@ -545,7 +546,8 @@ impl ExitMessage {
 #[cfg(target_family = "unix")]
 async fn signal_listener() {
     use tokio::signal::unix::{signal, SignalKind};
-    // SIGTERM is commonly sent for graceful shutdown of applications, followed by 30 seconds of grace time, then a SIGKILL.
+    // SIGTERM is commonly sent for graceful shutdown of applications,
+    // followed by 30 seconds of grace time, then a SIGKILL.
     let mut sigterm = signal(SignalKind::terminate()).expect("listen for SIGTERM");
     // SIGINT is usually sent due to ctrl-c in the terminal.
     let mut sigint = signal(SignalKind::interrupt()).expect("listen for SIGINT");

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -17,6 +17,7 @@ use musig2::BinaryEncoding;
 use musig2::SecNonceBuilder;
 use secp256k1::{Secp256k1, XOnlyPublicKey};
 use std::collections::hash_map::Entry;
+use std::iter;
 #[cfg(test)]
 use std::{
     backtrace::Backtrace,
@@ -3327,6 +3328,7 @@ impl TlcState {
             self.received_tlcs.tlcs.retain(|tlc| tlc.tlc_id != tlc_id);
         }
     }
+
     pub fn add_offered_tlc(&mut self, tlc: TlcInfo) {
         self.offered_tlcs.add_tlc(tlc);
     }
@@ -5333,7 +5335,7 @@ impl ChannelActorState {
 
             debug!("Updated local balance to {} and remote balance to {} by removing tlc {:?} with reason {:?}",
                             to_local_amount, to_remote_amount, tlc_id, reason);
-            self.tlc_state.apply_remove_tlc(tlc_id);
+            self.apply_remove_tlc(tlc_id);
         }
         debug!(
             "Removed tlc payment_hash {:?} with reason {:?}",
@@ -5341,6 +5343,21 @@ impl ChannelActorState {
         );
 
         Ok((current.clone(), reason))
+    }
+
+    fn apply_remove_tlc(&mut self, tlc_id: TLCId) {
+        self.tlc_state.apply_remove_tlc(tlc_id);
+
+        let points: HashSet<u64> = self
+            .tlc_state
+            .all_tlcs()
+            .flat_map(|x| [x.created_at.get_local(), x.created_at.get_remote()])
+            .chain(iter::once(self.get_local_commitment_number()))
+            .chain(iter::once(self.get_remote_commitment_number()))
+            .collect();
+
+        self.remote_commitment_points
+            .retain(|(number, _)| points.contains(number));
     }
 
     pub fn clean_up_failed_tlcs(&mut self) {
@@ -5425,7 +5442,13 @@ impl ChannelActorState {
                     None
                 }
             })
-            .expect("remote commitment point should exist")
+            .expect(
+                format!(
+                    "remote commitment point: {:?} should exist",
+                    commitment_number
+                )
+                .as_str(),
+            )
     }
 
     fn get_current_local_commitment_point(&self) -> Pubkey {
@@ -6755,19 +6778,12 @@ impl ChannelActorState {
         self.remote_commitment_points
             .push((self.get_local_commitment_number(), commitment_point));
 
-        // shrink the remote commitment points list
-        // TODO: use all_tlcs as filter instead of select the minimal commitment number
-        let len = self.remote_commitment_points.len();
-        if len > (self.local_constraints.max_tlc_number_in_flight + 1) as usize {
-            let min_remote_commitment = self
-                .tlc_state
-                .all_tlcs()
-                .map(|x| x.created_at.remote.min(x.created_at.local))
-                .min()
-                .unwrap_or_default();
-            self.remote_commitment_points
-                .retain(|(num, _)| *num >= min_remote_commitment);
-        }
+        debug_assert!(
+            self.remote_commitment_points.len()
+                <= self.local_constraints.max_tlc_number_in_flight as usize
+                    + self.remote_constraints.max_tlc_number_in_flight as usize
+                    + 2
+        );
     }
 
     fn handle_revoke_and_ack_peer_message(

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -2071,6 +2071,8 @@ async fn do_test_remove_tlc_with_wrong_hash_algorithm(
 
 #[tokio::test]
 async fn do_test_channel_remote_commitment_error() {
+    crate::init_tracing();
+
     // https://github.com/nervosnetwork/fiber/issues/447
     let node_a_funding_amount = 100000000000;
     let node_b_funding_amount = 100000000000;

--- a/tests/nodes/wait.sh
+++ b/tests/nodes/wait.sh
@@ -42,6 +42,6 @@ while [ $count -lt $try_number ]; do
           echo "Reached maximum number of tries ($try_number), exiting with status 1"
             exit 1
         fi
-        sleep 5
+        sleep 10
     fi
 done


### PR DESCRIPTION
The old strategy for shrinking the remote commitment points list is not optimized, which makes `remote_commitment_points` may in a large size, it will cost a lot of memory and CPU when a Node is running for a long time.