### PR TITLE
Update check-migrate version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ gen-rpc-doc:
 check-dirty-rpc-doc: gen-rpc-doc
 	git diff --exit-code ./crates/fiber-lib/src/rpc/README.md
 
-MIGRATION_CHECK_VERSION := 0.2.6
+MIGRATION_CHECK_VERSION := 0.3.1
 install-migration-check:
 	@if ! command -v migration-check >/dev/null 2>&1 || [ "$$(migration-check --version | awk '{print $$2}')" != "$(MIGRATION_CHECK_VERSION)" ]; then \
 		echo "Installing migration-check $(MIGRATION_CHECK_VERSION)..."; \


### PR DESCRIPTION
fixed a issue that `migration-check` may produce different finger print on different OS.
