### PR TITLE
Fix negative metrics

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -2763,9 +2763,6 @@ where
             }
         }
 
-        #[cfg(feature = "metrics")]
-        metrics::gauge!(crate::metrics::TOTAL_CHANNEL_COUNT).increment(1);
-
         Ok(())
     }
 
@@ -2799,8 +2796,6 @@ where
             NetworkActorEvent::ChannelActorStopped(state.get_id(), stop_reason),
         ));
 
-        #[cfg(feature = "metrics")]
-        metrics::gauge!(crate::metrics::TOTAL_CHANNEL_COUNT).decrement(1);
         Ok(())
     }
 }

--- a/crates/fiber-lib/src/metrics.rs
+++ b/crates/fiber-lib/src/metrics.rs
@@ -1,7 +1,10 @@
 use std::net::ToSocketAddrs;
 use tracing::error;
 
+/// READY_CHANNEL_COUNT + SHUTTING_DOWN_CHANNEL_COUNT
 pub const TOTAL_CHANNEL_COUNT: &str = "fiber.total_channel_count";
+pub const READY_CHANNEL_COUNT: &str = "fiber.ready_channel_count";
+pub const SHUTTING_DOWN_CHANNEL_COUNT: &str = "fiber.shutting_down_channel_count";
 pub const TOTAL_PEER_COUNT: &str = "fiber.total_peer_count";
 pub const INBOUND_PEER_COUNT: &str = "fiber.inbound_peer_count";
 pub const OUTBOUND_PEER_COUNT: &str = "fiber.outbound_peer_count";


### PR DESCRIPTION
1. Fixes the negative metrics value by set absolute value in `CheckChannels` instead the counter API.

2. Add two new `channels` metrics:

``` rust
pub const READY_CHANNEL_COUNT: &str = "fiber.ready_channel_count";
pub const SHUTTING_DOWN_CHANNEL_COUNT: &str = "fiber.shutting_down_channel_count";
```