### PR TITLE
Payment actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,7 +4773,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 [[package]]
 name = "ractor"
 version = "0.15.6"
-source = "git+https://github.com/officeyutong/ractor?branch=use-non-send-future-in-wasm#547ee6aea5efb9fc20a2f281225bcd510919c373"
+source = "git+https://github.com/officeyutong/ractor?branch=use-non-send-future-in-wasm#ea9b5065e5a2108b33c77108ebc6ebcfdc31e367"
 dependencies = [
  "async-trait",
  "bon",
@@ -4792,7 +4792,7 @@ dependencies = [
 [[package]]
 name = "ractor_async_trait_decl"
 version = "0.15.6"
-source = "git+https://github.com/officeyutong/ractor?branch=use-non-send-future-in-wasm#547ee6aea5efb9fc20a2f281225bcd510919c373"
+source = "git+https://github.com/officeyutong/ractor?branch=use-non-send-future-in-wasm#ea9b5065e5a2108b33c77108ebc6ebcfdc31e367"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -16,8 +16,8 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 use crate::ckb::contracts::{get_script_by_contract, Contract};
 use crate::fiber::hash_algorithm::HashAlgorithm;
-use crate::fiber::network::SendPaymentCommand;
 use crate::fiber::payment::PaymentStatus;
+use crate::fiber::payment::SendPaymentCommand;
 use crate::fiber::types::{Hash256, Privkey};
 use crate::fiber::ASSUME_NETWORK_ACTOR_ALIVE;
 use crate::fiber::{NetworkActorCommand, NetworkActorMessage};

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -9,7 +9,7 @@ use crate::fiber::config::MILLI_SECONDS_PER_EPOCH;
 use crate::fiber::fee::{check_open_channel_parameters, check_tlc_delta_with_epochs};
 #[cfg(any(debug_assertions, feature = "bench"))]
 use crate::fiber::network::DebugEvent;
-use crate::fiber::network::PaymentCustomRecords;
+use crate::fiber::payment::PaymentCustomRecords;
 use crate::fiber::types::TxSignatures;
 use crate::utils::actor::ActorHandleLogGuard;
 use crate::{debug_event, fiber::types::TxAbort, utils::tx::compute_tx_message};
@@ -43,9 +43,8 @@ use crate::{
         },
         hash_algorithm::HashAlgorithm,
         key::blake2b_hash_with_salt,
-        network::{
-            get_chain_hash, sign_network_message, FiberMessageWithPeerId, SendOnionPacketCommand,
-        },
+        network::SendOnionPacketCommand,
+        network::{get_chain_hash, sign_network_message, FiberMessageWithPeerId},
         serde_utils::{CompactSignatureAsBytes, EntityHex, PubNonceAsBytes},
         types::{
             AcceptChannel, AddTlc, AnnouncementSignatures, BroadcastMessageWithTimestamp,
@@ -1751,18 +1750,23 @@ where
         peeled_onion_packet: PeeledPaymentOnionPacket,
         forward_fee: u128,
     ) {
+        let (send, _recv) = oneshot::channel::<Result<(), TlcErr>>();
+        let port = RpcReplyPort::from(send);
         match self.network.send_message(NetworkActorMessage::Command(
-            NetworkActorCommand::SendPaymentOnionPacket(SendOnionPacketCommand {
-                peeled_onion_packet: peeled_onion_packet.clone(),
-                previous_tlc: Some(PrevTlcInfo::new(
-                    state.get_id(),
-                    u64::from(tlc_id),
-                    forward_fee,
-                )),
-                payment_hash,
-                // forward tlc always set attempt_id to None
-                attempt_id: None,
-            }),
+            NetworkActorCommand::SendPaymentOnionPacket(
+                SendOnionPacketCommand {
+                    peeled_onion_packet: peeled_onion_packet.clone(),
+                    previous_tlc: Some(PrevTlcInfo::new(
+                        state.get_id(),
+                        u64::from(tlc_id),
+                        forward_fee,
+                    )),
+                    payment_hash,
+                    // forward tlc always set attempt_id to None
+                    attempt_id: None,
+                },
+                port,
+            ),
         )) {
             Ok(_) => {
                 // we successfully sent the forward tlc, we will wait for the result

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -3,8 +3,9 @@ use super::config::AnnouncedNodeName;
 use super::features::FeatureVector;
 use super::gossip::GossipMessageStore;
 use super::history::{Direction, InternalResult, PaymentHistory, TimedResult};
-use super::network::{get_chain_hash, BuildRouterCommand, HopHint, SendPaymentData};
+use super::network::{get_chain_hash, BuildRouterCommand, SendPaymentData};
 use super::path::NodeHeap;
+use super::payment::HopHint;
 use super::types::{
     BroadcastMessageID, BroadcastMessageWithTimestamp, ChannelAnnouncement, ChannelUpdate, Hash256,
     NodeAnnouncement,

--- a/crates/fiber-lib/src/fiber/mod.rs
+++ b/crates/fiber-lib/src/fiber/mod.rs
@@ -25,8 +25,9 @@ pub use in_flight_ckb_tx_actor::{
 pub use key::KeyPair;
 pub use network::{
     start_network, NetworkActor, NetworkActorCommand, NetworkActorEvent, NetworkActorMessage,
-    NetworkServiceEvent, PaymentCustomRecords,
+    NetworkServiceEvent,
 };
+pub use payment::PaymentCustomRecords;
 
 pub(crate) const ASSUME_NETWORK_ACTOR_ALIVE: &str = "network actor must be alive";
 

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -13,7 +13,6 @@ use ractor::{
 };
 use rand::seq::{IteratorRandom, SliceRandom};
 use rand::Rng;
-use secp256k1::Secp256k1;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::borrow::Cow;
@@ -93,12 +92,15 @@ use crate::fiber::gossip::{GossipConfig, GossipService, SubscribableGossipMessag
 use crate::fiber::graph::GraphChannelStat;
 #[cfg(any(debug_assertions, test, feature = "bench"))]
 use crate::fiber::payment::SessionRoute;
-use crate::fiber::payment::{Attempt, AttemptStatus, PaymentSession, PaymentStatus};
+use crate::fiber::payment::{
+    Attempt, AttemptStatus, HopHint, PaymentActor, PaymentActorArguments, PaymentActorInitCommand,
+    PaymentActorMessage, PaymentCustomRecords, PaymentSession, PaymentStatus, SendPaymentCommand,
+    SendPaymentWithRouterCommand, USER_CUSTOM_RECORDS_MAX_INDEX,
+};
 use crate::fiber::serde_utils::EntityHex;
 use crate::fiber::types::{
     FiberChannelMessage, PeeledPaymentOnionPacket, TlcErrPacket, TxAbort, TxSignatures,
 };
-use crate::fiber::KeyPair;
 use crate::invoice::{
     CkbInvoice, CkbInvoiceStatus, InvoiceError, InvoiceStore, PreimageStore, SettleInvoiceError,
 };
@@ -130,7 +132,7 @@ pub const MAX_CUSTOM_RECORDS_SIZE: usize = 2 * 1024; // 2 KB
 const ASSUME_CHAIN_ACTOR_ALWAYS_ALIVE_FOR_NOW: &str =
     "We currently assume that chain actor is always alive, but it failed. This is a known issue.";
 
-const ASSUME_NETWORK_MYSELF_ALIVE: &str = "network actor myself alive";
+pub(crate) const ASSUME_NETWORK_MYSELF_ALIVE: &str = "network actor myself alive";
 
 const ASSUME_GOSSIP_ACTOR_ALIVE: &str = "gossip actor must be alive";
 
@@ -158,8 +160,6 @@ const CHECK_PEER_INIT_INTERVAL: Duration = Duration::from_secs(20);
 // and the latest cursor.
 const MAX_GRAPH_MISSING_BROADCAST_MESSAGE_TIMESTAMP_DRIFT: Duration =
     Duration::from_secs(60 * 60 * 2);
-
-const MAX_RETRY_SEND_PAYMENTS: usize = 30;
 
 static CHAIN_HASH_INSTANCE: OnceCell<Hash256> = OnceCell::new();
 
@@ -256,6 +256,16 @@ pub struct PeerInfo {
     pub address: MultiAddr,
 }
 
+#[derive(Debug, Clone)]
+pub struct SendOnionPacketCommand {
+    pub peeled_onion_packet: PeeledPaymentOnionPacket,
+    // We are currently forwarding a previous tlc. The previous tlc's channel id, tlc id
+    // and the fee paid are included here.
+    pub previous_tlc: Option<PrevTlcInfo>,
+    pub payment_hash: Hash256,
+    pub attempt_id: Option<u64>,
+}
+
 /// The struct here is used both internally and as an API to the outside world.
 /// If we want to send a reply to the caller, we need to wrap the message with
 /// a RpcReplyPort. Since outsider users have no knowledge of RpcReplyPort, we
@@ -300,7 +310,7 @@ pub enum NetworkActorCommand {
     ControlFiberChannel(ChannelCommandWithId),
     // The first parameter is the peeled onion in binary via `PeeledPaymentOnionPacket::serialize`. `PeeledPaymentOnionPacket::current`
     // is for the current node.
-    SendPaymentOnionPacket(SendOnionPacketCommand),
+    SendPaymentOnionPacket(SendOnionPacketCommand, RpcReplyPort<Result<(), TlcErr>>),
     UpdateChannelFunding(Hash256, Transaction, FundingRequest),
     VerifyFundingTx {
         local_tx: Transaction,
@@ -334,6 +344,8 @@ pub enum NetworkActorCommand {
         BuildRouterCommand,
         RpcReplyPort<Result<PaymentRouter, String>>,
     ),
+    // Get the count of inflight payments
+    GetInflightPaymentCount(RpcReplyPort<Result<u32, String>>),
 
     AddInvoice(
         CkbInvoice,
@@ -378,106 +390,6 @@ pub struct OpenChannelCommand {
     pub tlc_fee_proportional_millionths: Option<u128>,
     pub max_tlc_value_in_flight: Option<u128>,
     pub max_tlc_number_in_flight: Option<u64>,
-}
-
-#[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct SendPaymentCommand {
-    // the identifier of the payment target
-    pub target_pubkey: Option<Pubkey>,
-    // the amount of the payment
-    pub amount: Option<u128>,
-    // The hash to use within the payment's HTLC
-    pub payment_hash: Option<Hash256>,
-    // the encoded invoice to send to the recipient
-    pub invoice: Option<String>,
-    // the TLC expiry delta that should be used to set the timelock for the final hop
-    pub final_tlc_expiry_delta: Option<u64>,
-    // the TLC expiry for whole payment, in milliseconds
-    pub tlc_expiry_limit: Option<u64>,
-    // the payment timeout in seconds, if the payment is not completed within this time, it will be cancelled
-    pub timeout: Option<u64>,
-    // the maximum fee amounts in shannons that the sender is willing to pay, default is 1000 shannons CKB.
-    pub max_fee_amount: Option<u128>,
-    // max parts for the payment, only used for multi-part payments
-    pub max_parts: Option<u64>,
-    // keysend payment, default is false
-    pub keysend: Option<bool>,
-    // udt type script
-    #[serde_as(as = "Option<EntityHex>")]
-    pub udt_type_script: Option<Script>,
-    // allow self payment, default is false
-    pub allow_self_payment: bool,
-    // custom records
-    pub custom_records: Option<PaymentCustomRecords>,
-    // the hop hint which may help the find path algorithm to find the path
-    pub hop_hints: Option<Vec<HopHint>>,
-    // dry_run only used for checking, default is false
-    pub dry_run: bool,
-}
-
-#[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct SendPaymentWithRouterCommand {
-    /// the hash to use within the payment's HTLC
-    pub payment_hash: Option<Hash256>,
-
-    /// The router to use for the payment
-    pub router: Vec<RouterHop>,
-
-    /// the encoded invoice to send to the recipient
-    pub invoice: Option<String>,
-
-    /// Some custom records for the payment which contains a map of u32 to Vec<u8>
-    /// The key is the record type, and the value is the serialized data
-    /// For example:
-    /// ```json
-    /// "custom_records": {
-    ///    "0x1": "0x01020304",
-    ///    "0x2": "0x05060708",
-    ///    "0x3": "0x090a0b0c",
-    ///    "0x4": "0x0d0e0f10010d090a0b0c"
-    ///  }
-    /// ```
-    pub custom_records: Option<PaymentCustomRecords>,
-
-    /// keysend payment
-    pub keysend: Option<bool>,
-
-    /// udt type script for the payment
-    #[serde_as(as = "Option<EntityHex>")]
-    pub udt_type_script: Option<Script>,
-
-    /// dry_run for payment, used for check whether we can build valid router and the fee for this payment,
-    /// it's useful for the sender to double check the payment before sending it to the network,
-    /// default is false
-    pub dry_run: bool,
-}
-
-// 0 ~ 65535 is reserved for endpoint usage, index aboving 65535 is reserved for internal usage
-pub const USER_CUSTOM_RECORDS_MAX_INDEX: u32 = 65535;
-/// The custom records to be included in the payment.
-/// The key is hex encoded of `u32`, and the value is hex encoded of `Vec<u8>` with `0x` as prefix.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
-pub struct PaymentCustomRecords {
-    /// The custom records to be included in the payment.
-    pub data: HashMap<u32, Vec<u8>>,
-}
-
-/// A hop hint is a hint for a node to use a specific channel,
-/// will usually used for the last hop to the target node.
-#[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct HopHint {
-    /// The public key of the node
-    pub(crate) pubkey: Pubkey,
-    /// The outpoint for the channel
-    #[serde_as(as = "EntityHex")]
-    pub(crate) channel_outpoint: OutPoint,
-    /// The fee rate to use this hop to forward the payment.
-    pub(crate) fee_rate: u64,
-    /// The TLC expiry delta to use this hop to forward the payment.
-    pub(crate) tlc_expiry_delta: u64,
 }
 
 /// A hop requirement need to meet when building router, do not including the source node,
@@ -765,16 +677,6 @@ pub struct AcceptChannelCommand {
     pub tlc_expiry_delta: Option<u64>,
 }
 
-#[derive(Debug, Clone)]
-pub struct SendOnionPacketCommand {
-    pub peeled_onion_packet: PeeledPaymentOnionPacket,
-    // We are currently forwarding a previous tlc. The previous tlc's channel id, tlc id
-    // and the fee paid are included here.
-    pub previous_tlc: Option<PrevTlcInfo>,
-    pub payment_hash: Hash256,
-    pub attempt_id: Option<u64>,
-}
-
 impl NetworkActorMessage {
     pub fn new_event(event: NetworkActorEvent) -> Self {
         Self::Event(event)
@@ -932,6 +834,9 @@ pub enum NetworkActorEvent {
 
     // A channel actor stopped event.
     ChannelActorStopped(Hash256, StopReason),
+
+    // A payment actor stopped event.
+    PaymentActorStopped(Hash256),
 }
 
 #[derive(Debug)]
@@ -1091,14 +996,6 @@ where
         Ok(())
     }
 
-    // We normally don't need to manually call this to update graph from store data,
-    // because network actor will automatically update the graph when it receives
-    // updates. But in some standalone tests, we may need to manually update the graph.
-    async fn update_graph(&self) {
-        let mut graph = self.network_graph.write().await;
-        graph.load_from_store();
-    }
-
     pub async fn handle_event(
         &self,
         myself: ActorRef<NetworkActorMessage>,
@@ -1203,7 +1100,6 @@ where
                         );
                         self.register_payment_retry(
                             myself.clone(),
-                            state,
                             attempt.payment_hash,
                             Some(attempt.id),
                         );
@@ -1292,10 +1188,27 @@ where
                 }
             }
             NetworkActorEvent::RetrySendPayment(payment_hash, attempt_id) => {
-                state.retry_send_payment_count = state.retry_send_payment_count.saturating_sub(1);
-                let _ = self
-                    .resume_payment_session(myself, state, payment_hash, attempt_id)
+                if let Some(actor) = state.inflight_payments.get(&payment_hash) {
+                    if let Err(err) =
+                        actor.send_message(PaymentActorMessage::RetrySendPayment(attempt_id))
+                    {
+                        debug!(
+                            "RetrySendPayment message dropped because payment actor is likely stopping, error: {err}"
+                        );
+                    }
+                } else {
+                    debug!("Can't find inflight payment actor for {payment_hash:?} {attempt_id:?}, start a new payment actor");
+
+                    let (send, _recv) = oneshot::channel::<Result<_, _>>();
+                    let port = RpcReplyPort::from(send);
+                    self.start_payment_actor(
+                        myself,
+                        state,
+                        PaymentActorInitCommand::Resume(payment_hash, attempt_id),
+                        port,
+                    )
                     .await;
+                }
             }
             NetworkActorEvent::AddTlcResult(
                 payment_hash,
@@ -1333,6 +1246,9 @@ where
             }
             NetworkActorEvent::ChannelActorStopped(channel_id, reason) => {
                 state.on_channel_actor_stopped(channel_id, reason).await;
+            }
+            NetworkActorEvent::PaymentActorStopped(payment_hash) => {
+                state.on_payment_actor_stopped(payment_hash).await;
             }
         }
         Ok(())
@@ -1779,6 +1695,8 @@ where
                         .set(ready_channels_count as u32);
                     metrics::gauge!(crate::metrics::SHUTTING_DOWN_CHANNEL_COUNT)
                         .set(shuttingdown_channels_count as u32);
+                    metrics::gauge!(crate::metrics::INFLIGHT_PAYMENTS_COUNT)
+                        .set(state.inflight_payments.len() as u32);
 
                     // peers
                     let total_peers = state.peer_session_map.len();
@@ -2029,20 +1947,29 @@ where
                     .send_command_to_channel(c.channel_id, c.command)
                     .await?
             }
-            NetworkActorCommand::SendPaymentOnionPacket(command) => {
-                if let Err(err) = self
+            NetworkActorCommand::SendPaymentOnionPacket(command, reply) => {
+                match self
                     .handle_send_onion_packet_command(state, command.clone())
                     .await
                 {
-                    self.on_add_tlc_result_event(
-                        myself,
-                        state,
-                        command.payment_hash,
-                        command.attempt_id,
-                        Err((ProcessingChannelError::TlcForwardingError(err.clone()), err)),
-                        command.previous_tlc,
-                    )
-                    .await;
+                    Ok(()) => {
+                        let _ = reply.send(Ok(()));
+                    }
+                    Err(err) => {
+                        self.on_add_tlc_result_event(
+                            myself,
+                            state,
+                            command.payment_hash,
+                            command.attempt_id,
+                            Err((
+                                ProcessingChannelError::TlcForwardingError(err.clone()),
+                                err.clone(),
+                            )),
+                            command.previous_tlc,
+                        )
+                        .await;
+                        let _ = reply.send(Err(err));
+                    }
                 }
             }
             NetworkActorCommand::UpdateChannelFunding(channel_id, transaction, request) => {
@@ -2270,29 +2197,40 @@ where
                     .expect(ASSUME_GOSSIP_ACTOR_ALIVE);
             }
             NetworkActorCommand::SendPayment(payment_request, reply) => {
-                match self.on_send_payment(myself, state, payment_request).await {
-                    Ok(payment) => {
-                        let _ = reply.send(Ok(payment));
+                let payment_request = match payment_request.build_send_payment_data() {
+                    Ok(payment) => payment,
+                    Err(err) => {
+                        error!("Failed to build payment from command: {:?}", err);
+                        let _ = reply.send(Err(err.to_string()));
+                        return Ok(());
                     }
-                    Err(e) => {
-                        error!("Failed to send payment: {:?}", e);
-                        let _ = reply.send(Err(e.to_string()));
-                    }
-                }
+                };
+
+                self.start_payment_actor(
+                    myself,
+                    state,
+                    PaymentActorInitCommand::Send(payment_request),
+                    reply,
+                )
+                .await;
             }
             NetworkActorCommand::SendPaymentWithRouter(payment_request, reply) => {
-                match self
-                    .on_send_payment_with_router(myself, state, payment_request)
-                    .await
-                {
-                    Ok(payment) => {
-                        let _ = reply.send(Ok(payment));
+                let source = self.network_graph.read().await.get_source_pubkey();
+                let payment_request = match payment_request.build_send_payment_data(source) {
+                    Ok(payment) => payment,
+                    Err(err) => {
+                        error!("Failed to build payment from command: {:?}", err);
+                        let _ = reply.send(Err(err.to_string()));
+                        return Ok(());
                     }
-                    Err(e) => {
-                        error!("Failed to send payment: {:?}", e);
-                        let _ = reply.send(Err(e.to_string()));
-                    }
-                }
+                };
+                self.start_payment_actor(
+                    myself,
+                    state,
+                    PaymentActorInitCommand::Send(payment_request),
+                    reply,
+                )
+                .await;
             }
             NetworkActorCommand::BuildPaymentRouter(build_payment_router, reply) => {
                 match self.on_build_payment_router(build_payment_router).await {
@@ -2347,6 +2285,9 @@ where
                     udt_cfg_infos: get_udt_whitelist(),
                 };
                 let _ = rpc.send(Ok(response));
+            }
+            NetworkActorCommand::GetInflightPaymentCount(reply) => {
+                let _ = reply.send(Ok(state.inflight_payments.len() as u32));
             }
             NetworkActorCommand::ListPeers(_, rpc) => {
                 let peers = state
@@ -2674,7 +2615,13 @@ where
                 // the payment session status maybe changed into Success
                 session.update_with_attempt(attempt);
                 if !session.is_dry_run() {
+                    let status_is_final = session.status.is_final();
                     self.store.insert_payment_session(session);
+
+                    // terminate payment actor when status is final
+                    if status_is_final {
+                        self.notify_payment_final(state, payment_hash);
+                    }
                 }
             }
             RemoveTlcReason::RemoveTlcFail(reason) => {
@@ -2698,6 +2645,8 @@ where
                 );
 
                 self.set_attempt_fail_with_error(
+                    state,
+                    payment_hash,
                     &mut session,
                     &mut attempt,
                     error_detail.error_code.as_ref(),
@@ -2705,7 +2654,7 @@ where
                 );
 
                 if attempt.is_retrying() {
-                    self.register_payment_retry(myself, state, payment_hash, Some(attempt.id));
+                    self.register_payment_retry(myself, payment_hash, Some(attempt.id));
                 }
             }
         }
@@ -2764,197 +2713,6 @@ where
         }
     }
 
-    async fn resend_payment_attempt(
-        &self,
-        myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
-        session: &mut PaymentSession,
-        attempt: &mut Attempt,
-    ) -> Result<(), Error> {
-        assert!(attempt.is_retrying());
-
-        if attempt.last_error.as_ref().is_some_and(|e| !e.is_empty()) {
-            // `session.remain_amount()` do not contains this part of amount,
-            // so we need to add the receiver amount to it, so we may make fewer
-            // attempts to send the payment.
-            let amount = session.remain_amount() + attempt.route.receiver_amount();
-            let max_fee = session.remain_fee_amount();
-            let graph = self.network_graph.read().await;
-
-            session.request.channel_stats = GraphChannelStat::new(Some(graph.channel_stats()));
-
-            let hops = graph
-                .build_route(amount, None, max_fee, &session.request)
-                .map_err(|e| {
-                    Error::BuildPaymentRouteError(format!("Failed to build route, {}", e))
-                })?;
-
-            attempt.update_route(hops);
-        }
-
-        self.send_attempt(myself, state, session, attempt).await?;
-        Ok(())
-    }
-
-    async fn build_payment_routes(
-        &self,
-        session: &mut PaymentSession,
-    ) -> Result<Vec<Attempt>, Error> {
-        let graph = self.network_graph.read().await;
-        let source = graph.get_source_pubkey();
-        let active_parts = session.attempts().filter(|a| a.is_active()).count();
-        let mut remain_amount = session.remain_amount();
-        let mut max_fee = session.remain_fee_amount();
-        let mut result = vec![];
-
-        if remain_amount == 0 {
-            let error = format!("Send amount {} is not expected to be 0", remain_amount);
-            self.set_payment_fail_with_error(session, &error);
-            return Err(Error::SendPaymentError(error));
-        }
-
-        session.request.channel_stats = GraphChannelStat::new(Some(graph.channel_stats()));
-        let mut attempt_id = session.attempts_count() as u64;
-        let mut target_amount = remain_amount;
-        let amount_low_bound = Some(1);
-        let mut iteration = 0;
-
-        while (result.len() < session.max_parts() - active_parts) && remain_amount > 0 {
-            iteration += 1;
-
-            debug!(
-                "build route iteration {}, target_amount: {} amount_low_bound: {:?} remain_amount: {}",
-                iteration,
-                target_amount,
-                amount_low_bound,
-                remain_amount,
-            );
-            match graph.build_route(target_amount, amount_low_bound, max_fee, &session.request) {
-                Err(e) => {
-                    let error = format!("Failed to build route, {}", e);
-                    self.set_payment_fail_with_error(session, &error);
-                    return Err(Error::SendPaymentError(error));
-                }
-                Ok(hops) => {
-                    assert_ne!(hops[0].funding_tx_hash, Hash256::default());
-                    let new_attempt_id = if session.is_dry_run() {
-                        0
-                    } else {
-                        attempt_id += 1;
-                        attempt_id
-                    };
-
-                    let attempt = session.new_attempt(
-                        new_attempt_id,
-                        source,
-                        session.request.target_pubkey,
-                        hops,
-                    );
-
-                    let session_route = &attempt.route;
-                    #[cfg(debug_assertions)]
-                    dbg!(
-                        "left amount: {}, minimal_amount: {} target amount: {}",
-                        remain_amount - session_route.receiver_amount(),
-                        target_amount,
-                        session_route.receiver_amount()
-                    );
-
-                    for (from, channel_outpoint, amount) in session_route.channel_outpoints() {
-                        if let Some(sent_node) = graph.get_channel_sent_node(channel_outpoint, from)
-                        {
-                            session.request.channel_stats.add_channel(
-                                channel_outpoint,
-                                sent_node,
-                                amount,
-                            );
-                        }
-                    }
-                    remain_amount -= session_route.receiver_amount();
-                    target_amount = remain_amount;
-                    if let Some(fee) = max_fee {
-                        max_fee = Some(fee - session_route.fee());
-                    }
-                    result.push(attempt);
-                }
-            };
-        }
-
-        if remain_amount > 0 {
-            let error = "Failed to build enough routes for MPP payment".to_string();
-            self.set_payment_fail_with_error(session, &error);
-            return Err(Error::SendPaymentError(error));
-        }
-
-        for attempt in &result {
-            session.append_attempt(attempt.clone());
-        }
-
-        return Ok(result);
-    }
-
-    async fn send_payment_onion_packet(
-        &self,
-        state: &mut NetworkActorState<S>,
-        session: &mut PaymentSession,
-        attempt: &mut Attempt,
-    ) -> Result<(), Error> {
-        let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
-        assert_ne!(attempt.route_hops[0].funding_tx_hash, Hash256::default());
-
-        attempt.session_key.copy_from_slice(session_key.as_ref());
-
-        let peeled_onion_packet = match PeeledPaymentOnionPacket::create(
-            session_key,
-            attempt.route_hops.clone(),
-            Some(attempt.hash.as_ref().to_vec()),
-            &Secp256k1::signing_only(),
-        ) {
-            Ok(packet) => packet,
-            Err(e) => {
-                let err = format!(
-                    "Failed to create onion packet: {:?}, error: {:?}",
-                    attempt.hash, e
-                );
-                self.set_attempt_fail_with_error(session, attempt, &err, false);
-                return Err(Error::FirstHopError(err, false));
-            }
-        };
-
-        match self
-            .handle_send_onion_packet_command(
-                state,
-                SendOnionPacketCommand {
-                    peeled_onion_packet,
-                    previous_tlc: None,
-                    payment_hash: attempt.payment_hash,
-                    attempt_id: Some(attempt.id),
-                },
-            )
-            .await
-        {
-            Err(error_detail) => {
-                self.update_graph_with_tlc_fail(&state.network, &error_detail)
-                    .await;
-                let need_to_retry = self.network_graph.write().await.record_attempt_fail(
-                    attempt,
-                    error_detail.clone(),
-                    true,
-                );
-                let err = format!(
-                    "Failed to send onion packet with error {}",
-                    error_detail.error_code_as_str()
-                );
-                self.set_attempt_fail_with_error(session, attempt, &err, need_to_retry);
-                return Err(Error::FirstHopError(err, need_to_retry));
-            }
-            Ok(_) => {
-                self.store.insert_attempt(attempt.clone());
-                return Ok(());
-            }
-        }
-    }
-
     async fn on_add_tlc_result_event(
         &self,
         myself: ActorRef<NetworkActorMessage>,
@@ -2991,6 +2749,10 @@ where
         let (Some(mut session), Some(mut attempt)) =
             self.get_payment_session_with_attempt(payment_hash, attempt_id)
         else {
+            warn!(
+                "Payment session not found: {:?} attempt_id: {:?}",
+                payment_hash, attempt_id
+            );
             return;
         };
 
@@ -3015,6 +2777,8 @@ where
                     true,
                 );
                 self.set_attempt_fail_with_error(
+                    state,
+                    payment_hash,
                     &mut session,
                     &mut attempt,
                     &error.to_string(),
@@ -3022,28 +2786,47 @@ where
                 );
                 // retry the current attempt if it is retryable
                 if attempt.is_retrying() {
-                    self.register_payment_retry(myself, state, payment_hash, Some(attempt.id));
+                    self.register_payment_retry(myself, payment_hash, Some(attempt.id));
                 }
             }
         }
     }
 
-    fn set_payment_fail_with_error(&self, session: &mut PaymentSession, error: &str) {
+    fn notify_payment_final(&self, state: &mut NetworkActorState<S>, payment_hash: Hash256) {
+        if let Some(actor) = state.inflight_payments.get(&payment_hash) {
+            if let Err(err) = actor.send_message(PaymentActorMessage::NotifyPaymentFinal) {
+                debug!(
+                    "CheckPayment message dropped because payment actor is likely stopping, error: {err}"
+                );
+            }
+        }
+    }
+
+    fn set_payment_fail_with_error(
+        &self,
+        state: &mut NetworkActorState<S>,
+        payment_hash: Hash256,
+        session: &mut PaymentSession,
+        error: &str,
+    ) {
         session.set_failed_status(error);
         if !session.is_dry_run() {
             self.store.insert_payment_session(session.clone());
+            self.notify_payment_final(state, payment_hash);
         }
     }
 
     fn set_attempt_fail_with_error(
         &self,
+        state: &mut NetworkActorState<S>,
+        payment_hash: Hash256,
         session: &mut PaymentSession,
         attempt: &mut Attempt,
         error: &str,
         retryable: bool,
     ) {
         if !retryable && !session.active_attempts().any(|a| a.id != attempt.id) {
-            self.set_payment_fail_with_error(session, error);
+            self.set_payment_fail_with_error(state, payment_hash, session, error);
         }
 
         attempt.set_failed_status(error, retryable);
@@ -3052,278 +2835,67 @@ where
         }
     }
 
-    async fn send_attempt(
-        &self,
-        myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
-        session: &mut PaymentSession,
-        attempt: &mut Attempt,
-    ) -> Result<(), Error> {
-        if let Err(err) = self
-            .send_payment_onion_packet(state, session, attempt)
-            .await
-        {
-            let need_retry = matches!(err, Error::FirstHopError(_, true));
-            if need_retry {
-                debug!("Retrying payment attempt due to first hop error: {:?}", err);
-                self.register_payment_retry(
-                    myself,
-                    state,
-                    session.payment_hash(),
-                    Some(attempt.id),
-                );
-                return Ok(());
-            } else {
-                self.set_attempt_fail_with_error(session, attempt, &err.to_string(), false);
-                return Err(err);
-            }
-        }
-        Ok(())
-    }
-
-    /// Resume the payment session
-    async fn resume_payment_session(
-        &self,
-        myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
-        payment_hash: Hash256,
-        attempt_id: Option<u64>,
-    ) -> Result<(), Error> {
-        self.update_graph().await;
-        let Some(mut session) = self.store.get_payment_session(payment_hash) else {
-            return Err(Error::InvalidParameter(payment_hash.to_string()));
-        };
-
-        if session.status.is_final() {
-            return Ok(());
-        }
-
-        self.retry_payment_attempt(myself.clone(), state, &mut session, attempt_id)
-            .await?;
-
-        if !self.payment_need_more_retry(&mut session)? {
-            return Ok(());
-        }
-
-        // here we begin to create attempts and routes for the payment session,
-        // it depends on the path finding algorithm to create how many of attempts,
-        // if a payment can not be met in the network graph, an build path error will be returned
-        // and no attempts be stored in the payment session and db.
-        let mut attempts = self
-            .build_payment_routes(&mut session)
-            .await
-            .inspect_err(|e| {
-                self.set_payment_fail_with_error(&mut session, &e.to_string());
-            })?;
-
-        for attempt in attempts.iter_mut() {
-            self.send_attempt(myself.clone(), state, &mut session, attempt)
-                .await?;
-        }
-
-        if let Ok(true) = self.payment_need_more_retry(&mut session) {
-            self.register_payment_retry(myself, state, payment_hash, None);
-        }
-
-        Ok(())
-    }
-
-    async fn retry_payment_attempt(
-        &self,
-        myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
-        session: &mut PaymentSession,
-        attempt_id: Option<u64>,
-    ) -> Result<(), Error> {
-        let Some(attempt_id) = attempt_id else {
-            return Ok(());
-        };
-
-        match self.store.get_attempt(session.payment_hash(), attempt_id) {
-            Some(mut attempt) if attempt.is_retrying() => {
-                match self
-                    .resend_payment_attempt(myself, state, session, &mut attempt)
-                    .await
-                {
-                    Err(err) if session.allow_mpp() => {
-                        // usually `resend_payment_route` will only try build a route with same amount,
-                        // because most of the time, resend payment caused by the first hop
-                        // error with WaitingTlcAck, if resend failed we should try more attempts in MPP,
-                        // so we may create more attempts with different split amounts
-                        attempt.set_failed_status(&err.to_string(), false);
-                        self.store.insert_attempt(attempt);
-                    }
-                    Err(err) => {
-                        self.set_attempt_fail_with_error(
-                            session,
-                            &mut attempt,
-                            &err.to_string(),
-                            false,
-                        );
-                        return Err(err);
-                    }
-                    _ => {}
-                }
-            }
-            Some(_) => {
-                // no retry for non-retryable attempts
-            }
-            None => {
-                return Err(Error::InvalidParameter(format!(
-                    "Attempt with id {:?} not found for payment hash: {:?}",
-                    attempt_id,
-                    session.payment_hash()
-                )));
-            }
-        }
-
-        Ok(())
-    }
-
-    fn payment_need_more_retry(&self, session: &mut PaymentSession) -> Result<bool, Error> {
-        session.flush_attempts(&self.store);
-        let more_attempt = session.allow_more_attempts();
-        if !more_attempt && session.remain_amount() > 0 {
-            let err = "Can not send payment with limited attempts";
-            self.set_payment_fail_with_error(session, err);
-            return Err(Error::SendPaymentError(err.to_string()));
-        }
-        Ok(more_attempt)
-    }
-
     fn register_payment_retry(
         &self,
         myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
         payment_hash: Hash256,
         attempt_id: Option<u64>,
     ) {
-        // This is a performance tuning result, the basic idea is when there are more pending
-        // retrying payment in ractor framework, we will increase the delay time to avoid
-        // flooding the network actor with too many retrying payments.
-        state.retry_send_payment_count += 1;
-        let delay = (state.retry_send_payment_count as u64) * 20_u64;
-        myself.send_after(Duration::from_millis(delay), move || {
-            NetworkActorMessage::new_event(NetworkActorEvent::RetrySendPayment(
-                payment_hash,
-                attempt_id,
-            ))
-        });
-    }
-
-    async fn on_send_payment(
-        &self,
-        myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
-        payment_request: SendPaymentCommand,
-    ) -> Result<SendPaymentResponse, Error> {
-        let payment_data = SendPaymentData::new(payment_request.clone()).map_err(|e| {
-            error!("Failed to validate payment request: {:?}", e);
-            Error::InvalidParameter(format!("Failed to validate payment request: {:?}", e))
-        })?;
-
-        if !payment_data.dry_run && state.retry_send_payment_count >= MAX_RETRY_SEND_PAYMENTS {
-            return Err(Error::InvalidParameter(
-                "Too many pending retrying payment requests".to_string(),
-            ));
+        if let Err(err) = myself.send_message(NetworkActorMessage::new_event(
+            NetworkActorEvent::RetrySendPayment(payment_hash, attempt_id),
+        )) {
+            debug!("Failed to register payment retry for {payment_hash:?} {attempt_id:?}: {err:?}");
         }
-        self.send_payment_with_payment_data(myself, state, payment_data)
-            .await
     }
 
-    async fn on_send_payment_with_router(
+    async fn start_payment_actor(
         &self,
         myself: ActorRef<NetworkActorMessage>,
         state: &mut NetworkActorState<S>,
-        command: SendPaymentWithRouterCommand,
-    ) -> Result<SendPaymentResponse, Error> {
-        // Only proceed if we have at least one hop requirement
-        let Some(last_edge) = command.router.last() else {
-            return Err(Error::InvalidParameter(
-                "No hop requirements provided".to_string(),
-            ));
+        init_command: PaymentActorInitCommand,
+        reply: RpcReplyPort<Result<SendPaymentResponse, String>>,
+    ) {
+        let payment_hash = match &init_command {
+            PaymentActorInitCommand::Send(payment_request) => payment_request.payment_hash,
+            PaymentActorInitCommand::Resume(payment_hash, _) => *payment_hash,
         };
 
-        let source = self.network_graph.read().await.get_source_pubkey();
-        let target = last_edge.target;
-        let amount = last_edge.amount_received;
+        if state.inflight_payments.contains_key(&payment_hash) {
+            error!("Already had a payment actor with the same hash {payment_hash:?}");
+            let _ = reply.send(Err(format!(
+                "Payment session already exists, stop start new payment actor for {payment_hash:?}"
+            )));
+            return;
+        }
 
-        // Create payment command with defaults from the last hop
-        let payment_command = SendPaymentCommand {
-            target_pubkey: Some(target),
-            payment_hash: command.payment_hash,
-            invoice: command.invoice,
-            allow_self_payment: target == source,
-            dry_run: command.dry_run,
-            amount: Some(amount),
-            keysend: command.keysend,
-            udt_type_script: command.udt_type_script.clone(),
-            ..Default::default()
+        let args = PaymentActorArguments {
+            init_command,
+            send_payment_reply: Some(reply),
         };
-
-        let mut payment_data = SendPaymentData::new(payment_command).map_err(|e| {
-            error!("Failed to validate payment request: {:?}", e);
-            Error::InvalidParameter(format!("Failed to validate payment request: {:?}", e))
-        })?;
-
-        // specify the router to be used
-        payment_data.router = command.router.clone();
-        self.send_payment_with_payment_data(myself, state, payment_data)
-            .await
-    }
-
-    async fn send_payment_with_payment_data(
-        &self,
-        myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
-        payment_data: SendPaymentData,
-    ) -> Result<SendPaymentResponse, Error> {
-        // initialize the payment session in db and begin the payment process lifecycle
-        if let Some(payment_session) = self.store.get_payment_session(payment_data.payment_hash) {
-            // we only allow retrying payment session with status failed
-            if payment_session.status != PaymentStatus::Failed {
-                return Err(Error::InvalidParameter(format!(
-                    "Payment session already exists: {} with payment session status: {:?}",
-                    payment_data.payment_hash, payment_session.status
-                )));
-            } else {
-                // even if the payment session is failed, we still need to check whether
-                // some attempts are still flight state, this means some middle hops
-                // haven't send back the result of the onion packet, so we can not retry the payment session
-                // otherwise, we are sure it's safe to cleanup all the previous attempts
-                if payment_session.attempts().any(|a| a.is_inflight()) {
-                    return Err(Error::InvalidParameter(format!(
-                        "Payment session {} has attempts that are in flight state, can not retry",
-                        payment_data.payment_hash
-                    )));
-                }
-                if !payment_data.dry_run {
-                    self.store.delete_attempts(payment_data.payment_hash);
-                }
+        match Actor::spawn_linked(
+            Some(format!(
+                "Payment-{} Node({:?})",
+                payment_hash,
+                myself.get_name(),
+            )),
+            PaymentActor::new(
+                self.store.clone(),
+                self.network_graph.clone(),
+                myself.clone(),
+            ),
+            args,
+            myself.get_cell(),
+        )
+        .await
+        {
+            Ok((actor, _handle)) => {
+                debug!("Payment actor start {payment_hash}");
+                state.inflight_payments.insert(payment_hash, actor);
+            }
+            Err(err) => {
+                error!("Failed to start payment actor: {:?}", err);
             }
         }
-
-        // for dry run, we only build the route and return the hops info,
-        // will not store the payment session and send the onion packet
-        if payment_data.dry_run {
-            let mut payment_session = PaymentSession::new(&self.store, payment_data, 0);
-            self.build_payment_routes(&mut payment_session).await?;
-            return Ok(payment_session.into());
-        }
-
-        let try_limit = if payment_data.allow_mpp() {
-            payment_data.max_parts() as u32 * DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT
-        } else {
-            DEFAULT_PAYMENT_TRY_LIMIT
-        };
-        let mut payment_session = PaymentSession::new(&self.store, payment_data, try_limit);
-        assert!(payment_session.attempts_count() == 0);
-        self.store.insert_payment_session(payment_session.clone());
-
-        self.resume_payment_session(myself, state, payment_session.payment_hash(), None)
-            .await?;
-        payment_session.flush_attempts(&self.store);
-        return Ok(payment_session.into());
     }
 
     async fn on_build_payment_router(
@@ -3416,11 +2988,8 @@ pub struct NetworkActorState<S> {
     features: FeatureVector,
     channel_ephemeral_config: ChannelEphemeralConfig,
 
-    // the number of pending retrying send payments, we track it for
-    // set retry delay dynamically, pending too many payments may have a negative impact
-    // on the node performance, which in worst case may lead node not response revoke_and_ack
-    // in expected time, and then the peer will disconnect us.
-    retry_send_payment_count: usize,
+    // Inflight payment actors
+    inflight_payments: HashMap<Hash256, ActorRef<PaymentActorMessage>>,
 }
 
 #[derive(Debug, Clone)]
@@ -4558,6 +4127,13 @@ where
         .await;
     }
 
+    async fn on_payment_actor_stopped(&mut self, payment_hash: Hash256) {
+        debug!("Payment actor stopped {payment_hash}");
+        if self.inflight_payments.remove(&payment_hash).is_none() {
+            error!("Can't find inflight payment actor");
+        }
+    }
+
     async fn send_message_to_channel_actor(
         &mut self,
         channel_id: Hash256,
@@ -4867,7 +4443,7 @@ where
             channel_ephemeral_config: ChannelEphemeralConfig {
                 funding_timeout_seconds: config.funding_timeout_seconds,
             },
-            retry_send_payment_count: 0,
+            inflight_payments: Default::default(),
         };
 
         let node_announcement = state.get_or_create_new_node_announcement_message();

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -1,15 +1,38 @@
-use super::network::{SendPaymentData, SendPaymentResponse};
-use super::types::Hash256;
-use super::types::Pubkey;
-use crate::fiber::graph::NetworkGraphStateStore;
-use crate::fiber::network::DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::network::{
+    SendOnionPacketCommand, SendPaymentData, SendPaymentResponse, ASSUME_NETWORK_MYSELF_ALIVE,
+};
+use super::types::{Hash256, Privkey, Pubkey, TlcErrData};
+use crate::fiber::channel::ChannelActorStateStore;
+use crate::fiber::gossip::GossipMessageStore;
+use crate::fiber::graph::{GraphChannelStat, NetworkGraph, NetworkGraphStateStore, RouterHop};
+use crate::fiber::network::{
+    NetworkActorStateStore, DEFAULT_CHAIN_ACTOR_TIMEOUT, DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT,
+    DEFAULT_PAYMENT_TRY_LIMIT,
+};
 use crate::fiber::serde_utils::EntityHex;
 use crate::fiber::serde_utils::U128Hex;
-use crate::fiber::types::PaymentHopData;
+use crate::fiber::types::{
+    BroadcastMessageWithTimestamp, PaymentHopData, PeeledPaymentOnionPacket, TlcErr, TlcErrorCode,
+};
+use crate::fiber::{
+    KeyPair, NetworkActorCommand, NetworkActorEvent, NetworkActorMessage,
+    ASSUME_NETWORK_ACTOR_ALIVE,
+};
+use crate::invoice::{InvoiceStore, PreimageStore};
 use crate::now_timestamp_as_millis_u64;
-use ckb_types::packed::OutPoint;
+use crate::Error;
+use ckb_types::packed::{OutPoint, Script};
+use ractor::{call_t, Actor, ActorProcessingErr};
+use ractor::{concurrency::Duration, ActorRef, RpcReplyPort};
+use secp256k1::Secp256k1;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use strum::AsRefStr;
+use tokio::sync::{oneshot, RwLock};
+use tracing::{debug, error};
 
 /// The status of a payment, will update as the payment progresses.
 /// The transfer path for payment status is `Created -> Inflight -> Success | Failed`.
@@ -520,5 +543,864 @@ impl Attempt {
     pub fn hops_public_keys(&self) -> Vec<Pubkey> {
         // Skip the first node, which is the sender.
         self.route.nodes.iter().skip(1).map(|x| x.pubkey).collect()
+    }
+}
+
+/// A hop hint is a hint for a node to use a specific channel,
+/// will usually used for the last hop to the target node.
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HopHint {
+    /// The public key of the node
+    pub(crate) pubkey: Pubkey,
+    /// The outpoint for the channel
+    #[serde_as(as = "EntityHex")]
+    pub(crate) channel_outpoint: OutPoint,
+    /// The fee rate to use this hop to forward the payment.
+    pub(crate) fee_rate: u64,
+    /// The TLC expiry delta to use this hop to forward the payment.
+    pub(crate) tlc_expiry_delta: u64,
+}
+
+// 0 ~ 65535 is reserved for endpoint usage, index aboving 65535 is reserved for internal usage
+pub const USER_CUSTOM_RECORDS_MAX_INDEX: u32 = 65535;
+/// The custom records to be included in the payment.
+/// The key is hex encoded of `u32`, and the value is hex encoded of `Vec<u8>` with `0x` as prefix.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct PaymentCustomRecords {
+    /// The custom records to be included in the payment.
+    pub data: HashMap<u32, Vec<u8>>,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct SendPaymentCommand {
+    // the identifier of the payment target
+    pub target_pubkey: Option<Pubkey>,
+    // the amount of the payment
+    pub amount: Option<u128>,
+    // The hash to use within the payment's HTLC
+    pub payment_hash: Option<Hash256>,
+    // the encoded invoice to send to the recipient
+    pub invoice: Option<String>,
+    // the TLC expiry delta that should be used to set the timelock for the final hop
+    pub final_tlc_expiry_delta: Option<u64>,
+    // the TLC expiry for whole payment, in milliseconds
+    pub tlc_expiry_limit: Option<u64>,
+    // the payment timeout in seconds, if the payment is not completed within this time, it will be cancelled
+    pub timeout: Option<u64>,
+    // the maximum fee amounts in shannons that the sender is willing to pay, default is 1000 shannons CKB.
+    pub max_fee_amount: Option<u128>,
+    // max parts for the payment, only used for multi-part payments
+    pub max_parts: Option<u64>,
+    // keysend payment, default is false
+    pub keysend: Option<bool>,
+    // udt type script
+    #[serde_as(as = "Option<EntityHex>")]
+    pub udt_type_script: Option<Script>,
+    // allow self payment, default is false
+    pub allow_self_payment: bool,
+    // custom records
+    pub custom_records: Option<PaymentCustomRecords>,
+    // the hop hint which may help the find path algorithm to find the path
+    pub hop_hints: Option<Vec<HopHint>>,
+    // dry_run only used for checking, default is false
+    pub dry_run: bool,
+}
+
+impl SendPaymentCommand {
+    pub fn build_send_payment_data(self) -> Result<SendPaymentData, Error> {
+        SendPaymentData::new(self).map_err(|e| {
+            error!("Failed to validate payment request: {:?}", e);
+            Error::InvalidParameter(format!("Failed to validate payment request: {:?}", e))
+        })
+    }
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct SendPaymentWithRouterCommand {
+    /// the hash to use within the payment's HTLC
+    pub payment_hash: Option<Hash256>,
+
+    /// The router to use for the payment
+    pub router: Vec<RouterHop>,
+
+    /// the encoded invoice to send to the recipient
+    pub invoice: Option<String>,
+
+    /// Some custom records for the payment which contains a map of u32 to Vec<u8>
+    /// The key is the record type, and the value is the serialized data
+    /// For example:
+    /// ```json
+    /// "custom_records": {
+    ///    "0x1": "0x01020304",
+    ///    "0x2": "0x05060708",
+    ///    "0x3": "0x090a0b0c",
+    ///    "0x4": "0x0d0e0f10010d090a0b0c"
+    ///  }
+    /// ```
+    pub custom_records: Option<PaymentCustomRecords>,
+
+    /// keysend payment
+    pub keysend: Option<bool>,
+
+    /// udt type script for the payment
+    #[serde_as(as = "Option<EntityHex>")]
+    pub udt_type_script: Option<Script>,
+
+    /// dry_run for payment, used for check whether we can build valid router and the fee for this payment,
+    /// it's useful for the sender to double check the payment before sending it to the network,
+    /// default is false
+    pub dry_run: bool,
+}
+
+impl SendPaymentWithRouterCommand {
+    pub fn build_send_payment_data(self, source: Pubkey) -> Result<SendPaymentData, Error> {
+        // Only proceed if we have at least one hop requirement
+        let Some(last_edge) = self.router.last() else {
+            return Err(Error::InvalidParameter(
+                "No hop requirements provided".to_string(),
+            ));
+        };
+
+        // let source = self.network_graph.read().await.get_source_pubkey();
+        let target = last_edge.target;
+        let amount = last_edge.amount_received;
+
+        // Create payment command with defaults from the last hop
+        let payment_command = SendPaymentCommand {
+            target_pubkey: Some(target),
+            payment_hash: self.payment_hash,
+            invoice: self.invoice,
+            allow_self_payment: target == source,
+            dry_run: self.dry_run,
+            amount: Some(amount),
+            keysend: self.keysend,
+            udt_type_script: self.udt_type_script.clone(),
+            ..Default::default()
+        };
+
+        let mut payment_data = SendPaymentData::new(payment_command).map_err(|e| {
+            error!("Failed to validate payment request: {:?}", e);
+            Error::InvalidParameter(format!("Failed to validate payment request: {:?}", e))
+        })?;
+
+        // specify the router to be used
+        payment_data.router = self.router.clone();
+        Ok(payment_data)
+    }
+}
+
+#[derive(Debug, AsRefStr)]
+pub enum PaymentActorMessage {
+    // SendPayment
+    SendPayment(
+        SendPaymentData,
+        RpcReplyPort<Result<SendPaymentResponse, String>>,
+    ),
+    RetrySendPayment(Option<u64>),
+    // Check payment status, stop actor if payment is end
+    NotifyPaymentFinal,
+}
+
+pub enum PaymentActorInitCommand {
+    Send(SendPaymentData),
+    Resume(Hash256, Option<u64>),
+}
+
+pub struct PaymentActorState {
+    payment_hash: Hash256,
+    init_command: PaymentActorInitCommand,
+    send_payment_reply: Option<RpcReplyPort<Result<SendPaymentResponse, String>>>,
+
+    // the number of pending retrying send payments, we track it for
+    // set retry delay dynamically, pending too many payments may have a negative impact
+    // on the node performance, which in worst case may lead node not response revoke_and_ack
+    // in expected time, and then the peer will disconnect us.
+    retry_send_payment_count: usize,
+}
+
+impl PaymentActorState {
+    pub fn new(args: PaymentActorArguments) -> Self {
+        let PaymentActorArguments {
+            init_command,
+            send_payment_reply,
+        } = args;
+        let payment_hash = match &init_command {
+            PaymentActorInitCommand::Send(payment_request) => payment_request.payment_hash,
+            PaymentActorInitCommand::Resume(payment_hash, _) => *payment_hash,
+        };
+        Self {
+            payment_hash,
+            init_command,
+            send_payment_reply,
+            retry_send_payment_count: 0,
+        }
+    }
+}
+
+pub struct PaymentActorArguments {
+    pub init_command: PaymentActorInitCommand,
+    pub send_payment_reply: Option<RpcReplyPort<Result<SendPaymentResponse, String>>>,
+}
+
+pub struct PaymentActor<S> {
+    // An event emitter to notify outside observers.
+    store: S,
+    network_graph: Arc<RwLock<NetworkGraph<S>>>,
+    network: ActorRef<NetworkActorMessage>,
+}
+
+#[cfg_attr(target_arch="wasm32",async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<S> Actor for PaymentActor<S>
+where
+    S: NetworkActorStateStore
+        + ChannelActorStateStore
+        + NetworkGraphStateStore
+        + GossipMessageStore
+        + PreimageStore
+        + InvoiceStore
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    type Msg = PaymentActorMessage;
+    type State = PaymentActorState;
+    type Arguments = PaymentActorArguments;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let state = PaymentActorState::new(args);
+        Ok(state)
+    }
+
+    async fn post_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let reply = state.send_payment_reply.take().unwrap_or_else(|| {
+            let (send, _recv) = oneshot::channel::<Result<_, _>>();
+            RpcReplyPort::from(send)
+        });
+        let init_msg = match &state.init_command {
+            PaymentActorInitCommand::Send(payment_request) => {
+                PaymentActorMessage::SendPayment(payment_request.clone(), reply)
+            }
+            PaymentActorInitCommand::Resume(_payment_hash, attempt_id) => {
+                PaymentActorMessage::RetrySendPayment(*attempt_id)
+            }
+        };
+        myself.send_message(init_msg).map_err(Into::into)
+    }
+
+    async fn post_stop(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        debug!("Payment actor is stopped {:?}", myself.get_name());
+        self.network
+            .send_message(NetworkActorMessage::Event(
+                NetworkActorEvent::PaymentActorStopped(state.payment_hash),
+            ))
+            .map_err(Into::into)
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        #[cfg(feature = "metrics")]
+        let start = crate::now_timestamp_as_millis_u64();
+        #[cfg(feature = "metrics")]
+        let name = format!("fiber.payment_actor.{}", message.as_ref());
+
+        if let Err(err) = self.handle_command(myself, state, message).await {
+            error!("Failed to handle payment actor command: {}", err);
+        }
+
+        #[cfg(feature = "metrics")]
+        {
+            let end = crate::now_timestamp_as_millis_u64();
+            let elapsed = end - start;
+            metrics::histogram!(name).record(elapsed as u32);
+        }
+
+        Ok(())
+    }
+}
+
+impl<S> PaymentActor<S>
+where
+    S: NetworkActorStateStore
+        + ChannelActorStateStore
+        + NetworkGraphStateStore
+        + GossipMessageStore
+        + PreimageStore
+        + InvoiceStore
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    pub fn new(
+        store: S,
+        network_graph: Arc<RwLock<NetworkGraph<S>>>,
+        network: ActorRef<NetworkActorMessage>,
+    ) -> Self {
+        Self {
+            store: store.clone(),
+            network_graph,
+            network,
+        }
+    }
+
+    // We normally don't need to manually call this to update graph from store data,
+    // because network actor will automatically update the graph when it receives
+    // updates. But in some standalone tests, we may need to manually update the graph.
+    async fn update_graph(&self) {
+        let mut graph = self.network_graph.write().await;
+        graph.load_from_store();
+    }
+
+    pub async fn handle_command(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+        command: PaymentActorMessage,
+    ) -> crate::Result<()> {
+        match command {
+            PaymentActorMessage::SendPayment(payment_request, reply) => {
+                match self
+                    .on_send_payment(myself.clone(), state, payment_request)
+                    .await
+                {
+                    Ok(payment) => {
+                        let _ = reply.send(Ok(payment));
+                        self.check_payment_final(myself, state);
+                    }
+                    Err(e) => {
+                        error!("Failed to send payment: {:?}", e);
+                        let _ = reply.send(Err(e.to_string()));
+
+                        // stop actor
+                        myself.stop(Some("Failed to send payment".to_string()));
+                    }
+                }
+            }
+            PaymentActorMessage::RetrySendPayment(attempt_id) => {
+                let _ = self
+                    .resume_payment_session(myself.clone(), state, attempt_id)
+                    .await;
+                self.check_payment_final(myself, state);
+            }
+            PaymentActorMessage::NotifyPaymentFinal => {
+                self.check_payment_final(myself, state);
+            }
+        };
+        Ok(())
+    }
+
+    fn check_payment_final(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+    ) {
+        if let Some(session) = self.store.get_payment_session(state.payment_hash) {
+            if session.status.is_final() {
+                myself.stop(Some(format!(
+                    "Payment complete with status {:?}",
+                    session.status
+                )));
+            }
+        } else {
+            error!("Can't find payment session");
+            myself.stop(Some("Can't find payment session".to_string()));
+        }
+    }
+
+    async fn update_graph_with_tlc_fail(
+        &self,
+        network: &ActorRef<NetworkActorMessage>,
+        tlc_error_detail: &TlcErr,
+    ) {
+        let error_code = tlc_error_detail.error_code();
+        // https://github.com/lightning/bolts/blob/master/04-onion-routing.md#rationale-6
+        // we now still update the graph, maybe we need to remove it later?
+        if error_code.is_update() {
+            if let Some(TlcErrData::ChannelFailed {
+                channel_update: Some(channel_update),
+                ..
+            }) = &tlc_error_detail.extra_data
+            {
+                network
+                    .send_message(NetworkActorMessage::new_command(
+                        NetworkActorCommand::BroadcastMessages(vec![
+                            BroadcastMessageWithTimestamp::ChannelUpdate(channel_update.clone()),
+                        ]),
+                    ))
+                    .expect(ASSUME_NETWORK_MYSELF_ALIVE);
+            }
+        }
+        match tlc_error_detail.error_code() {
+            TlcErrorCode::PermanentChannelFailure
+            | TlcErrorCode::ChannelDisabled
+            | TlcErrorCode::UnknownNextPeer => {
+                let channel_outpoint = tlc_error_detail
+                    .error_channel_outpoint()
+                    .expect("expect channel outpoint");
+                let mut graph = self.network_graph.write().await;
+                debug!("debug mark channel failed: {:?}", channel_outpoint);
+                graph.mark_channel_failed(&channel_outpoint);
+            }
+            TlcErrorCode::PermanentNodeFailure => {
+                let node_id = tlc_error_detail.error_node_id().expect("expect node id");
+                let mut graph = self.network_graph.write().await;
+                graph.mark_node_failed(node_id);
+            }
+            _ => {}
+        }
+    }
+
+    async fn resend_payment_attempt(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+        session: &mut PaymentSession,
+        attempt: &mut Attempt,
+    ) -> Result<(), Error> {
+        assert!(attempt.is_retrying());
+
+        if attempt.last_error.as_ref().is_some_and(|e| !e.is_empty()) {
+            // `session.remain_amount()` do not contains this part of amount,
+            // so we need to add the receiver amount to it, so we may make fewer
+            // attempts to send the payment.
+            let amount = session.remain_amount() + attempt.route.receiver_amount();
+            let max_fee = session.remain_fee_amount();
+            let graph = self.network_graph.read().await;
+
+            session.request.channel_stats = GraphChannelStat::new(Some(graph.channel_stats()));
+
+            let hops = graph
+                .build_route(amount, None, max_fee, &session.request)
+                .map_err(|e| {
+                    Error::BuildPaymentRouteError(format!("Failed to build route, {}", e))
+                })?;
+
+            attempt.update_route(hops);
+        }
+
+        self.send_attempt(myself, state, session, attempt).await?;
+        Ok(())
+    }
+
+    async fn build_payment_routes(
+        &self,
+        session: &mut PaymentSession,
+    ) -> Result<Vec<Attempt>, Error> {
+        let graph = self.network_graph.read().await;
+        let source = graph.get_source_pubkey();
+        let active_parts = session.attempts().filter(|a| a.is_active()).count();
+        let mut remain_amount = session.remain_amount();
+        let mut max_fee = session.remain_fee_amount();
+        let mut result = vec![];
+
+        if remain_amount == 0 {
+            let error = format!("Send amount {} is not expected to be 0", remain_amount);
+            self.set_payment_fail_with_error(session, &error);
+            return Err(Error::SendPaymentError(error));
+        }
+
+        session.request.channel_stats = GraphChannelStat::new(Some(graph.channel_stats()));
+        let mut attempt_id = session.attempts_count() as u64;
+        let mut target_amount = remain_amount;
+        let amount_low_bound = Some(1);
+        let mut iteration = 0;
+
+        while (result.len() < session.max_parts() - active_parts) && remain_amount > 0 {
+            iteration += 1;
+
+            debug!(
+                "build route iteration {}, target_amount: {} amount_low_bound: {:?} remain_amount: {}",
+                iteration,
+                target_amount,
+                amount_low_bound,
+                remain_amount,
+            );
+            match graph.build_route(target_amount, amount_low_bound, max_fee, &session.request) {
+                Err(e) => {
+                    let error = format!("Failed to build route, {}", e);
+                    self.set_payment_fail_with_error(session, &error);
+                    return Err(Error::SendPaymentError(error));
+                }
+                Ok(hops) => {
+                    assert_ne!(hops[0].funding_tx_hash, Hash256::default());
+                    let new_attempt_id = if session.is_dry_run() {
+                        0
+                    } else {
+                        attempt_id += 1;
+                        attempt_id
+                    };
+
+                    let attempt = session.new_attempt(
+                        new_attempt_id,
+                        source,
+                        session.request.target_pubkey,
+                        hops,
+                    );
+
+                    let session_route = &attempt.route;
+                    #[cfg(debug_assertions)]
+                    dbg!(
+                        "left amount: {}, minimal_amount: {} target amount: {}",
+                        remain_amount - session_route.receiver_amount(),
+                        target_amount,
+                        session_route.receiver_amount()
+                    );
+
+                    for (from, channel_outpoint, amount) in session_route.channel_outpoints() {
+                        if let Some(sent_node) = graph.get_channel_sent_node(channel_outpoint, from)
+                        {
+                            session.request.channel_stats.add_channel(
+                                channel_outpoint,
+                                sent_node,
+                                amount,
+                            );
+                        }
+                    }
+                    remain_amount -= session_route.receiver_amount();
+                    target_amount = remain_amount;
+                    if let Some(fee) = max_fee {
+                        max_fee = Some(fee - session_route.fee());
+                    }
+                    result.push(attempt);
+                }
+            };
+        }
+
+        if remain_amount > 0 {
+            let error = "Failed to build enough routes for MPP payment".to_string();
+            self.set_payment_fail_with_error(session, &error);
+            return Err(Error::SendPaymentError(error));
+        }
+
+        for attempt in &result {
+            session.append_attempt(attempt.clone());
+        }
+
+        return Ok(result);
+    }
+
+    async fn send_payment_onion_packet(
+        &self,
+        session: &mut PaymentSession,
+        attempt: &mut Attempt,
+    ) -> Result<(), Error> {
+        let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
+        assert_ne!(attempt.route_hops[0].funding_tx_hash, Hash256::default());
+
+        attempt.session_key.copy_from_slice(session_key.as_ref());
+
+        let peeled_onion_packet = match PeeledPaymentOnionPacket::create(
+            session_key,
+            attempt.route_hops.clone(),
+            Some(attempt.hash.as_ref().to_vec()),
+            &Secp256k1::signing_only(),
+        ) {
+            Ok(packet) => packet,
+            Err(e) => {
+                let err = format!(
+                    "Failed to create onion packet: {:?}, error: {:?}",
+                    attempt.hash, e
+                );
+                self.set_attempt_fail_with_error(session, attempt, &err, false);
+                return Err(Error::FirstHopError(err, false));
+            }
+        };
+
+        if !session.is_dry_run() {
+            self.store.insert_attempt(attempt.clone());
+        }
+
+        match call_t!(
+            self.network,
+            |tx| {
+                NetworkActorMessage::new_command(NetworkActorCommand::SendPaymentOnionPacket(
+                    SendOnionPacketCommand {
+                        peeled_onion_packet,
+                        previous_tlc: None,
+                        payment_hash: attempt.payment_hash,
+                        attempt_id: Some(attempt.id),
+                    },
+                    tx,
+                ))
+            },
+            DEFAULT_CHAIN_ACTOR_TIMEOUT
+        )
+        .expect(ASSUME_NETWORK_ACTOR_ALIVE)
+        {
+            Err(error_detail) => {
+                self.update_graph_with_tlc_fail(&self.network, &error_detail)
+                    .await;
+                let need_to_retry = self.network_graph.write().await.record_attempt_fail(
+                    attempt,
+                    error_detail.clone(),
+                    true,
+                );
+                let err = format!(
+                    "Failed to send onion packet with error {}",
+                    error_detail.error_code_as_str()
+                );
+                self.set_attempt_fail_with_error(session, attempt, &err, need_to_retry);
+                return Err(Error::FirstHopError(err, need_to_retry));
+            }
+            Ok(_) => {
+                return Ok(());
+            }
+        }
+    }
+
+    fn set_payment_fail_with_error(&self, session: &mut PaymentSession, error: &str) {
+        session.set_failed_status(error);
+        if !session.is_dry_run() {
+            self.store.insert_payment_session(session.clone());
+        }
+    }
+
+    fn set_attempt_fail_with_error(
+        &self,
+        session: &mut PaymentSession,
+        attempt: &mut Attempt,
+        error: &str,
+        retryable: bool,
+    ) {
+        if !retryable && !session.active_attempts().any(|a| a.id != attempt.id) {
+            self.set_payment_fail_with_error(session, error);
+        }
+
+        attempt.set_failed_status(error, retryable);
+        if !session.is_dry_run() {
+            self.store.insert_attempt(attempt.clone());
+        }
+    }
+
+    async fn send_attempt(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+        session: &mut PaymentSession,
+        attempt: &mut Attempt,
+    ) -> Result<(), Error> {
+        if let Err(err) = self.send_payment_onion_packet(session, attempt).await {
+            let need_retry = matches!(err, Error::FirstHopError(_, true));
+            if need_retry {
+                debug!("Retrying payment attempt due to first hop error: {:?}", err);
+                self.register_payment_retry(myself, state, Some(attempt.id));
+                return Ok(());
+            } else {
+                self.set_attempt_fail_with_error(session, attempt, &err.to_string(), false);
+                return Err(err);
+            }
+        }
+        Ok(())
+    }
+
+    /// Resume the payment session
+    async fn resume_payment_session(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+        attempt_id: Option<u64>,
+    ) -> Result<(), Error> {
+        let payment_hash = state.payment_hash;
+
+        self.update_graph().await;
+        let Some(mut session) = self.store.get_payment_session(payment_hash) else {
+            return Err(Error::InvalidParameter(payment_hash.to_string()));
+        };
+
+        if session.status.is_final() {
+            return Ok(());
+        }
+
+        self.retry_payment_attempt(myself.clone(), state, &mut session, attempt_id)
+            .await?;
+
+        if !self.payment_need_more_retry(&mut session)? {
+            return Ok(());
+        }
+
+        // here we begin to create attempts and routes for the payment session,
+        // it depends on the path finding algorithm to create how many of attempts,
+        // if a payment can not be met in the network graph, an build path error will be returned
+        // and no attempts be stored in the payment session and db.
+        let mut attempts = self
+            .build_payment_routes(&mut session)
+            .await
+            .inspect_err(|e| {
+                self.set_payment_fail_with_error(&mut session, &e.to_string());
+            })?;
+
+        for attempt in attempts.iter_mut() {
+            self.send_attempt(myself.clone(), state, &mut session, attempt)
+                .await?;
+        }
+
+        if let Ok(true) = self.payment_need_more_retry(&mut session) {
+            self.register_payment_retry(myself, state, None);
+        }
+
+        Ok(())
+    }
+
+    async fn retry_payment_attempt(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+        session: &mut PaymentSession,
+        attempt_id: Option<u64>,
+    ) -> Result<(), Error> {
+        let Some(attempt_id) = attempt_id else {
+            return Ok(());
+        };
+
+        match self.store.get_attempt(session.payment_hash(), attempt_id) {
+            Some(mut attempt) if attempt.is_retrying() => {
+                match self
+                    .resend_payment_attempt(myself, state, session, &mut attempt)
+                    .await
+                {
+                    Err(err) if session.allow_mpp() => {
+                        // usually `resend_payment_route` will only try build a route with same amount,
+                        // because most of the time, resend payment caused by the first hop
+                        // error with WaitingTlcAck, if resend failed we should try more attempts in MPP,
+                        // so we may create more attempts with different split amounts
+                        attempt.set_failed_status(&err.to_string(), false);
+                        self.store.insert_attempt(attempt);
+                    }
+                    Err(err) => {
+                        self.set_attempt_fail_with_error(
+                            session,
+                            &mut attempt,
+                            &err.to_string(),
+                            false,
+                        );
+                        return Err(err);
+                    }
+                    _ => {}
+                }
+            }
+            Some(_) => {
+                // no retry for non-retryable attempts
+            }
+            None => {
+                return Err(Error::InvalidParameter(format!(
+                    "Attempt with id {:?} not found for payment hash: {:?}",
+                    attempt_id,
+                    session.payment_hash()
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn payment_need_more_retry(&self, session: &mut PaymentSession) -> Result<bool, Error> {
+        session.flush_attempts(&self.store);
+        let more_attempt = session.allow_more_attempts();
+        if !more_attempt && session.remain_amount() > 0 {
+            let err = "Can not send payment with limited attempts";
+            self.set_payment_fail_with_error(session, err);
+            return Err(Error::SendPaymentError(err.to_string()));
+        }
+        Ok(more_attempt)
+    }
+
+    fn register_payment_retry(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+        attempt_id: Option<u64>,
+    ) {
+        // This is a performance tuning result, the basic idea is when there are more pending
+        // retrying payment in ractor framework, we will increase the delay time to avoid
+        // flooding the network actor with too many retrying payments.
+        state.retry_send_payment_count += 1;
+        let delay = (state.retry_send_payment_count as u64) * 20_u64;
+        myself.send_after(Duration::from_millis(delay), move || {
+            PaymentActorMessage::RetrySendPayment(attempt_id)
+        });
+    }
+
+    async fn on_send_payment(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+        payment_data: SendPaymentData,
+    ) -> Result<SendPaymentResponse, Error> {
+        self.send_payment_with_payment_data(myself, state, payment_data)
+            .await
+    }
+
+    async fn send_payment_with_payment_data(
+        &self,
+        myself: ActorRef<PaymentActorMessage>,
+        state: &mut PaymentActorState,
+        payment_data: SendPaymentData,
+    ) -> Result<SendPaymentResponse, Error> {
+        // initialize the payment session in db and begin the payment process lifecycle
+        if let Some(payment_session) = self.store.get_payment_session(payment_data.payment_hash) {
+            // we only allow retrying payment session with status failed
+            if payment_session.status != PaymentStatus::Failed {
+                return Err(Error::InvalidParameter(format!(
+                    "Payment session already exists: {} with payment session status: {:?}",
+                    payment_data.payment_hash, payment_session.status
+                )));
+            } else {
+                // even if the payment session is failed, we still need to check whether
+                // some attempts are still flight state, this means some middle hops
+                // haven't send back the result of the onion packet, so we can not retry the payment session
+                // otherwise, we are sure it's safe to cleanup all the previous attempts
+                if payment_session.attempts().any(|a| a.is_inflight()) {
+                    return Err(Error::InvalidParameter(format!(
+                        "Payment session {} has attempts that are in flight state, can not retry",
+                        payment_data.payment_hash
+                    )));
+                }
+                if !payment_data.dry_run {
+                    self.store.delete_attempts(payment_data.payment_hash);
+                }
+            }
+        }
+
+        // for dry run, we only build the route and return the hops info,
+        // will not store the payment session and send the onion packet
+        if payment_data.dry_run {
+            let mut payment_session = PaymentSession::new(&self.store, payment_data, 0);
+            self.build_payment_routes(&mut payment_session).await?;
+            return Ok(payment_session.into());
+        }
+
+        let try_limit = if payment_data.allow_mpp() {
+            payment_data.max_parts() as u32 * DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT
+        } else {
+            DEFAULT_PAYMENT_TRY_LIMIT
+        };
+        let mut payment_session = PaymentSession::new(&self.store, payment_data, try_limit);
+        assert!(payment_session.attempts_count() == 0);
+        self.store.insert_payment_session(payment_session.clone());
+
+        self.resume_payment_session(myself, state, None).await?;
+        payment_session.flush_attempts(&self.store);
+        return Ok(payment_session.into());
     }
 }

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -10,10 +10,8 @@ use crate::fiber::config::{
 };
 use crate::fiber::features::FeatureVector;
 use crate::fiber::graph::ChannelInfo;
-use crate::fiber::network::{
-    DebugEvent, FiberMessageWithPeerId, PeerDisconnectReason, SendPaymentCommand,
-};
-use crate::fiber::payment::PaymentStatus;
+use crate::fiber::network::{DebugEvent, FiberMessageWithPeerId, PeerDisconnectReason};
+use crate::fiber::payment::{PaymentStatus, SendPaymentCommand};
 use crate::fiber::types::{
     AddTlc, FiberMessage, Hash256, Init, PaymentHopData, PeeledPaymentOnionPacket, Pubkey, TlcErr,
     TlcErrorCode, NO_SHARED_SECRET,

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -8,7 +8,8 @@ use crate::fiber::types::{ChannelUpdateChannelFlags, ChannelUpdateMessageFlags, 
 use crate::{
     fiber::{
         graph::{NetworkGraph, RouterHop},
-        network::{get_chain_hash, SendPaymentCommand, SendPaymentData},
+        network::{get_chain_hash, SendPaymentData},
+        payment::SendPaymentCommand,
         types::{ChannelAnnouncement, ChannelUpdate, Hash256, NodeAnnouncement},
     },
     store::Store,

--- a/crates/fiber-lib/src/fiber/tests/invoice_settlement.rs
+++ b/crates/fiber-lib/src/fiber/tests/invoice_settlement.rs
@@ -1,5 +1,5 @@
 use crate::fiber::hash_algorithm::HashAlgorithm;
-use crate::fiber::network::SendPaymentCommand;
+use crate::fiber::payment::SendPaymentCommand;
 use crate::fiber::types::Hash256;
 use crate::gen_rand_sha256_hash;
 use crate::invoice::{

--- a/crates/fiber-lib/src/fiber/tests/mpp.rs
+++ b/crates/fiber-lib/src/fiber/tests/mpp.rs
@@ -11,8 +11,10 @@ use crate::{
         config::{CKB_SHANNONS, DEFAULT_TLC_EXPIRY_DELTA, PAYMENT_MAX_PARTS_LIMIT},
         features::FeatureVector,
         hash_algorithm::HashAlgorithm,
-        network::{DebugEvent, SendPaymentCommand, USER_CUSTOM_RECORDS_MAX_INDEX},
-        payment::{AttemptStatus, PaymentStatus},
+        network::DebugEvent,
+        payment::{
+            AttemptStatus, PaymentStatus, SendPaymentCommand, USER_CUSTOM_RECORDS_MAX_INDEX,
+        },
         types::{
             BasicMppPaymentData, Hash256, PaymentHopData, PeeledPaymentOnionPacket, RemoveTlcReason,
         },

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -13,9 +13,9 @@ use crate::{
         gossip::{GossipActorMessage, GossipMessageStore},
         graph::ChannelUpdateInfo,
         network::{
-            AcceptChannelCommand, NetworkActorStateStore, OpenChannelCommand, SendPaymentCommand,
-            SendPaymentData,
+            AcceptChannelCommand, NetworkActorStateStore, OpenChannelCommand, SendPaymentData,
         },
+        payment::SendPaymentCommand,
         types::{
             BroadcastMessage, BroadcastMessageWithTimestamp, BroadcastMessagesFilterResult,
             ChannelAnnouncement, ChannelUpdateChannelFlags, Cursor, GossipMessage,

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -7,12 +7,12 @@ use super::gen::fiber::{
 };
 use super::gen::gossip::{self as molecule_gossip};
 use super::hash_algorithm::{HashAlgorithm, UnknownHashAlgorithmError};
-use super::network::{get_chain_hash, PaymentCustomRecords};
+use super::network::get_chain_hash;
 use super::r#gen::fiber::PubNonceOpt;
 use super::serde_utils::{EntityHex, PubNonceAsBytes, SliceBase58, SliceHex};
 use crate::ckb::config::{UdtArgInfo, UdtCellDep, UdtCfgInfos, UdtDep, UdtScript};
 use crate::ckb::contracts::get_udt_whitelist;
-use crate::fiber::network::USER_CUSTOM_RECORDS_MAX_INDEX;
+use crate::fiber::payment::{PaymentCustomRecords, USER_CUSTOM_RECORDS_MAX_INDEX};
 
 use anyhow::anyhow;
 use bitcoin::hashes::Hash;

--- a/crates/fiber-lib/src/metrics.rs
+++ b/crates/fiber-lib/src/metrics.rs
@@ -9,6 +9,7 @@ pub const TOTAL_PEER_COUNT: &str = "fiber.total_peer_count";
 pub const INBOUND_PEER_COUNT: &str = "fiber.inbound_peer_count";
 pub const OUTBOUND_PEER_COUNT: &str = "fiber.outbound_peer_count";
 pub const DOWN_WITH_CHANNEL_PEER_COUNT: &str = "fiber.down_with_channel_peer_count";
+pub const INFLIGHT_PAYMENTS_COUNT: &str = "fiber.inflight_payments_count";
 
 pub const CCH_LND_TRACKER_INVOICE_QUEUE_LEN: &str = "fiber.cch.lnd_tracker.invoice_queue_len";
 pub const CCH_LND_TRACKER_ACTIVE_INVOICE_TRACKERS: &str =

--- a/crates/fiber-lib/src/rpc/payment.rs
+++ b/crates/fiber-lib/src/rpc/payment.rs
@@ -1,15 +1,14 @@
 use crate::fiber::graph::RouterHop;
 use crate::fiber::network::BuildRouterCommand;
 use crate::fiber::network::HopRequire;
-use crate::fiber::network::SendPaymentWithRouterCommand;
+use crate::fiber::payment::SendPaymentWithRouterCommand;
 #[cfg(debug_assertions)]
 use crate::fiber::payment::SessionRoute;
 use crate::fiber::serde_utils::SliceHex;
 use crate::fiber::serde_utils::U32Hex;
 use crate::fiber::{
     channel::ChannelActorStateStore,
-    network::{HopHint as NetworkHopHint, SendPaymentCommand},
-    payment::PaymentStatus,
+    payment::{HopHint as NetworkHopHint, PaymentStatus, SendPaymentCommand},
     serde_utils::{EntityHex, U128Hex, U64Hex},
     types::{Hash256, Pubkey},
     NetworkActorCommand, NetworkActorMessage,

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -20,7 +20,9 @@ use std::path::Path;
 use super::db_migrate::DbMigrate;
 use super::schema::*;
 use crate::fiber::gossip::GossipMessageStore;
-use crate::fiber::payment::{Attempt, AttemptStatus, PaymentSession, PaymentStatus};
+use crate::fiber::payment::{
+    Attempt, AttemptStatus, PaymentCustomRecords, PaymentSession, PaymentStatus,
+};
 use crate::fiber::types::{HoldTlc, CURSOR_SIZE};
 #[cfg(feature = "watchtower")]
 use crate::fiber::types::{Privkey, Pubkey};
@@ -29,7 +31,7 @@ use crate::{
         channel::{ChannelActorState, ChannelActorStateStore, ChannelState},
         graph::NetworkGraphStateStore,
         history::{Direction, TimedResult},
-        network::{NetworkActorStateStore, PaymentCustomRecords, PersistentNetworkActorState},
+        network::{NetworkActorStateStore, PersistentNetworkActorState},
         types::{BroadcastMessage, BroadcastMessageID, Cursor, Hash256},
     },
     invoice::{CkbInvoice, CkbInvoiceStatus, InvoiceError, InvoiceStore, PreimageStore},

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -2,7 +2,7 @@ use crate::fiber::channel::*;
 use crate::fiber::config::AnnouncedNodeName;
 use crate::fiber::features::FeatureVector;
 use crate::fiber::gossip::GossipMessageStore;
-use crate::fiber::network::PaymentCustomRecords;
+use crate::fiber::payment::PaymentCustomRecords;
 use crate::fiber::types::*;
 #[allow(unused)]
 use crate::fiber::{

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -12,6 +12,8 @@ use crate::fiber::network::*;
 use crate::fiber::payment::Attempt;
 use crate::fiber::payment::PaymentSession;
 use crate::fiber::payment::PaymentStatus;
+use crate::fiber::payment::SendPaymentCommand;
+use crate::fiber::payment::SendPaymentWithRouterCommand;
 use crate::fiber::payment::SessionRoute;
 use crate::fiber::types::EcdsaSignature;
 use crate::fiber::types::FiberMessage;
@@ -19,6 +21,7 @@ use crate::fiber::types::GossipMessage;
 use crate::fiber::types::Init;
 use crate::fiber::types::Pubkey;
 use crate::fiber::types::Shutdown;
+use crate::fiber::PaymentCustomRecords;
 use crate::fiber::ASSUME_NETWORK_ACTOR_ALIVE;
 use crate::gen_rand_sha256_hash;
 use crate::invoice::*;
@@ -97,7 +100,7 @@ use crate::{
 static RETAIN_VAR: &str = "TEST_TEMP_RETAIN";
 pub const MIN_RESERVED_CKB: u128 = 99 * CKB_SHANNONS as u128;
 pub const HUGE_CKB_AMOUNT: u128 = MIN_RESERVED_CKB + 1000000 * CKB_SHANNONS as u128;
-const DEFAULT_WAIT_UNTIL_TIME: u64 = 60 * 5; // seconds
+const DEFAULT_WAIT_UNTIL_TIME: u64 = 60 * 10; // seconds
 
 #[derive(Debug)]
 pub struct TempDir(ManuallyDrop<OldTempDir>);
@@ -891,6 +894,15 @@ impl NetworkNode {
             ..Default::default()
         })
         .await
+    }
+
+    pub async fn get_inflight_payment_count(&self) -> u32 {
+        let message = |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::GetInflightPaymentCount(rpc_reply))
+        };
+        call!(self.network_actor, message)
+            .expect("source_node alive")
+            .expect("get inflight payment count")
     }
 
     pub fn set_auth_token(&mut self, token: String) {


### PR DESCRIPTION
## Intention

Move the send payment logic from network actor to a new payment actor.
The path finding of payment blocking the network actor thread, this change will fix this problem.

## potential issue

Since we move some payment logic into payment actor, we may encounter sychronize / lock issues.

## TODO

- [x] Handle resume payment actor after channel ready
- [x] TPS benchmark regression

A new metrics is added

``` rust
pub const INFLIGHT_PAYMENTS_COUNT: &str = "fiber.inflight_payments_count";
```