### PR TITLE
fix: correct watchtower e2e tests on pending TLCs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,18 @@ jobs:
           # - cross-chain-hub
           - router-pay
           - udt-router-pay
-          - watchtower
+          - watchtower/force-close
+          - watchtower/force-close-after-multiple-payments
+          - watchtower/force-close-after-open-channel
+          - watchtower/force-close-preimage
+          - watchtower/force-close-preimage-multiple
+          - watchtower/force-close-remote-with-pending-tlcs-and-stop-watchtower
+          - watchtower/force-close-remote-without-pending-tlcs-and-stop-watchtower
+          - watchtower/force-close-with-consecutive-settlement
+          - watchtower/force-close-with-pending-tlcs
+          - watchtower/force-close-with-pending-tlcs-and-stop-watchtower
+          - watchtower/force-close-with-pending-tlcs-and-udt
+          - watchtower/revocation
         release:
           - "0.202.0"
         test_env:
@@ -85,6 +96,9 @@ jobs:
           set -euo pipefail
           # Save matrix values to generate unique ID for upload-artifact
           echo '${{ toJSON(matrix) }}' > matrix.json
+          # Create a safe workflow name for artifact upload (replace / with -)
+          SAFE_WORKFLOW_NAME="${{ matrix.workflow }}"
+          echo "SAFE_WORKFLOW_NAME=${SAFE_WORKFLOW_NAME//\//-}" >> $GITHUB_ENV
 
           # Prebuild the program so that we can run the following script faster
           cargo build --locked
@@ -106,6 +120,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure() && steps.e2eTests.outcome == 'failure'
         with:
-          name: e2e-test-${{ matrix.workflow }}-${{ hashFiles('matrix.json') }}-logs
+          name: e2e-test-${{ env.SAFE_WORKFLOW_NAME }}-${{ hashFiles('matrix.json') }}-logs
           path: tests/nodes/*.log
 

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/18-generate-blocks-for-settlement-tx1-committed.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/18-generate-blocks-for-settlement-tx1-committed.bru
@@ -1,7 +1,7 @@
 meta {
   name: generate a few blocks for settlement tx1 committed
   type: http
-  seq: 19
+  seq: 18
 }
 
 post {
@@ -29,6 +29,6 @@ assert {
 }
 
 script:post-response {
-  // Wait for the settlement tx2 to be generated
+  // Wait for the settlement tx1 to be committed
   await new Promise(r => setTimeout(r, 5000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/19-generate-blocks-for-onchain-timestamp-updates.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/19-generate-blocks-for-onchain-timestamp-updates.bru
@@ -1,7 +1,7 @@
 meta {
   name: generate a few blocks for onchain timestamp updates
   type: http
-  seq: 16
+  seq: 18
 }
 
 post {
@@ -29,7 +29,7 @@ assert {
 }
 
 script:pre-request {
-  // wait 20 seconds for the onchain timestamp to be updated
+  // Wait until the first TLC expires
   await new Promise(r => setTimeout(r, 20000));
 }
 

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/20-generate-blocks-for-settlement-tx2-committed.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/20-generate-blocks-for-settlement-tx2-committed.bru
@@ -29,6 +29,6 @@ assert {
 }
 
 script:post-response {
-  // Wait for the final settlement tx to be generated
+  // Wait for the settlement tx2 to be committed
   await new Promise(r => setTimeout(r, 5000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/16-generate-blocks-for-settlement-tx1-committed.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/16-generate-blocks-for-settlement-tx1-committed.bru
@@ -1,7 +1,7 @@
 meta {
-  name: generate a few blocks for onchain timestamp updates
+  name: generate a few blocks for settlement tx1 committed
   type: http
-  seq: 18
+  seq: 16
 }
 
 post {
@@ -28,12 +28,7 @@ assert {
   res.status: eq 200
 }
 
-script:pre-request {
-  // wait 20 seconds for the onchain timestamp to be updated
-  await new Promise(r => setTimeout(r, 20000));
-}
-
 script:post-response {
-  // Wait for the settlement tx1 to be generated
+  // Wait for the settlement tx1 to be committed
   await new Promise(r => setTimeout(r, 5000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/17-generate-blocks-for-onchain-timestamp-updates.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/17-generate-blocks-for-onchain-timestamp-updates.bru
@@ -1,5 +1,5 @@
 meta {
-  name: generate a few blocks for settlement tx1 committed
+  name: generate a few blocks for onchain timestamp updates
   type: http
   seq: 17
 }
@@ -28,7 +28,12 @@ assert {
   res.status: eq 200
 }
 
+script:pre-request {
+  // Wait until the first TLC expires
+  await new Promise(r => setTimeout(r, 12000));
+}
+
 script:post-response {
-  // Wait for the settlement tx2 to be generated
+  // Wait for the settlement tx1 to be generated
   await new Promise(r => setTimeout(r, 5000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/18-generate-blocks-for-settlement-tx2-committed.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/18-generate-blocks-for-settlement-tx2-committed.bru
@@ -29,6 +29,6 @@ assert {
 }
 
 script:post-response {
-  // Wait for the final settlement tx to be generated
+  // Wait for the settlement tx2 to be committed
   await new Promise(r => setTimeout(r, 5000));
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This is a stacked PR:
> - #966  :point_left:
>     - #961

## Summary

This PR fixes the watchtower e2e tests to properly handle pending TLCs.

## Changes

### 1. Run watchtower e2e tests in separate jobs

Split watchtower e2e tests into individual CI jobs to make it easier to locate causes for failures.

### 2. Correct e2e watchtower tests on preimage settlement

Adjust the test sequence to let the preimage settlement tx commit before any TLC expires. Then wait until the first TLC expires so the second timeout settlement tx can be committed.

## Files Changed

- `.github/workflows/e2e.yml` - Split watchtower tests into separate CI jobs
- `tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/` - Reorder and fix test sequences
- `tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/` - Reorder and fix test sequences