### PR TITLE
Fix UDT hash type and re-enable cross-chain hub e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
           - open-use-close-a-channel
           - udt
           - reestablish
-          # - cross-chain-hub
+          - cross-chain-hub
           - router-pay
           - udt-router-pay
           - watchtower/force-close

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1680,6 +1680,13 @@ where
 
                 debug_assert_eq!(to, cur_hop.node_id);
                 if &udt_type_script != channel_info.udt_type_script() {
+                    if tracing::enabled!(tracing::Level::TRACE)
+                        && udt_type_script.is_some()
+                        && channel_info.udt_type_script().is_some()
+                    {
+                        // Common errors that channel and payment uses different UDT type scripts
+                        trace!("skip channel because of different UDT type scripts: payment: {:?}, channel: {:?}", udt_type_script, channel_info.udt_type_script());
+                    }
                     continue;
                 }
 

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -440,7 +440,7 @@ fn test_verify_hard_coded_node_announcement() {
                             "e1e354d6d643ad42724d40967e334984534e0367405c5ae42a9d7d63d77df419",
                         )
                         .expect("valid hash"),
-                        hash_type: ScriptHashType::Data1,
+                        hash_type: ScriptHashType::Data2,
                         args: "0x.*".to_string(),
                     },
                     auto_accept_amount: Some(1000),
@@ -462,7 +462,7 @@ fn test_verify_hard_coded_node_announcement() {
                             "50bd8d6680b8b9cf98b73f3c08faf8b2a21914311954118ad6609be6e78a1b95",
                         )
                         .expect("valid hash"),
-                        hash_type: ScriptHashType::Data1,
+                        hash_type: ScriptHashType::Data2,
                         args: "0x.*".to_string(),
                     },
                     auto_accept_amount: Some(1000),
@@ -534,8 +534,8 @@ fn test_verify_hard_coded_node_announcement() {
 
     for (signature, message, node_announcement) in [
         (
-            "80a0e9d4ed35eb76e086038983dfd2572e7298a795b4cde7b113d805eeb495192cf552e4cc631e73fee76c4f0479a33327488f8a99978a10e2583b7faba2cf61",
-            "044e5172e9a9d7b383c15f40d8dac30f86422e7082af2b4d7db7f5484b4a1701",
+            "7cd5e05013bd41c8de80fdef75d6ffd1be45408d8e2a8cd54f0994d2bfdb590826583e662e05ca39cdb844f796fc43c4627746a485fc8e54c1859f710122008a",
+            "18564fef8fcea0fcef42a982d4df86a0dd0b7838159e05a12aa4e74498aca4ff",
             node1(),
         ),
         (
@@ -632,7 +632,7 @@ fn test_convert_udt_arg_info() {
                 "e1e354d6d643ad42724d40967e334984534e0367405c5ae42a9d7d63d77df419",
             )
             .expect("valid hash"),
-            hash_type: ScriptHashType::Data1,
+            hash_type: ScriptHashType::Data2,
             args: "0x.*".to_string(),
         },
         auto_accept_amount: Some(1000),

--- a/tests/bruno/e2e/cross-chain-hub/04-node1-open-channel-to-node3.bru
+++ b/tests/bruno/e2e/cross-chain-hub/04-node1-open-channel-to-node3.bru
@@ -26,7 +26,7 @@ body:json {
         "funding_amount": "0x30d40",
         "funding_udt_type_script": {
           "code_hash": "{{UDT_CODE_HASH}}",
-          "hash_type": "data1",
+          "hash_type": "data2",
           "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
         }
       }

--- a/tests/bruno/e2e/cross-chain-hub/09-node1-add-fiber-invoice.bru
+++ b/tests/bruno/e2e/cross-chain-hub/09-node1-add-fiber-invoice.bru
@@ -27,7 +27,7 @@ body:json {
         "udt_type_script": {
           "args": "{{UDT_SCRIPT_ARGS}}",
           "code_hash": "0xe1e354d6d643ad42724d40967e334984534e0367405c5ae42a9d7d63d77df419",
-          "hash_type": "data1"
+          "hash_type": "data2"
         },
         "description": "test invoice",
         "payment_preimage": "{{payment_preimage}}"

--- a/tests/bruno/e2e/udt-router-pay/03-node1-node2-open-channel.bru
+++ b/tests/bruno/e2e/udt-router-pay/03-node1-node2-open-channel.bru
@@ -27,7 +27,7 @@ body:json {
         "tlc_fee_proportional_millionths": "0x4B0",
         "funding_udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
       }

--- a/tests/bruno/e2e/udt-router-pay/07-node2-node3-open-channel.bru
+++ b/tests/bruno/e2e/udt-router-pay/07-node2-node3-open-channel.bru
@@ -26,7 +26,7 @@ body:json {
         "funding_amount": "0x3B9ACA00",
         "funding_udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
         }
       }

--- a/tests/bruno/e2e/udt-router-pay/11-node3-gen-invoice.bru
+++ b/tests/bruno/e2e/udt-router-pay/11-node3-gen-invoice.bru
@@ -30,7 +30,7 @@ body:json {
         "payment_preimage": "{{payment_preimage}}",
         "udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
         }
       }

--- a/tests/bruno/e2e/udt-router-pay/12-node1-send-payment.bru
+++ b/tests/bruno/e2e/udt-router-pay/12-node1-send-payment.bru
@@ -27,7 +27,7 @@ body:json {
         "payment_hash": "{{payment_hash}}",
         "udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
         }
       }

--- a/tests/bruno/e2e/udt-router-pay/13-node3-gen-invoice-later.bru
+++ b/tests/bruno/e2e/udt-router-pay/13-node3-gen-invoice-later.bru
@@ -30,7 +30,7 @@ body:json {
         "payment_preimage": "{{payment_preimage}}",
         "udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
         }
       }

--- a/tests/bruno/e2e/udt-router-pay/15-node1-send-payment-keysend.bru
+++ b/tests/bruno/e2e/udt-router-pay/15-node1-send-payment-keysend.bru
@@ -27,7 +27,7 @@ body:json {
         "keysend": true,
         "udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
         }
       }

--- a/tests/bruno/e2e/udt-router-pay/16-node1-send-payment-keysend-large-amount.bru
+++ b/tests/bruno/e2e/udt-router-pay/16-node1-send-payment-keysend-large-amount.bru
@@ -27,7 +27,7 @@ body:json {
         "keysend": true,
         "udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
         }
       }

--- a/tests/bruno/e2e/udt/02-node1-node2-open-channel-amount-err.bru
+++ b/tests/bruno/e2e/udt/02-node1-node2-open-channel-amount-err.bru
@@ -27,7 +27,7 @@ body:json {
           "funding_amount": "0x4b0",
           "funding_udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac0794a"
           }
       }

--- a/tests/bruno/e2e/udt/04-node1-node2-open-channel.bru
+++ b/tests/bruno/e2e/udt/04-node1-node2-open-channel.bru
@@ -27,7 +27,7 @@ body:json {
           "funding_amount": "0xfffffffffffffffffffffffffffff",
           "funding_udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
       }

--- a/tests/bruno/e2e/udt/07-node2-gen-invoice.bru
+++ b/tests/bruno/e2e/udt/07-node2-gen-invoice.bru
@@ -43,7 +43,7 @@ body:json {
         "payment_preimage": "{{payment_preimage}}",
         "udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
         }
       }

--- a/tests/bruno/e2e/udt/10-node1-node2-open-channel-invalid.bru
+++ b/tests/bruno/e2e/udt/10-node1-node2-open-channel-invalid.bru
@@ -27,7 +27,7 @@ body:json {
           "funding_amount": "0x4b0",
           "funding_udt_type_script": {
             "code_hash": "0xe1e354d6d643ad42724d40967e334984534e0367405c5ae42a9d7d63d77df410",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
       }

--- a/tests/bruno/e2e/udt/11-node1-node2-open-channel-no-auto-accept.bru
+++ b/tests/bruno/e2e/udt/11-node1-node2-open-channel-no-auto-accept.bru
@@ -27,7 +27,7 @@ body:json {
           "funding_amount": "0x200",
           "funding_udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
       }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/04-get-node1-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/04-get-node1-balance.bru
@@ -26,7 +26,7 @@ body:json {
         "filter": {
           "script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
         }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/05-get-node2-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/05-get-node2-balance.bru
@@ -26,7 +26,7 @@ body:json {
         "filter": {
           "script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
         }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/08-open-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/08-open-channel.bru
@@ -28,7 +28,7 @@ body:json {
         "tlc_fee_proportional_millionths": "0x4B0",
         "funding_udt_type_script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
       }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/24-check-balance-node1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/24-check-balance-node1.bru
@@ -26,7 +26,7 @@ body:json {
         "filter": {
           "script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
         }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/25-check-balance-node2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/25-check-balance-node2.bru
@@ -26,7 +26,7 @@ body:json {
         "filter": {
           "script": {
             "code_hash": "{{UDT_CODE_HASH}}",
-            "hash_type": "data1",
+            "hash_type": "data2",
             "args": "0x32e555f3ff8e135cece1351a6a2971518392c1e30375c1e006ad0ce8eac07947"
           }
         }

--- a/tests/deploy/udt-init/src/main.rs
+++ b/tests/deploy/udt-init/src/main.rs
@@ -48,7 +48,7 @@ fn get_udt_info(udt_kind: &str) -> (H256, H256, usize) {
 
 fn gen_dev_udt_handler(udt_kind: &str) -> SudtHandler {
     let (data_hash, genesis_tx, index) = get_udt_info(udt_kind);
-    let script_id = ScriptId::new_data1(data_hash);
+    let script_id = ScriptId::new(data_hash, ScriptHashType::Data2);
 
     let udt_cell_dep = CellDep::new_builder()
         .out_point(
@@ -162,7 +162,7 @@ fn generate_udt_type_script(udt_kind: &str, address: &str) -> ckb_types::packed:
     let (code_hash, _, _) = get_udt_info(udt_kind);
     Script::new_builder()
         .code_hash(code_hash.pack())
-        .hash_type(ScriptHashType::Data1.into())
+        .hash_type(ScriptHashType::Data2.into())
         .args(sudt_owner_lock_script.calc_script_hash().as_bytes().pack())
         .build()
 }
@@ -294,7 +294,7 @@ fn generate_nodes_config() {
             auto_accept_amount: Some(1000),
             script: UdtScript {
                 code_hash: code_hash,
-                hash_type: "Data1".to_string(),
+                hash_type: "Data2".to_string(),
                 args: "0x.*".to_string(),
             },
             cell_deps: vec![UdtDep {


### PR DESCRIPTION
## Summary

- enable the cross-chain-hub Bruno flow in the e2e workflow matrix
- switch all UDT-related configs, scripts, and tests to ScriptHashType::Data2
- add trace logging when payment and channel UDT scripts mismatch for easier debugging