### PR TITLE
Fix panick when start peer filter actor

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -88,6 +88,7 @@ const GET_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 const MAX_NUM_CONCURRENT_QUERY_TASKS: usize = 10;
 
 const QUERY_BROADCAST_MESSAGES_TIMEOUT: Duration = Duration::from_secs(20);
+const UPDATE_PEER_FILTER_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 fn max_acceptable_gossip_message_timestamp() -> u64 {
     now_timestamp_as_millis_u64() + MAX_BROADCAST_MESSAGE_TIMESTAMP_DRIFT_MILLIS
@@ -361,6 +362,8 @@ pub enum GossipActorMessage {
     TryBroadcastMessages(Vec<BroadcastMessageWithTimestamp>),
     // Send gossip message to a peer.
     SendGossipMessage(GossipMessageWithPeerId),
+    // Update peer filter
+    UpdatePeerFilter(PeerId, Cursor),
     // Received GossipMessage from a peer
     GossipMessageReceived(GossipMessageWithPeerId),
 }
@@ -502,6 +505,56 @@ where
         Self {
             _phantom: Default::default(),
         }
+    }
+
+    async fn update_peer_filter(
+        &self,
+        state: &mut GossipActorState<S>,
+        peer_id: &PeerId,
+        after_cursor: &Cursor,
+        myself: ActorRef<GossipActorMessage>,
+    ) {
+        match state.peer_states.get_mut(peer_id) {
+            Some(peer_state) => {
+                if let Some(filter_processor) = peer_state.filter_processor.as_mut() {
+                    filter_processor.update_filter(after_cursor);
+                    return;
+                }
+                let filter_processor = match PeerFilterProcessor::new(
+                    state.store.clone(),
+                    peer_id.clone(),
+                    after_cursor.clone(),
+                    myself.clone(),
+                )
+                .await
+                {
+                    Ok(processor) => processor,
+                    Err(error) => {
+                        debug!(
+                            "Failed to start peer filter processor actor {:?}, error: {:?}. maybe the previous actor haven't terminated, retry later",
+                            peer_id, error
+                        );
+                        let retry_peer = peer_id.clone();
+                        let retry_cursor = after_cursor.clone();
+                        myself.send_after(UPDATE_PEER_FILTER_RETRY_DELAY, move || {
+                            GossipActorMessage::UpdatePeerFilter(retry_peer, retry_cursor)
+                        });
+                        return;
+                    }
+                };
+                peer_state.filter_processor = Some(filter_processor);
+                // Also start passive syncer to peer so that we have less silos.
+                if peer_state.sync_status.can_start_passive_syncing() {
+                    state.start_passive_syncer(peer_id).await;
+                }
+            }
+            None => {
+                warn!(
+                    "Received BroadcastMessagesFilter from unknown peer: {:?}",
+                    peer_id
+                );
+            }
+        };
     }
 }
 
@@ -758,7 +811,7 @@ impl PeerFilterProcessor {
         peer: PeerId,
         filter: Cursor,
         gossip_actor: ActorRef<GossipActorMessage>,
-    ) -> Self
+    ) -> Result<Self, ActorProcessingErr>
     where
         S: SubscribableGossipMessageStore + Clone + Send + Sync + 'static,
         S::Subscription: Send,
@@ -778,9 +831,8 @@ impl PeerFilterProcessor {
             filter.clone(),
             supervisor,
         )
-        .await
-        .expect("start peer filter processor actor");
-        Self { filter, actor }
+        .await?;
+        Ok(Self { filter, actor })
     }
 
     fn update_filter(&mut self, filter: &Cursor) {
@@ -2563,6 +2615,10 @@ where
                     ))
                     .expect("store actor alive");
             }
+            GossipActorMessage::UpdatePeerFilter(peer_id, cursor) => {
+                self.update_peer_filter(state, &peer_id, &cursor, myself)
+                    .await;
+            }
 
             GossipActorMessage::TickNetworkMaintenance => {
                 trace!(
@@ -2632,151 +2688,118 @@ where
             GossipActorMessage::GossipMessageReceived(GossipMessageWithPeerId {
                 peer_id,
                 message,
-            }) => {
-                match message {
-                    GossipMessage::BroadcastMessagesFilter(BroadcastMessagesFilter {
-                        chain_hash,
-                        after_cursor,
-                    }) => {
-                        if let Err(e) = check_chain_hash(&chain_hash) {
-                            error!("Failed to check chain hash: {:?}", e);
-                            return Ok(());
-                        }
-                        if after_cursor.is_max() {
-                            info!(
+            }) => match message {
+                GossipMessage::BroadcastMessagesFilter(BroadcastMessagesFilter {
+                    chain_hash,
+                    after_cursor,
+                }) => {
+                    if let Err(e) = check_chain_hash(&chain_hash) {
+                        error!("Failed to check chain hash: {:?}", e);
+                        return Ok(());
+                    }
+                    if after_cursor.is_max() {
+                        info!(
                                 "Received BroadcastMessagesFilter with max cursor from peer, stopping filter processor to {:?}",
                                 &peer_id
                             );
-                            state.peer_states.remove(&peer_id);
-                            return Ok(());
-                        }
-                        match state.peer_states.get_mut(&peer_id) {
-                            Some(peer_state) => {
-                                match peer_state.filter_processor.as_mut() {
-                                    Some(filter_processor) => {
-                                        filter_processor.update_filter(&after_cursor);
-                                        return Ok(());
-                                    }
-                                    _ => {
-                                        peer_state.filter_processor = Some(
-                                            PeerFilterProcessor::new(
-                                                state.store.clone(),
-                                                peer_id.clone(),
-                                                after_cursor.clone(),
-                                                myself,
-                                            )
-                                            .await,
-                                        );
-                                    }
-                                };
-                                // Also start passive syncer to peer so that we have less silos.
-                                if peer_state.sync_status.can_start_passive_syncing() {
-                                    state.start_passive_syncer(&peer_id).await;
-                                }
-                            }
-                            None => {
-                                warn!(
-                                    "Received BroadcastMessagesFilter from unknown peer: {:?}",
-                                    &peer_id
-                                );
-                                return Ok(());
-                            }
-                        };
+                        state.peer_states.remove(&peer_id);
+                        return Ok(());
                     }
-                    GossipMessage::BroadcastMessagesFilterResult(
-                        BroadcastMessagesFilterResult { messages },
-                    ) => {
-                        state
-                            .try_to_verify_and_save_broadcast_messages(peer_id, messages)
-                            .await;
+                    self.update_peer_filter(state, &peer_id, &after_cursor, myself)
+                        .await;
+                }
+                GossipMessage::BroadcastMessagesFilterResult(BroadcastMessagesFilterResult {
+                    messages,
+                }) => {
+                    state
+                        .try_to_verify_and_save_broadcast_messages(peer_id, messages)
+                        .await;
+                }
+                GossipMessage::GetBroadcastMessages(get_broadcast_messages) => {
+                    if let Err(e) = check_chain_hash(&get_broadcast_messages.chain_hash) {
+                        error!("Failed to check chain hash: {:?}", e);
+                        return Ok(());
                     }
-                    GossipMessage::GetBroadcastMessages(get_broadcast_messages) => {
-                        if let Err(e) = check_chain_hash(&get_broadcast_messages.chain_hash) {
-                            error!("Failed to check chain hash: {:?}", e);
-                            return Ok(());
-                        }
-                        if get_broadcast_messages.count > MAX_NUM_OF_BROADCAST_MESSAGES {
-                            warn!(
-                                "Received GetBroadcastMessages with too many messages: {:?}",
-                                get_broadcast_messages.count
-                            );
-                            return Ok(());
-                        }
-                        let id = get_broadcast_messages.id;
-                        let messages = state.get_store().get_broadcast_messages(
-                            &get_broadcast_messages.after_cursor,
-                            Some(get_broadcast_messages.count),
+                    if get_broadcast_messages.count > MAX_NUM_OF_BROADCAST_MESSAGES {
+                        warn!(
+                            "Received GetBroadcastMessages with too many messages: {:?}",
+                            get_broadcast_messages.count
                         );
-                        let result =
-                            GossipMessage::GetBroadcastMessagesResult(GetBroadcastMessagesResult {
-                                id,
-                                messages: messages.into_iter().map(|m| m.into()).collect(),
-                            });
-                        if let Err(error) = state.send_message_to_peer(&peer_id, result).await {
-                            error!(
-                                "Failed to send GetBroadcastMessagesResult to peer {:?}: {:?}",
-                                &peer_id, error
-                            );
-                        }
+                        return Ok(());
                     }
-                    GossipMessage::GetBroadcastMessagesResult(result) => {
-                        let peer_state = state.peer_states.get(&peer_id);
-                        if let Some(PeerState {
-                            sync_status: PeerSyncStatus::ActiveGet(actor),
-                            ..
-                        }) = peer_state
-                        {
-                            let _ = actor
-                                .send_message(GossipSyncingActorMessage::ResponseReceived(result));
-                        } else {
-                            warn!(
-                                "Received GetBroadcastMessagesResult from peer {:?} in state {:?}",
-                                &peer_id, &peer_state
-                            );
-                        }
-                    }
-                    GossipMessage::QueryBroadcastMessages(QueryBroadcastMessages {
-                        id,
-                        chain_hash,
-                        queries,
-                    }) => {
-                        if let Err(e) = check_chain_hash(&chain_hash) {
-                            error!("Failed to check chain hash: {:?}", e);
-                            return Ok(());
-                        }
-                        if queries.len() > MAX_NUM_OF_BROADCAST_MESSAGES as usize {
-                            warn!(
-                                "Received QueryBroadcastMessages with too many queries: {:?}",
-                                queries.len()
-                            );
-                            return Ok(());
-                        }
-                        let (results, missing_queries) =
-                            state.get_store().query_broadcast_messages(queries);
-                        let result = GossipMessage::QueryBroadcastMessagesResult(
-                            QueryBroadcastMessagesResult {
-                                id,
-                                messages: results.into_iter().map(|m| m.into()).collect(),
-                                missing_queries,
-                            },
+                    let id = get_broadcast_messages.id;
+                    let messages = state.get_store().get_broadcast_messages(
+                        &get_broadcast_messages.after_cursor,
+                        Some(get_broadcast_messages.count),
+                    );
+                    let result =
+                        GossipMessage::GetBroadcastMessagesResult(GetBroadcastMessagesResult {
+                            id,
+                            messages: messages.into_iter().map(|m| m.into()).collect(),
+                        });
+                    if let Err(error) = state.send_message_to_peer(&peer_id, result).await {
+                        error!(
+                            "Failed to send GetBroadcastMessagesResult to peer {:?}: {:?}",
+                            &peer_id, error
                         );
-                        if let Err(error) = state.send_message_to_peer(&peer_id, result).await {
-                            error!(
-                                "Failed to send QueryBroadcastMessagesResult to peer {:?}: {:?}",
-                                &peer_id, error
-                            );
-                        }
-                    }
-                    GossipMessage::QueryBroadcastMessagesResult(result) => {
-                        if let Some(reply) = state
-                            .query_reply_ports
-                            .remove(&(peer_id.clone(), result.id))
-                        {
-                            let _ = reply.send(Ok(result));
-                        }
                     }
                 }
-            }
+                GossipMessage::GetBroadcastMessagesResult(result) => {
+                    let peer_state = state.peer_states.get(&peer_id);
+                    if let Some(PeerState {
+                        sync_status: PeerSyncStatus::ActiveGet(actor),
+                        ..
+                    }) = peer_state
+                    {
+                        let _ =
+                            actor.send_message(GossipSyncingActorMessage::ResponseReceived(result));
+                    } else {
+                        warn!(
+                            "Received GetBroadcastMessagesResult from peer {:?} in state {:?}",
+                            &peer_id, &peer_state
+                        );
+                    }
+                }
+                GossipMessage::QueryBroadcastMessages(QueryBroadcastMessages {
+                    id,
+                    chain_hash,
+                    queries,
+                }) => {
+                    if let Err(e) = check_chain_hash(&chain_hash) {
+                        error!("Failed to check chain hash: {:?}", e);
+                        return Ok(());
+                    }
+                    if queries.len() > MAX_NUM_OF_BROADCAST_MESSAGES as usize {
+                        warn!(
+                            "Received QueryBroadcastMessages with too many queries: {:?}",
+                            queries.len()
+                        );
+                        return Ok(());
+                    }
+                    let (results, missing_queries) =
+                        state.get_store().query_broadcast_messages(queries);
+                    let result =
+                        GossipMessage::QueryBroadcastMessagesResult(QueryBroadcastMessagesResult {
+                            id,
+                            messages: results.into_iter().map(|m| m.into()).collect(),
+                            missing_queries,
+                        });
+                    if let Err(error) = state.send_message_to_peer(&peer_id, result).await {
+                        error!(
+                            "Failed to send QueryBroadcastMessagesResult to peer {:?}: {:?}",
+                            &peer_id, error
+                        );
+                    }
+                }
+                GossipMessage::QueryBroadcastMessagesResult(result) => {
+                    if let Some(reply) = state
+                        .query_reply_ports
+                        .remove(&(peer_id.clone(), result.id))
+                    {
+                        let _ = reply.send(Ok(result));
+                    }
+                }
+            },
         }
 
         Ok(())


### PR DESCRIPTION
``` txt
thread 'tokio-runtime-worker' (486467) panicked at /var/lib/jenkins/workspace/build-fiber-binary/crates/fiber-lib/src/fiber/gossip.rs:782:10:
start peer filter processor actor: ActorAlreadyRegistered("peer filter actor for peer PeerId(QmZCoQHbbFPXE7ybuDpHjJEVETQxcEDG6mfedzyqduzmwK) supervised by Local(4)")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'tokio-runtime-worker' (486467) panicked at /var/lib/jenkins/workspace/build-fiber-binary/crates/fiber-lib/src/fiber/network.rs:4517:17:
Actor unexpectedly panicked (id: Actor { name: Some("gossip actor QmZ5Y8YBMrbETvrKeRqNFc1vKRzMQg8LWUA79rpoMQa9yZ"), id: Local(4) }): "start peer filter processor actor: ActorAlreadyRegistered(\"peer filter actor for peer PeerId(QmZCoQHbbFPXE7ybuDpHjJEVETQxcEDG6mfedzyqduzmwK) supervised by Local(4)\")"
  2025-12-13T02:08:41.493012Z DEBUG fnn: Event processing service exited
    at crates/fiber-bin/src/main.rs:299

```

This PR fix panick during start peer filter actor.

Issue:

When we try to start a new peer filter actor, the old one may still not terminated, so the name of the two actors are conflict.

Solution:

We move the code of update peer filter into a message, if the actor is failed to start, we just retry after 500ms.