### PR TITLE
Invoice status will not update from Receive to Open

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -1917,15 +1917,6 @@ where
                         // remove hold tlc from store
                         self.store
                             .remove_payment_hold_tlc(&payment_hash, &channel_id, tlc_id);
-
-                        // reset invoice status to Open if there are no more hold tlc
-                        let invoice_status = self.store.get_invoice_status(&payment_hash);
-                        if invoice_status.is_some_and(|s| s == CkbInvoiceStatus::Received)
-                            && self.store.get_payment_hold_tlcs(payment_hash).is_empty()
-                        {
-                            self.store
-                                .update_invoice_status(&payment_hash, CkbInvoiceStatus::Open)?;
-                        }
                     }
                     Err(err) => {
                         error!(

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -5584,11 +5584,18 @@ async fn test_send_payment_will_fail_with_no_invoice_preimage() {
     let old_amount = node_3.get_local_balance_from_channel(channels[2]);
 
     let preimage = gen_rand_sha256_hash();
+    // with a short expiry time for test purpose
+    let expiry_time_in_seconds = 5;
+    let timer_started = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("get time now")
+        .as_secs();
+
     let ckb_invoice = InvoiceBuilder::new(Currency::Fibd)
         .amount(Some(100))
         .payment_preimage(preimage)
         .payee_pub_key(target_pubkey.into())
-        .expiry_time(Duration::from_secs(100))
+        .expiry_time(Duration::from_secs(expiry_time_in_seconds))
         .build()
         .expect("build invoice success");
 
@@ -5614,14 +5621,35 @@ async fn test_send_payment_will_fail_with_no_invoice_preimage() {
         .assert_payment_status(payment_hash, PaymentStatus::Failed, Some(1))
         .await;
 
+    let time_elapsed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("get time now")
+        .as_secs()
+        - timer_started;
+
+    assert!(time_elapsed >= expiry_time_in_seconds);
+
     let new_amount = node_3.get_local_balance_from_channel(channels[2]);
     assert_eq!(new_amount, old_amount);
 
-    // we should never update the invoice status if there is an error
+    // the invoice is updated to Received
     assert_eq!(
         node_3.get_invoice_status(ckb_invoice.payment_hash()),
-        Some(CkbInvoiceStatus::Open)
+        Some(CkbInvoiceStatus::Received)
     );
+
+    // send the same payment_hash again will also fail
+    let res = source_node
+        .send_payment(SendPaymentCommand {
+            target_pubkey: Some(target_pubkey),
+            amount: Some(100),
+            invoice: Some(ckb_invoice.to_string()),
+            ..Default::default()
+        })
+        .await;
+
+    let error = res.unwrap_err();
+    assert!(error.contains("invoice is expired"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
1. Invoice status will not update from Receive to Open
2. Fix `test_send_payment_will_fail_with_no_invoice_preimage` for running too long.