### PR TITLE
feat: add logging for channel auto-accept failures

### DIFF
--- a/crates/fiber-lib/src/ckb/tests/config.rs
+++ b/crates/fiber-lib/src/ckb/tests/config.rs
@@ -2,7 +2,10 @@ use crate::ckb::config::{UdtArgInfo, UdtCellDep, UdtCfgInfos, UdtDep, UdtScript}
 use crate::fiber::gen::fiber::UdtCfgInfos as MoleculeUdtCfgInfos;
 use ckb_jsonrpc_types::OutPoint;
 use ckb_types::core::{DepType, ScriptHashType};
+use ckb_types::packed::Script;
+use ckb_types::prelude::{Builder, Pack};
 use ckb_types::H256;
+use hex;
 use molecule::prelude::Entity;
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -29,4 +32,194 @@ fn test_udt_whitelist() {
     let deserialized =
         UdtCfgInfos::from(MoleculeUdtCfgInfos::from_slice(&serialized).expect("invalid mol"));
     assert_eq!(udt_whitelist, deserialized);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_find_matching_udt_exact_match() {
+    let code_hash = H256::from([1u8; 32]);
+    let args = "0x1234".to_string();
+    let udt_whitelist = UdtCfgInfos(vec![UdtArgInfo {
+        name: "TestUDT".to_string(),
+        script: UdtScript {
+            code_hash: code_hash.clone(),
+            hash_type: ScriptHashType::Data,
+            args: args.clone(),
+        },
+        auto_accept_amount: Some(100),
+        cell_deps: vec![],
+    }]);
+
+    let args_bytes = hex::decode(&args[2..]).unwrap();
+    let script = Script::new_builder()
+        .code_hash(code_hash.pack())
+        .hash_type(ScriptHashType::Data.into())
+        .args(args_bytes.pack())
+        .build();
+
+    let found = udt_whitelist.find_matching_udt(&script);
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().name, "TestUDT");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_find_matching_udt_regex_pattern() {
+    let code_hash = H256::from([2u8; 32]);
+    let udt_whitelist = UdtCfgInfos(vec![UdtArgInfo {
+        name: "RegexUDT".to_string(),
+        script: UdtScript {
+            code_hash: code_hash.clone(),
+            hash_type: ScriptHashType::Data,
+            args: "0x[0-9a-f]{4}".to_string(), // Regex pattern matching 4 hex digits
+        },
+        auto_accept_amount: Some(200),
+        cell_deps: vec![],
+    }]);
+
+    // Test with matching args
+    let args_bytes = hex::decode("abcd").unwrap();
+    let script = Script::new_builder()
+        .code_hash(code_hash.pack())
+        .hash_type(ScriptHashType::Data.into())
+        .args(args_bytes.pack())
+        .build();
+
+    let found = udt_whitelist.find_matching_udt(&script);
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().name, "RegexUDT");
+
+    // Test with non-matching args
+    let args_bytes_no_match = hex::decode("ab").unwrap(); // Only 2 hex digits (1 byte), doesn't match pattern
+    let script_no_match = Script::new_builder()
+        .code_hash(code_hash.pack())
+        .hash_type(ScriptHashType::Data.into())
+        .args(args_bytes_no_match.pack())
+        .build();
+
+    let found = udt_whitelist.find_matching_udt(&script_no_match);
+    assert!(found.is_none());
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_find_matching_udt_wrong_code_hash() {
+    let code_hash1 = H256::from([3u8; 32]);
+    let code_hash2 = H256::from([4u8; 32]);
+    let udt_whitelist = UdtCfgInfos(vec![UdtArgInfo {
+        name: "TestUDT".to_string(),
+        script: UdtScript {
+            code_hash: code_hash1.clone(),
+            hash_type: ScriptHashType::Data,
+            args: "0x00".to_string(),
+        },
+        auto_accept_amount: Some(100),
+        cell_deps: vec![],
+    }]);
+
+    let args_bytes = hex::decode("00").unwrap();
+    let script = Script::new_builder()
+        .code_hash(code_hash2.pack()) // Different code_hash
+        .hash_type(ScriptHashType::Data.into())
+        .args(args_bytes.pack())
+        .build();
+
+    let found = udt_whitelist.find_matching_udt(&script);
+    assert!(found.is_none());
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_find_matching_udt_wrong_hash_type() {
+    let code_hash = H256::from([5u8; 32]);
+    let udt_whitelist = UdtCfgInfos(vec![UdtArgInfo {
+        name: "TestUDT".to_string(),
+        script: UdtScript {
+            code_hash: code_hash.clone(),
+            hash_type: ScriptHashType::Data,
+            args: "0x00".to_string(),
+        },
+        auto_accept_amount: Some(100),
+        cell_deps: vec![],
+    }]);
+
+    let args_bytes = hex::decode("00").unwrap();
+    let script = Script::new_builder()
+        .code_hash(code_hash.pack())
+        .hash_type(ScriptHashType::Type.into()) // Different hash_type
+        .args(args_bytes.pack())
+        .build();
+
+    let found = udt_whitelist.find_matching_udt(&script);
+    assert!(found.is_none());
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_find_matching_udt_multiple_udts() {
+    let code_hash1 = H256::from([6u8; 32]);
+    let code_hash2 = H256::from([7u8; 32]);
+    let udt_whitelist = UdtCfgInfos(vec![
+        UdtArgInfo {
+            name: "FirstUDT".to_string(),
+            script: UdtScript {
+                code_hash: code_hash1.clone(),
+                hash_type: ScriptHashType::Data,
+                args: "0x00".to_string(),
+            },
+            auto_accept_amount: Some(100),
+            cell_deps: vec![],
+        },
+        UdtArgInfo {
+            name: "SecondUDT".to_string(),
+            script: UdtScript {
+                code_hash: code_hash2.clone(),
+                hash_type: ScriptHashType::Data,
+                args: "0x01".to_string(),
+            },
+            auto_accept_amount: Some(200),
+            cell_deps: vec![],
+        },
+    ]);
+
+    // Test finding first UDT
+    let args_bytes1 = hex::decode("00").unwrap();
+    let script1 = Script::new_builder()
+        .code_hash(code_hash1.pack())
+        .hash_type(ScriptHashType::Data.into())
+        .args(args_bytes1.pack())
+        .build();
+
+    let found = udt_whitelist.find_matching_udt(&script1);
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().name, "FirstUDT");
+
+    // Test finding second UDT
+    let args_bytes2 = hex::decode("01").unwrap();
+    let script2 = Script::new_builder()
+        .code_hash(code_hash2.pack())
+        .hash_type(ScriptHashType::Data.into())
+        .args(args_bytes2.pack())
+        .build();
+
+    let found = udt_whitelist.find_matching_udt(&script2);
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().name, "SecondUDT");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_find_matching_udt_empty_whitelist() {
+    let udt_whitelist = UdtCfgInfos(vec![]);
+    let code_hash = H256::from([8u8; 32]);
+
+    let args_bytes = hex::decode("00").unwrap();
+    let script = Script::new_builder()
+        .code_hash(code_hash.pack())
+        .hash_type(ScriptHashType::Data.into())
+        .args(args_bytes.pack())
+        .build();
+
+    let found = udt_whitelist.find_matching_udt(&script);
+    assert!(found.is_none());
 }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -74,7 +74,9 @@ use super::{
     ASSUME_NETWORK_ACTOR_ALIVE,
 };
 use crate::ckb::config::UdtCfgInfos;
-use crate::ckb::contracts::{check_udt_script, get_udt_whitelist, is_udt_type_auto_accept};
+use crate::ckb::contracts::{
+    check_udt_script, get_udt_info, get_udt_whitelist, is_udt_type_auto_accept,
+};
 use crate::ckb::{CkbChainMessage, FundingError, FundingRequest, FundingTx, GetShutdownTxResponse};
 use crate::fiber::channel::{
     tlc_expiry_delay, AddTlcCommand, AddTlcResponse, ChannelActorState, ChannelEphemeralConfig,
@@ -692,6 +694,7 @@ where
             FiberMessage::ChannelInitialization(open_channel) => {
                 state.check_feature_compatibility(&peer_id)?;
                 let temp_channel_id = open_channel.channel_id;
+                let peer_id_for_logging = peer_id.clone();
                 match state
                     .on_open_channel_msg(peer_id, open_channel.clone())
                     .await
@@ -722,6 +725,14 @@ where
                                 tlc_expiry_delta: None,
                             };
                             state.create_inbound_channel(accept_channel).await?;
+                        } else {
+                            // Log warning when auto-accept fails
+                            state.log_receiver_auto_accept_failure(
+                                &peer_id_for_logging,
+                                &open_channel,
+                                temp_channel_id,
+                            );
+                            debug_event!(myself, "ChannelAutoAcceptFailed");
                         }
                     }
                     Err(err) => {
@@ -1692,7 +1703,11 @@ where
                 }
             }
             NetworkActorCommand::OpenChannel(open_channel, reply) => {
-                match state.create_outbound_channel(open_channel).await {
+                let network_graph = self.network_graph.clone();
+                match state
+                    .create_outbound_channel(open_channel, network_graph)
+                    .await
+                {
                     Ok((_, channel_id)) => {
                         let _ = reply.send(Ok(OpenChannelResponse { channel_id }));
                     }
@@ -2855,9 +2870,199 @@ where
         result
     }
 
+    /// Check peer's node announcement and log warnings if funding amount is insufficient for auto-accept
+    fn check_and_log_peer_auto_accept_requirements(
+        node_info: &super::graph::NodeInfo,
+        peer_id: &PeerId,
+        funding_amount: u128,
+        funding_udt_type_script: &Option<Script>,
+    ) {
+        if !tracing::enabled!(tracing::Level::WARN) {
+            return;
+        }
+        if let Some(udt_type_script) = funding_udt_type_script.as_ref() {
+            Self::log_sender_udt_funding_warning(
+                node_info,
+                peer_id,
+                funding_amount,
+                udt_type_script,
+            );
+        } else {
+            Self::log_sender_ckb_funding_warning(node_info, peer_id, funding_amount);
+        }
+    }
+
+    /// Log warning when opening channel with UDT funding amount is insufficient for peer's auto-accept
+    fn log_sender_udt_funding_warning(
+        node_info: &super::graph::NodeInfo,
+        peer_id: &PeerId,
+        funding_amount: u128,
+        udt_type_script: &Script,
+    ) {
+        if !tracing::enabled!(tracing::Level::WARN) {
+            return;
+        }
+        if let Some(udt_cfg_info) = node_info.udt_cfg_infos.find_matching_udt(udt_type_script) {
+            if let Some(auto_accept_amount) = udt_cfg_info.auto_accept_amount {
+                if funding_amount < auto_accept_amount {
+                    warn!(
+                        "Opening channel to peer {:?} (node: {:?}) with UDT {:?} (name: {:?}) funding amount {} is less than peer's announced auto-accept minimum {}. The channel may not be auto-accepted.",
+                        peer_id,
+                        node_info.node_name,
+                        udt_type_script,
+                        udt_cfg_info.name,
+                        funding_amount,
+                        auto_accept_amount
+                    );
+                }
+            } else {
+                warn!(
+                    "Opening channel to peer {:?} (node: {:?}) with UDT {:?} (name: {:?}). Peer has this UDT configured but auto-accept is not enabled. The channel may not be auto-accepted.",
+                    peer_id,
+                    node_info.node_name,
+                    udt_type_script,
+                    udt_cfg_info.name
+                );
+            }
+        } else {
+            warn!(
+                "Opening channel to peer {:?} (node: {:?}) with UDT {:?}. UDT type not found in peer's udt_cfg_infos. The channel may not be auto-accepted.",
+                peer_id,
+                node_info.node_name,
+                udt_type_script
+            );
+        }
+    }
+
+    /// Log warning when opening channel with CKB funding amount is insufficient for peer's auto-accept
+    fn log_sender_ckb_funding_warning(
+        node_info: &super::graph::NodeInfo,
+        peer_id: &PeerId,
+        funding_amount: u128,
+    ) {
+        if !tracing::enabled!(tracing::Level::WARN) {
+            return;
+        }
+        if node_info.auto_accept_min_ckb_funding_amount == 0 {
+            warn!(
+                "Opening channel to peer {:?} (node: {:?}) with CKB funding amount {}. Auto-accept is disabled (auto_accept_min_ckb_funding_amount is 0). The channel may not be auto-accepted.",
+                peer_id,
+                node_info.node_name,
+                funding_amount
+            );
+        } else if funding_amount < node_info.auto_accept_min_ckb_funding_amount as u128 {
+            warn!(
+                "Opening channel to peer {:?} (node: {:?}) with CKB funding amount {} is less than peer's announced auto-accept minimum {}. The channel may not be auto-accepted.",
+                peer_id,
+                node_info.node_name,
+                funding_amount,
+                node_info.auto_accept_min_ckb_funding_amount
+            );
+        }
+    }
+
+    /// Log warning when auto-accept fails for a received OpenChannel request
+    fn log_receiver_auto_accept_failure(
+        &self,
+        peer_id: &PeerId,
+        open_channel: &OpenChannel,
+        temp_channel_id: Hash256,
+    ) {
+        if !tracing::enabled!(tracing::Level::WARN) {
+            return;
+        }
+        if let Some(udt_type_script) = open_channel.funding_udt_type_script.as_ref() {
+            Self::log_receiver_udt_auto_accept_failure(
+                peer_id,
+                udt_type_script,
+                open_channel.funding_amount,
+                temp_channel_id,
+            );
+        } else {
+            Self::log_receiver_ckb_auto_accept_failure(
+                peer_id,
+                open_channel.funding_amount,
+                temp_channel_id,
+                self.auto_accept_channel_ckb_funding_amount,
+                self.open_channel_auto_accept_min_ckb_funding_amount,
+            );
+        }
+    }
+
+    /// Log warning when auto-accept fails for UDT channel
+    fn log_receiver_udt_auto_accept_failure(
+        peer_id: &PeerId,
+        udt_type_script: &Script,
+        funding_amount: u128,
+        temp_channel_id: Hash256,
+    ) {
+        if !tracing::enabled!(tracing::Level::WARN) {
+            return;
+        }
+        // Find matching UDT in local whitelist
+        if let Some(udt_info) = get_udt_info(udt_type_script) {
+            if let Some(auto_accept_amount) = udt_info.auto_accept_amount {
+                warn!(
+                    "Received OpenChannel request from peer {:?} with UDT {:?} (name: {:?}) funding amount {} is less than required auto-accept minimum {}. Channel {:?} will not be auto-accepted and is pending manual acceptance.",
+                    peer_id,
+                    udt_type_script,
+                    udt_info.name,
+                    funding_amount,
+                    auto_accept_amount,
+                    temp_channel_id
+                );
+            } else {
+                warn!(
+                    "Received OpenChannel request from peer {:?} with UDT {:?} (name: {:?}). Auto-accept is not enabled for this UDT. Channel {:?} will not be auto-accepted and is pending manual acceptance.",
+                    peer_id,
+                    udt_type_script,
+                    udt_info.name,
+                    temp_channel_id
+                );
+            }
+        } else {
+            warn!(
+                "Received OpenChannel request from peer {:?} with UDT {:?} that is not configured for auto-accept. Channel {:?} will not be auto-accepted and is pending manual acceptance.",
+                peer_id,
+                udt_type_script,
+                temp_channel_id
+            );
+        }
+    }
+
+    /// Log warning when auto-accept fails for CKB channel
+    fn log_receiver_ckb_auto_accept_failure(
+        peer_id: &PeerId,
+        funding_amount: u128,
+        temp_channel_id: Hash256,
+        auto_accept_channel_ckb_funding_amount: u64,
+        open_channel_auto_accept_min_ckb_funding_amount: u64,
+    ) {
+        if !tracing::enabled!(tracing::Level::WARN) {
+            return;
+        }
+        if auto_accept_channel_ckb_funding_amount == 0 {
+            warn!(
+                "Received OpenChannel request from peer {:?} with CKB funding amount {}. Auto-accept is disabled (auto_accept_channel_ckb_funding_amount is 0). Channel {:?} will not be auto-accepted and is pending manual acceptance.",
+                peer_id,
+                funding_amount,
+                temp_channel_id
+            );
+        } else {
+            warn!(
+                "Received OpenChannel request from peer {:?} with CKB funding amount {} is less than required auto-accept minimum {}. Channel {:?} will not be auto-accepted and is pending manual acceptance.",
+                peer_id,
+                funding_amount,
+                open_channel_auto_accept_min_ckb_funding_amount,
+                temp_channel_id
+            );
+        }
+    }
+
     pub async fn create_outbound_channel(
         &mut self,
         open_channel: OpenChannelCommand,
+        network_graph: Arc<RwLock<NetworkGraph<S>>>,
     ) -> Result<(ActorRef<ChannelActorMessage>, Hash256), ProcessingChannelError> {
         let store = self.store.clone();
         let network = self.network.clone();
@@ -2885,6 +3090,18 @@ where
                     "Peer {:?} pubkey not found",
                     &peer_id
                 )))?;
+
+        // Check peer's node announcement for auto-accept requirements
+        let graph = network_graph.read().await;
+        if let Some(node_info) = graph.get_node(&remote_pubkey) {
+            Self::check_and_log_peer_auto_accept_requirements(
+                node_info,
+                &peer_id,
+                funding_amount,
+                &funding_udt_type_script,
+            );
+        }
+        drop(graph);
 
         if let Some(udt_type_script) = funding_udt_type_script.as_ref() {
             if !check_udt_script(udt_type_script) {

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -6119,6 +6119,51 @@ async fn test_funding_timeout() {
 }
 
 #[tokio::test]
+async fn test_auto_accept_fails_debug_event() {
+    let funding_amount: u128 = 100000000000;
+    let mut nodes = NetworkNode::new_n_interconnected_nodes_with_config(2, |i| {
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some(format!("node-{}", i)))
+            .base_dir_prefix(&format!("test-fnn-node-{}-", i))
+            .fiber_config_updater(move |config| {
+                if i == 1 {
+                    // Node 1 (receiver) requires more funding than what node 0 will send
+                    config.open_channel_auto_accept_min_ckb_funding_amount = Some(100000000001);
+                }
+            })
+            .build()
+    })
+    .await;
+
+    let message = |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::OpenChannel(
+            OpenChannelCommand {
+                peer_id: nodes[1].peer_id.clone(),
+                public: false,
+                shutdown_script: None,
+                funding_amount,
+                funding_udt_type_script: None,
+                commitment_fee_rate: None,
+                commitment_delay_epoch: None,
+                funding_fee_rate: None,
+                tlc_expiry_delta: None,
+                tlc_min_value: None,
+                tlc_fee_proportional_millionths: None,
+                max_tlc_number_in_flight: None,
+                max_tlc_value_in_flight: None,
+            },
+            rpc_reply,
+        ))
+    };
+    call!(nodes[0].network_actor, message)
+        .expect("node_a alive")
+        .expect("open channel success");
+
+    // Verify debug event is triggered when auto-accept fails
+    nodes[1].expect_debug_event("ChannelAutoAcceptFailed").await;
+}
+
+#[tokio::test]
 async fn test_channel_one_peer_check_active_fail() {
     init_tracing();
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive logging for channel auto-accept failures to help operators understand why channels aren't being auto-accepted, making debugging easier when channel opening fails.

## Changes

### Refactoring
- Extracted UDT matching logic into a reusable `find_matching_udt` method in `UdtCfgInfos` to avoid code duplication
- Refactored `get_udt_info` in `contracts.rs` to use the new method
- Made `get_udt_info` public to enable logging functionality

### Logging
- **Sender-side logging**: Added warnings when opening channels with insufficient funding amounts (CKB or UDT) that don't meet peer's auto-accept requirements
- **Receiver-side logging**: Added warnings when auto-accept fails for incoming channel requests, including:
  - Insufficient funding amounts
  - UDT types not configured for auto-accept
  - Auto-accept disabled scenarios
- All logging is conditional on `tracing::Level::WARN` being enabled to avoid performance overhead
- Added `ChannelAutoAcceptFailed` debug event when auto-accept fails

### Testing
- Added comprehensive unit tests for `find_matching_udt` covering:
  - Exact match scenarios
  - Regex pattern matching
  - Wrong code_hash, hash_type, and args
  - Multiple UDTs in whitelist
  - Empty whitelist
- Added integration test `test_auto_accept_fails_debug_event` to verify debug event is triggered

## Benefits

- Operators can now easily diagnose why channels aren't being auto-accepted
- Reduces debugging time by providing clear, actionable log messages
- Helps identify configuration mismatches between peers
- Maintains performance by only logging when WARN level is enabled

