### PR TITLE
refactor: improve hold TLC settlement logic

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1653,6 +1653,8 @@ where
         {
             self.store_preimage(payment_hash, payment_preimage);
         }
+        self.store
+            .remove_payment_hold_tlc(&payment_hash, &state.id, command.id);
         let msg = FiberMessageWithPeerId::new(
             state.get_remote_peer_id(),
             FiberMessage::remove_tlc(RemoveTlc {

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -937,8 +937,7 @@ where
                             // Use the default expiry for mpp
                             Some(now_timestamp_as_millis_u64() + DEFAULT_HOLD_TLC_TIMEOUT)
                         } else {
-                            // Use 0 to indicate to not create HoldTLC for single path payment
-                            // with preimage.
+                            // Do not hold this TLC for a single path payment with preimage.
                             None
                         }
                     } else {

--- a/crates/fiber-lib/src/fiber/mod.rs
+++ b/crates/fiber-lib/src/fiber/mod.rs
@@ -17,6 +17,7 @@ mod fee;
 mod in_flight_ckb_tx_actor;
 mod key;
 mod path;
+mod settle_tlc_set_command;
 
 pub use config::FiberConfig;
 pub use in_flight_ckb_tx_actor::{
@@ -28,6 +29,7 @@ pub use network::{
     NetworkServiceEvent,
 };
 pub use payment::PaymentCustomRecords;
+pub use settle_tlc_set_command::SettleTlcSetCommand;
 
 pub(crate) const ASSUME_NETWORK_ACTOR_ALIVE: &str = "network actor must be alive";
 

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -102,6 +102,7 @@ use crate::fiber::types::{
     FiberChannelMessage, PeeledPaymentOnionPacket, TlcErrPacket, TrampolineHopPayload,
     TrampolineOnionPacket, TxAbort, TxSignatures,
 };
+use crate::fiber::SettleTlcSetCommand;
 use crate::invoice::{
     CkbInvoice, CkbInvoiceStatus, InvoiceError, InvoiceStore, PreimageStore, SettleInvoiceError,
 };
@@ -287,8 +288,10 @@ pub enum NetworkActorCommand {
     CheckChannels,
     // Timeout a hold tlc
     TimeoutHoldTlc(Hash256, Hash256, u64),
-    // Settle tlc set, including MPP and normal tlc set
-    SettleTlcSet(Hash256, Option<(Hash256, u64)>),
+    // Settle tlc set by given a list of `(channel_id, tlc_id)`
+    SettleTlcSet(Hash256, Vec<(Hash256, u64)>),
+    // Settle hold tlc set saved for a payment hash
+    SettleHoldTlcSet(Hash256),
     // Check peer send us Init message in an expected time, otherwise disconnect with the peer.
     CheckPeerInit(PeerId, SessionId),
     // For internal use and debugging only. Most of the messages requires some
@@ -1540,113 +1543,19 @@ where
                     }
                 }
             }
-            NetworkActorCommand::SettleTlcSet(payment_hash, tlc_info) => {
-                let tlc_ids = if let Some((channel_id, tlc_id)) = tlc_info {
-                    vec![(channel_id, tlc_id)]
-                } else {
-                    self.store
-                        .get_payment_hold_tlcs(payment_hash)
-                        .iter()
-                        .map(|hold_tlc| (hold_tlc.channel_id, hold_tlc.tlc_id))
-                        .collect()
-                };
-                let tlcs: Vec<_> = tlc_ids
-                    .into_iter()
-                    .filter_map(|(channel_id, tlc_id)| {
-                        let state = self.store.get_channel_actor_state(&channel_id)?;
-                        let tlc_id = TLCId::Received(tlc_id);
-                        state
-                            .get_received_tlc(tlc_id)
-                            .map(|tlc| (channel_id, tlc.clone()))
-                    })
+            NetworkActorCommand::SettleHoldTlcSet(payment_hash) => {
+                let channel_tlc_ids = self
+                    .store
+                    .get_payment_hold_tlcs(payment_hash)
+                    .iter()
+                    .map(|hold_tlc| (hold_tlc.channel_id, hold_tlc.tlc_id))
                     .collect();
-
-                let not_mpp = tlc_info.is_some();
-                let mut tlc_fail = None;
-
-                // check if all tlcs have the same total amount
-                if tlcs.len() > 1
-                    && !tlcs
-                        .windows(2)
-                        .all(|w| w[0].1.total_amount == w[1].1.total_amount)
-                {
-                    error!("TLCs have inconsistent total_amount: {:?}", tlcs);
-                    tlc_fail = Some(TlcErr::new(TlcErrorCode::IncorrectOrUnknownPaymentDetails));
-                }
-                let Some(invoice) = self.store.get_invoice(&payment_hash) else {
-                    error!(
-                        "Try to settle mpp tlc set, but invoice not found for payment hash {:?}",
-                        payment_hash
-                    );
-                    return Ok(());
-                };
-
-                let fulfilled = is_invoice_fulfilled(&invoice, tlcs.iter().map(|(_, tlc)| tlc));
-                if not_mpp {
-                    if self.store.get_invoice_status(&payment_hash) != Some(CkbInvoiceStatus::Open)
-                        || !fulfilled
-                    {
-                        tlc_fail =
-                            Some(TlcErr::new(TlcErrorCode::IncorrectOrUnknownPaymentDetails));
-                    }
-                } else if !fulfilled {
-                    return Ok(());
-                }
-
-                // if we have enough tlcs to fulfill the invoice, update invoice status to Received
-                // for hold invoice we may don't have preimages yet, so just update status here
-                self.store
-                    .update_invoice_status(&payment_hash, CkbInvoiceStatus::Received)
-                    .expect("update invoice status failed");
-
-                let Some(preimage) = self.store.get_preimage(&payment_hash) else {
-                    return Ok(());
-                };
-
-                // remove tlcs
-                for (channel_id, tlc) in tlcs {
-                    let (send, _recv) = oneshot::channel();
-                    let rpc_reply = RpcReplyPort::from(send);
-                    let remove_reason = match tlc_fail.clone() {
-                        Some(tlc_fail) => RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
-                            tlc_fail,
-                            &tlc.shared_secret,
-                        )),
-                        None => RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
-                            payment_preimage: preimage,
-                        }),
-                    };
-
-                    match state
-                        .send_command_to_channel(
-                            channel_id,
-                            ChannelCommand::RemoveTlc(
-                                RemoveTlcCommand {
-                                    id: tlc.id(),
-                                    reason: remove_reason,
-                                },
-                                rpc_reply,
-                            ),
-                        )
-                        .await
-                    {
-                        Ok(_) => {
-                            self.store.remove_payment_hold_tlc(
-                                &payment_hash,
-                                &channel_id,
-                                tlc.id(),
-                            );
-                        }
-                        Err(err) => {
-                            error!(
-                                "Failed to remove tlc {:?} for channel {:?}: {}",
-                                tlc.id(),
-                                channel_id,
-                                err
-                            );
-                        }
-                    }
-                }
+                self.settle_tlc_set(state, payment_hash, channel_tlc_ids, true)
+                    .await;
+            }
+            NetworkActorCommand::SettleTlcSet(payment_hash, channel_tlc_ids) => {
+                self.settle_tlc_set(state, payment_hash, channel_tlc_ids, false)
+                    .await;
             }
             NetworkActorCommand::TimeoutHoldTlc(payment_hash, channel_id, tlc_id) => {
                 debug!(
@@ -2137,6 +2046,48 @@ where
         Ok(())
     }
 
+    async fn settle_tlc_set(
+        &self,
+        state: &mut NetworkActorState<S, C>,
+        payment_hash: Hash256,
+        channel_tlc_ids: Vec<(Hash256, u64)>,
+        is_hold_tlc_set: bool,
+    ) {
+        let settle_command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &self.store);
+        for tlc_settlement in settle_command.run() {
+            let (send, _recv) = oneshot::channel();
+            let rpc_reply = RpcReplyPort::from(send);
+            match state
+                .send_command_to_channel(
+                    tlc_settlement.channel_id(),
+                    ChannelCommand::RemoveTlc(
+                        tlc_settlement.remove_tlc_command().clone(),
+                        rpc_reply,
+                    ),
+                )
+                .await
+            {
+                Ok(_) => {
+                    if is_hold_tlc_set {
+                        self.store.remove_payment_hold_tlc(
+                            &payment_hash,
+                            &tlc_settlement.channel_id(),
+                            tlc_settlement.tlc_id(),
+                        );
+                    }
+                }
+                Err(err) => {
+                    error!(
+                        "Failed to remove tlc {:?} for channel {:?}: {}",
+                        tlc_settlement.tlc_id(),
+                        tlc_settlement.channel_id(),
+                        err
+                    );
+                }
+            }
+        }
+    }
+
     /// Async version of check_channel_shutdown that runs in spawned task.
     /// Checks if the channel funding cell has been spent (indicating remote force close).
     async fn check_channel_shutdown(
@@ -2350,13 +2301,9 @@ where
         }
 
         self.store.insert_preimage(payment_hash, payment_preimage);
-        let _ = myself.send_message(NetworkActorMessage::new_notification(
-            NetworkServiceEvent::PreimageCreated(payment_hash, payment_preimage),
-        ));
-
         // We will send network actor a message to settle the invoice immediately if possible.
         let _ = myself.send_message(NetworkActorMessage::new_command(
-            NetworkActorCommand::SettleTlcSet(payment_hash, None),
+            NetworkActorCommand::SettleHoldTlcSet(payment_hash),
         ));
 
         Ok(())
@@ -4683,7 +4630,7 @@ where
             if !already_timeout {
                 myself
                     .send_message(NetworkActorMessage::new_command(
-                        NetworkActorCommand::SettleTlcSet(payment_hash, None),
+                        NetworkActorCommand::SettleHoldTlcSet(payment_hash),
                     ))
                     .expect(ASSUME_NETWORK_MYSELF_ALIVE);
             }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -2328,6 +2328,13 @@ where
         }
 
         self.store.insert_preimage(payment_hash, payment_preimage);
+        // Notify watchtower about the preimage so it can settle TLCs on-chain if needed
+        // (e.g., after force close).
+        myself
+            .send_message(NetworkActorMessage::new_notification(
+                NetworkServiceEvent::PreimageCreated(payment_hash, payment_preimage),
+            ))
+            .expect(ASSUME_NETWORK_MYSELF_ALIVE);
         // We will send network actor a message to settle the invoice immediately if possible.
         let _ = myself.send_message(NetworkActorMessage::new_command(
             NetworkActorCommand::SettleHoldTlcSet(payment_hash),

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -1997,11 +1997,10 @@ where
             payment_hash, channel_id, tlc_id
         );
 
-        if self.store.get_invoice_status(&payment_hash) == Some(CkbInvoiceStatus::Received)
-            && self.store.get_preimage(&payment_hash).is_some()
-        {
-            // When invoice is marked as received and preimage is available, we only timeout when
-            // the TLC itself has expired.
+        if self.store.get_invoice_status(&payment_hash) == Some(CkbInvoiceStatus::Received) {
+            // When invoice is marked as received, we ignore the hold TLC timeout and only
+            // remove the TLC when it actually expires. Expired TLCs are removed in the
+            // CheckChannels routine (see NetworkActorCommand::CheckChannels handler).
             return;
         }
 

--- a/crates/fiber-lib/src/fiber/settle_tlc_set_command.rs
+++ b/crates/fiber-lib/src/fiber/settle_tlc_set_command.rs
@@ -1,0 +1,299 @@
+use crate::{
+    fiber::{
+        channel::{ChannelActorStateStore, RemoveTlcCommand, TLCId, TlcInfo},
+        types::{Hash256, RemoveTlcFulfill, RemoveTlcReason, TlcErr, TlcErrPacket, TlcErrorCode},
+    },
+    invoice::{CkbInvoice, CkbInvoiceStatus, InvoiceStore, PreimageStore},
+};
+
+pub struct SettleTlcSetCommand<'s, S> {
+    payment_hash: Hash256,
+    tlcs: Vec<TlcSettlementContext>,
+    store: &'s S,
+}
+
+#[derive(Debug)]
+pub struct TlcSettlementContext {
+    channel_id: Hash256,
+    id: u64,
+    amount: u128,
+    total_amount: Option<u128>,
+    shared_secret: [u8; 32],
+}
+
+impl TlcSettlementContext {
+    pub fn new(tlc_info: &TlcInfo, channel_id: Hash256) -> Self {
+        Self {
+            channel_id,
+            id: tlc_info.id(),
+            amount: tlc_info.amount,
+            total_amount: tlc_info.total_amount,
+            shared_secret: tlc_info.shared_secret,
+        }
+    }
+
+    fn total_amount_or_amount(&self) -> u128 {
+        self.total_amount.unwrap_or(self.amount)
+    }
+
+    fn into_remove_tlc_fail_settlement(self, error_code: TlcErrorCode) -> TlcSettlement {
+        TlcSettlement::new(
+            self.channel_id,
+            RemoveTlcCommand {
+                id: self.id,
+                reason: RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
+                    TlcErr::new(error_code),
+                    &self.shared_secret,
+                )),
+            },
+        )
+    }
+
+    fn into_remove_tlc_fulfill_settlement(self, payment_preimage: Hash256) -> TlcSettlement {
+        TlcSettlement::new(
+            self.channel_id,
+            RemoveTlcCommand {
+                id: self.id,
+                reason: RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill { payment_preimage }),
+            },
+        )
+    }
+}
+
+impl<'s, S> SettleTlcSetCommand<'s, S>
+where
+    S: PreimageStore + InvoiceStore + ChannelActorStateStore,
+{
+    pub fn new(payment_hash: Hash256, channel_tlc_ids: Vec<(Hash256, u64)>, store: &'s S) -> Self {
+        let tlcs: Vec<_> = channel_tlc_ids
+            .into_iter()
+            .filter_map(|(channel_id, tlc_id)| {
+                let state = store.get_channel_actor_state(&channel_id)?;
+                let tlc_id = TLCId::Received(tlc_id);
+                state
+                    .get_received_tlc(tlc_id)
+                    .map(|tlc_info| TlcSettlementContext::new(tlc_info, channel_id))
+            })
+            .collect();
+        Self {
+            payment_hash,
+            tlcs,
+            store,
+        }
+    }
+
+    pub fn run(mut self) -> Vec<TlcSettlement> {
+        let (Some(invoice), Some(invoice_status)) = (
+            self.store.get_invoice(&self.payment_hash),
+            self.store.get_invoice_status(&self.payment_hash),
+        ) else {
+            // TLC without invoice should not be added as hold TLC, reject them as invoice
+            // canceled.
+            return self.reject_all(TlcErrorCode::InvoiceCancelled);
+        };
+
+        if let Err(error_code) = self.verify(&invoice, &invoice_status) {
+            return self.reject_all(error_code);
+        }
+
+        let mut rejected = self.leave_just_fulfilled_tlcs(&invoice);
+        if self.tlcs.is_empty() {
+            return rejected;
+        }
+
+        // Now we are sure the invoice is fulfilled, and `self.tlcs` is ready to be settled.
+        // Update invoice status to Received
+        self.mark_invoice_as_received_if_still_open(&invoice_status);
+
+        let mut settlements = self.try_settle_all();
+        settlements.append(&mut rejected);
+        settlements
+    }
+
+    /// Leave just fulfilled tlcs, and reject the rest.
+    ///
+    /// Return settlements for rejected tlcs.
+    ///
+    /// When the invoice is not fulfilled:
+    /// - If invoice allows mpp, clear tlcs and return empty settlements,
+    /// - Otherwise, reject all tlcs and return settlements for rejected tlcs.
+    ///
+    /// When this function returns, and `self.tlcs` is not empty, it means the
+    /// invoice is now fulfilled, and `self.tlcs` is ready to be settled.
+    fn leave_just_fulfilled_tlcs(&mut self, invoice: &CkbInvoice) -> Vec<TlcSettlement> {
+        if invoice.allow_mpp() {
+            self.leave_just_fulfilled_tlcs_for_mpp_invoice(invoice)
+        } else {
+            self.leave_just_fulfilled_tlcs_for_non_mpp_invoice(invoice)
+        }
+    }
+
+    fn leave_just_fulfilled_tlcs_for_mpp_invoice(
+        &mut self,
+        invoice: &CkbInvoice,
+    ) -> Vec<TlcSettlement> {
+        let Some(first_tlc) = self.tlcs.first() else {
+            return Vec::new();
+        };
+
+        let total_amount = first_tlc.total_amount_or_amount();
+        if total_amount < invoice.amount.unwrap_or_default() {
+            return self.reject_all(TlcErrorCode::IncorrectOrUnknownPaymentDetails);
+        }
+
+        let mut accumulated_amount = 0;
+        // Remove overpaid TLCs
+        let mut retain_len: usize = 0;
+        for tlc in self.tlcs.iter() {
+            if accumulated_amount < total_amount {
+                accumulated_amount = accumulated_amount.saturating_add(tlc.amount);
+                retain_len += 1;
+            }
+        }
+
+        // If not fulfilled, clear tlcs and return empty settlements.
+        if accumulated_amount < total_amount {
+            self.tlcs.clear();
+            Vec::new()
+        } else {
+            let overpaid_tlcs = self.tlcs.split_off(retain_len);
+            self.reject_tlcs(overpaid_tlcs, TlcErrorCode::HoldTlcTimeout)
+        }
+    }
+
+    fn leave_just_fulfilled_tlcs_for_non_mpp_invoice(
+        &mut self,
+        invoice: &CkbInvoice,
+    ) -> Vec<TlcSettlement> {
+        let required_amount = invoice.amount.unwrap_or_default();
+
+        let Some(index) = self
+            .tlcs
+            .iter()
+            .position(|tlc| tlc.amount >= required_amount)
+        else {
+            // No one fulfilled, reject all
+            return self.reject_all(TlcErrorCode::IncorrectOrUnknownPaymentDetails);
+        };
+
+        let mut rejected_tlcs = std::mem::take(&mut self.tlcs);
+        self.tlcs.push(rejected_tlcs.swap_remove(index));
+        self.reject_tlcs(rejected_tlcs, TlcErrorCode::HoldTlcTimeout)
+    }
+
+    /// Verify TLCs against the invoice.
+    ///
+    /// Returns `Err` to reject all tlcs with the error code.
+    fn verify(
+        &self,
+        invoice: &CkbInvoice,
+        invoice_status: &CkbInvoiceStatus,
+    ) -> Result<(), TlcErrorCode> {
+        self.verify_invoice_status(invoice_status)?;
+        self.verify_mpp_tlcs_have_consistent_total_amount(invoice)?;
+        Ok(())
+    }
+
+    fn verify_invoice_status(&self, invoice_status: &CkbInvoiceStatus) -> Result<(), TlcErrorCode> {
+        match invoice_status {
+            CkbInvoiceStatus::Open | CkbInvoiceStatus::Received => Ok(()),
+            CkbInvoiceStatus::Expired => Err(TlcErrorCode::InvoiceExpired),
+            CkbInvoiceStatus::Cancelled => Err(TlcErrorCode::InvoiceCancelled),
+            // When invoice is paid, TLCs will eventually timeout, so we reject them now with the same reason.
+            CkbInvoiceStatus::Paid => Err(TlcErrorCode::HoldTlcTimeout),
+        }
+    }
+
+    fn verify_mpp_tlcs_have_consistent_total_amount(
+        &self,
+        invoice: &CkbInvoice,
+    ) -> Result<(), TlcErrorCode> {
+        if invoice.allow_mpp()
+            && self.tlcs.len() > 1
+            && !self
+                .tlcs
+                .windows(2)
+                .all(|w| w[0].total_amount == w[1].total_amount)
+        {
+            tracing::error!("TLCs have inconsistent total_amount");
+            return Err(TlcErrorCode::IncorrectOrUnknownPaymentDetails);
+        }
+        Ok(())
+    }
+
+    fn try_settle_all(self) -> Vec<TlcSettlement> {
+        if let Some(payment_preimage) = self.store.get_preimage(&self.payment_hash) {
+            self.tlcs
+                .into_iter()
+                .map(|tlc| tlc.into_remove_tlc_fulfill_settlement(payment_preimage))
+                .collect()
+        } else {
+            // Skip this time and retry later when the preimage is available.
+            self.skip_all()
+        }
+    }
+
+    fn reject_tlcs(
+        &self,
+        tlcs: Vec<TlcSettlementContext>,
+        error_code: TlcErrorCode,
+    ) -> Vec<TlcSettlement> {
+        tracing::error!(
+            "Remove TLCs for payment hash {} because of error {:?}",
+            self.payment_hash,
+            error_code,
+        );
+        tracing::debug!(
+            "Removed TLCs for payment hash {} because of error {:?}: {:?}",
+            self.payment_hash,
+            error_code,
+            tlcs,
+        );
+        tlcs.into_iter()
+            .map(|tlc| tlc.into_remove_tlc_fail_settlement(error_code))
+            .collect()
+    }
+
+    fn reject_all(&mut self, error_code: TlcErrorCode) -> Vec<TlcSettlement> {
+        let tlcs = std::mem::take(&mut self.tlcs);
+        self.reject_tlcs(tlcs, error_code)
+    }
+
+    fn skip_all(self) -> Vec<TlcSettlement> {
+        Vec::new()
+    }
+
+    fn mark_invoice_as_received_if_still_open(&self, invoice_status: &CkbInvoiceStatus) {
+        if *invoice_status == CkbInvoiceStatus::Open {
+            self.store
+                .update_invoice_status(&self.payment_hash, CkbInvoiceStatus::Received)
+                .expect("update invoice status failed");
+        }
+    }
+}
+
+pub struct TlcSettlement {
+    channel_id: Hash256,
+    remove_tlc_command: RemoveTlcCommand,
+}
+
+impl TlcSettlement {
+    pub fn new(channel_id: Hash256, remove_tlc_command: RemoveTlcCommand) -> Self {
+        Self {
+            channel_id,
+            remove_tlc_command,
+        }
+    }
+
+    pub fn channel_id(&self) -> Hash256 {
+        self.channel_id
+    }
+
+    pub fn tlc_id(&self) -> u64 {
+        self.remove_tlc_command.id
+    }
+
+    pub fn remove_tlc_command(&self) -> &RemoveTlcCommand {
+        &self.remove_tlc_command
+    }
+}

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -5596,7 +5596,11 @@ async fn test_send_payment_will_succeed_with_valid_invoice() {
 }
 
 #[tokio::test]
-async fn test_send_payment_will_fail_with_no_invoice_preimage() {
+async fn test_received_invoice_without_preimage_keeps_payment_pending() {
+    // When an invoice is in Received status but no preimage is available,
+    // the payment should stay pending (Inflight) until TLCs expire.
+    // Hold TLC timeout is ignored when invoice is Received, so TLCs are
+    // only removed when they actually expire.
     init_tracing();
 
     let (nodes, channels) = create_n_nodes_network(
@@ -5615,22 +5619,18 @@ async fn test_send_payment_will_fail_with_no_invoice_preimage() {
     let old_amount = node_3.get_local_balance_from_channel(channels[2]);
 
     let preimage = gen_rand_sha256_hash();
-    // with a short expiry time for test purpose
-    let expiry_time_in_seconds = 5;
-    let timer_started = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("get time now")
-        .as_secs();
+    // Use a short invoice expiry time for test purposes
+    let invoice_expiry_seconds = 3;
 
     let ckb_invoice = InvoiceBuilder::new(Currency::Fibd)
         .amount(Some(100))
         .payment_preimage(preimage)
         .payee_pub_key(target_pubkey.into())
-        .expiry_time(Duration::from_secs(expiry_time_in_seconds))
+        .expiry_time(Duration::from_secs(invoice_expiry_seconds))
         .build()
         .expect("build invoice success");
 
-    // insert invoice without preimage
+    // Insert invoice WITHOUT preimage - this simulates a hold invoice scenario
     node_3.insert_invoice(ckb_invoice.clone(), None);
 
     let res = source_node
@@ -5643,45 +5643,27 @@ async fn test_send_payment_will_fail_with_no_invoice_preimage() {
         })
         .await;
 
-    // expect send payment to failed because we can not find preimage
     assert!(res.is_ok());
-
     let payment_hash = res.unwrap().payment_hash;
 
-    source_node.wait_until_failed(payment_hash).await;
-    source_node
-        .assert_payment_status(payment_hash, PaymentStatus::Failed, Some(1))
-        .await;
+    // Wait for invoice to expire and a bit more for processing
+    tokio::time::sleep(tokio::time::Duration::from_secs(invoice_expiry_seconds + 2)).await;
 
-    let time_elapsed = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("get time now")
-        .as_secs()
-        - timer_started;
-
-    assert!(time_elapsed >= expiry_time_in_seconds);
-
-    let new_amount = node_3.get_local_balance_from_channel(channels[2]);
-    assert_eq!(new_amount, old_amount);
-
-    // the invoice is updated to Received
+    // The invoice should be in Received status
     assert_eq!(
         node_3.get_invoice_status(ckb_invoice.payment_hash()),
         Some(CkbInvoiceStatus::Received)
     );
 
-    // send the same payment_hash again will also fail
-    let res = source_node
-        .send_payment(SendPaymentCommand {
-            target_pubkey: Some(target_pubkey),
-            amount: Some(100),
-            invoice: Some(ckb_invoice.to_string()),
-            ..Default::default()
-        })
+    // The payment should still be Inflight (pending), not failed
+    // because TLCs are held until they expire (not based on hold timeout)
+    source_node
+        .assert_payment_status(payment_hash, PaymentStatus::Inflight, None)
         .await;
 
-    let error = res.unwrap_err();
-    assert!(error.contains("invoice is expired"));
+    // Balance should not have changed
+    let new_amount = node_3.get_local_balance_from_channel(channels[2]);
+    assert_eq!(new_amount, old_amount);
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/mod.rs
+++ b/crates/fiber-lib/src/fiber/tests/mod.rs
@@ -14,6 +14,7 @@ mod payment;
 #[cfg(not(target_arch = "wasm32"))]
 mod rpc;
 mod serde_utils;
+mod settle_tlc_set_command_tests;
 mod tlc_op;
 #[cfg(not(target_arch = "wasm32"))]
 mod trampoline;

--- a/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
@@ -1,0 +1,1045 @@
+//! Tests for SettleTlcSetCommand
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use ckb_types::packed::{OutPoint, Script};
+use tentacle::secio::PeerId;
+
+use crate::fiber::channel::InboundTlcStatus;
+use crate::fiber::channel::{
+    AppliedFlags, ChannelActorState, ChannelActorStateStore, ChannelBasePublicKeys,
+    ChannelConstraints, ChannelState, ChannelTlcInfo, CommitmentNumbers, InMemorySigner, TLCId,
+    TlcInfo, TlcState, TlcStatus,
+};
+use crate::fiber::hash_algorithm::HashAlgorithm;
+use crate::fiber::payment::PaymentCustomRecords;
+use crate::fiber::settle_tlc_set_command::{SettleTlcSetCommand, TlcSettlement};
+use crate::fiber::types::{Hash256, HoldTlc, RemoveTlcReason, TlcErrorCode, NO_SHARED_SECRET};
+use crate::gen_rand_sha256_hash;
+use crate::invoice::{CkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder, InvoiceError};
+use crate::invoice::{InvoiceStore, PreimageStore};
+use crate::now_timestamp_as_millis_u64;
+use crate::tests::gen_utils::gen_rand_fiber_public_key;
+use crate::time::SystemTime;
+
+/// Mock store for testing that implements PreimageStore, InvoiceStore, and ChannelActorStateStore
+struct MockStore {
+    invoices: RefCell<HashMap<Hash256, CkbInvoice>>,
+    invoice_statuses: RefCell<HashMap<Hash256, CkbInvoiceStatus>>,
+    preimages: RefCell<HashMap<Hash256, Hash256>>,
+    channel_states: RefCell<HashMap<Hash256, ChannelActorState>>,
+}
+
+impl MockStore {
+    fn new() -> Self {
+        Self {
+            invoices: RefCell::new(HashMap::new()),
+            invoice_statuses: RefCell::new(HashMap::new()),
+            preimages: RefCell::new(HashMap::new()),
+            channel_states: RefCell::new(HashMap::new()),
+        }
+    }
+
+    fn with_invoice(self, invoice: CkbInvoice, status: CkbInvoiceStatus) -> Self {
+        let payment_hash = *invoice.payment_hash();
+        self.invoices.borrow_mut().insert(payment_hash, invoice);
+        self.invoice_statuses
+            .borrow_mut()
+            .insert(payment_hash, status);
+        self
+    }
+
+    fn with_preimage(self, payment_hash: Hash256, preimage: Hash256) -> Self {
+        self.preimages.borrow_mut().insert(payment_hash, preimage);
+        self
+    }
+
+    fn with_channel_state(self, state: ChannelActorState) -> Self {
+        let channel_id = state.id;
+        self.channel_states.borrow_mut().insert(channel_id, state);
+        self
+    }
+}
+
+impl InvoiceStore for MockStore {
+    fn get_invoice(&self, id: &Hash256) -> Option<CkbInvoice> {
+        self.invoices.borrow().get(id).cloned()
+    }
+
+    fn insert_invoice(
+        &self,
+        invoice: CkbInvoice,
+        _preimage: Option<Hash256>,
+    ) -> Result<(), InvoiceError> {
+        let payment_hash = *invoice.payment_hash();
+        self.invoices.borrow_mut().insert(payment_hash, invoice);
+        self.invoice_statuses
+            .borrow_mut()
+            .insert(payment_hash, CkbInvoiceStatus::Open);
+        Ok(())
+    }
+
+    fn update_invoice_status(
+        &self,
+        id: &Hash256,
+        status: CkbInvoiceStatus,
+    ) -> Result<(), InvoiceError> {
+        self.invoice_statuses.borrow_mut().insert(*id, status);
+        Ok(())
+    }
+
+    fn get_invoice_status(&self, id: &Hash256) -> Option<CkbInvoiceStatus> {
+        self.invoice_statuses.borrow().get(id).cloned()
+    }
+}
+
+impl PreimageStore for MockStore {
+    fn insert_preimage(&self, payment_hash: Hash256, preimage: Hash256) {
+        self.preimages.borrow_mut().insert(payment_hash, preimage);
+    }
+
+    fn remove_preimage(&self, payment_hash: &Hash256) {
+        self.preimages.borrow_mut().remove(payment_hash);
+    }
+
+    fn get_preimage(&self, payment_hash: &Hash256) -> Option<Hash256> {
+        self.preimages.borrow().get(payment_hash).cloned()
+    }
+}
+
+impl ChannelActorStateStore for MockStore {
+    fn get_channel_actor_state(&self, id: &Hash256) -> Option<ChannelActorState> {
+        self.channel_states.borrow().get(id).cloned()
+    }
+
+    fn insert_channel_actor_state(&self, state: ChannelActorState) {
+        let channel_id = state.id;
+        self.channel_states.borrow_mut().insert(channel_id, state);
+    }
+
+    fn delete_channel_actor_state(&self, id: &Hash256) {
+        self.channel_states.borrow_mut().remove(id);
+    }
+
+    fn get_channel_ids_by_peer(&self, _peer_id: &PeerId) -> Vec<Hash256> {
+        self.channel_states.borrow().keys().cloned().collect()
+    }
+
+    fn get_channel_states(&self, _peer_id: Option<PeerId>) -> Vec<(PeerId, Hash256, ChannelState)> {
+        vec![]
+    }
+
+    fn get_channel_state_by_outpoint(&self, _id: &OutPoint) -> Option<ChannelActorState> {
+        None
+    }
+
+    fn insert_payment_custom_records(
+        &self,
+        _payment_hash: &Hash256,
+        _custom_records: PaymentCustomRecords,
+    ) {
+        // No-op for tests
+    }
+
+    fn get_payment_custom_records(&self, _payment_hash: &Hash256) -> Option<PaymentCustomRecords> {
+        None
+    }
+
+    fn insert_payment_hold_tlc(&self, _payment_hash: Hash256, _hold_tlc: HoldTlc) {
+        // No-op for tests
+    }
+
+    fn remove_payment_hold_tlc(
+        &self,
+        _payment_hash: &Hash256,
+        _channel_id: &Hash256,
+        _tlc_id: u64,
+    ) {
+        // No-op for tests
+    }
+
+    fn get_payment_hold_tlcs(&self, _payment_hash: Hash256) -> Vec<HoldTlc> {
+        vec![]
+    }
+
+    fn get_node_hold_tlcs(&self) -> HashMap<Hash256, Vec<HoldTlc>> {
+        HashMap::new()
+    }
+
+    fn is_tlc_settled(&self, _channel_id: &Hash256, _payment_hash: &Hash256) -> bool {
+        false
+    }
+}
+
+fn create_test_invoice(payment_hash: Hash256, amount: Option<u128>, allow_mpp: bool) -> CkbInvoice {
+    let mut builder = InvoiceBuilder::new(Currency::Fibd)
+        .payment_hash(payment_hash)
+        .amount(amount);
+
+    if allow_mpp {
+        builder = builder
+            .allow_mpp(true)
+            .payment_secret(gen_rand_sha256_hash());
+    }
+
+    builder.build().expect("build invoice")
+}
+
+fn create_test_channel_state_with_tlc(
+    channel_id: Hash256,
+    tlc_id: u64,
+    amount: u128,
+    payment_hash: Hash256,
+    total_amount: Option<u128>,
+) -> ChannelActorState {
+    let tlc_info = TlcInfo {
+        status: TlcStatus::Inbound(InboundTlcStatus::Committed),
+        tlc_id: TLCId::Received(tlc_id),
+        amount,
+        payment_hash,
+        total_amount,
+        payment_secret: None,
+        attempt_id: None,
+        expiry: now_timestamp_as_millis_u64() + 1000000,
+        hash_algorithm: HashAlgorithm::CkbHash,
+        onion_packet: None,
+        shared_secret: NO_SHARED_SECRET,
+        is_trampoline_hop: false,
+        created_at: CommitmentNumbers::default(),
+        removed_reason: None,
+        removed_confirmed_at: None,
+        applied_flags: AppliedFlags::empty(),
+        forwarding_tlc: None,
+    };
+
+    let mut tlc_state = TlcState::default();
+    tlc_state.received_tlcs.tlcs.push(tlc_info);
+    tlc_state.received_tlcs.next_tlc_id = tlc_id + 1;
+
+    let seed = [0u8; 32];
+    let signer = InMemorySigner::generate_from_seed(&seed);
+
+    ChannelActorState {
+        state: ChannelState::ChannelReady,
+        public_channel_info: None,
+        local_tlc_info: ChannelTlcInfo::default(),
+        remote_tlc_info: None,
+        local_pubkey: gen_rand_fiber_public_key(),
+        remote_pubkey: gen_rand_fiber_public_key(),
+        id: channel_id,
+        funding_tx: None,
+        funding_tx_confirmed_at: None,
+        funding_udt_type_script: None,
+        is_acceptor: false,
+        is_one_way: false,
+        to_local_amount: 0,
+        to_remote_amount: 0,
+        local_reserved_ckb_amount: 0,
+        remote_reserved_ckb_amount: 0,
+        commitment_fee_rate: 0,
+        commitment_delay_epoch: 0,
+        funding_fee_rate: 0,
+        signer,
+        local_channel_public_keys: ChannelBasePublicKeys {
+            funding_pubkey: gen_rand_fiber_public_key(),
+            tlc_base_key: gen_rand_fiber_public_key(),
+        },
+        commitment_numbers: CommitmentNumbers::default(),
+        local_constraints: ChannelConstraints::default(),
+        remote_constraints: ChannelConstraints::default(),
+        tlc_state,
+        retryable_tlc_operations: std::collections::VecDeque::new(),
+        waiting_forward_tlc_tasks: HashMap::new(),
+        remote_shutdown_script: None,
+        local_shutdown_script: Script::default(),
+        last_committed_remote_nonce: None,
+        remote_revocation_nonce_for_verify: None,
+        remote_revocation_nonce_for_send: None,
+        remote_revocation_nonce_for_next: None,
+        remote_commitment_points: vec![],
+        remote_channel_public_keys: None,
+        local_shutdown_info: None,
+        remote_shutdown_info: None,
+        shutdown_transaction_hash: None,
+        latest_commitment_transaction: None,
+        reestablishing: false,
+        last_revoke_ack_msg: None,
+        created_at: SystemTime::now(),
+        waiting_peer_response: None,
+        network: None,
+        scheduled_channel_update_handle: None,
+        pending_notify_settle_tlcs: vec![],
+        ephemeral_config: Default::default(),
+        private_key: None,
+    }
+}
+
+fn is_fulfill_settlement(settlement: &TlcSettlement) -> bool {
+    matches!(
+        settlement.remove_tlc_command().reason,
+        RemoveTlcReason::RemoveTlcFulfill(_)
+    )
+}
+
+fn get_error_code(settlement: &TlcSettlement) -> Option<TlcErrorCode> {
+    match &settlement.remove_tlc_command().reason {
+        RemoveTlcReason::RemoveTlcFail(packet) => {
+            packet.decode(&[0u8; 32], vec![]).map(|e| e.error_code)
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn test_no_invoice_rejects_all_tlcs() {
+    let payment_hash = gen_rand_sha256_hash();
+    let channel_id_0 = gen_rand_sha256_hash();
+    let channel_id_1 = gen_rand_sha256_hash();
+
+    let store = MockStore::new()
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_0,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ))
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_1,
+            1,
+            2000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id_0, 0), (channel_id_1, 1)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 2);
+    for settlement in &settlements {
+        assert!(!is_fulfill_settlement(settlement));
+        assert_eq!(
+            get_error_code(settlement),
+            Some(TlcErrorCode::InvoiceCancelled)
+        );
+    }
+}
+
+#[test]
+fn test_invoice_without_status_rejects_all() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+
+    // Only insert invoice but not status
+    let store = MockStore::new().with_channel_state(create_test_channel_state_with_tlc(
+        channel_id,
+        0,
+        1000,
+        payment_hash,
+        None,
+    ));
+    store.invoices.borrow_mut().insert(payment_hash, invoice);
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert_eq!(
+        get_error_code(&settlements[0]),
+        Some(TlcErrorCode::InvoiceCancelled)
+    );
+}
+
+#[test]
+fn test_expired_invoice_rejects_all() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Expired)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert_eq!(
+        get_error_code(&settlements[0]),
+        Some(TlcErrorCode::InvoiceExpired)
+    );
+}
+
+#[test]
+fn test_cancelled_invoice_rejects_all() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Cancelled)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert_eq!(
+        get_error_code(&settlements[0]),
+        Some(TlcErrorCode::InvoiceCancelled)
+    );
+}
+
+#[test]
+fn test_paid_invoice_rejects_with_timeout() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Paid)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert_eq!(
+        get_error_code(&settlements[0]),
+        Some(TlcErrorCode::HoldTlcTimeout)
+    );
+}
+
+#[test]
+fn test_open_invoice_proceeds_to_settlement() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert!(is_fulfill_settlement(&settlements[0]));
+}
+
+#[test]
+fn test_received_invoice_proceeds_to_settlement() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Received)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert!(is_fulfill_settlement(&settlements[0]));
+}
+
+#[test]
+fn test_non_mpp_insufficient_amount_rejects_all() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id_0 = gen_rand_sha256_hash();
+    let channel_id_1 = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_0,
+            0,
+            500,
+            payment_hash,
+            None,
+        ))
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_1,
+            1,
+            400,
+            payment_hash,
+            None,
+        ));
+
+    // All TLCs have insufficient amount
+    let channel_tlc_ids = vec![(channel_id_0, 0), (channel_id_1, 1)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 2);
+    for settlement in &settlements {
+        assert_eq!(
+            get_error_code(settlement),
+            Some(TlcErrorCode::IncorrectOrUnknownPaymentDetails)
+        );
+    }
+}
+
+#[test]
+fn test_non_mpp_single_fulfilling_tlc_settles() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert!(is_fulfill_settlement(&settlements[0]));
+}
+
+#[test]
+fn test_non_mpp_overpaying_tlc_settles() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            2000,
+            payment_hash,
+            None,
+        )); // Overpaying
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert!(is_fulfill_settlement(&settlements[0]));
+}
+
+#[test]
+fn test_non_mpp_multiple_tlcs_keeps_first_fulfilling_rejects_rest() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id_0 = gen_rand_sha256_hash();
+    let channel_id_1 = gen_rand_sha256_hash();
+    let channel_id_2 = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_0,
+            0,
+            500,
+            payment_hash,
+            None,
+        )) // Not enough
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_1,
+            1,
+            1000,
+            payment_hash,
+            None,
+        )) // Enough - should be kept
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_2,
+            2,
+            1500,
+            payment_hash,
+            None,
+        )); // Also enough but rejected
+
+    let channel_tlc_ids = vec![(channel_id_0, 0), (channel_id_1, 1), (channel_id_2, 2)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 3);
+
+    // Find the fulfilled settlement (should be from channel_id_1)
+    let fulfilled: Vec<_> = settlements
+        .iter()
+        .filter(|s| is_fulfill_settlement(s))
+        .collect();
+    let rejected: Vec<_> = settlements
+        .iter()
+        .filter(|s| !is_fulfill_settlement(s))
+        .collect();
+
+    assert_eq!(fulfilled.len(), 1);
+    assert_eq!(rejected.len(), 2);
+
+    // The fulfilled TLC should be from channel_id_1 (first one meeting the threshold)
+    assert_eq!(fulfilled[0].channel_id(), channel_id_1);
+
+    // Rejected TLCs should have HoldTlcTimeout error
+    for settlement in rejected {
+        assert_eq!(
+            get_error_code(settlement),
+            Some(TlcErrorCode::HoldTlcTimeout)
+        );
+    }
+}
+
+#[test]
+fn test_mpp_inconsistent_total_amount_rejects_all() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(3000), true);
+    let channel_id_0 = gen_rand_sha256_hash();
+    let channel_id_1 = gen_rand_sha256_hash();
+    let channel_id_2 = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_0,
+            0,
+            1000,
+            payment_hash,
+            Some(3000),
+        ))
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_1,
+            1,
+            1000,
+            payment_hash,
+            Some(4000),
+        )) // Different!
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_2,
+            2,
+            1000,
+            payment_hash,
+            Some(3000),
+        ));
+
+    // TLCs with inconsistent total_amount
+    let channel_tlc_ids = vec![(channel_id_0, 0), (channel_id_1, 1), (channel_id_2, 2)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 3);
+    for settlement in &settlements {
+        assert_eq!(
+            get_error_code(settlement),
+            Some(TlcErrorCode::IncorrectOrUnknownPaymentDetails)
+        );
+    }
+}
+
+#[test]
+fn test_mpp_total_amount_below_invoice_rejects_all() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(5000), true);
+    let channel_id_0 = gen_rand_sha256_hash();
+    let channel_id_1 = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_0,
+            0,
+            1000,
+            payment_hash,
+            Some(3000),
+        ))
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_1,
+            1,
+            1000,
+            payment_hash,
+            Some(3000),
+        ));
+
+    // total_amount is less than invoice amount
+    let channel_tlc_ids = vec![(channel_id_0, 0), (channel_id_1, 1)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 2);
+    for settlement in &settlements {
+        assert_eq!(
+            get_error_code(settlement),
+            Some(TlcErrorCode::IncorrectOrUnknownPaymentDetails)
+        );
+    }
+}
+
+#[test]
+fn test_mpp_not_enough_accumulated_returns_empty() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(3000), true);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            Some(3000),
+        ));
+
+    // Only 1000 accumulated, need 3000
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    // Not enough to fulfill, should return empty (waiting for more TLCs)
+    assert!(settlements.is_empty());
+}
+
+#[test]
+fn test_mpp_accumulated_fulfills_settles_all() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(3000), true);
+    let channel_id_0 = gen_rand_sha256_hash();
+    let channel_id_1 = gen_rand_sha256_hash();
+    let channel_id_2 = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_0,
+            0,
+            1000,
+            payment_hash,
+            Some(3000),
+        ))
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_1,
+            1,
+            1000,
+            payment_hash,
+            Some(3000),
+        ))
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_2,
+            2,
+            1000,
+            payment_hash,
+            Some(3000),
+        ));
+
+    // Exactly enough: 1000 + 1000 + 1000 = 3000
+    let channel_tlc_ids = vec![(channel_id_0, 0), (channel_id_1, 1), (channel_id_2, 2)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 3);
+    for settlement in &settlements {
+        assert!(is_fulfill_settlement(settlement));
+    }
+}
+
+#[test]
+fn test_mpp_overpaid_tlcs_rejected() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(3000), true);
+    let channel_id_0 = gen_rand_sha256_hash();
+    let channel_id_1 = gen_rand_sha256_hash();
+    let channel_id_2 = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_0,
+            0,
+            2000,
+            payment_hash,
+            Some(3000),
+        ))
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_1,
+            1,
+            2000,
+            payment_hash,
+            Some(3000),
+        ))
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id_2,
+            2,
+            2000,
+            payment_hash,
+            Some(3000),
+        )); // Overpaid
+
+    // More than enough: 2000 + 2000 + 2000 = 6000 (need 3000)
+    // Should keep first two and reject third
+    let channel_tlc_ids = vec![(channel_id_0, 0), (channel_id_1, 1), (channel_id_2, 2)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 3);
+
+    let fulfilled: Vec<_> = settlements
+        .iter()
+        .filter(|s| is_fulfill_settlement(s))
+        .collect();
+    let rejected: Vec<_> = settlements
+        .iter()
+        .filter(|s| !is_fulfill_settlement(s))
+        .collect();
+
+    assert_eq!(fulfilled.len(), 2);
+    assert_eq!(rejected.len(), 1);
+
+    // Overpaid TLC should be rejected
+    assert_eq!(rejected[0].channel_id(), channel_id_2);
+    assert_eq!(
+        get_error_code(rejected[0]),
+        Some(TlcErrorCode::HoldTlcTimeout)
+    );
+}
+
+#[test]
+fn test_mpp_single_tlc_consistent_total_amount_check_passes() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), true);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            Some(1000),
+        ));
+
+    // Single TLC for MPP invoice - should not fail consistency check
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert!(is_fulfill_settlement(&settlements[0]));
+}
+
+#[test]
+fn test_no_preimage_skips_settlement() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+    // Note: no preimage added
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    // Should skip settlement and return empty
+    assert!(settlements.is_empty());
+}
+
+#[test]
+fn test_open_invoice_marked_as_received() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let _settlements = command.run();
+
+    // Check that invoice status was updated to Received
+    assert_eq!(
+        store.get_invoice_status(&payment_hash),
+        Some(CkbInvoiceStatus::Received)
+    );
+}
+
+#[test]
+fn test_received_invoice_not_updated() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Received)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let _settlements = command.run();
+
+    // Status should remain Received
+    assert_eq!(
+        store.get_invoice_status(&payment_hash),
+        Some(CkbInvoiceStatus::Received)
+    );
+}
+
+#[test]
+fn test_empty_tlcs_returns_empty() {
+    let payment_hash = gen_rand_sha256_hash();
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let store = MockStore::new().with_invoice(invoice, CkbInvoiceStatus::Open);
+
+    let channel_tlc_ids: Vec<(Hash256, u64)> = vec![];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert!(settlements.is_empty());
+}
+
+#[test]
+fn test_invoice_without_amount_accepts_any() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, None, false); // No amount
+    let channel_id = gen_rand_sha256_hash();
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            0,
+            1,
+            payment_hash,
+            None,
+        )); // Any amount should be accepted
+
+    let channel_tlc_ids = vec![(channel_id, 0)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    assert!(is_fulfill_settlement(&settlements[0]));
+}
+
+#[test]
+fn test_tlc_settlement_accessors() {
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+    let invoice = create_test_invoice(payment_hash, Some(1000), false);
+    let channel_id = gen_rand_sha256_hash();
+    let tlc_id = 42u64;
+    let store = MockStore::new()
+        .with_invoice(invoice, CkbInvoiceStatus::Open)
+        .with_preimage(payment_hash, preimage)
+        .with_channel_state(create_test_channel_state_with_tlc(
+            channel_id,
+            tlc_id,
+            1000,
+            payment_hash,
+            None,
+        ));
+
+    let channel_tlc_ids = vec![(channel_id, tlc_id)];
+
+    let command = SettleTlcSetCommand::new(payment_hash, channel_tlc_ids, &store);
+    let settlements = command.run();
+
+    assert_eq!(settlements.len(), 1);
+    let settlement = &settlements[0];
+
+    assert_eq!(settlement.channel_id(), channel_id);
+    assert_eq!(settlement.tlc_id(), tlc_id);
+    assert!(matches!(
+        settlement.remove_tlc_command().reason,
+        RemoveTlcReason::RemoveTlcFulfill(_)
+    ));
+}

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -3014,7 +3014,7 @@ async fn test_trampoline_node_restart() {
     node_c
         .network_actor
         .send_message(NetworkActorMessage::Command(
-            NetworkActorCommand::SettleTlcSet(payment_hash, None),
+            NetworkActorCommand::SettleHoldTlcSet(payment_hash),
         ))
         .expect("Failed to send settle command");
 


### PR DESCRIPTION
Refactor hold TLC settlement logic to improve payment handling:

- Add invoice status validation (Expired, Cancelled, Paid states properly handled)
- Ensure `RemoveTlc` is called for invalid TLCs
- Reject overpaid TLCs for MPP invoices
- For non-MPP invoices, accept only one fulfilled TLC and reject all others

### Key Changes

1. **New `SettleTlcSetCommand` module**: Encapsulates TLC settlement logic with clear verification steps and settlement actions
2. **Separated command handling**: Split `SettleTlcSet` into two distinct commands:
   - `SettleTlcSet(payment_hash, tlc_ids)` - Settle TLCs by given list of `(channel_id, tlc_id)`
   - `SettleHoldTlcSet(payment_hash)` - Settle hold TLC set saved for a payment hash
3. **Improved channel actor**: Removed `is_mpp` field from `PendingNotifySettleTlc` and simplified the settlement flow
4. **Comprehensive test coverage**: Added unit tests for various scenarios including invoice status validation, MPP handling, and edge cases

### Behavior Notes

This refactoring ensures that, in the presence of multiple payments to the same invoice, at most one payment succeeds. However, due to the lack of database transaction support, there remains a small window where the total accepted amount may exceed the invoice amount.

Additionally, in the case of two concurrent MPP payments, it's possible to partially accept TLCs from both without either payment fully succeeding. This is an inherent limitation of MPP and cannot be avoided on the recipient side.

## Related Issues

Closes #965
