### PR TITLE
Fix pprof output incorrect stack calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,8 +4458,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pprof"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+source = "git+https://github.com/tikv/pprof-rs.git?rev=01cff82dbe6fe110a707bf2b38d8ebb1d14a18f8#01cff82dbe6fe110a707bf2b38d8ebb1d14a18f8"
 dependencies = [
  "aligned-vec",
  "backtrace",
@@ -4470,6 +4469,8 @@ dependencies = [
  "log",
  "nix",
  "once_cell",
+ "protobuf",
+ "protobuf-codegen",
  "smallvec",
  "spin",
  "symbolic-demangle",
@@ -4666,6 +4667,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap 2.10.0",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GRCOV_EXCL_LINE = ^\s*(\})*(\))*(;)*$$|\s*((log::|tracing::)?(trace|debug|info|w
 
 .PHONY: build-metrics-prof
 build-metrics-prof:
-	RUSTFLAGS="${RUSTFLAGS} --cfg tokio_unstable" cargo build --profile prof --features "metrics pprof"
+	RUSTFLAGS="${RUSTFLAGS} --cfg tokio_unstable -Cforce-frame-pointers=yes" cargo +nightly build --profile prof --features "metrics pprof"
 
 .PHONY: test
 test:

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -94,7 +94,7 @@ tower = { version = "0.5" }
 tokio-metrics = { version = "0.4.5", optional = true, features = ["metrics-rs-integration"] }
 metrics = { version = "0.24.2", optional = true }
 metrics-exporter-prometheus = { version = "0.17.2", optional = true }
-pprof = { version = "0.15", features = ["flamegraph"], optional = true }
+pprof = { git = "https://github.com/tikv/pprof-rs.git", rev = "01cff82dbe6fe110a707bf2b38d8ebb1d14a18f8", features = ["flamegraph", "protobuf-codec", "frame-pointer"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 biscuit-auth = { version = "6.0.0-beta.3", features = ["wasm"] }

--- a/crates/fiber-lib/src/fiber/profiling.rs
+++ b/crates/fiber-lib/src/fiber/profiling.rs
@@ -1,39 +1,188 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use anyhow::{bail, Context, Result};
+use once_cell::sync::OnceCell;
+use tokio::sync::RwLock;
 
-use anyhow::{Context, Result};
-
-use pprof::ProfilerGuardBuilder;
+use pprof::{protos::Message, ProfilerGuard, ProfilerGuardBuilder};
 
 const OUTPUT_DIR: &str = "profiles";
+const SAMPLE_FREQUENCY: i32 = 1000;
 
-/// Collects a flamegraph for the given duration and writes it under `./profiles`.
+static PROFILER: OnceCell<Arc<Profiler>> = OnceCell::new();
+
+/// Describes the exported artifacts produced from a captured CPU profile.
+#[derive(Debug, Clone)]
+pub struct ProfileArtifacts {
+    /// Path to the SVG flamegraph for quick visual inspection.
+    pub flamegraph_svg: PathBuf,
+    /// Path to the raw pprof profile (protobuf) compatible with `go tool pprof` and `perf`.
+    pub raw_profile: PathBuf,
+}
+
+/// Convenience helper for ad-hoc captures.
+///
+/// Starts the global profiler, awaits the requested duration without blocking the
+/// runtime, and exports both an SVG flamegraph and a protobuf profile under
+/// `./profiles`.
 pub async fn collect_flamegraph(duration_secs: u64) -> Result<PathBuf> {
     let duration_secs = duration_secs.max(1);
 
-    tokio::task::spawn_blocking(move || -> Result<PathBuf> {
-        let guard = ProfilerGuardBuilder::default()
-            .frequency(99)
-            .build()
-            .context("starting profiler")?;
+    global_profiler().start().await?;
 
-        std::thread::sleep(Duration::from_secs(duration_secs));
+    tokio::time::sleep(Duration::from_secs(duration_secs)).await;
 
-        let report = guard.report().build().context("building profiler report")?;
+    global_profiler().stop().await?;
+    let artifacts = global_profiler().export().await?;
 
-        std::fs::create_dir_all(OUTPUT_DIR).context("creating output directory")?;
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .context("computing timestamp")?
-            .as_secs();
-        let output = PathBuf::from(OUTPUT_DIR).join(format!("flamegraph-{timestamp}.svg"));
+    Ok(artifacts.flamegraph_svg)
+}
 
-        let file = std::fs::File::create(&output).context("creating flamegraph file")?;
-        report.flamegraph(file).context("writing flamegraph svg")?;
+fn global_profiler() -> &'static Arc<Profiler> {
+    PROFILER.get_or_init(|| Arc::new(Profiler::default()))
+}
 
-        Ok(output)
-    })
-    .await
-    .context("profiling task panicked")?
+/// Tracks the lifetime of a single process-wide `ProfilerGuard`.
+///
+/// A guard installed once via `pprof` hooks into the OS signal-based sampler, so
+/// every Tokio worker, `spawn_blocking` helper, and custom thread in the process is
+/// sampled without needing per-thread instrumentation. Keeping it in a global
+/// singleton ensures we never lose samples because a request handler dropped the
+/// guard too early.
+#[derive(Default)]
+struct Profiler {
+    state: RwLock<ProfilerState>,
+}
+
+#[derive(Default)]
+struct ProfilerState {
+    /// Active guard while profiling is in flight.
+    guard: Option<ProfilerGuard<'static>>,
+    /// Last completed profile, ready to be written to disk by any caller.
+    last_capture: Option<CompletedProfile>,
+}
+
+#[derive(Clone)]
+struct CompletedProfile {
+    /// Pre-rendered flamegraph bytes so exports avoid recomputing heavy work.
+    flamegraph: Arc<Vec<u8>>,
+    /// Serialized protobuf profile compatible with external tooling.
+    protobuf: Arc<Vec<u8>>,
+    /// Wall-clock start time of the capture for easy correlation.
+    started_at: SystemTime,
+    /// Total runtime of the capture window.
+    duration: Duration,
+}
+
+impl Profiler {
+    async fn start(&self) -> Result<()> {
+        {
+            let state = self.state.read().await;
+            if state.guard.is_some() {
+                bail!("CPU profiler is already running");
+            }
+        }
+
+        // Building the guard installs signal handlers and touches TLS state, so keep it off the runtime.
+        let guard = tokio::task::spawn_blocking(|| {
+            ProfilerGuardBuilder::default()
+                .frequency(SAMPLE_FREQUENCY)
+                .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+                .build()
+                .context("starting profiler")
+        })
+        .await
+        .context("joining profiler start task")??;
+
+        let mut state = self.state.write().await;
+        state.guard = Some(guard);
+        // Discard stale exports so callers cannot read a profile from a previous run by mistake.
+        state.last_capture = None;
+
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        let guard = {
+            let mut state = self.state.write().await;
+            state.guard.take().context("CPU profiler is not running")?
+        };
+
+        // Generating the report can take a while, so do the heavy lifting off the runtime.
+        let (flamegraph_bytes, profile_bytes, started_at, duration) = tokio::task::spawn_blocking(
+            move || -> Result<(Vec<u8>, Vec<u8>, SystemTime, Duration)> {
+                let report = guard.report().build().context("building profiler report")?;
+                let started_at = report.timing.start_time;
+                let duration = report.timing.duration;
+
+                let mut flamegraph_bytes = Vec::new();
+                report
+                    .flamegraph(&mut flamegraph_bytes)
+                    .context("rendering flamegraph svg")?;
+
+                let profile = report.pprof().context("building pprof profile")?;
+                let mut buffer = Vec::new();
+                profile
+                    .write_to_vec(&mut buffer)
+                    .context("serializing pprof profile")?;
+
+                Ok((flamegraph_bytes, buffer, started_at, duration))
+            },
+        )
+        .await
+        .context("joining profiler stop task")??;
+
+        let mut state = self.state.write().await;
+        state.last_capture = Some(CompletedProfile {
+            flamegraph: Arc::new(flamegraph_bytes),
+            protobuf: Arc::new(profile_bytes),
+            started_at,
+            duration,
+        });
+
+        Ok(())
+    }
+
+    async fn export(&self) -> Result<ProfileArtifacts> {
+        let capture = {
+            let state = self.state.read().await;
+            state
+                .last_capture
+                .clone()
+                .context("no completed profile available; call stop_cpu_profiling() first")?
+        };
+
+        tokio::task::spawn_blocking(move || -> Result<ProfileArtifacts> {
+            std::fs::create_dir_all(OUTPUT_DIR).context("creating output directory")?;
+
+            let start = capture
+                .started_at
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default();
+            let file_stem = format!(
+                "profile-{}-{}ms",
+                start.as_secs(),
+                capture.duration.as_millis()
+            );
+
+            let flamegraph_path = PathBuf::from(OUTPUT_DIR).join(format!("{file_stem}.svg"));
+            std::fs::write(&flamegraph_path, capture.flamegraph.as_ref())
+                .context("writing flamegraph svg")?;
+
+            let profile_path = PathBuf::from(OUTPUT_DIR).join(format!("{file_stem}.pb"));
+            std::fs::write(&profile_path, capture.protobuf.as_ref())
+                .context("writing raw profile")?;
+
+            Ok(ProfileArtifacts {
+                flamegraph_svg: flamegraph_path,
+                raw_profile: profile_path,
+            })
+        })
+        .await
+        .context("joining profiler export task")?
+    }
 }


### PR DESCRIPTION
* Set profiler to a global variable instead of local
* Enable `frame-pointer` (require nightly)
* Increase `pprof` samples frequency

With these changes we can generate flamegragh that contains all threads stack call information.