### PR TITLE
Support profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -89,6 +90,15 @@ name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
 
 [[package]]
 name = "android-tzdata"
@@ -707,6 +717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +748,7 @@ dependencies = [
  "futures",
  "hex",
  "libc",
- "memmap2",
+ "memmap2 0.5.10",
  "miette",
  "reflink-copy",
  "serde",
@@ -1599,6 +1615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +1849,15 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "der"
@@ -2054,6 +2088,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2246,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2325,7 @@ dependencies = [
  "ouroboros",
  "parking_lot",
  "paste",
+ "pprof",
  "ractor",
  "rand 0.8.5",
  "regex",
@@ -3182,6 +3249,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash 0.8.12",
+ "indexmap 2.10.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "merkle-cbt"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,6 +3932,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,6 +3973,16 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
 
 [[package]]
 name = "num-traits"
@@ -4341,6 +4456,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "smallvec",
+ "spin",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4560,6 +4697,15 @@ dependencies = [
  "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4884,6 +5030,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -5556,6 +5711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5604,6 +5768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5636,6 +5806,29 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symbolic-common"
+version = "12.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f433c9befeea460a01d750e698aa86caf86dcfbd77d552885cd6c89d52f50"
+dependencies = [
+ "debugid",
+ "memmap2 0.9.8",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d359ef6192db1760a34321ec4f089245ede4342c27e59be99642f12a859de8"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -6452,6 +6645,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -94,6 +94,7 @@ tower = { version = "0.5" }
 tokio-metrics = { version = "0.4.5", optional = true, features = ["metrics-rs-integration"] }
 metrics = { version = "0.24.2", optional = true }
 metrics-exporter-prometheus = { version = "0.17.2", optional = true }
+pprof = { version = "0.15", features = ["flamegraph"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 biscuit-auth = { version = "6.0.0-beta.3", features = ["wasm"] }
@@ -123,6 +124,7 @@ default = ["watchtower"]
 portable = ["rocksdb/portable"]
 watchtower = []
 metrics = ["dep:metrics", "tokio-metrics", "metrics-exporter-prometheus"]
+pprof = ["dep:pprof"]
 
 [dev-dependencies]
 ciborium = "0.2.2"

--- a/crates/fiber-lib/src/fiber/mod.rs
+++ b/crates/fiber-lib/src/fiber/mod.rs
@@ -8,6 +8,8 @@ pub mod hash_algorithm;
 pub mod history;
 pub mod network;
 pub mod payment;
+#[cfg(all(feature = "pprof", not(target_arch = "wasm32")))]
+pub mod profiling;
 pub mod serde_utils;
 pub mod types;
 

--- a/crates/fiber-lib/src/fiber/profiling.rs
+++ b/crates/fiber-lib/src/fiber/profiling.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+
+use pprof::ProfilerGuardBuilder;
+
+const OUTPUT_DIR: &str = "profiles";
+
+/// Collects a flamegraph for the given duration and writes it under `./profiles`.
+pub async fn collect_flamegraph(duration_secs: u64) -> Result<PathBuf> {
+    let duration_secs = duration_secs.max(1);
+
+    tokio::task::spawn_blocking(move || -> Result<PathBuf> {
+        let guard = ProfilerGuardBuilder::default()
+            .frequency(99)
+            .build()
+            .context("starting profiler")?;
+
+        std::thread::sleep(Duration::from_secs(duration_secs));
+
+        let report = guard.report().build().context("building profiler report")?;
+
+        std::fs::create_dir_all(OUTPUT_DIR).context("creating output directory")?;
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("computing timestamp")?
+            .as_secs();
+        let output = PathBuf::from(OUTPUT_DIR).join(format!("flamegraph-{timestamp}.svg"));
+
+        let file = std::fs::File::create(&output).context("creating flamegraph file")?;
+        report.flamegraph(file).context("writing flamegraph svg")?;
+
+        Ok(output)
+    })
+    .await
+    .context("profiling task panicked")?
+}

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -50,6 +50,8 @@ You may refer to the e2e test cases in the `tests/bruno/e2e` directory for examp
         * [Method `connect_peer`](#peer-connect_peer)
         * [Method `disconnect_peer`](#peer-disconnect_peer)
         * [Method `list_peers`](#peer-list_peers)
+    * [Module Prof](#module-prof)
+        * [Method `pprof`](#prof-pprof)
     * [Module Watchtower](#module-watchtower)
         * [Method `create_watch_channel`](#watchtower-create_watch_channel)
         * [Method `remove_watch_channel`](#watchtower-remove_watch_channel)
@@ -851,6 +853,29 @@ List connected peers
 ##### Returns
 
 * `peers` - <em>Vec<[PeerInfo](#type-peerinfo)></em>, A list of connected peers.
+
+---
+
+
+
+<a id="prof"></a>
+### Module `Prof`
+RPC module for profiling
+ This module require build with pprof feature and debug symbol.
+
+
+<a id="prof-pprof"></a>
+#### Method `pprof`
+
+Collects a temporary CPU profile and writes a flamegraph SVG to disk.
+
+##### Params
+
+* `duration_secs` - <em>`Option<u64>`</em>, Duration to profile in seconds. Defaults 10s.
+
+##### Returns
+
+* `path` - <em>`String`</em>, Path of the generated flamegraph SVG.
 
 ---
 

--- a/crates/fiber-lib/src/rpc/biscuit.rs
+++ b/crates/fiber-lib/src/rpc/biscuit.rs
@@ -94,6 +94,8 @@ fn build_rules() -> HashMap<&'static str, AuthRule> {
         "submit_commitment_transaction",
         r#"allow if write("chain");"#,
     );
+    // prof
+    b.rule("pprof", r#"allow if write("pprof");"#);
     // graph
     b.rule("graph_nodes", r#"allow if read("graph");"#);
     b.rule("graph_channels", r#"allow if read("graph");"#);

--- a/crates/fiber-lib/src/rpc/mod.rs
+++ b/crates/fiber-lib/src/rpc/mod.rs
@@ -14,6 +14,8 @@ pub mod invoice;
 mod middleware;
 pub mod payment;
 pub mod peer;
+#[cfg(all(feature = "pprof", not(target_arch = "wasm32")))]
+pub mod prof;
 pub mod utils;
 pub mod watchtower;
 #[cfg(not(target_arch = "wasm32"))]
@@ -35,6 +37,8 @@ pub mod server {
     use crate::rpc::payment::PaymentRpcServer;
     use crate::rpc::payment::PaymentRpcServerImpl;
     use crate::rpc::peer::{PeerRpcServer, PeerRpcServerImpl};
+    #[cfg(all(feature = "pprof", not(target_arch = "wasm32")))]
+    use crate::rpc::prof::{ProfRpcServer, ProfRpcServerImpl};
     use crate::{
         cch::CchMessage,
         fiber::{
@@ -307,6 +311,11 @@ pub mod server {
                         .into_rpc(),
                     )
                     .unwrap();
+            }
+
+            #[cfg(all(feature = "pprof", not(target_arch = "wasm32")))]
+            if config.is_module_enabled("prof") {
+                modules.merge(ProfRpcServerImpl::new().into_rpc()).unwrap();
             }
         }
         if let Some(cch_actor) = cch_actor {

--- a/crates/fiber-lib/src/rpc/prof.rs
+++ b/crates/fiber-lib/src/rpc/prof.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+
+use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::types::{error::CALL_EXECUTION_FAILED_CODE, ErrorObjectOwned};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PprofParams {
+    /// Duration to profile in seconds. Defaults 10s.
+    #[serde(default)]
+    pub duration_secs: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PprofResult {
+    /// Path of the generated flamegraph SVG.
+    pub path: String,
+}
+
+/// RPC module for profiling
+/// This module require build with pprof feature and debug symbol.
+#[rpc(server)]
+trait ProfRpc {
+    /// Collects a temporary CPU profile and writes a flamegraph SVG to disk.
+    #[method(name = "pprof")]
+    async fn pprof(&self, params: PprofParams) -> Result<PprofResult, ErrorObjectOwned>;
+}
+
+#[derive(Default)]
+pub struct ProfRpcServerImpl;
+
+impl ProfRpcServerImpl {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl ProfRpcServer for ProfRpcServerImpl {
+    async fn pprof(&self, params: PprofParams) -> Result<PprofResult, ErrorObjectOwned> {
+        self.pprof(params).await
+    }
+}
+
+impl ProfRpcServerImpl {
+    pub async fn pprof(&self, params: PprofParams) -> Result<PprofResult, ErrorObjectOwned> {
+        let duration = params.duration_secs.unwrap_or(10).max(1);
+
+        match crate::fiber::profiling::collect_flamegraph(duration).await {
+            Ok(path) => Ok(PprofResult {
+                path: path.to_string_lossy().into_owned(),
+            }),
+            Err(err) => Err(ErrorObjectOwned::owned(
+                CALL_EXECUTION_FAILED_CODE,
+                err.to_string(),
+                Some(params),
+            )),
+        }
+    }
+}

--- a/tests/nodes/deployer/config.yml
+++ b/tests/nodes/deployer/config.yml
@@ -21,6 +21,7 @@ rpc:
     - peer
     - watchtower
     - dev
+    - prof
 
 cch:
   ignore_startup_failure: true


### PR DESCRIPTION
Add a new RPC dev_pprof to do profiling and output flamegraph.
To enable this Rpc make sure the binary is compiled with flamegraph feature and add rpc module prof in the config file.

Note: The dev rpc module is required debug build. But profiling suppose work under release build, to keep consistency we use a standalone RPC module for profiling.

Replace #923 

```
jjy@jdevmac:~/Workspace/fiber(profiling-rpc)$ curl -v -s \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"pprof","params": [{"duration_secs":15}]}' \
  http://127.0.0.1:21714
{"jsonrpc":"2.0","id":1,"result":{"path":"profiles/flamegraph-1760081967.svg"}}
```

```
CARGO_PROFILE_RELEASE_DEBUG=true cargo build --features pprof --release
```