### PR TITLE
feat(cch): add expiry, preimage, and invoice validations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bru -whitespace

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -448,6 +448,8 @@ impl CchState {
             {
                 return Err(CchError::WrappedBTCTypescriptMismatch);
             }
+        } else {
+            return Err(CchError::WrappedBTCTypescriptMismatch);
         }
 
         // Validate hash algorithm - must be SHA256 for LND compatibility

--- a/crates/fiber-lib/src/cch/config.rs
+++ b/crates/fiber-lib/src/cch/config.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 use clap_serde_derive::ClapSerde;
 
 /// Default cross-chain order relative expiry time in seconds.
-pub const DEFAULT_ORDER_EXPIRY_DELTA_SECONDS: u64 = 24 * 60 * 60; // 24 hours
+pub const DEFAULT_ORDER_EXPIRY_DELTA_SECONDS: u64 = 36 * 60 * 60; // 36 hours
 /// Default BTC final-hop HTLC expiry time in blocks.
-pub const DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS: u64 = 120; // 20 hours
+pub const DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS: u64 = 180; // 30 hours
 /// Default CKB final-hop HTLC expiry delta in seconds.
-pub const DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS: u64 = 20 * 60 * 60; // 20 hours
+pub const DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS: u64 = 30 * 60 * 60; // 30 hours
 /// Default minimum outgoing invoice relative expiry time in seconds.
 pub const DEFAULT_MIN_OUTGOING_INVOICE_EXPIRY_DELTA_SECONDS: u64 = 6 * 60 * 60; // 6 hours
 

--- a/crates/fiber-lib/src/cch/config.rs
+++ b/crates/fiber-lib/src/cch/config.rs
@@ -2,12 +2,14 @@ use std::path::PathBuf;
 
 use clap_serde_derive::ClapSerde;
 
-/// Default cross-chain order expiry time in seconds.
-pub const DEFAULT_ORDER_EXPIRY_TIME: u64 = 3600;
-/// Default BTC final-hop HTLC expiry time in seconds.
-pub const DEFAULT_BTC_FINAL_TLC_EXPIRY_TIME: u64 = 36;
-/// Default CKB final-hop HTLC expiry delta in timestamp (in milliseconds), 24 hours.
-pub const DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA: u64 = 24 * 60 * 60 * 1000;
+/// Default cross-chain order relative expiry time in seconds.
+pub const DEFAULT_ORDER_EXPIRY_DELTA_SECONDS: u64 = 24 * 60 * 60; // 24 hours
+/// Default BTC final-hop HTLC expiry time in blocks.
+pub const DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS: u64 = 120; // 20 hours
+/// Default CKB final-hop HTLC expiry delta in seconds.
+pub const DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS: u64 = 20 * 60 * 60; // 20 hours
+/// Default minimum outgoing invoice relative expiry time in seconds.
+pub const DEFAULT_MIN_OUTGOING_INVOICE_EXPIRY_DELTA_SECONDS: u64 = 6 * 60 * 60; // 6 hours
 
 // Use prefix `cch-`/`CCH_`
 #[derive(ClapSerde, Debug, Clone)]
@@ -56,14 +58,14 @@ pub struct CchConfig {
     pub wrapped_btc_type_script_args: String,
 
     /// Cross-chain order expiry time in seconds.
-    #[default(DEFAULT_ORDER_EXPIRY_TIME)]
+    #[default(DEFAULT_ORDER_EXPIRY_DELTA_SECONDS)]
     #[arg(
-        name = "CCH_ORDER_EXPIRY",
-        long = "cch-order-expiry",
+        name = "CCH_ORDER_EXPIRY_DELTA_SECONDS",
+        long = "cch-order-expiry-delta-seconds",
         env,
-        help = format!("order expiry time in seconds, default is {}", DEFAULT_ORDER_EXPIRY_TIME),
+        help = format!("order relative expiry time in seconds, default is {}", DEFAULT_ORDER_EXPIRY_DELTA_SECONDS),
     )]
-    pub order_expiry: u64,
+    pub order_expiry_delta_seconds: u64,
 
     #[default(0)]
     #[arg(
@@ -84,24 +86,34 @@ pub struct CchConfig {
     pub fee_rate_per_million_sats: u64,
 
     /// Final tlc expiry time for BTC network.
-    #[default(DEFAULT_BTC_FINAL_TLC_EXPIRY_TIME)]
+    #[default(DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS)]
     #[arg(
-        name = "CCH_BTC_FINAL_TLC_EXPIRY",
-        long = "cch-btc-final-tlc-expiry",
+        name = "CCH_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS",
+        long = "cch-btc-final-tlc-expiry-delta-blocks",
         env,
-        help = format!("final tlc expiry time in seconds for BTC network, default is {}", DEFAULT_BTC_FINAL_TLC_EXPIRY_TIME),
+        help = format!("final tlc relative expiry time in blocks for BTC network, default is {}", DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS),
     )]
-    pub btc_final_tlc_expiry: u64,
+    pub btc_final_tlc_expiry_delta_blocks: u64,
 
     /// Tlc expiry time for CKB network in blocks.
-    #[default(DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA)]
+    #[default(DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS)]
     #[arg(
-        name = "CCH_CKB_FINAL_TLC_EXPIRY_DELTA",
-        long = "cch-ckb-final-tlc-expiry-delta",
+        name = "CCH_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS",
+        long = "cch-ckb-final-tlc-expiry-delta-seconds",
         env,
-        help = format!("final tlc expiry delta in timestamp for CKB network, default is {}", DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA),
+        help = format!("final tlc relative expiry time in seconds for CKB network, default is {}", DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS),
     )]
-    pub ckb_final_tlc_expiry_delta: u64,
+    pub ckb_final_tlc_expiry_delta_seconds: u64,
+
+    /// Minimum acceptable relative expiry time in seconds for the cch outgoing invoice.
+    #[default(DEFAULT_MIN_OUTGOING_INVOICE_EXPIRY_DELTA_SECONDS)]
+    #[arg(
+        name = "CCH_MIN_OUTGOING_INVOICE_EXPIRY_DELTA_SECONDS",
+        long = "cch-min-outgoing-invoice-expiry-delta-seconds",
+        env,
+        help = format!("minimum acceptable relative expiry time in seconds for the cch outgoing invoice, default is {}", DEFAULT_MIN_OUTGOING_INVOICE_EXPIRY_DELTA_SECONDS),
+    )]
+    pub min_outgoing_invoice_expiry_delta_seconds: u64,
 
     /// Ignore the failure when starting the cch service.
     #[default(false)]

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -31,6 +31,8 @@ pub enum CchError {
     ReceiveBTCOrderAmountTooLarge,
     #[error("Expect preimage in settled payment but missing")]
     SettledPaymentMissingPreimage,
+    #[error("Preimage hash mismatch")]
+    PreimageHashMismatch,
     #[error("Invalid transition from {0:?} to {1:?}")]
     InvalidTransition(CchOrderStatus, CchOrderStatus),
     #[error("System time error: {0}")]

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -15,16 +15,16 @@ pub enum CchError {
     BTCInvoiceExpired,
     #[error("BTC invoice missing amount")]
     BTCInvoiceMissingAmount,
-    #[error("BTC invoice final TLC expiry delta is too small")]
-    BTCInvoiceFinalTlcExpiryDeltaTooSmall,
+    #[error("BTC invoice final TLC expiry delta exceeds safe limit for cross-chain swap")]
+    BTCInvoiceFinalTlcExpiryDeltaTooLarge,
     #[error("CKB invoice error: {0}")]
     CKBInvoiceError(#[from] crate::invoice::InvoiceError),
     #[error("CKB invoice expired")]
     CKBInvoiceExpired,
     #[error("CKB invoice missing amount")]
     CKBInvoiceMissingAmount,
-    #[error("CKB invoice final TLC expiry delta is too small")]
-    CKBInvoiceFinalTlcExpiryDeltaTooSmall,
+    #[error("CKB invoice final TLC expiry delta exceeds safe limit for cross-chain swap")]
+    CKBInvoiceFinalTlcExpiryDeltaTooLarge,
     #[error("ReceiveBTC order payment amount is too small")]
     ReceiveBTCOrderAmountTooSmall,
     #[error("ReceiveBTC order payment amount is too large")]

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -25,10 +25,14 @@ pub enum CchError {
     CKBInvoiceMissingAmount,
     #[error("CKB invoice final TLC expiry delta exceeds safe limit for cross-chain swap")]
     CKBInvoiceFinalTlcExpiryDeltaTooLarge,
+    #[error("CKB invoice hash algorithm is not SHA256, which is required for LND compatibility")]
+    CKBInvoiceIncompatibleHashAlgorithm,
     #[error("ReceiveBTC order payment amount is too small")]
     ReceiveBTCOrderAmountTooSmall,
     #[error("ReceiveBTC order payment amount is too large")]
     ReceiveBTCOrderAmountTooLarge,
+    #[error("Wrapped BTC type script mismatch")]
+    WrappedBTCTypescriptMismatch,
     #[error("Expect preimage in settled payment but missing")]
     SettledPaymentMissingPreimage,
     #[error("Preimage hash mismatch")]

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -7,16 +7,24 @@ use thiserror::Error;
 pub enum CchError {
     #[error("Database error: {0}")]
     DbError(#[from] super::order::CchDbError),
+    #[error("Outgoing invoice expiry time is too short")]
+    OutgoingInvoiceExpiryTooShort,
     #[error("BTC invoice parse error: {0}")]
     BTCInvoiceParseError(#[from] lightning_invoice::ParseOrSemanticError),
     #[error("BTC invoice expired")]
     BTCInvoiceExpired,
     #[error("BTC invoice missing amount")]
     BTCInvoiceMissingAmount,
+    #[error("BTC invoice final TLC expiry delta is too small")]
+    BTCInvoiceFinalTlcExpiryDeltaTooSmall,
     #[error("CKB invoice error: {0}")]
     CKBInvoiceError(#[from] crate::invoice::InvoiceError),
+    #[error("CKB invoice expired")]
+    CKBInvoiceExpired,
     #[error("CKB invoice missing amount")]
     CKBInvoiceMissingAmount,
+    #[error("CKB invoice final TLC expiry delta is too small")]
+    CKBInvoiceFinalTlcExpiryDeltaTooSmall,
     #[error("ReceiveBTC order payment amount is too small")]
     ReceiveBTCOrderAmountTooSmall,
     #[error("ReceiveBTC order payment amount is too large")]

--- a/crates/fiber-lib/src/cch/mod.rs
+++ b/crates/fiber-lib/src/cch/mod.rs
@@ -8,10 +8,7 @@ mod trackers;
 pub use trackers::CchFiberStoreWatcher;
 
 mod config;
-pub use config::{
-    CchConfig, DEFAULT_BTC_FINAL_TLC_EXPIRY_TIME, DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA,
-    DEFAULT_ORDER_EXPIRY_TIME,
-};
+pub use config::CchConfig;
 
 mod order;
 pub use order::{CchDbError, CchInvoice, CchOrder, CchOrderStatus, CchOrdersDb};

--- a/crates/fiber-lib/src/cch/order/mod.rs
+++ b/crates/fiber-lib/src/cch/order/mod.rs
@@ -40,12 +40,9 @@ pub struct CchOrder {
     // Seconds since epoch when the order is created
     #[serde_as(as = "U64Hex")]
     pub created_at: u64,
-    // Seconds after timestamp that the order expires
+    // Relative expiry time in seconds from `created_at` that the order expires
     #[serde_as(as = "U64Hex")]
-    pub expires_after: u64,
-    // The minimal expiry delta in milliseconds of the final TLC hop in the CKB network
-    #[serde_as(as = "U64Hex")]
-    pub ckb_final_tlc_expiry_delta: u64,
+    pub expiry_delta_seconds: u64,
 
     pub wrapped_btc_type_script: ckb_jsonrpc_types::Script,
 

--- a/crates/fiber-lib/src/cch/order/mod.rs
+++ b/crates/fiber-lib/src/cch/order/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod state_machine;
 mod status;
 
 pub use db::{CchDbError, CchOrdersDb};
-pub use state_machine::{CchOrderAction, CchOrderStateMachine, CchOrderTransition};
+pub use state_machine::CchOrderStateMachine;
 pub use status::CchOrderStatus;
 
 use lightning_invoice::Bolt11Invoice;

--- a/crates/fiber-lib/src/cch/order/state_machine.rs
+++ b/crates/fiber-lib/src/cch/order/state_machine.rs
@@ -18,57 +18,24 @@ pub enum CchOrderEvent {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CchOrderAction {
-    TrackIncomingInvoice,
-    SendOutgoingPayment,
-    TrackOutgoingPayment,
-    SettleIncomingInvoice,
-}
-
-/// The state machine transition result contains the new order and the actions to be taken.
-#[derive(Debug, Clone)]
-pub struct CchOrderTransition {
-    pub order: CchOrder,
-    /// Whether the order has been modified.
-    pub dirty: bool,
-    pub actions: Vec<CchOrderAction>,
-}
-
 pub struct CchOrderStateMachine;
 
 impl CchOrderStateMachine {
-    /// The actions to be taken when the order enters a new status.
-    pub fn on_entering(order: &CchOrder) -> Vec<CchOrderAction> {
-        match order.status {
-            CchOrderStatus::Pending => vec![CchOrderAction::TrackIncomingInvoice],
-            CchOrderStatus::IncomingAccepted => vec![
-                CchOrderAction::SendOutgoingPayment,
-                CchOrderAction::TrackOutgoingPayment,
-            ],
-            CchOrderStatus::OutgoingInFlight => vec![CchOrderAction::TrackOutgoingPayment],
-            CchOrderStatus::OutgoingSucceeded => vec![CchOrderAction::SettleIncomingInvoice],
-            CchOrderStatus::Succeeded => vec![],
-            CchOrderStatus::Failed => vec![],
-        }
-    }
-
     /// Apply an event to the order and return the transition.
+    ///
+    /// Returns `Ok(Some(new_status))` if the order is transit to a new status.
+    /// or `Ok(None)` if the order stays in the same status without changes.
     pub fn apply(
-        mut order: CchOrder,
+        order: &mut CchOrder,
         event: CchOrderEvent,
-    ) -> Result<CchOrderTransition, CchError> {
-        let prev_status = order.status;
-
+    ) -> Result<Option<CchOrderStatus>, CchError> {
         match event {
             CchOrderEvent::IncomingInvoiceChanged {
                 status,
                 failure_reason,
-            } => {
-                Self::try_transite_to(&mut order, status.into(), move || {
-                    failure_reason.unwrap_or_else(|| format!("incoming invoice failed: {}", status))
-                })?;
-            }
+            } => Self::try_transite_to(order, status.into(), move || {
+                failure_reason.unwrap_or_else(|| format!("incoming invoice failed: {}", status))
+            }),
             CchOrderEvent::OutgoingPaymentChanged {
                 status,
                 payment_preimage,
@@ -77,28 +44,16 @@ impl CchOrderStateMachine {
                 if status == PaymentStatus::Success && payment_preimage.is_none() {
                     return Err(CchError::SettledPaymentMissingPreimage);
                 }
-                Self::try_transite_to(&mut order, status.into(), move || {
+                let new_status = Self::try_transite_to(order, status.into(), move || {
                     failure_reason
                         .unwrap_or_else(|| format!("outgoing payment failed: {:?}", status))
                 })?;
-                if order.payment_preimage.is_none() {
+                if new_status.is_some() && order.payment_preimage.is_none() {
                     order.payment_preimage = payment_preimage;
                 }
+                Ok(new_status)
             }
         }
-
-        // Currently we won't modify the order unless after a transition to a new status.
-        let dirty = order.status != prev_status;
-        let actions = if dirty {
-            Self::on_entering(&order)
-        } else {
-            vec![]
-        };
-        Ok(CchOrderTransition {
-            order,
-            dirty,
-            actions,
-        })
     }
 
     fn allow_transition(from: CchOrderStatus, to: CchOrderStatus) -> bool {
@@ -123,18 +78,22 @@ impl CchOrderStateMachine {
         order: &mut CchOrder,
         to: CchOrderStatus,
         failure_reason_fn: F,
-    ) -> Result<(), CchError>
+    ) -> Result<Option<CchOrderStatus>, CchError>
     where
         F: FnOnce() -> String,
     {
         if !Self::allow_transition(order.status, to) {
             return Err(CchError::InvalidTransition(order.status, to));
         }
-        order.status = to;
-        if to == CchOrderStatus::Failed {
-            order.failure_reason = Some(failure_reason_fn());
+        if order.status != to {
+            order.status = to;
+            if to == CchOrderStatus::Failed {
+                order.failure_reason = Some(failure_reason_fn());
+            }
+            Ok(Some(to))
+        } else {
+            Ok(None)
         }
-        Ok(())
     }
 }
 

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -297,6 +297,8 @@ async fn setup_test_harness() -> TestHarness {
     let config = CchConfig {
         lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
         wrapped_btc_type_script_args: "0x".to_string(),
+        // Use a low minimum expiry for testing (test invoices have 1-hour expiry)
+        min_outgoing_invoice_expiry_delta_seconds: 60,
         ..Default::default()
     };
 
@@ -468,8 +470,7 @@ async fn test_receive_btc_happy_path() {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs(),
-        expires_after: 3600,
-        ckb_final_tlc_expiry_delta: 40,
+        expiry_delta_seconds: 3600,
         wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
         outgoing_pay_req: fiber_invoice.to_string(),
         incoming_invoice: CchInvoice::Lightning(lightning_invoice),

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -344,12 +344,14 @@ fn create_test_lightning_invoice() -> lightning_invoice::Bolt11Invoice {
     let payment_secret = lightning_invoice::PaymentSecret([0u8; 32]);
 
     // Build the invoice with current timestamp (will be valid for 1 hour)
+    // Use 36 blocks (~6 hours) for final CLTV, which is less than half of the default
+    // CKB final TLC expiry (20 hours), satisfying the cross-chain safety requirement.
     LnInvoiceBuilder::new(LnCurrency::Bitcoin)
         .description("test invoice".to_string())
         .payment_hash(payment_hash)
         .payment_secret(payment_secret)
         .current_timestamp()
-        .min_final_cltv_expiry_delta(144)
+        .min_final_cltv_expiry_delta(36)
         .amount_milli_satoshis(100_000_000) // 100k sats
         .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &private_key))
         .expect("build lightning invoice")

--- a/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
@@ -32,8 +32,7 @@ fn create_order_with_lightning_invoice(status: CchOrderStatus) -> CchOrder {
 
     CchOrder {
         created_at: 1000,
-        expires_after: 3600,
-        ckb_final_tlc_expiry_delta: 86400000,
+        expiry_delta_seconds: 3600,
         wrapped_btc_type_script: ckb_jsonrpc_types::Script {
             code_hash: Default::default(),
             hash_type: ckb_jsonrpc_types::ScriptHashType::Data,
@@ -88,8 +87,7 @@ fn create_order_with_fiber_invoice(status: CchOrderStatus) -> CchOrder {
 
     CchOrder {
         created_at: 1000,
-        expires_after: 3600,
-        ckb_final_tlc_expiry_delta: 86400000,
+        expiry_delta_seconds: 3600,
         wrapped_btc_type_script: ckb_jsonrpc_types::Script {
             code_hash: Default::default(),
             hash_type: ckb_jsonrpc_types::ScriptHashType::Data,

--- a/crates/fiber-lib/src/cch/tests/state_machine_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/state_machine_tests.rs
@@ -30,8 +30,7 @@ fn create_test_order(status: CchOrderStatus) -> CchOrder {
 
     CchOrder {
         created_at: 1700000000,
-        expires_after: 3600,
-        ckb_final_tlc_expiry_delta: 86400000,
+        expiry_delta_seconds: 3600,
         wrapped_btc_type_script: ckb_jsonrpc_types::Script {
             code_hash: Default::default(),
             hash_type: ckb_jsonrpc_types::ScriptHashType::Data,

--- a/crates/fiber-lib/src/cch/tests/state_machine_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/state_machine_tests.rs
@@ -7,8 +7,7 @@
 //! - Failure transitions from any state
 
 use crate::cch::order::{
-    state_machine::CchOrderEvent, CchInvoice, CchOrder, CchOrderAction, CchOrderStateMachine,
-    CchOrderStatus,
+    state_machine::CchOrderEvent, CchInvoice, CchOrder, CchOrderStateMachine, CchOrderStatus,
 };
 use crate::cch::CchError;
 use crate::fiber::payment::PaymentStatus;
@@ -50,115 +49,51 @@ fn create_test_order(status: CchOrderStatus) -> CchOrder {
 }
 
 // ============================================================================
-// Tests for on_entering actions
-// ============================================================================
-
-#[test]
-fn test_on_entering_pending_returns_track_incoming_invoice() {
-    let order = create_test_order(CchOrderStatus::Pending);
-    let actions = CchOrderStateMachine::on_entering(&order);
-    assert_eq!(actions, vec![CchOrderAction::TrackIncomingInvoice]);
-}
-
-#[test]
-fn test_on_entering_incoming_accepted_returns_send_and_track_payment() {
-    let order = create_test_order(CchOrderStatus::IncomingAccepted);
-    let actions = CchOrderStateMachine::on_entering(&order);
-    assert_eq!(
-        actions,
-        vec![
-            CchOrderAction::SendOutgoingPayment,
-            CchOrderAction::TrackOutgoingPayment,
-        ]
-    );
-}
-
-#[test]
-fn test_on_entering_outgoing_in_flight_returns_track_payment() {
-    let order = create_test_order(CchOrderStatus::OutgoingInFlight);
-    let actions = CchOrderStateMachine::on_entering(&order);
-    assert_eq!(actions, vec![CchOrderAction::TrackOutgoingPayment]);
-}
-
-#[test]
-fn test_on_entering_outgoing_succeeded_returns_settle_invoice() {
-    let order = create_test_order(CchOrderStatus::OutgoingSucceeded);
-    let actions = CchOrderStateMachine::on_entering(&order);
-    assert_eq!(actions, vec![CchOrderAction::SettleIncomingInvoice]);
-}
-
-#[test]
-fn test_on_entering_succeeded_returns_empty() {
-    let order = create_test_order(CchOrderStatus::Succeeded);
-    let actions = CchOrderStateMachine::on_entering(&order);
-    assert!(actions.is_empty());
-}
-
-#[test]
-fn test_on_entering_failed_returns_empty() {
-    let order = create_test_order(CchOrderStatus::Failed);
-    let actions = CchOrderStateMachine::on_entering(&order);
-    assert!(actions.is_empty());
-}
-
-// ============================================================================
 // Tests for valid state transitions via invoice events
 // ============================================================================
 
 #[test]
 fn test_transition_pending_to_incoming_accepted_via_invoice_received() {
-    let order = create_test_order(CchOrderStatus::Pending);
+    let mut order = create_test_order(CchOrderStatus::Pending);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Received,
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::IncomingAccepted);
-    assert_eq!(
-        transition.actions,
-        vec![
-            CchOrderAction::SendOutgoingPayment,
-            CchOrderAction::TrackOutgoingPayment,
-        ]
-    );
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::IncomingAccepted);
 }
 
 #[test]
 fn test_transition_pending_to_failed_via_invoice_cancelled() {
-    let order = create_test_order(CchOrderStatus::Pending);
+    let mut order = create_test_order(CchOrderStatus::Pending);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Cancelled,
         failure_reason: Some("cancelled by user".to_string()),
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Failed);
-    assert_eq!(
-        transition.order.failure_reason,
-        Some("cancelled by user".to_string())
-    );
-    assert!(transition.actions.is_empty());
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Failed);
+    assert_eq!(order.failure_reason, Some("cancelled by user".to_string()));
 }
 
 #[test]
 fn test_transition_pending_to_failed_via_invoice_expired() {
-    let order = create_test_order(CchOrderStatus::Pending);
+    let mut order = create_test_order(CchOrderStatus::Pending);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Expired,
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Failed);
-    assert!(transition.order.failure_reason.is_some());
-    assert!(transition.actions.is_empty());
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Failed);
+    assert!(order.failure_reason.is_some());
 }
 
 #[test]
@@ -171,11 +106,10 @@ fn test_transition_outgoing_succeeded_to_succeeded_via_invoice_paid() {
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Succeeded);
-    assert!(transition.actions.is_empty());
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Succeeded);
 }
 
 // ============================================================================
@@ -184,26 +118,22 @@ fn test_transition_outgoing_succeeded_to_succeeded_via_invoice_paid() {
 
 #[test]
 fn test_transition_incoming_accepted_to_outgoing_in_flight_via_payment_inflight() {
-    let order = create_test_order(CchOrderStatus::IncomingAccepted);
+    let mut order = create_test_order(CchOrderStatus::IncomingAccepted);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Inflight,
         payment_preimage: None,
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::OutgoingInFlight);
-    assert_eq!(
-        transition.actions,
-        vec![CchOrderAction::TrackOutgoingPayment]
-    );
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
 }
 
 #[test]
 fn test_transition_incoming_accepted_to_outgoing_succeeded_via_payment_success() {
-    let order = create_test_order(CchOrderStatus::IncomingAccepted);
+    let mut order = create_test_order(CchOrderStatus::IncomingAccepted);
     let preimage = test_payment_hash(42);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Success,
@@ -211,20 +141,16 @@ fn test_transition_incoming_accepted_to_outgoing_succeeded_via_payment_success()
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::OutgoingSucceeded);
-    assert_eq!(transition.order.payment_preimage, Some(preimage));
-    assert_eq!(
-        transition.actions,
-        vec![CchOrderAction::SettleIncomingInvoice]
-    );
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::OutgoingSucceeded);
+    assert_eq!(order.payment_preimage, Some(preimage));
 }
 
 #[test]
 fn test_transition_outgoing_in_flight_to_outgoing_succeeded_via_payment_success() {
-    let order = create_test_order(CchOrderStatus::OutgoingInFlight);
+    let mut order = create_test_order(CchOrderStatus::OutgoingInFlight);
     let preimage = test_payment_hash(42);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Success,
@@ -232,52 +158,43 @@ fn test_transition_outgoing_in_flight_to_outgoing_succeeded_via_payment_success(
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::OutgoingSucceeded);
-    assert_eq!(transition.order.payment_preimage, Some(preimage));
-    assert_eq!(
-        transition.actions,
-        vec![CchOrderAction::SettleIncomingInvoice]
-    );
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::OutgoingSucceeded);
+    assert_eq!(order.payment_preimage, Some(preimage));
 }
 
 #[test]
 fn test_transition_incoming_accepted_to_failed_via_payment_failed() {
-    let order = create_test_order(CchOrderStatus::IncomingAccepted);
+    let mut order = create_test_order(CchOrderStatus::IncomingAccepted);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Failed,
         payment_preimage: None,
         failure_reason: Some("no route found".to_string()),
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Failed);
-    assert_eq!(
-        transition.order.failure_reason,
-        Some("no route found".to_string())
-    );
-    assert!(transition.actions.is_empty());
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Failed);
+    assert_eq!(order.failure_reason, Some("no route found".to_string()));
 }
 
 #[test]
 fn test_transition_outgoing_in_flight_to_failed_via_payment_failed() {
-    let order = create_test_order(CchOrderStatus::OutgoingInFlight);
+    let mut order = create_test_order(CchOrderStatus::OutgoingInFlight);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Failed,
         payment_preimage: None,
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Failed);
-    assert!(transition.order.failure_reason.is_some());
-    assert!(transition.actions.is_empty());
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Failed);
+    assert!(order.failure_reason.is_some());
 }
 
 // ============================================================================
@@ -286,33 +203,31 @@ fn test_transition_outgoing_in_flight_to_failed_via_payment_failed() {
 
 #[test]
 fn test_staying_in_pending_via_invoice_open() {
-    let order = create_test_order(CchOrderStatus::Pending);
+    let mut order = create_test_order(CchOrderStatus::Pending);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Open,
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(!transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Pending);
-    assert!(transition.actions.is_empty());
+    assert!(transition.is_none());
+    assert_eq!(order.status, CchOrderStatus::Pending);
 }
 
 #[test]
 fn test_staying_in_outgoing_in_flight_via_payment_inflight() {
-    let order = create_test_order(CchOrderStatus::OutgoingInFlight);
+    let mut order = create_test_order(CchOrderStatus::OutgoingInFlight);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Inflight,
         payment_preimage: None,
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(!transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::OutgoingInFlight);
-    assert!(transition.actions.is_empty());
+    assert!(transition.is_none());
+    assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
 }
 
 // ============================================================================
@@ -321,21 +236,21 @@ fn test_staying_in_outgoing_in_flight_via_payment_inflight() {
 
 #[test]
 fn test_invalid_transition_pending_to_outgoing_in_flight() {
-    let order = create_test_order(CchOrderStatus::Pending);
+    let mut order = create_test_order(CchOrderStatus::Pending);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Inflight,
         payment_preimage: None,
         failure_reason: None,
     };
 
-    let result = CchOrderStateMachine::apply(order, event);
+    let result = CchOrderStateMachine::apply(&mut order, event);
 
     assert!(matches!(result, Err(CchError::InvalidTransition(_, _))));
 }
 
 #[test]
 fn test_invalid_transition_pending_to_outgoing_succeeded() {
-    let order = create_test_order(CchOrderStatus::Pending);
+    let mut order = create_test_order(CchOrderStatus::Pending);
     let preimage = test_payment_hash(42);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Success,
@@ -343,46 +258,46 @@ fn test_invalid_transition_pending_to_outgoing_succeeded() {
         failure_reason: None,
     };
 
-    let result = CchOrderStateMachine::apply(order, event);
+    let result = CchOrderStateMachine::apply(&mut order, event);
 
     assert!(matches!(result, Err(CchError::InvalidTransition(_, _))));
 }
 
 #[test]
 fn test_invalid_transition_pending_to_succeeded() {
-    let order = create_test_order(CchOrderStatus::Pending);
+    let mut order = create_test_order(CchOrderStatus::Pending);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Paid,
         failure_reason: None,
     };
 
-    let result = CchOrderStateMachine::apply(order, event);
+    let result = CchOrderStateMachine::apply(&mut order, event);
 
     assert!(matches!(result, Err(CchError::InvalidTransition(_, _))));
 }
 
 #[test]
 fn test_invalid_transition_succeeded_to_any_other() {
-    let order = create_test_order(CchOrderStatus::Succeeded);
+    let mut order = create_test_order(CchOrderStatus::Succeeded);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Open,
         failure_reason: None,
     };
 
-    let result = CchOrderStateMachine::apply(order, event);
+    let result = CchOrderStateMachine::apply(&mut order, event);
 
     assert!(matches!(result, Err(CchError::InvalidTransition(_, _))));
 }
 
 #[test]
 fn test_invalid_transition_failed_to_any_other() {
-    let order = create_test_order(CchOrderStatus::Failed);
+    let mut order = create_test_order(CchOrderStatus::Failed);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Open,
         failure_reason: None,
     };
 
-    let result = CchOrderStateMachine::apply(order, event);
+    let result = CchOrderStateMachine::apply(&mut order, event);
 
     assert!(matches!(result, Err(CchError::InvalidTransition(_, _))));
 }
@@ -393,14 +308,14 @@ fn test_invalid_transition_failed_to_any_other() {
 
 #[test]
 fn test_payment_success_without_preimage_returns_error() {
-    let order = create_test_order(CchOrderStatus::IncomingAccepted);
+    let mut order = create_test_order(CchOrderStatus::IncomingAccepted);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Success,
         payment_preimage: None, // Missing preimage!
         failure_reason: None,
     };
 
-    let result = CchOrderStateMachine::apply(order, event);
+    let result = CchOrderStateMachine::apply(&mut order, event);
 
     assert!(matches!(
         result,
@@ -414,60 +329,60 @@ fn test_payment_success_without_preimage_returns_error() {
 
 #[test]
 fn test_failure_from_pending() {
-    let order = create_test_order(CchOrderStatus::Pending);
+    let mut order = create_test_order(CchOrderStatus::Pending);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Failed,
         payment_preimage: None,
         failure_reason: Some("test failure".to_string()),
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Failed);
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Failed);
 }
 
 #[test]
 fn test_failure_from_incoming_accepted() {
-    let order = create_test_order(CchOrderStatus::IncomingAccepted);
+    let mut order = create_test_order(CchOrderStatus::IncomingAccepted);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Cancelled,
         failure_reason: Some("test failure".to_string()),
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Failed);
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Failed);
 }
 
 #[test]
 fn test_failure_from_outgoing_in_flight() {
-    let order = create_test_order(CchOrderStatus::OutgoingInFlight);
+    let mut order = create_test_order(CchOrderStatus::OutgoingInFlight);
     let event = CchOrderEvent::OutgoingPaymentChanged {
         status: PaymentStatus::Failed,
         payment_preimage: None,
         failure_reason: Some("test failure".to_string()),
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Failed);
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Failed);
 }
 
 #[test]
 fn test_failure_from_outgoing_succeeded() {
-    let order = create_test_order(CchOrderStatus::OutgoingSucceeded);
+    let mut order = create_test_order(CchOrderStatus::OutgoingSucceeded);
     let event = CchOrderEvent::IncomingInvoiceChanged {
         status: CkbInvoiceStatus::Cancelled,
         failure_reason: Some("test failure".to_string()),
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
 
-    assert!(transition.dirty);
-    assert_eq!(transition.order.status, CchOrderStatus::Failed);
+    assert!(transition.is_some());
+    assert_eq!(order.status, CchOrderStatus::Failed);
 }
 
 // ============================================================================
@@ -487,10 +402,9 @@ fn test_preimage_not_overwritten_if_already_set() {
         failure_reason: None,
     };
 
-    let transition = CchOrderStateMachine::apply(order, event).unwrap();
-
+    CchOrderStateMachine::apply(&mut order, event).unwrap();
     // Should keep the original preimage
-    assert_eq!(transition.order.payment_preimage, Some(original_preimage));
+    assert_eq!(order.payment_preimage, Some(original_preimage));
 }
 
 // ============================================================================

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -111,18 +111,20 @@ RPC module for cross chain hub demonstration.
 <a id="cch-send_btc"></a>
 #### Method `send_btc`
 
-Send BTC to a address.
+Creates a CCH order for a BTC Lightning payee.
 
 ##### Params
 
-* `btc_pay_req` - <em>`String`</em>, Bitcoin payment request string
+* `btc_pay_req` - <em>`String`</em>, Payment request string for the BTC Lightning payee.
+
+ The invoice should not be expired soon. The remaining expiry time should be greater than the CCH config
+ `min_incoming_invoice_expiry_delta_seconds`.
 * `currency` - <em>[Currency](#type-currency)</em>, Request currency
 
 ##### Returns
 
 * `timestamp` - <em>`u64`</em>, Seconds since epoch when the order is created
-* `expiry` - <em>`u64`</em>, Seconds after timestamp that the order expires
-* `ckb_final_tlc_expiry_delta` - <em>`u64`</em>, The minimal expiry in seconds of the final TLC in the CKB network
+* `expiry_delta_seconds` - <em>`u64`</em>, Relative expiry time in seconds from `created_at` that the order expires
 * `wrapped_btc_type_script` - <em>`ckb_jsonrpc_types::Script`</em>, Wrapped BTC type script
 * `incoming_invoice` - <em>[CchInvoice](#type-cchinvoice)</em>, Generated invoice for the incoming payment
 * `outgoing_pay_req` - <em>`String`</em>, The final payee to accept the payment. It has the different network with incoming invoice.
@@ -138,17 +140,19 @@ Send BTC to a address.
 <a id="cch-receive_btc"></a>
 #### Method `receive_btc`
 
-Receive BTC from a payment hash.
+Creates a CCH order for a CKB Fiber payee.
 
 ##### Params
 
-* `fiber_pay_req` - <em>`String`</em>, Fiber payment request string
+* `fiber_pay_req` - <em>`String`</em>, Payment request string for the CKB Fiber payee.
+
+ The invoice should not be expired soon. The remaining expiry time should be greater than the CCH config
+ `min_incoming_invoice_expiry_delta_seconds`.
 
 ##### Returns
 
 * `timestamp` - <em>`u64`</em>, Seconds since epoch when the order is created
-* `expiry` - <em>`u64`</em>, Seconds after timestamp that the order expires
-* `ckb_final_tlc_expiry_delta` - <em>`u64`</em>, The minimal expiry in seconds of the final TLC in the CKB network
+* `expiry_delta_seconds` - <em>`u64`</em>, Relative expiry time in seconds from `created_at` that the order expires
 * `wrapped_btc_type_script` - <em>`ckb_jsonrpc_types::Script`</em>, Wrapped BTC type script
 * `incoming_invoice` - <em>[CchInvoice](#type-cchinvoice)</em>, Generated invoice for the incoming payment
 * `outgoing_pay_req` - <em>`String`</em>, The final payee to accept the payment. It has the different network with incoming invoice.
@@ -164,7 +168,7 @@ Receive BTC from a payment hash.
 <a id="cch-get_cch_order"></a>
 #### Method `get_cch_order`
 
-Get receive BTC order by payment hash.
+Get a CCH order by payment hash.
 
 ##### Params
 
@@ -173,8 +177,7 @@ Get receive BTC order by payment hash.
 ##### Returns
 
 * `timestamp` - <em>`u64`</em>, Seconds since epoch when the order is created
-* `expiry` - <em>`u64`</em>, Seconds after timestamp that the order expires
-* `ckb_final_tlc_expiry_delta` - <em>`u64`</em>, The minimal expiry in seconds of the final TLC in the CKB network
+* `expiry_delta_seconds` - <em>`u64`</em>, Relative expiry time in seconds from `created_at` that the order expires
 * `wrapped_btc_type_script` - <em>`ckb_jsonrpc_types::Script`</em>, Wrapped BTC type script
 * `incoming_invoice` - <em>[CchInvoice](#type-cchinvoice)</em>, Generated invoice for the incoming payment
 * `outgoing_pay_req` - <em>`String`</em>, The final payee to accept the payment. It has the different network with incoming invoice.

--- a/crates/fiber-lib/src/rpc/cch.rs
+++ b/crates/fiber-lib/src/rpc/cch.rs
@@ -31,7 +31,7 @@ pub struct CchOrderResponse {
     /// Seconds since epoch when the order is created
     #[serde_as(as = "U64Hex")]
     pub timestamp: u64,
-    // Relative expiry time in seconds from `created_at` that the order expires
+    /// Relative expiry time in seconds from `created_at` that the order expires
     #[serde_as(as = "U64Hex")]
     pub expiry_delta_seconds: u64,
 

--- a/crates/fiber-lib/src/rpc/cch.rs
+++ b/crates/fiber-lib/src/rpc/cch.rs
@@ -16,7 +16,10 @@ use serde_with::serde_as;
 
 #[derive(Serialize, Deserialize)]
 pub struct SendBTCParams {
-    /// Bitcoin payment request string
+    /// Payment request string for the BTC Lightning payee.
+    ///
+    /// The invoice should not be expired soon. The remaining expiry time should be greater than the CCH config
+    /// `min_incoming_invoice_expiry_delta_seconds`.
     pub btc_pay_req: String,
     /// Request currency
     pub currency: Currency,
@@ -28,12 +31,9 @@ pub struct CchOrderResponse {
     /// Seconds since epoch when the order is created
     #[serde_as(as = "U64Hex")]
     pub timestamp: u64,
-    /// Seconds after timestamp that the order expires
+    // Relative expiry time in seconds from `created_at` that the order expires
     #[serde_as(as = "U64Hex")]
-    pub expiry: u64,
-    /// The minimal expiry in seconds of the final TLC in the CKB network
-    #[serde_as(as = "U64Hex")]
-    pub ckb_final_tlc_expiry_delta: u64,
+    pub expiry_delta_seconds: u64,
 
     /// Wrapped BTC type script
     pub wrapped_btc_type_script: ckb_jsonrpc_types::Script,
@@ -57,7 +57,10 @@ pub struct CchOrderResponse {
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct ReceiveBTCParams {
-    /// Fiber payment request string
+    /// Payment request string for the CKB Fiber payee.
+    ///
+    /// The invoice should not be expired soon. The remaining expiry time should be greater than the CCH config
+    /// `min_incoming_invoice_expiry_delta_seconds`.
     pub fiber_pay_req: String,
 }
 
@@ -70,18 +73,18 @@ pub struct GetCchOrderParams {
 /// RPC module for cross chain hub demonstration.
 #[rpc(server)]
 trait CchRpc {
-    /// Send BTC to a address.
+    /// Creates a CCH order for a BTC Lightning payee.
     #[method(name = "send_btc")]
     async fn send_btc(&self, params: SendBTCParams) -> Result<CchOrderResponse, ErrorObjectOwned>;
 
-    /// Receive BTC from a payment hash.
+    /// Creates a CCH order for a CKB Fiber payee.
     #[method(name = "receive_btc")]
     async fn receive_btc(
         &self,
         params: ReceiveBTCParams,
     ) -> Result<CchOrderResponse, ErrorObjectOwned>;
 
-    /// Get receive BTC order by payment hash.
+    /// Get a CCH order by payment hash.
     #[method(name = "get_cch_order")]
     async fn get_cch_order(
         &self,
@@ -197,8 +200,7 @@ impl From<CchOrder> for CchOrderResponse {
     fn from(value: CchOrder) -> Self {
         Self {
             timestamp: value.created_at,
-            expiry: value.expires_after,
-            ckb_final_tlc_expiry_delta: value.ckb_final_tlc_expiry_delta,
+            expiry_delta_seconds: value.expiry_delta_seconds,
             wrapped_btc_type_script: value.wrapped_btc_type_script,
             outgoing_pay_req: value.outgoing_pay_req,
             incoming_invoice: value.incoming_invoice,

--- a/docs/specs/cch-expiry-dependency.md
+++ b/docs/specs/cch-expiry-dependency.md
@@ -12,4 +12,13 @@ CCH config provides the following options:
 
 ## Default Behavior
 
-The default values for the first two options ensure a 20-hour window to settle the outgoing payment. This relies on LND and Fiber verifying that the final TLC expiry time meets the configured threshold specified in the invoice.
+The default values for the first two options ensure a 30-hour window to settle the outgoing payment. This relies on LND and Fiber verifying that the final TLC expiry time meets the configured threshold specified in the invoice.
+
+## Outgoing Invoice Final Expiry Validation
+
+CCH validates that the outgoing invoice's final CLTV/TLC expiry is less than half of the configured expiry for the incoming invoice. This ensures the CCH operator has sufficient time to settle the incoming side before the outgoing side expires.
+
+- **SendBTC** (Fiber → Lightning): The BTC invoice's `min_final_cltv_expiry_delta` (converted to seconds assuming 10 min/block) must be less than `ckb_final_tlc_expiry_delta_seconds / 2`.
+- **ReceiveBTC** (Lightning → Fiber): The Fiber invoice's `final_tlc_minimum_expiry_delta` must be less than `btc_final_tlc_expiry_delta_blocks / 2` (converted to milliseconds).
+
+If this validation fails, the swap is rejected with an error indicating the final expiry delta exceeds the safe limit for cross-chain swaps.

--- a/docs/specs/cch-expiry-dependency.md
+++ b/docs/specs/cch-expiry-dependency.md
@@ -1,0 +1,15 @@
+# CCH Expiry Dependency
+
+For CCH to complete a swap successfully, the incoming payment must leave sufficient expiry time for the outgoing payment to settle.
+
+## Configuration Options
+
+CCH config provides the following options:
+
+- **`btc_final_tlc_expiry_delta_blocks`**: The minimum final CLTV expiry used when creating the incoming invoice in LND.
+- **`ckb_final_tlc_expiry_delta_seconds`**: The minimum final TLC expiry used when creating the incoming invoice in Fiber.
+- **`min_outgoing_invoice_expiry_delta_seconds`**: The minimum remaining time before the outgoing invoice expires. CCH will reject swaps if the outgoing invoice expires sooner than this threshold.
+
+## Default Behavior
+
+The default values for the first two options ensure a 20-hour window to settle the outgoing payment. This relies on LND and Fiber verifying that the final TLC expiry time meets the configured threshold specified in the invoice.

--- a/docs/specs/cross-chain-htlc.md
+++ b/docs/specs/cross-chain-htlc.md
@@ -42,6 +42,8 @@ To understand how HTLCs can be used for cross-chain payments, let's break down t
    - Once Ingrid has the preimage, he can use it to unlock the funds on Blockchain A.
    - Both transactions are completed atomically, meaning either both are completed, or neither is.
 
+The process can be extended to routed payments in both Blockchain A and B.
+
 ## Example Between Bitcoin and CKB
 
 ### Setup

--- a/tests/bruno/e2e/cross-chain-hub/08-check-hub-received-wrapped-btc.bru
+++ b/tests/bruno/e2e/cross-chain-hub/08-check-hub-received-wrapped-btc.bru
@@ -50,8 +50,8 @@ script:post-response {
   if (i < n) {
     console.log(`Try ${i+1}/${n}`);
   }
-
-  if (parseInt(res.body.result.channels[0].local_balance, 16) >= 100000) {
+  
+  if (parseInt(res.body.result.channels[0].local_balance, 16) === 100000) {
     console.log("Hub has received the payment");
     await new Promise(r => setTimeout(r, 1000));
     bru.setVar("iteration", 0);

--- a/tests/bruno/e2e/cross-chain-hub/09-check-payee-received-btc-in-lnd.bru
+++ b/tests/bruno/e2e/cross-chain-hub/09-check-payee-received-btc-in-lnd.bru
@@ -12,6 +12,7 @@ get {
 
 vars:post-response {
   max_iterations: 10
+  LND_BOB_BALANCE: res.body.remote_balance.sat
 }
 
 assert {

--- a/tests/bruno/e2e/cross-chain-hub/10-node1-add-fiber-invoice.bru
+++ b/tests/bruno/e2e/cross-chain-hub/10-node1-add-fiber-invoice.bru
@@ -24,6 +24,7 @@ body:json {
       {
         "amount": "0xc350",
         "currency": "Fibd",
+        "hash_algorithm": "sha256",
         "udt_type_script": {
           "args": "{{UDT_SCRIPT_ARGS}}",
           "code_hash": "0xe1e354d6d643ad42724d40967e334984534e0367405c5ae42a9d7d63d77df419",

--- a/tests/bruno/e2e/cross-chain-hub/14-check-hub-received-btc-in-lnd.bru
+++ b/tests/bruno/e2e/cross-chain-hub/14-check-hub-received-btc-in-lnd.bru
@@ -30,8 +30,9 @@ script:post-response {
   if (i < n) {
     console.log(`Try ${i+1}/${n}`);
   }
-
-  if (parseInt(res.body.local_balance.sat, 10) === 50000) {
+  
+  const before = parseInt(bru.getVar("LND_BOB_BALANCE"), 10);
+  if (parseInt(res.body.remote_balance.sat, 10) - before === 50000) {
     console.log("Hub has received the payment");
     await new Promise(r => setTimeout(r, 1000));
     bru.setVar("iteration", 0);

--- a/tests/bruno/e2e/cross-chain-hub/15-check-payee-received-wrapped-btc.bru
+++ b/tests/bruno/e2e/cross-chain-hub/15-check-payee-received-wrapped-btc.bru
@@ -32,5 +32,5 @@ assert {
   res.body.error: isUndefined
   res.body.result.channels: isDefined
   res.body.result.channels[0].channel_id: eq {{N1N3_CHANNEL_ID}}
-  res.body.result.channels[0].remote_balance: eq "0xc350"
+  res.body.result.channels[0].local_balance: eq "0x249f0"
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This is a stacked PR:
> - #971
>     - #998 :point_left:
>         - #1045 

## Summary

Add comprehensive verification and validation for CCH cross-chain swaps to ensure swap safety and prevent failures due to expiry timing, hash mismatches, or incompatible invoice configurations.

## Changes

### Expiry Verification
- Added validation in both `send_btc` and `receive_btc` flows to check that outgoing invoices have sufficient remaining expiry time
- Introduced `min_outgoing_invoice_expiry_delta_seconds` config option (default: 6 hours) to control the minimum acceptable invoice expiry
- Returns `OutgoingInvoiceExpiryTooShort` error when validation fails

### Final Expiry Safety Validation
- Ensures the outgoing invoice's final CLTV/TLC expiry is less than half of the incoming invoice's configured expiry, giving the CCH operator sufficient time to settle the incoming side before the outgoing side expires

### Preimage and Hash Validation
- Validates preimage matches payment hash when settling CCH orders
- Validates wrapped BTC type script matches the invoice UDT type script
- Validates hash algorithm is SHA256 for LND compatibility

### Config Improvements
- Renamed config fields with explicit units for clarity:
  - `order_expiry` → `order_expiry_delta_seconds`
  - `btc_final_tlc_expiry` → `btc_final_tlc_expiry_delta_blocks`
  - `ckb_final_tlc_expiry_delta` → `ckb_final_tlc_expiry_delta_seconds`
- Updated default values:
  - BTC final TLC expiry: 180 blocks (~30 hours)
  - CKB final TLC expiry: 30 hours

### Order Structure
- Simplified `CchOrder` by removing `ckb_final_tlc_expiry_delta` field
- Renamed `expires_after` to `expiry_delta_seconds` for consistency

### New Error Types
- `OutgoingInvoiceExpiryTooShort`
- `CKBInvoiceExpired`
- `BTCInvoiceFinalTlcExpiryDeltaTooSmall`
- `CKBInvoiceFinalTlcExpiryDeltaTooSmall`
- `PreimagePaymentHashMismatch`
- `WrappedBtcTypeScriptMismatch`
- `IncompatibleHashAlgorithm`

### Documentation
- Added `docs/specs/cch-expiry-dependency.md` explaining CCH expiry configuration and default behavior
