### PR TITLE
feat: monitor fiber store changes for cch

### DIFF
--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -1,4 +1,4 @@
-use crate::{invoice::SettleInvoiceError, time::SystemTimeError};
+use crate::time::SystemTimeError;
 
 use jsonrpsee::types::{error::CALL_EXECUTION_FAILED_CODE, ErrorObjectOwned};
 use thiserror::Error;
@@ -26,20 +26,10 @@ pub enum CchError {
     CKBInvoiceError(#[from] crate::invoice::InvoiceError),
     #[error("CKB invoice missing amount")]
     CKBInvoiceMissingAmount,
-    #[error("Fail to settle CKB invoice: {0}")]
-    CKBSettleInvoiceError(#[from] SettleInvoiceError),
-    #[error("SendBTC order already paid")]
-    SendBTCOrderAlreadyPaid,
-    #[error("SendBTC received payment amount is too small")]
-    SendBTCReceivedAmountTooSmall,
     #[error("ReceiveBTC order payment amount is too small")]
     ReceiveBTCOrderAmountTooSmall,
     #[error("ReceiveBTC order payment amount is too large")]
     ReceiveBTCOrderAmountTooLarge,
-    #[error("ReceiveBTC order already paid")]
-    ReceiveBTCOrderAlreadyPaid,
-    #[error("ReceiveBTC received payment amount is too small")]
-    ReceiveBTCReceivedAmountTooSmall,
     #[error("Expect preimage in settled payment but missing")]
     SettledPaymentMissingPreimage,
     #[error("System time error: {0}")]

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -40,8 +40,8 @@ pub enum CchError {
     ReceiveBTCOrderAlreadyPaid,
     #[error("ReceiveBTC received payment amount is too small")]
     ReceiveBTCReceivedAmountTooSmall,
-    #[error("ReceiveBTC expected preimage but missing")]
-    ReceiveBTCMissingPreimage,
+    #[error("Expect preimage in settled payment but missing")]
+    SettledPaymentMissingPreimage,
     #[error("System time error: {0}")]
     SystemTimeError(#[from] SystemTimeError),
     #[error("JSON serialization error: {0}")]

--- a/crates/fiber-lib/src/cch/events.rs
+++ b/crates/fiber-lib/src/cch/events.rs
@@ -73,8 +73,6 @@ pub enum CchIncomingEvent {
     InvoiceChanged {
         /// The payment hash of the invoice.
         payment_hash: Hash256,
-        /// The preimage of the invoice.
-        payment_preimage: Option<Hash256>,
         status: CchIncomingPaymentStatus,
     },
 

--- a/crates/fiber-lib/src/cch/events.rs
+++ b/crates/fiber-lib/src/cch/events.rs
@@ -1,0 +1,97 @@
+use lnd_grpc_tonic_client::lnrpc;
+
+use crate::{cch::CchOrderStatus, fiber::types::Hash256};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CchIncomingPaymentStatus {
+    // The incoming payment is in-flight
+    InFlight = 0,
+    // Incoming payment TLCs have been accepted
+    Accepted = 1,
+    Settled = 2,
+    Failed = 3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CchOutgoingPaymentStatus {
+    // The outgoing payment is in-flight
+    InFlight = 0,
+    Settled = 2,
+    Failed = 3,
+}
+
+impl From<CchIncomingPaymentStatus> for CchOrderStatus {
+    fn from(status: CchIncomingPaymentStatus) -> Self {
+        match status {
+            CchIncomingPaymentStatus::InFlight => CchOrderStatus::Pending,
+            CchIncomingPaymentStatus::Accepted => CchOrderStatus::IncomingAccepted,
+            CchIncomingPaymentStatus::Settled => CchOrderStatus::Succeeded,
+            CchIncomingPaymentStatus::Failed => CchOrderStatus::Failed,
+        }
+    }
+}
+
+impl From<CchOutgoingPaymentStatus> for CchOrderStatus {
+    fn from(status: CchOutgoingPaymentStatus) -> Self {
+        match status {
+            CchOutgoingPaymentStatus::InFlight => CchOrderStatus::OutgoingInFlight,
+            CchOutgoingPaymentStatus::Settled => CchOrderStatus::OutgoingSettled,
+            CchOutgoingPaymentStatus::Failed => CchOrderStatus::Failed,
+        }
+    }
+}
+
+/// Lnd invoice is the incoming part of a CCHOrder to receive BTC from Lightning to Fiber
+impl From<lnrpc::invoice::InvoiceState> for CchIncomingPaymentStatus {
+    fn from(state: lnrpc::invoice::InvoiceState) -> Self {
+        use lnrpc::invoice::InvoiceState;
+        match state {
+            InvoiceState::Open => CchIncomingPaymentStatus::InFlight,
+            InvoiceState::Settled => CchIncomingPaymentStatus::Settled,
+            InvoiceState::Canceled => CchIncomingPaymentStatus::Failed,
+            InvoiceState::Accepted => CchIncomingPaymentStatus::Accepted,
+        }
+    }
+}
+
+/// Lnd payment is the outgoing part of a CCHOrder to send BTC from Fiber to Lightning
+impl From<lnrpc::payment::PaymentStatus> for CchOutgoingPaymentStatus {
+    fn from(status: lnrpc::payment::PaymentStatus) -> Self {
+        use lnrpc::payment::PaymentStatus;
+        match status {
+            PaymentStatus::Unknown => CchOutgoingPaymentStatus::InFlight,
+            PaymentStatus::InFlight => CchOutgoingPaymentStatus::InFlight,
+            PaymentStatus::Succeeded => CchOutgoingPaymentStatus::Settled,
+            PaymentStatus::Failed => CchOutgoingPaymentStatus::Failed,
+            PaymentStatus::Initiated => CchOutgoingPaymentStatus::InFlight,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CchIncomingEvent {
+    InvoiceChanged {
+        /// The payment hash of the invoice.
+        payment_hash: Hash256,
+        /// The preimage of the invoice.
+        payment_preimage: Option<Hash256>,
+        status: CchIncomingPaymentStatus,
+    },
+
+    PaymentChanged {
+        /// The payment hash of the invoice.
+        payment_hash: Hash256,
+        /// The preimage of the invoice.
+        payment_preimage: Option<Hash256>,
+        status: CchOutgoingPaymentStatus,
+    },
+}
+
+impl CchIncomingEvent {
+    pub fn payment_hash(&self) -> &Hash256 {
+        match self {
+            CchIncomingEvent::InvoiceChanged { payment_hash, .. } => payment_hash,
+            CchIncomingEvent::PaymentChanged { payment_hash, .. } => payment_hash,
+        }
+    }
+}

--- a/crates/fiber-lib/src/cch/mod.rs
+++ b/crates/fiber-lib/src/cch/mod.rs
@@ -4,6 +4,11 @@ pub use actor::{start_cch, CchActor, CchArgs, CchMessage, ReceiveBTC, SendBTC};
 mod error;
 pub use error::{CchError, CchResult};
 
+mod events;
+pub use events::{CchIncomingEvent, CchIncomingPaymentStatus, CchOutgoingPaymentStatus};
+mod trackers;
+pub use trackers::{LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage};
+
 mod config;
 pub use config::{
     CchConfig, DEFAULT_BTC_FINAL_TLC_EXPIRY_TIME, DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA,
@@ -15,3 +20,6 @@ pub use order::{CchInvoice, CchOrder, CchOrderStatus};
 
 mod orders_db;
 pub use orders_db::CchOrdersDb;
+
+#[cfg(test)]
+pub mod tests;

--- a/crates/fiber-lib/src/cch/mod.rs
+++ b/crates/fiber-lib/src/cch/mod.rs
@@ -7,7 +7,9 @@ pub use error::{CchError, CchResult};
 mod events;
 pub use events::{CchIncomingEvent, CchIncomingPaymentStatus, CchOutgoingPaymentStatus};
 mod trackers;
-pub use trackers::{LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage};
+pub use trackers::{
+    CchFiberStoreWatcher, LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage,
+};
 
 mod config;
 pub use config::{

--- a/crates/fiber-lib/src/cch/order.rs
+++ b/crates/fiber-lib/src/cch/order.rs
@@ -74,7 +74,47 @@ pub struct CchOrder {
 }
 
 impl CchOrder {
-    pub fn is_from_fiber_to_lightning(&self) -> bool {
+    pub fn is_incoming_invoice_fiber(&self) -> bool {
         matches!(self.incoming_invoice, CchInvoice::Fiber(_))
+    }
+    pub fn is_incoming_invoice_lnd(&self) -> bool {
+        matches!(self.incoming_invoice, CchInvoice::Lightning(_))
+    }
+    pub fn is_outgoing_payment_fiber(&self) -> bool {
+        self.is_incoming_invoice_lnd()
+    }
+    pub fn is_outgoing_payment_lnd(&self) -> bool {
+        self.is_incoming_invoice_fiber()
+    }
+
+    pub fn is_awaiting_invoice_event(&self) -> bool {
+        self.status.is_awaiting_invoice_event()
+    }
+    pub fn is_awaiting_fiber_invoice_event(&self) -> bool {
+        self.is_awaiting_invoice_event() && self.is_incoming_invoice_fiber()
+    }
+    pub fn is_awaiting_lnd_invoice_event(&self) -> bool {
+        self.is_awaiting_invoice_event() && self.is_incoming_invoice_lnd()
+    }
+    pub fn is_awaiting_payment_event(&self) -> bool {
+        self.status.is_awaiting_payment_event()
+    }
+    pub fn is_awaiting_fiber_payment_event(&self) -> bool {
+        self.is_awaiting_payment_event() && self.is_outgoing_payment_fiber()
+    }
+    pub fn is_awaiting_lnd_payment_event(&self) -> bool {
+        self.is_awaiting_payment_event() && self.is_outgoing_payment_lnd()
+    }
+}
+
+impl CchOrderStatus {
+    pub fn is_awaiting_invoice_event(&self) -> bool {
+        matches!(self, CchOrderStatus::Pending)
+    }
+    pub fn is_awaiting_payment_event(&self) -> bool {
+        matches!(
+            self,
+            CchOrderStatus::IncomingAccepted | CchOrderStatus::OutgoingInFlight
+        )
     }
 }

--- a/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
@@ -1,0 +1,185 @@
+use std::sync::Arc;
+
+use crate::{
+    cch::{LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage},
+    fiber::types::Hash256,
+};
+
+use ractor::{concurrency::Duration as RactorDuration, Actor, ActorRef, OutputPort};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+
+// Helper function to create test arguments
+fn create_test_args() -> LndTrackerArgs {
+    let port = Arc::new(OutputPort::default());
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+    let lnd_connection = LndConnectionInfo {
+        // Tracker will keep running because this URI is unreachable
+        uri: "https://localhost:10009".parse().unwrap(),
+        cert: None,
+        macaroon: None,
+    };
+
+    LndTrackerArgs {
+        port,
+        lnd_connection,
+        token,
+        tracker,
+    }
+}
+
+// Helper function to create a test payment hash
+fn test_payment_hash(value: u8) -> Hash256 {
+    let mut bytes = [0u8; 32];
+    bytes[0] = value;
+    Hash256::from(bytes)
+}
+
+// Helper function to create a test `LndTrackerActor` (without spawning trackers)
+async fn create_test_actor() -> (ActorRef<LndTrackerMessage>, tokio::task::JoinHandle<()>) {
+    // Use spawn instead of spawn_linked to avoid needing a root actor
+    let args = create_test_args();
+    let (actor_ref, actor_handle) = Actor::spawn(None, LndTrackerActor, args)
+        .await
+        .expect("Failed to spawn test actor");
+
+    (actor_ref, actor_handle)
+}
+
+// Test completion decrements active_invoice_trackers counter
+#[tokio::test]
+async fn test_completion_decrements_counter() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(1);
+
+    // Add invoice to queue (without processing to avoid LND calls)
+    actor_ref
+        .cast(LndTrackerMessage::TrackInvoice(payment_hash))
+        .expect("Failed to send TrackInvoice");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Send completion message (simulating a tracker that finished)
+    actor_ref
+        .cast(LndTrackerMessage::InvoiceTrackerCompleted {
+            payment_hash,
+            completed_successfully: true,
+        })
+        .expect("Failed to send completion");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Verify counter behavior (should handle completion gracefully)
+    let final_state = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Actor should be responsive after completion");
+
+    assert!(final_state.is_success());
+    let final_state = final_state.unwrap();
+    assert_eq!(final_state.invoice_queue_len, 0);
+    assert_eq!(final_state.active_invoice_trackers, 0);
+}
+
+// Test completion triggers queue processing for waiting invoices
+#[tokio::test]
+async fn test_completion_triggers_queue_processing() {
+    let (actor_ref, _handle) = create_test_actor().await;
+
+    // Add 6 invoices to queue
+    for i in 0..6 {
+        let payment_hash = test_payment_hash(i);
+        actor_ref
+            .cast(LndTrackerMessage::TrackInvoice(payment_hash))
+            .expect("Failed to send TrackInvoice");
+    }
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Verify invoices are queued
+    let state_before = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Failed to get state")
+        .expect("Failed to get state");
+
+    assert_eq!(
+        state_before.invoice_queue_len, 1,
+        "Should have 1 invoice in queue"
+    );
+    assert_eq!(
+        state_before.active_invoice_trackers, 5,
+        "Should have 5 active invoice trackers"
+    );
+
+    let completed_hash = test_payment_hash(1);
+    actor_ref
+        .cast(LndTrackerMessage::InvoiceTrackerCompleted {
+            payment_hash: completed_hash,
+            completed_successfully: true,
+        })
+        .expect("Failed to send completion");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Verify actor is still responsive
+    let state_after = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Failed to get state")
+        .expect("Failed to get state");
+
+    assert_eq!(
+        state_after.invoice_queue_len, 0,
+        "Should have 0 invoices in queue"
+    );
+    assert_eq!(
+        state_after.active_invoice_trackers, 5,
+        "Should have 5 active invoice trackers"
+    );
+}
+
+// Test timeout re-queues active invoices to end of queue
+#[tokio::test]
+async fn test_timeout_requeues_active_invoices() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(1);
+
+    // Add invoice to queue (without processing to avoid LND calls)
+    actor_ref
+        .cast(LndTrackerMessage::TrackInvoice(payment_hash))
+        .expect("Failed to send TrackInvoice");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Send completion message (simulating a tracker that finished)
+    actor_ref
+        .cast(LndTrackerMessage::InvoiceTrackerCompleted {
+            payment_hash,
+            completed_successfully: false,
+        })
+        .expect("Failed to send completion");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Verify counter behavior (should handle completion gracefully)
+    let final_state = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Actor should be responsive after completion");
+
+    assert!(final_state.is_success());
+    let final_state = final_state.unwrap();
+    assert_eq!(final_state.invoice_queue_len, 0);
+    assert_eq!(final_state.active_invoice_trackers, 1);
+}

--- a/crates/fiber-lib/src/cch/tests/mod.rs
+++ b/crates/fiber-lib/src/cch/tests/mod.rs
@@ -1,0 +1,1 @@
+mod lnd_trackers_tests;

--- a/crates/fiber-lib/src/cch/trackers/fiber_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/fiber_trackers.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use ractor::OutputPort;
+
+use crate::cch::{CchIncomingEvent, CchIncomingPaymentStatus, CchOutgoingPaymentStatus};
+use crate::fiber::payment::PaymentStatus;
+use crate::invoice::{CkbInvoiceStatus, PreimageStore as _};
+use crate::store::store_impl::{StoreChange, StoreChangeWatcher};
+use crate::store::Store;
+
+/// Maps StoreChange events into CchIncomingEvent and emits them via an OutputPort.
+#[derive(Debug)]
+pub struct CchFiberStoreWatcher {
+    // Requires a reference to the store to potentially read additional data
+    store: Store,
+    out: Arc<OutputPort<CchIncomingEvent>>,
+}
+
+impl CchFiberStoreWatcher {
+    pub fn new(store: Store, out: Arc<OutputPort<CchIncomingEvent>>) -> Self {
+        Self { store, out }
+    }
+
+    pub fn port(&self) -> Arc<OutputPort<CchIncomingEvent>> {
+        self.out.clone()
+    }
+
+    fn map_store_change_to_event(&self, change: &StoreChange) -> Option<CchIncomingEvent> {
+        match change {
+            StoreChange::PutCkbInvoiceStatus {
+                payment_hash,
+                invoice_status,
+            } => Some(CchIncomingEvent::InvoiceChanged {
+                payment_hash: *payment_hash,
+                status: map_invoice_status(*invoice_status),
+            }),
+
+            StoreChange::PutPaymentSession {
+                payment_hash,
+                payment_session,
+            } => {
+                let status = map_payment_status(payment_session.status);
+                let payment_preimage = self.store.get_preimage(payment_hash);
+                // If preimage is not available for a settled payment, defer the notification on deleting preimage.
+                (status != CchOutgoingPaymentStatus::Settled || payment_preimage.is_some())
+                    .then_some(CchIncomingEvent::PaymentChanged {
+                        payment_hash: *payment_hash,
+                        payment_preimage,
+                        status,
+                    })
+            }
+            StoreChange::PutPreimage {
+                payment_hash,
+                payment_preimage,
+            } => {
+                // When preimage is inserted, assume the payment is settled.
+                Some(CchIncomingEvent::PaymentChanged {
+                    payment_hash: *payment_hash,
+                    payment_preimage: Some(*payment_preimage),
+                    status: CchOutgoingPaymentStatus::Settled,
+                })
+            }
+        }
+    }
+}
+
+impl StoreChangeWatcher for CchFiberStoreWatcher {
+    fn on_store_change(&self, change: StoreChange) {
+        tracing::debug!("CchStoreWatcher received store change: {:?}", change);
+        if let Some(event) = self.map_store_change_to_event(&change) {
+            tracing::debug!("CchStoreWatcher emitting event: {:?}", event);
+            self.out.send(event);
+        } else {
+            tracing::trace!("CchStoreWatcher ignoring non-relevant change: {:?}", change);
+        }
+    }
+}
+
+fn map_invoice_status(status: CkbInvoiceStatus) -> CchIncomingPaymentStatus {
+    match status {
+        CkbInvoiceStatus::Open => CchIncomingPaymentStatus::InFlight,
+        CkbInvoiceStatus::Received => CchIncomingPaymentStatus::Accepted,
+        CkbInvoiceStatus::Paid => CchIncomingPaymentStatus::Settled,
+        CkbInvoiceStatus::Cancelled => CchIncomingPaymentStatus::Failed,
+        CkbInvoiceStatus::Expired => CchIncomingPaymentStatus::Failed,
+    }
+}
+
+fn map_payment_status(status: PaymentStatus) -> CchOutgoingPaymentStatus {
+    match status {
+        PaymentStatus::Created | PaymentStatus::Inflight => CchOutgoingPaymentStatus::InFlight,
+        PaymentStatus::Success => CchOutgoingPaymentStatus::Settled,
+        PaymentStatus::Failed => CchOutgoingPaymentStatus::Failed,
+    }
+}

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -522,11 +522,6 @@ impl InvoiceTracker {
     // Return true to quit the tracker
     async fn on_invoice(&self, invoice: lnrpc::Invoice) -> Result<bool> {
         tracing::debug!("[InvoiceTracker] invoice: {:?}", invoice);
-        let payment_preimage = if !invoice.r_preimage.is_empty() {
-            Some(Hash256::try_from(invoice.r_preimage.as_slice())?)
-        } else {
-            None
-        };
         use lnrpc::invoice::InvoiceState;
         let status: CchIncomingPaymentStatus = InvoiceState::try_from(invoice.state)
             .unwrap_or(InvoiceState::Open)
@@ -534,7 +529,6 @@ impl InvoiceTracker {
 
         let event = CchIncomingEvent::InvoiceChanged {
             payment_hash: Hash256::try_from(invoice.r_hash.as_slice())?,
-            payment_preimage,
             status,
         };
         self.port.send(event);

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -1,0 +1,535 @@
+//! LND Payment and Invoice Tracker Actor
+//!
+//! This module implements `LndTrackerActor`, which manages concurrent tracking of
+//! Lightning Network invoices and payments via LND (Lightning Network Daemon).
+//!
+//! ## Key Features
+//!
+//! - **Concurrent Tracking**: Tracks up to 5 invoices simultaneously to avoid overwhelming LND
+//! - **Queue Management**: Maintains FIFO queue for pending invoice tracking requests
+//! - **Timeout**: Re-queues active invoices after 5 minutes to prevent indefinite blocking
+//! - **Completion Handling**: Properly cleans up when tracker tasks complete, timeout or fail
+//!
+//! ## Architecture
+//!
+//! The actor uses a message-passing model with two main message types:
+//! - `TrackInvoice(Hash256)`: Adds invoice to tracking queue
+//! - `InvoiceTrackerCompleted{...}`: Sent by spawned tracker tasks when they finish
+//!
+//! When a tracker task completes (successfully or with error), it ALWAYS sends
+//! `InvoiceTrackerCompleted` back to the actor. The actor maintains two data structures:
+//! - `invoice_queue`: VecDeque of pending invoice hashes
+//! - `active_invoice_trackers`: Number of active invoice trackers
+//!
+//! When completion message arrives:
+//! 1. Decrement `active_invoice_trackers` counter
+//! 2. Re-queue if failed
+//! 3. Dequeue invoices from the queue and start tracking
+
+use std::{collections::VecDeque, str::FromStr, sync::Arc, time::Duration};
+
+use anyhow::{anyhow, Result};
+use futures::StreamExt as _;
+use lnd_grpc_tonic_client::{
+    create_invoices_client, create_router_client, invoicesrpc, lnrpc, routerrpc, InvoicesClient,
+    RouterClient, Uri,
+};
+use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, OutputPort};
+use tokio::{select, time::sleep};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+
+use crate::{
+    cch::{CchIncomingEvent, CchIncomingPaymentStatus, CchOutgoingPaymentStatus},
+    fiber::types::Hash256,
+};
+
+const MAX_CONCURRENT_INVOICE_TRACKERS: usize = 5;
+const INVOICE_TRACKING_TIMEOUT: Duration = Duration::from_secs(5 * 60); // 5 minutes
+
+/// LND connection information
+///
+/// This struct contains the connection details for communicating with an LND node.
+#[derive(Clone)]
+pub struct LndConnectionInfo {
+    pub uri: Uri,
+    pub cert: Option<Vec<u8>>,
+    pub macaroon: Option<Vec<u8>>,
+}
+
+impl LndConnectionInfo {
+    pub fn new(uri: Uri, cert: Option<Vec<u8>>, macaroon: Option<Vec<u8>>) -> Self {
+        Self {
+            uri,
+            cert,
+            macaroon,
+        }
+    }
+
+    pub async fn create_router_client(
+        &self,
+    ) -> Result<RouterClient, lnd_grpc_tonic_client::channel::Error> {
+        create_router_client(
+            self.uri.clone(),
+            self.cert.as_deref(),
+            self.macaroon.as_deref(),
+        )
+        .await
+    }
+
+    pub async fn create_invoices_client(
+        &self,
+    ) -> Result<InvoicesClient, lnd_grpc_tonic_client::channel::Error> {
+        create_invoices_client(
+            self.uri.clone(),
+            self.cert.as_deref(),
+            self.macaroon.as_deref(),
+        )
+        .await
+    }
+}
+
+/// Message types for the LndTrackerActor
+#[derive(Debug)]
+pub enum LndTrackerMessage {
+    /// Track a new invoice
+    TrackInvoice(Hash256),
+
+    /// Notification that an invoice tracker task has completed
+    ///
+    /// Sent by InvoiceTracker tasks when they terminate (either successfully
+    /// when invoice reaches final state, or due to error).
+    InvoiceTrackerCompleted {
+        payment_hash: Hash256,
+        completed_successfully: bool,
+    },
+
+    /// Get current state snapshot (for testing)
+    #[cfg(test)]
+    GetState(ractor::RpcReplyPort<StateSnapshot>),
+}
+
+/// Snapshot of actor state (for testing)
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub struct StateSnapshot {
+    pub invoice_queue_len: usize,
+    pub active_invoice_trackers: usize,
+}
+
+/// Arguments for starting the LndTrackerActor
+pub struct LndTrackerArgs {
+    pub port: Arc<OutputPort<CchIncomingEvent>>,
+    pub lnd_connection: LndConnectionInfo,
+    pub token: CancellationToken,
+    pub tracker: TaskTracker,
+}
+
+/// State for the LndTrackerActor
+pub struct LndTrackerState {
+    port: Arc<OutputPort<CchIncomingEvent>>,
+    lnd_connection: LndConnectionInfo,
+    token: CancellationToken,
+    tracker: TaskTracker,
+    /// Queue of payment hashes waiting to be tracked
+    invoice_queue: VecDeque<Hash256>,
+    /// Number of currently active invoice trackers
+    active_invoice_trackers: usize,
+}
+
+/// Ractor Actor to track LND payments and invoices
+///
+/// This actor manages tracking of Lightning Network Daemon (LND) payments and invoices.
+/// It provides the following features:
+///
+/// ## Payment Tracking
+/// - Automatically tracks all LND payments in the background
+/// - Sends `CchIncomingEvent::PaymentChanged` events to the output port
+///
+/// ## Invoice Tracking
+/// - Supports tracking individual invoices via `LndTrackerMessage::TrackInvoice`
+/// - Implements concurrency control: maximum 5 concurrent invoice connections
+/// - Track invoices with a 5-minute timeout and automatically retry them later
+/// - Queues additional invoices when concurrency limit is reached
+///
+/// ## Example Usage
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use ractor::{ActorCell, OutputPort};
+/// use tokio_util::{sync::CancellationToken, task::TaskTracker};
+///
+/// // Create output port for events
+/// let port = Arc::new(OutputPort::<CchIncomingEvent>::default());
+///
+/// // Create connection info
+/// let lnd_connection = LndConnectionInfo {
+///     uri: "https://localhost:10009".parse().unwrap(),
+///     cert: Some(cert_bytes),
+///     macaroon: Some(macaroon_bytes),
+/// };
+///
+/// // Start the actor
+/// let args = LndTrackerArgs {
+///     port: port.clone(),
+///     lnd_connection,
+///     token: CancellationToken::new(),
+///     tracker: TaskTracker::new(),
+/// };
+///
+/// let actor = LndTrackerActor::start(args, root_actor).await?;
+///
+/// // Track an invoice
+/// actor.cast(LndTrackerMessage::TrackInvoice(payment_hash))?;
+/// ```
+#[derive(Default)]
+pub struct LndTrackerActor;
+
+impl LndTrackerActor {
+    pub async fn start(
+        args: LndTrackerArgs,
+        root_actor: ActorCell,
+    ) -> Result<ActorRef<LndTrackerMessage>> {
+        let (actor, _handle) = Actor::spawn_linked(
+            Some("lnd_tracker_actor".to_string()),
+            LndTrackerActor,
+            args,
+            root_actor,
+        )
+        .await?;
+        Ok(actor)
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor for LndTrackerActor {
+    type Msg = LndTrackerMessage;
+    type State = LndTrackerState;
+    type Arguments = LndTrackerArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let state = LndTrackerState {
+            port: args.port.clone(),
+            lnd_connection: args.lnd_connection.clone(),
+            token: args.token.clone(),
+            tracker: args.tracker.clone(),
+            invoice_queue: VecDeque::new(),
+            active_invoice_trackers: 0,
+        };
+
+        // Start payment tracker in background
+        let payment_tracker = PaymentTracker {
+            port: args.port,
+            lnd_connection: args.lnd_connection,
+            token: args.token,
+        };
+
+        args.tracker.spawn(async move {
+            payment_tracker.run().await;
+        });
+
+        Ok(state)
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            LndTrackerMessage::TrackInvoice(payment_hash) => {
+                state.invoice_queue.push_back(payment_hash);
+                state.process_invoice_queue(myself).await?;
+                Ok(())
+            }
+            LndTrackerMessage::InvoiceTrackerCompleted {
+                payment_hash,
+                completed_successfully,
+            } => {
+                tracing::debug!(
+                    "Processing completion for payment_hash={}, success={}, active={}/{}",
+                    payment_hash,
+                    completed_successfully,
+                    state.active_invoice_trackers,
+                    MAX_CONCURRENT_INVOICE_TRACKERS
+                );
+                state.active_invoice_trackers = state.active_invoice_trackers.saturating_sub(1);
+                // Re-queue failed tracker
+                if !completed_successfully {
+                    state.invoice_queue.push_back(payment_hash);
+                }
+
+                // Now that a slot is free, we can start tracking more invoices from the queue
+                state.process_invoice_queue(myself).await?;
+
+                Ok(())
+            }
+
+            #[cfg(test)]
+            LndTrackerMessage::GetState(reply_port) => {
+                let snapshot = StateSnapshot {
+                    invoice_queue_len: state.invoice_queue.len(),
+                    active_invoice_trackers: state.active_invoice_trackers,
+                };
+                let _ = reply_port.send(snapshot);
+                Ok(())
+            }
+        }
+    }
+}
+
+impl LndTrackerState {
+    async fn process_invoice_queue(
+        &mut self,
+        myself: ActorRef<LndTrackerMessage>,
+    ) -> Result<(), ActorProcessingErr> {
+        // Process invoices from queue
+        while self.active_invoice_trackers < MAX_CONCURRENT_INVOICE_TRACKERS {
+            let Some(payment_hash) = self.invoice_queue.pop_front() else {
+                break;
+            };
+            self.active_invoice_trackers += 1;
+
+            let tracker = InvoiceTracker {
+                port: self.port.clone(),
+                lnd_connection: self.lnd_connection.clone(),
+                token: self.token.clone(),
+                payment_hash,
+            };
+
+            // Spawned Task Completion Flow:
+            // 1. Clone actor reference and payment hash before moving into async task
+            // 2. Spawn tracker in background (tokio::spawn)
+            // 3. Capture result from tracker.run()
+            // 4. ALWAYS send InvoiceTrackerCompleted message back to actor
+            //    - This ensures we decrement counter and remove from queue
+            //    - Even on error, the tracker has quit, so we must clean up
+
+            let myself_clone = myself.clone();
+            self.tracker.spawn(async move {
+                select! {
+                    _ = sleep(INVOICE_TRACKING_TIMEOUT) => {
+                        myself_clone.cast(LndTrackerMessage::InvoiceTrackerCompleted {
+                            payment_hash,
+                            completed_successfully: false,
+                        }).expect("cast LndTrackerMessage");
+                    }
+                    result = tracker.run() => {
+                        myself_clone.cast(LndTrackerMessage::InvoiceTrackerCompleted {
+                            payment_hash,
+                            completed_successfully: result.is_ok(),
+                        }).expect("cast LndTrackerMessage");
+                    }
+                }
+            });
+
+            tracing::debug!(
+                "Started invoice tracker for payment_hash={}, active={}/{}",
+                payment_hash,
+                self.active_invoice_trackers,
+                MAX_CONCURRENT_INVOICE_TRACKERS
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Internal struct for tracking payments
+struct PaymentTracker {
+    port: Arc<OutputPort<CchIncomingEvent>>,
+    lnd_connection: LndConnectionInfo,
+    token: CancellationToken,
+}
+
+impl PaymentTracker {
+    async fn run(self) {
+        tracing::debug!("PaymentTracker: will connect {}", self.lnd_connection.uri);
+
+        loop {
+            select! {
+                result = self.run_inner() => {
+                    match result {
+                        Ok(_) => {
+                            break;
+                        }
+                        Err(err) => {
+                            tracing::error!(
+                                "Error tracking LND payments, retry 15 seconds later: {:?}",
+                                err
+                            );
+                            select! {
+                                _ = sleep(Duration::from_secs(15)) => {
+                                    // continue
+                                }
+                                _ = self.token.cancelled() => {
+                                    tracing::debug!("Cancellation received, shutting down payment tracker");
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+                _ = self.token.cancelled() => {
+                    tracing::debug!("Cancellation received, shutting down payment tracker");
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn run_inner(&self) -> Result<()> {
+        let mut client = self.lnd_connection.create_router_client().await?;
+        let mut stream = client
+            .track_payments(routerrpc::TrackPaymentsRequest {
+                no_inflight_updates: true,
+            })
+            .await?
+            .into_inner();
+
+        loop {
+            select! {
+                payment_opt = stream.next() => {
+                    match payment_opt {
+                        Some(Ok(payment)) => self.on_payment(payment).await?,
+                        Some(Err(err)) => return Err(err.into()),
+                        None => return Err(anyhow!("unexpected closed stream")),
+                    }
+                }
+                _ = self.token.cancelled() => {
+                    tracing::debug!("Cancellation received, shutting down payment tracker");
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    async fn on_payment(&self, payment: lnrpc::Payment) -> Result<()> {
+        tracing::debug!("payment: {:?}", payment);
+        let payment_preimage = if !payment.payment_preimage.is_empty() {
+            Some(Hash256::from_str(&payment.payment_preimage)?)
+        } else {
+            None
+        };
+        use lnrpc::payment::PaymentStatus;
+        let status: CchOutgoingPaymentStatus = PaymentStatus::try_from(payment.status)
+            .unwrap_or(PaymentStatus::InFlight)
+            .into();
+
+        let event = CchIncomingEvent::PaymentChanged {
+            payment_hash: Hash256::from_str(&payment.payment_hash)?,
+            payment_preimage,
+            status,
+        };
+        self.port.send(event);
+        Ok(())
+    }
+}
+
+/// Internal struct for tracking individual invoices
+struct InvoiceTracker {
+    port: Arc<OutputPort<CchIncomingEvent>>,
+    payment_hash: Hash256,
+    lnd_connection: LndConnectionInfo,
+    token: CancellationToken,
+}
+
+impl InvoiceTracker {
+    async fn run(self) -> Result<()> {
+        tracing::debug!(
+            "InvoiceTracker: will connect {} for payment_hash={}",
+            self.lnd_connection.uri,
+            self.payment_hash
+        );
+
+        loop {
+            select! {
+                result = self.run_inner() => {
+                    match result {
+                        Ok(_) => {
+                            tracing::debug!("InvoiceTracker completed successfully for payment_hash={}", self.payment_hash);
+                            return Ok(());
+                        }
+                        Err(err) => {
+                            tracing::error!(
+                                "Error tracking LND invoice {}, retry 15 seconds later: {:?}",
+                                self.payment_hash,
+                                err
+                            );
+                            select! {
+                                _ = sleep(Duration::from_secs(15)) => {
+                                    // continue
+                                }
+                                _ = self.token.cancelled() => {
+                                    tracing::debug!("Cancellation received, shutting down invoice tracker");
+                                    return Err(anyhow!("Cancelled"));
+                                }
+                            }
+                        }
+                    }
+                }
+                _ = self.token.cancelled() => {
+                    tracing::debug!("Cancellation received, shutting down invoice tracker");
+                    return Err(anyhow!("Cancelled"));
+                }
+            }
+        }
+    }
+
+    async fn run_inner(&self) -> Result<()> {
+        let mut client = self.lnd_connection.create_invoices_client().await?;
+        let mut stream = client
+            .subscribe_single_invoice(invoicesrpc::SubscribeSingleInvoiceRequest {
+                r_hash: self.payment_hash.into(),
+            })
+            .await?
+            .into_inner();
+
+        loop {
+            select! {
+                invoice_opt = stream.next() => {
+                    match invoice_opt {
+                        Some(Ok(invoice)) => if self.on_invoice(invoice).await? {
+                            return Ok(());
+                        },
+                        Some(Err(err)) => return Err(err.into()),
+                        None => return Err(anyhow!("unexpected closed stream")),
+                    }
+                }
+                _ = self.token.cancelled() => {
+                    tracing::debug!("Cancellation received, shutting down invoice tracker");
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    // Return true to quit the tracker
+    async fn on_invoice(&self, invoice: lnrpc::Invoice) -> Result<bool> {
+        tracing::debug!("[InvoiceTracker] invoice: {:?}", invoice);
+        let payment_preimage = if !invoice.r_preimage.is_empty() {
+            Some(Hash256::try_from(invoice.r_preimage.as_slice())?)
+        } else {
+            None
+        };
+        use lnrpc::invoice::InvoiceState;
+        let status: CchIncomingPaymentStatus = InvoiceState::try_from(invoice.state)
+            .unwrap_or(InvoiceState::Open)
+            .into();
+
+        let event = CchIncomingEvent::InvoiceChanged {
+            payment_hash: Hash256::try_from(invoice.r_hash.as_slice())?,
+            payment_preimage,
+            status,
+        };
+        self.port.send(event);
+
+        // Quit tracker when the status is final
+        Ok(status == CchIncomingPaymentStatus::Settled
+            || status == CchIncomingPaymentStatus::Failed)
+    }
+}

--- a/crates/fiber-lib/src/cch/trackers/mod.rs
+++ b/crates/fiber-lib/src/cch/trackers/mod.rs
@@ -1,2 +1,5 @@
 mod lnd_trackers;
 pub use lnd_trackers::{LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage};
+
+mod fiber_trackers;
+pub use fiber_trackers::CchFiberStoreWatcher;

--- a/crates/fiber-lib/src/cch/trackers/mod.rs
+++ b/crates/fiber-lib/src/cch/trackers/mod.rs
@@ -1,0 +1,2 @@
+mod lnd_trackers;
+pub use lnd_trackers::{LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage};

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -82,7 +82,7 @@ use musig2::{
 use ractor::call;
 use ractor::{
     concurrency::{Duration, JoinHandle},
-    Actor, ActorProcessingErr, ActorRef, MessagingErr, OutputPort, RpcReplyPort,
+    Actor, ActorProcessingErr, ActorRef, MessagingErr, RpcReplyPort,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -365,27 +365,11 @@ pub struct ChannelInitializationParameter {
     pub private_key: Privkey,
 }
 
-#[derive(Clone)]
-pub struct ChannelSubscribers {
-    pub pending_received_tlcs_subscribers: Arc<OutputPort<TlcNotification>>,
-    pub settled_tlcs_subscribers: Arc<OutputPort<TlcNotification>>,
-}
-
-impl Default for ChannelSubscribers {
-    fn default() -> Self {
-        Self {
-            pending_received_tlcs_subscribers: Arc::new(OutputPort::default()),
-            settled_tlcs_subscribers: Arc::new(OutputPort::default()),
-        }
-    }
-}
-
 pub struct ChannelActor<S> {
     local_pubkey: Pubkey,
     remote_pubkey: Pubkey,
     network: ActorRef<NetworkActorMessage>,
     store: S,
-    subscribers: ChannelSubscribers,
 }
 
 impl<S> ChannelActor<S>
@@ -397,14 +381,12 @@ where
         remote_pubkey: Pubkey,
         network: ActorRef<NetworkActorMessage>,
         store: S,
-        subscribers: ChannelSubscribers,
     ) -> Self {
         Self {
             local_pubkey,
             remote_pubkey,
             network,
             store,
-            subscribers,
         }
     }
 
@@ -1050,16 +1032,6 @@ where
             }
         }
 
-        if let Some(ref udt_type_script) = state.funding_udt_type_script {
-            self.subscribers
-                .pending_received_tlcs_subscribers
-                .send(TlcNotification {
-                    tlc: add_tlc.clone().into(),
-                    channel_id: state.get_id(),
-                    script: udt_type_script.clone(),
-                });
-        }
-
         // we don't need to settle down the tlc if it is not the last hop here,
         // some e2e tests are calling AddTlc manually, so we can not use onion packet to
         // check whether it's the last hop here, maybe need to revisit in future.
@@ -1376,7 +1348,6 @@ where
         state: &mut ChannelActorState,
         tlc_id: TLCId,
     ) -> ProcessingChannelResult {
-        let channel_id = state.get_id();
         let tlc = state.tlc_state.get_mut(&tlc_id).expect("expect tlc");
         tlc.applied_flags |= AppliedFlags::REMOVE;
 
@@ -1395,21 +1366,6 @@ where
             }
         }
 
-        if let (
-            Some(ref udt_type_script),
-            RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill { payment_preimage }),
-        ) = (state.funding_udt_type_script.clone(), &remove_reason)
-        {
-            let mut tlc_notify_info: TlcNotifyInfo = tlc_info.clone().into();
-            tlc_notify_info.payment_preimage = Some(*payment_preimage);
-            self.subscribers
-                .settled_tlcs_subscribers
-                .send(TlcNotification {
-                    tlc: tlc_notify_info,
-                    channel_id,
-                    script: udt_type_script.clone(),
-                });
-        }
         if tlc_info.previous_tlc.is_none() {
             // only the original sender of the TLC should send `TlcRemoveReceived` event
             // because only the original sender cares about the TLC event to settle the payment

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -51,9 +51,9 @@ use tracing::{debug, error, info, trace, warn};
 use super::channel::{
     get_funding_and_reserved_amount, AcceptChannelParameter, ChannelActor, ChannelActorMessage,
     ChannelActorStateStore, ChannelCommand, ChannelCommandWithId, ChannelEvent,
-    ChannelInitializationParameter, ChannelState, ChannelSubscribers, ChannelTlcInfo,
-    OpenChannelParameter, PrevTlcInfo, ProcessingChannelError, ProcessingChannelResult,
-    PublicChannelInfo, RemoveTlcCommand, RevocationData, SettlementData, StopReason, TLCId,
+    ChannelInitializationParameter, ChannelState, ChannelTlcInfo, OpenChannelParameter,
+    PrevTlcInfo, ProcessingChannelError, ProcessingChannelResult, PublicChannelInfo,
+    RemoveTlcCommand, RevocationData, SettlementData, StopReason, TLCId,
     DEFAULT_MAX_TLC_VALUE_IN_FLIGHT,
 };
 use super::config::AnnouncedNodeName;
@@ -3354,7 +3354,6 @@ pub struct NetworkActorState<S> {
     tlc_fee_proportional_millionths: u128,
     // The gossip messages actor to process and send gossip messages.
     gossip_actor: ActorRef<GossipActorMessage>,
-    channel_subscribers: ChannelSubscribers,
     max_inbound_peers: usize,
     min_outbound_peers: usize,
     // The features of the node, used to indicate the capabilities of the node.
@@ -3589,13 +3588,7 @@ where
         let (tx, rx) = oneshot::channel::<Hash256>();
         let channel = Actor::spawn_linked(
             Some(generate_channel_actor_name(&self.peer_id, &peer_id)),
-            ChannelActor::new(
-                self.get_public_key(),
-                remote_pubkey,
-                network.clone(),
-                store,
-                self.channel_subscribers.clone(),
-            ),
+            ChannelActor::new(self.get_public_key(), remote_pubkey, network.clone(), store),
             ChannelInitializationParameter {
                 operation: ChannelInitializationOperation::OpenChannel(OpenChannelParameter {
                     funding_amount,
@@ -3681,13 +3674,7 @@ where
         let (tx, rx) = oneshot::channel::<Hash256>();
         let channel = Actor::spawn_linked(
             Some(generate_channel_actor_name(&self.peer_id, &peer_id)),
-            ChannelActor::new(
-                self.get_public_key(),
-                remote_pubkey,
-                network.clone(),
-                store,
-                self.channel_subscribers.clone(),
-            ),
+            ChannelActor::new(self.get_public_key(), remote_pubkey, network.clone(), store),
             ChannelInitializationParameter {
                 operation: ChannelInitializationOperation::AcceptChannel(AcceptChannelParameter {
                     funding_amount,
@@ -4100,7 +4087,6 @@ where
                 remote_pubkey,
                 self.network.clone(),
                 self.store.clone(),
-                self.channel_subscribers.clone(),
             ),
             ChannelInitializationParameter {
                 operation: ChannelInitializationOperation::ReestablishChannel(channel_id),
@@ -4587,7 +4573,6 @@ where
 pub struct NetworkActorStartArguments {
     pub config: FiberConfig,
     pub tracker: TaskTracker,
-    pub channel_subscribers: ChannelSubscribers,
     pub default_shutdown_script: Script,
 }
 
@@ -4619,7 +4604,6 @@ where
             config,
             #[cfg(not(target_arch = "wasm32"))]
             tracker,
-            channel_subscribers,
             default_shutdown_script,
             ..
         } = args;
@@ -4821,7 +4805,6 @@ where
             tlc_min_value: config.tlc_min_value(),
             tlc_fee_proportional_millionths: config.tlc_fee_proportional_millionths(),
             gossip_actor,
-            channel_subscribers,
             max_inbound_peers: config.max_inbound_peers(),
             min_outbound_peers: config.min_outbound_peers(),
             features,
@@ -5112,7 +5095,6 @@ pub async fn start_network<
     tracker: TaskTracker,
     root_actor: ActorCell,
     store: S,
-    channel_subscribers: ChannelSubscribers,
     network_graph: Arc<RwLock<NetworkGraph<S>>>,
     default_shutdown_script: Script,
 ) -> ActorRef<NetworkActorMessage> {
@@ -5125,7 +5107,6 @@ pub async fn start_network<
         NetworkActorStartArguments {
             config,
             tracker,
-            channel_subscribers,
             default_shutdown_script,
         },
         root_actor,

--- a/crates/fiber-lib/src/metrics.rs
+++ b/crates/fiber-lib/src/metrics.rs
@@ -10,6 +10,10 @@ pub const INBOUND_PEER_COUNT: &str = "fiber.inbound_peer_count";
 pub const OUTBOUND_PEER_COUNT: &str = "fiber.outbound_peer_count";
 pub const DOWN_WITH_CHANNEL_PEER_COUNT: &str = "fiber.down_with_channel_peer_count";
 
+pub const CCH_LND_TRACKER_INVOICE_QUEUE_LEN: &str = "fiber.cch.lnd_tracker.invoice_queue_len";
+pub const CCH_LND_TRACKER_ACTIVE_INVOICE_TRACKERS: &str =
+    "fiber.cch.lnd_tracker.active_invoice_trackers";
+
 pub fn start_metrics(metrics_addr: &str) -> Result<(), Box<dyn std::error::Error>> {
     let socket_addr = metrics_addr
         .to_socket_addrs()

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -1083,7 +1083,7 @@ The status of a cross-chain hub order, will update as the order progresses.
 
 #### Enum with values of
 
-* `Pending` - Order is created and has not send out payments yet.
+* `Pending` - Order is created and has not received the incoming payment
 * `IncomingAccepted` - HTLC in the incoming payment is accepted.
 * `OutgoingInFlight` - There's an outgoing payment in flight.
 * `OutgoingSettled` - The outgoing payment is settled.

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -246,20 +246,13 @@ pub enum KeyValue {
 /// are recorded and sent to watchers.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum StoreChange {
-    PutCkbInvoice {
-        payment_hash: Hash256,
-        invoice: CkbInvoice,
-    },
     PutPreimage {
         payment_hash: Hash256,
         payment_preimage: Hash256,
     },
-    DeletePreimage {
-        payment_hash: Hash256,
-    },
     PutCkbInvoiceStatus {
         payment_hash: Hash256,
-        payment_status: CkbInvoiceStatus,
+        invoice_status: CkbInvoiceStatus,
     },
     PutPaymentSession {
         payment_hash: Hash256,

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -1007,13 +1007,12 @@ fn test_store_change_watcher() {
     store
         .insert_invoice(invoice.clone(), Some(preimage))
         .unwrap();
-    store.remove_preimage(&payment_hash);
 
     let changes = watcher.changes.read().unwrap();
     assert!(changes.iter().any(
-        |e| matches!(e, StoreChange::PutCkbInvoice { payment_hash: h, .. } if h == &payment_hash)
+        |e| matches!(e, StoreChange::PutCkbInvoiceStatus { payment_hash: h, invoice_status: CkbInvoiceStatus::Open } if h == &payment_hash)
     ));
     assert!(changes.iter().any(
-        |e| matches!(e, StoreChange::DeletePreimage { payment_hash: h } if h == &payment_hash)
+        |e| matches!(e, StoreChange::PutPreimage { payment_hash: h, payment_preimage: i } if h == &payment_hash && i == &preimage)
     ));
 }

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -1392,7 +1392,6 @@ impl NetworkNode {
             NetworkActorStartArguments {
                 config: fiber_config.clone(),
                 tracker: new_tokio_task_tracker(),
-                channel_subscribers: Default::default(),
                 default_shutdown_script: Default::default(),
             },
             root.get_cell(),

--- a/crates/fiber-wasm/src/lib.rs
+++ b/crates/fiber-wasm/src/lib.rs
@@ -14,7 +14,7 @@ use fnn::{
         CkbChainActor,
         contracts::{TypeIDResolver, try_init_contracts_context},
     },
-    fiber::{KeyPair, channel::ChannelSubscribers, graph::NetworkGraph, network::init_chain_hash},
+    fiber::{KeyPair, graph::NetworkGraph, network::init_chain_hash},
     rpc::{
         channel::ChannelRpcServerImpl,
         graph::GraphRpcServerImpl,
@@ -141,7 +141,6 @@ pub async fn fiber(
     let token = new_tokio_cancellation_token();
     let root_actor = RootActor::start(tracker, token).await;
     ROOT_ACTOR.set(root_actor.clone()).unwrap();
-    let subscribers = ChannelSubscribers::default();
 
     #[allow(unused_variables)]
     let (network_actor, ckb_chain_actor, network_graph) = match config.fiber.clone() {
@@ -212,7 +211,6 @@ pub async fn fiber(
                 new_tokio_task_tracker(),
                 root_actor.get_cell(),
                 store.clone(),
-                subscribers.clone(),
                 network_graph.clone(),
                 default_shutdown_script,
             )

--- a/tests/nodes/start.sh
+++ b/tests/nodes/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 export SHELLOPTS
-export RUST_BACKTRACE=full RUST_LOG=info,fnn=debug,fnn::cch::actor::tracker=off,fnn::fiber::gossip=off,fnn::fiber::graph=off
+export RUST_BACKTRACE=full RUST_LOG=info,fnn=debug,fnn::cch::trackers::lnd_trackers=off,fnn::fiber::gossip=off,fnn::fiber::graph=off
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 nodes_dir="$(dirname "$script_dir")/nodes"


### PR DESCRIPTION
> [!IMPORTANT]
> This is a stacked PR:
> - #948
>     - #950 :point_left:
>         - #971

- When an invoice state changes in Fiber (settled, failed, expired), the CCH order tracking system automatically detects and synchronizes the state without manual polling or intervention.
- When an outgoing payment state changes in Fiber (succeeded, failed, pending), the CCH order tracking system automatically detects and synchronizes the state without requiring manual status checks.
- CCH monitors invoice for the incoming payment. When CCH has received the incoming payment, it will send the outgoing payment to get the preimage.
- CCH monitors outgoing payment to get the preimage and use the obtained preimage the settle the incoming payment.

This PR will deprecate #615, which has been refactored and split into
- #930 
- #945 
- #942 
- #948 
- #950 :point_left: 

Actions:
- [x] Fix e2e test cross-chain-hub
