### PR TITLE
Ensure add tlc expiry is large than final tlc minimum expiry delta

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1098,6 +1098,11 @@ where
                 if !matches!(invoice_status, CkbInvoiceStatus::Open) {
                     return Err(ProcessingChannelError::FinalInvoiceInvalid(invoice_status));
                 }
+
+                // ensure tlc expiry is large than the now + final_tlc_minimum_expiry_delta
+                if invoice.is_tlc_expire_too_soon(add_tlc.expiry) {
+                    return Err(ProcessingChannelError::IncorrectFinalTlcExpiry);
+                }
             }
 
             let Some(tlc) = state.tlc_state.get_mut(&add_tlc.tlc_id) else {

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -952,7 +952,8 @@ where
                             Some(invoice_expiry) => u64::try_from(
                                 invoice_expiry
                                     .as_millis()
-                                    .saturating_add(invoice.data.timestamp),
+                                    .saturating_add(invoice.data.timestamp)
+                                    .min(tlc.expiry.into()),
                             )
                             .unwrap_or(u64::MAX),
                             None => tlc.expiry,

--- a/crates/fiber-lib/src/invoice/invoice_impl.rs
+++ b/crates/fiber-lib/src/invoice/invoice_impl.rs
@@ -113,7 +113,7 @@ pub struct CkbScript(#[serde_as(as = "EntityHex")] pub Script);
 #[serde(rename_all = "snake_case")]
 pub enum Attribute {
     #[serde(with = "U64Hex")]
-    /// The final tlc minimum expiry delta, in milliseconds, default is 1 day
+    /// The final tlc minimum expiry delta, in milliseconds, default is 160 minutes
     FinalHtlcMinimumExpiryDelta(u64),
     #[serde(with = "duration_hex")]
     /// The expiry time of the invoice, in seconds

--- a/crates/fiber-lib/src/invoice/invoice_impl.rs
+++ b/crates/fiber-lib/src/invoice/invoice_impl.rs
@@ -297,6 +297,19 @@ impl CkbInvoice {
         })
     }
 
+    pub fn is_tlc_expire_too_soon(&self, tlc_expiry: u64) -> bool {
+        let now = UNIX_EPOCH
+            .elapsed()
+            .expect("Duration since unix epoch")
+            .as_millis();
+        let required_expiry = now
+            + (self
+                .final_tlc_minimum_expiry_delta()
+                .cloned()
+                .unwrap_or_default() as u128);
+        (tlc_expiry as u128) < required_expiry
+    }
+
     /// Check that the invoice is signed correctly and that key recovery works
     pub fn check_signature(&self) -> Result<(), InvoiceError> {
         if self.signature.is_none() {

--- a/crates/fiber-lib/src/rpc/invoice.rs
+++ b/crates/fiber-lib/src/rpc/invoice.rs
@@ -411,21 +411,22 @@ where
                 invoice_builder = invoice_builder.payment_secret(payment_secret.into());
             }
         };
-        if let Some(final_expiry_delta) = params.final_expiry_delta {
-            if final_expiry_delta < MIN_TLC_EXPIRY_DELTA {
-                return error(&format!(
-                    "final_expiry_delta must be greater than or equal to {}",
-                    MIN_TLC_EXPIRY_DELTA
-                ));
-            }
-            if final_expiry_delta > MAX_PAYMENT_TLC_EXPIRY_LIMIT {
-                return error(&format!(
-                    "final_expiry_delta must be less than or equal to {}",
-                    MAX_PAYMENT_TLC_EXPIRY_LIMIT
-                ));
-            }
-            invoice_builder = invoice_builder.final_expiry_delta(final_expiry_delta);
-        };
+
+        let final_expiry_delta = params.final_expiry_delta.unwrap_or(MIN_TLC_EXPIRY_DELTA);
+        if final_expiry_delta < MIN_TLC_EXPIRY_DELTA {
+            return error(&format!(
+                "final_expiry_delta must be greater than or equal to {}",
+                MIN_TLC_EXPIRY_DELTA
+            ));
+        }
+        if final_expiry_delta > MAX_PAYMENT_TLC_EXPIRY_LIMIT {
+            return error(&format!(
+                "final_expiry_delta must be less than or equal to {}",
+                MAX_PAYMENT_TLC_EXPIRY_LIMIT
+            ));
+        }
+        invoice_builder = invoice_builder.final_expiry_delta(final_expiry_delta);
+
         if let Some(udt_type_script) = &params.udt_type_script {
             invoice_builder = invoice_builder.udt_type_script(udt_type_script.clone().into());
         };


### PR DESCRIPTION
Changes:

1. Ensure `add_tlc.expiry` satisfy the `invoice.final_tlc_minimum_expiry_delta` requirement.
2. Set `invoice.final_expiry_delta` default to `MIN_TLC_EXPIRY_DELTA` (160 minutes)
3. For CCH tlc we should use `min(tlc_expire, invoice_expire)` instead of `invoice_expire` time.

Reference [lnd code](https://github.com/lightningnetwork/lnd/blob/d5f70c0ae396982cc17403bc8e5fb5b7c0bd12c2/invoices/update.go#L267)

-------

Purpose:

MPP may use different expiry time, we ensure the following condition to gurantee we can settle all the parts:

1. `add_tlc.expiry < now + invoice.final_tlc_minimum_expiry_delta` - We add code to check this condition in this PR
2. hold_tlc get expired before `add_tlc.expire` - we already have the `HoldTimeout` to expire hold_tlc.