### PR TITLE
Add profile prof

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ inherits = "test"
 opt-level = 3
 debug = false
 
+[profile.prof]
+inherits = "release"
+debug = true

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ GRCOV_EXCL_START = ^\s*((log::|tracing::)?(trace|debug|info|warn|error)|(debug_)
 GRCOV_EXCL_STOP  = ^\s*\)(;)?$$
 GRCOV_EXCL_LINE = ^\s*(\})*(\))*(;)*$$|\s*((log::|tracing::)?(trace|debug|info|warn|error)|(debug_)?assert(_eq|_ne|_error_eq))!\(.*\)(;)?$$
 
+.PHONY: build-metrics-prof
+build-metrics-prof:
+	RUSTFLAGS="${RUSTFLAGS} --cfg tokio_unstable" cargo build --profile prof --features "metrics pprof"
+
 .PHONY: test
 test:
 	RUST_LOG=off cargo nextest run --no-fail-fast -p fnn -p fiber-bin


### PR DESCRIPTION
#924 

A new `make build-metrics-prof` command is added to build a binary in release with metrics and profiling support.

The binary should be `/target/prof/fnn`

> Note we need to update the fiber config to enable prof RPC module

https://github.com/nervosnetwork/fiber/pull/924/files#diff-bef0b4bf0e6307fd2a12b7b90fb3f4f20434a209ac1cfad7a11ea29dc641f1d2R24

<img width="420" height="270" alt="image" src="https://github.com/user-attachments/assets/37d18851-75f1-44f7-9603-db4ded205653" />
