### PR TITLE
Provide tokio metrics endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,6 +2249,7 @@ dependencies = [
  "jsonrpsee",
  "lightning-invoice",
  "lnd-grpc-tonic-client",
+ "metrics",
  "metrics-exporter-prometheus",
  "molecule",
  "musig2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +250,30 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libloading",
+]
 
 [[package]]
 name = "axum"
@@ -436,6 +472,26 @@ dependencies = [
  "shlex",
  "syn 2.0.104",
  "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.9.2",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -976,7 +1032,7 @@ version = "8.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e68e0993f54ba0d21152419a0668caa92adc928b5a9b01e45871ec055a31ce2"
 dependencies = [
- "bindgen",
+ "bindgen 0.68.1",
  "cc",
  "glob",
  "libc",
@@ -1406,6 +1462,15 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1886,6 +1951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2249,7 @@ dependencies = [
  "jsonrpsee",
  "lightning-invoice",
  "lnd-grpc-tonic-client",
+ "metrics-exporter-prometheus",
  "molecule",
  "musig2",
  "nom",
@@ -2200,6 +2272,7 @@ dependencies = [
  "tentacle",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-metrics",
  "tokio-util",
  "tower 0.5.2",
  "tracing",
@@ -2215,6 +2288,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -2239,6 +2318,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2572,7 +2657,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2592,6 +2677,9 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heapsize"
@@ -2813,6 +2901,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3582,6 +3671,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171d2f700835121c3b04ccf0880882987a050fd5c7ae88148abf537d33dd3a56"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "metrics"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+dependencies = [
+ "ahash 0.8.12",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap 2.10.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.4",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -4411,6 +4547,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4561,6 +4712,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.9.2",
 ]
 
 [[package]]
@@ -4805,6 +4974,7 @@ version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4868,6 +5038,7 @@ version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5330,6 +5501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5760,6 +5937,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01bbf7db0b3f5eee8930a119fe99bfa1438de1095fe3d26b25e652a5933ef3f"
+dependencies = [
+ "futures-util",
+ "metrics",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/crates/fiber-bin/Cargo.toml
+++ b/crates/fiber-bin/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "fnn"
 path = "src/main.rs"
 
+[features]
+metrics = ["fnn/metrics"]
+
 [dependencies]
 fnn = { path = "../fiber-lib" }
 ckb-chain-spec = "0.202.0"

--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -183,7 +183,9 @@ pub async fn main() -> Result<(), ExitMessage> {
                 );
             }
 
-            let watchtower_client = if let Some(url) = fiber_config.standalone_watchtower_rpc_url {
+            let watchtower_client = if let Some(url) =
+                fiber_config.standalone_watchtower_rpc_url.clone()
+            {
                 let mut client_builder = HttpClientBuilder::default();
 
                 if let Some(token) = fiber_config.standalone_watchtower_token.as_ref() {
@@ -232,6 +234,13 @@ pub async fn main() -> Result<(), ExitMessage> {
                 );
                 Some(watchtower_actor)
             };
+
+            #[cfg(feature = "metrics")]
+            if let Some(addr) = fiber_config.metrics_addr.as_ref() {
+                if let Err(e) = fnn::metrics::start_metrics(addr) {
+                    tracing::error!("Failed to start metrics server: {}", e);
+                }
+            }
 
             #[cfg(debug_assertions)]
             let rpc_dev_module_commitment_txs_clone = rpc_dev_module_commitment_txs.clone();

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -91,6 +91,8 @@ tokio = { version = "1", features = [
   "process",
 ] }
 tower = { version = "0.5" }
+tokio-metrics = { version = "0.4.5", optional = true, features = ["metrics-rs-integration"] }
+metrics-exporter-prometheus = { version = "0.17.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 biscuit-auth = { version = "6.0.0-beta.3", features = ["wasm"] }
@@ -119,6 +121,7 @@ bench = ["tempfile", "ckb-testtool"]
 default = ["watchtower"]
 portable = ["rocksdb/portable"]
 watchtower = []
+metrics = ["tokio-metrics", "metrics-exporter-prometheus"]
 
 [dev-dependencies]
 ciborium = "0.2.2"

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -92,6 +92,7 @@ tokio = { version = "1", features = [
 ] }
 tower = { version = "0.5" }
 tokio-metrics = { version = "0.4.5", optional = true, features = ["metrics-rs-integration"] }
+metrics = { version = "0.24.2", optional = true }
 metrics-exporter-prometheus = { version = "0.17.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -121,7 +122,7 @@ bench = ["tempfile", "ckb-testtool"]
 default = ["watchtower"]
 portable = ["rocksdb/portable"]
 watchtower = []
-metrics = ["tokio-metrics", "metrics-exporter-prometheus"]
+metrics = ["dep:metrics", "tokio-metrics", "metrics-exporter-prometheus"]
 
 [dev-dependencies]
 ciborium = "0.2.2"

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -2740,6 +2740,9 @@ where
             }
         }
 
+        #[cfg(feature = "metrics")]
+        metrics::gauge!(crate::metrics::TOTAL_CHANNEL_COUNT).increment(1);
+
         Ok(())
     }
 
@@ -2772,6 +2775,9 @@ where
         let _ = self.network.send_message(NetworkActorMessage::new_event(
             NetworkActorEvent::ChannelActorStopped(state.get_id(), stop_reason),
         ));
+
+        #[cfg(feature = "metrics")]
+        metrics::gauge!(crate::metrics::TOTAL_CHANNEL_COUNT).decrement(1);
         Ok(())
     }
 }

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -378,6 +378,16 @@ pub struct FiberConfig {
     )]
     #[default(true)]
     pub reuse_port_for_websocket: bool,
+
+    /// Metrics address
+    #[cfg(feature = "metrics")]
+    #[arg(
+        name = "FIBER_METRICS_ADDR",
+        long = "fiber-metrics-addr",
+        env,
+        help = "Address for metrics endpoint (e.g., 127.0.0.1:9090). Requires binary to be compiled with RUSTFLAGS=\"--cfg tokio_unstable\" and metrics feature enabled"
+    )]
+    pub metrics_addr: Option<String>,
 }
 
 /// Must be a valid utf-8 string of length maximal length 32 bytes.

--- a/crates/fiber-lib/src/lib.rs
+++ b/crates/fiber-lib/src/lib.rs
@@ -1,4 +1,6 @@
 mod config;
+#[cfg(feature = "metrics")]
+pub mod metrics;
 pub use config::Config;
 
 #[cfg(any(test, feature = "bench"))]

--- a/crates/fiber-lib/src/metrics.rs
+++ b/crates/fiber-lib/src/metrics.rs
@@ -1,6 +1,12 @@
 use std::net::ToSocketAddrs;
 use tracing::error;
 
+pub const TOTAL_CHANNEL_COUNT: &str = "fiber.total_channel_count";
+pub const TOTAL_PEER_COUNT: &str = "fiber.total_peer_count";
+pub const INBOUND_PEER_COUNT: &str = "fiber.inbound_peer_count";
+pub const OUTBOUND_PEER_COUNT: &str = "fiber.outbound_peer_count";
+pub const DOWN_WITH_CHANNEL_PEER_COUNT: &str = "fiber.down_with_channel_peer_count";
+
 pub fn start_metrics(metrics_addr: &str) -> Result<(), Box<dyn std::error::Error>> {
     let socket_addr = metrics_addr
         .to_socket_addrs()

--- a/crates/fiber-lib/src/metrics.rs
+++ b/crates/fiber-lib/src/metrics.rs
@@ -1,0 +1,38 @@
+use std::net::ToSocketAddrs;
+use tracing::error;
+
+pub fn start_metrics(metrics_addr: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let socket_addr = metrics_addr
+        .to_socket_addrs()
+        .map_err(|e| {
+            error!("Invalid metrics address '{}': {}", metrics_addr, e);
+            e
+        })?
+        .next()
+        .ok_or_else(|| {
+            let err = std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                format!("No valid socket address found for '{}'", metrics_addr),
+            );
+            error!("{}", err);
+            err
+        })?;
+
+    metrics_exporter_prometheus::PrometheusBuilder::new()
+        .with_http_listener(socket_addr)
+        .install()
+        .map_err(|e| {
+            error!("Failed to install Prometheus metrics exporter: {}", e);
+            Box::new(e) as Box<dyn std::error::Error>
+        })?;
+
+    tokio::task::spawn(
+        tokio_metrics::RuntimeMetricsReporterBuilder::default()
+            // the default metric sampling interval is 30 seconds, which is
+            // too long for quick tests, so have it be 1 second.
+            .with_interval(std::time::Duration::from_secs(1))
+            .describe_and_run(),
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Provide metrics endpoint. 

Requires binary to be compiled with RUSTFLAGS=\"--cfg tokio_unstable\" and metrics feature enabled.

``` bash
RUSTFLAGS="--cfg tokio_unstable" cargo build --features metrics
```

Then in the config file set `fiber.metrics_addr` option.

This PR add tokio metrics via [tokio-metrics](https://docs.rs/tokio-metrics/latest/tokio_metrics)

And provide the following fiber metrics:

``` rust
pub const TOTAL_CHANNEL_COUNT: &str = "fiber.total_channel_count";
pub const TOTAL_PEER_COUNT: &str = "fiber.total_peer_count";
pub const INBOUND_PEER_COUNT: &str = "fiber.inbound_peer_count";
pub const OUTBOUND_PEER_COUNT: &str = "fiber.outbound_peer_count";
pub const DOWN_WITH_CHANNEL_PEER_COUNT: &str = "fiber.down_with_channel_peer_count";
```