### PR TITLE
Avoid duplicated retryable tasks

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -229,7 +229,7 @@ pub enum TxCollaborationCommand {
     TxComplete(),
 }
 
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct AddTlcCommand {
     pub amount: u128,
     pub payment_hash: Hash256,
@@ -1853,6 +1853,17 @@ where
                 return;
             };
 
+            #[cfg(debug_assertions)]
+            {
+                let hashset: HashSet<RetryableTlcOperation> =
+                    state.retryable_tlc_operations.iter().cloned().collect();
+                assert_eq!(
+                    hashset.len(),
+                    state.retryable_tlc_operations.len(),
+                    "retryable_tlc_operations contains duplicated operations"
+                );
+            }
+
             let success = match operation {
                 RetryableTlcOperation::RemoveTlc(tlc_id, reason) => self
                     .handle_remove_tlc_command(
@@ -2986,7 +2997,7 @@ pub struct TlcInfo {
 
 // When we are forwarding a TLC, we need to know the previous TLC information.
 // This struct keeps the information of the previous TLC.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct PrevTlcInfo {
     pub(crate) prev_channel_id: Hash256,
     // The TLC is always a received TLC because we are forwarding it.
@@ -3093,7 +3104,7 @@ impl From<TlcInfo> for TlcNotifyInfo {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug, Hash)]
 pub enum RetryableTlcOperation {
     RemoveTlc(TLCId, RemoveTlcReason),
     AddTlc(AddTlcCommand),

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1743,6 +1743,13 @@ where
         state: &mut ChannelActorState,
         operation: RetryableTlcOperation,
     ) {
+        if state
+            .retryable_tlc_operations
+            .iter()
+            .any(|op| *op == operation)
+        {
+            return;
+        }
         state.retryable_tlc_operations.push_back(operation);
         if state.retryable_tlc_operations.len() == 1 {
             // if there are already some retryable tasks in queue, we don't need to trigger again
@@ -5835,8 +5842,8 @@ impl ChannelActorState {
 
     fn is_waiting_tlc_ack(&self) -> bool {
         self.tlc_state.waiting_ack
-            || (self.remote_revocation_nonce_for_send.is_none()
-                || self.remote_revocation_nonce_for_verify.is_none())
+            || self.remote_revocation_nonce_for_send.is_none()
+            || self.remote_revocation_nonce_for_verify.is_none()
     }
 
     fn check_tlc_limits(&self, add_amount: u128, is_sent: bool) -> ProcessingChannelResult {

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -2206,7 +2206,7 @@ where
                 myself.stop(Some("ChannelClosed".to_string()));
             }
             ChannelEvent::CheckActiveChannel => {
-                if state.should_disconnect_peer_awaiting_response() && !state.is_closed() {
+                if state.peer_does_not_reply_ack_in_time() && !state.is_closed() {
                     error!(
                         "Channel {} from peer {:?} is inactive for a time, shutting down it forcefully",
                         state.get_id(),
@@ -4138,7 +4138,7 @@ impl ChannelActorState {
         self.waiting_peer_response = None;
     }
 
-    pub fn should_disconnect_peer_awaiting_response(&self) -> bool {
+    pub fn peer_does_not_reply_ack_in_time(&self) -> bool {
         // this check only needed when other peer already shutdown force and we don't know it
         // if we are already got in ShuttingDown, means we already in normal shutdown process
         if matches!(self.state, ChannelState::ShuttingDown(_)) {


### PR DESCRIPTION
RemoveTlc with fullfill maybe duplicated.

It's may happen when RemoveCommand also invoked from cron tasks such as: 
https://github.com/chenyukang/fiber/blob/c963f5d98dd55901f58bbc4a8607db9b3b4b03d6/crates/fiber-lib/src/fiber/network.rs#L1544-L1565