### PR TITLE
chore: upgrade typos to v1.39.0 and fix typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.30.0
+        uses: crate-ci/typos@v1.39.0
       - name: Typos info
         if: failure()
         run: |
@@ -77,7 +77,7 @@ jobs:
 
   coverage:
     name: Code Coverage
-    needs: [ test ]
+    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -118,7 +118,6 @@ jobs:
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static-md
       - run: cargo build --locked --verbose --profile ${{ matrix.profile }}
-
 
   benchmark:
     name: Benchmark

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -1335,14 +1335,14 @@ impl<S: GossipMessageStore> ExtendedGossipMessageStoreState<S> {
         }
     }
 
-    fn get_channel_annnouncement(&self, outpoint: &OutPoint) -> Option<ChannelAnnouncement> {
+    fn get_channel_announcement(&self, outpoint: &OutPoint) -> Option<ChannelAnnouncement> {
         self.store
             .get_latest_channel_announcement(outpoint)
             .map(|(_, m)| m)
-            .or_else(|| self.get_channel_annnouncement_in_memory(outpoint))
+            .or_else(|| self.get_channel_announcement_in_memory(outpoint))
     }
 
-    fn get_channel_annnouncement_in_memory(
+    fn get_channel_announcement_in_memory(
         &self,
         outpoint: &OutPoint,
     ) -> Option<ChannelAnnouncement> {
@@ -1419,7 +1419,7 @@ impl<S: GossipMessageStore> ExtendedGossipMessageStoreState<S> {
     fn has_dependencies_available(&self, message: &BroadcastMessage) -> bool {
         match message {
             BroadcastMessage::ChannelUpdate(channel_update) => self
-                .get_channel_annnouncement(&channel_update.channel_outpoint)
+                .get_channel_announcement(&channel_update.channel_outpoint)
                 .is_some(),
             _ => true,
         }

--- a/crates/fiber-lib/src/fiber/tests/features.rs
+++ b/crates/fiber-lib/src/fiber/tests/features.rs
@@ -170,7 +170,7 @@ fn test_feature_random() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_featuer_compatibility() {
+fn test_feature_compatibility() {
     let mut vector = FeatureVector::new();
     let mut vector2 = FeatureVector::new();
 

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -1407,7 +1407,7 @@ fn mul(
     let new_integer = full_numerator / new_denominator;
     let new_numerator = full_numerator % new_denominator;
 
-    // nomalize the fraction (max epoch length is 1800)
+    // normalize the fraction (max epoch length is 1800)
     let scale_factor = if new_denominator > 1800 {
         new_denominator / 1800 + 1
     } else {


### PR DESCRIPTION
Errors reported by typos v1.39.0:

```
$ typos
error: `nomalize` should be `normalize`
     ╭▸ ./crates/fiber-lib/src/watchtower/actor.rs:1410:8
     │
1410 │     // nomalize the fraction (max epoch length is 1800)
     ╰╴       ━━━━━━━━
error: `annnouncement` should be `announcement`
     ╭▸ ./crates/fiber-lib/src/fiber/gossip.rs:1338:20
     │
1338 │     fn get_channel_annnouncement(&self, outpoint: &OutPoint) -> Option<ChannelAnnouncement> {
     ╰╴                   ━━━━━━━━━━━━━
error: `annnouncement` should be `announcement`
     ╭▸ ./crates/fiber-lib/src/fiber/gossip.rs:1342:42
     │
1342 │             .or_else(|| self.get_channel_annnouncement_in_memory(outpoint))
     ╰╴                                         ━━━━━━━━━━━━━
error: `annnouncement` should be `announcement`
     ╭▸ ./crates/fiber-lib/src/fiber/gossip.rs:1345:20
     │
1345 │     fn get_channel_annnouncement_in_memory(
     ╰╴                   ━━━━━━━━━━━━━
error: `annnouncement` should be `announcement`
     ╭▸ ./crates/fiber-lib/src/fiber/gossip.rs:1422:30
     │
1422 │                 .get_channel_annnouncement(&channel_update.channel_outpoint)
     ╰╴                             ━━━━━━━━━━━━━
error: `featuer` should be `feature`, `feather`
    ╭▸ ./crates/fiber-lib/src/fiber/tests/features.rs:173:9
    │
173 │ fn test_featuer_compatibility() {
    ╰╴        ━━━━━━━
```