### PR TITLE
Use CkbRpcClient to read from Ckb chain

### DIFF
--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -3,11 +3,12 @@ use ckb_resource::Resource;
 use core::default::Default;
 use fnn::actors::RootActor;
 use fnn::cch::{CchArgs, CchFiberStoreWatcher};
+use fnn::ckb::client::CkbRpcClient;
 use fnn::ckb::contracts::TypeIDResolver;
 #[cfg(debug_assertions)]
 use fnn::ckb::contracts::{get_cell_deps, Contract};
 use fnn::ckb::{contracts::try_init_contracts_context, CkbChainActor};
-use fnn::fiber::{graph::NetworkGraph, network::init_chain_hash};
+use fnn::fiber::{graph::NetworkGraph, network::init_chain_hash, network::NetworkActorMessage};
 use fnn::rpc::server::start_rpc;
 use fnn::rpc::watchtower::{
     CreatePreimageParams, CreateWatchChannelParams, RemovePreimageParams, RemoveWatchChannelParams,
@@ -166,8 +167,10 @@ pub async fn main() -> Result<(), ExitMessage> {
 
             info!("Starting fiber");
 
-            let network_actor = start_network(
+            let chain_client = CkbRpcClient::new(&ckb_config);
+            let network_actor: ActorRef<NetworkActorMessage> = start_network(
                 fiber_config.clone(),
+                chain_client,
                 ckb_chain_actor.clone(),
                 event_sender,
                 new_tokio_task_tracker(),

--- a/crates/fiber-lib/src/ckb/actor.rs
+++ b/crates/fiber-lib/src/ckb/actor.rs
@@ -1,10 +1,5 @@
-use ckb_jsonrpc_types::JsonBytes;
-use ckb_sdk::{rpc::ckb_indexer::*, CkbRpcAsyncClient, RpcError};
-use ckb_types::{
-    core::{tx_pool::TxStatus, TransactionView},
-    packed,
-    prelude::IntoTransactionView as _,
-};
+use ckb_sdk::RpcError;
+use ckb_types::{core::TransactionView, packed, prelude::IntoTransactionView as _};
 use ractor::{concurrency::Duration, Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -19,7 +14,6 @@ use crate::{
 
 use super::{
     funding::{FundingContext, LiveCellsExclusionMap},
-    jsonrpc_types_convert::{transaction_view_from_json, tx_status_from_json},
     tx_tracing_actor::{
         CkbTxTracer, CkbTxTracingActor, CkbTxTracingArguments, CkbTxTracingMessage,
     },
@@ -37,117 +31,6 @@ pub struct CkbChainState {
     secret_key: secp256k1::SecretKey,
     funding_source_lock_script: packed::Script,
     live_cells_exclusion_map: LiveCellsExclusionMap,
-}
-
-#[derive(Debug, Clone)]
-pub struct GetBlockTimestampRequest {
-    block_hash: Hash256,
-}
-
-impl GetBlockTimestampRequest {
-    pub fn from_block_hash(block_hash: Hash256) -> Self {
-        Self { block_hash }
-    }
-
-    pub fn block_hash(&self) -> Hash256 {
-        self.block_hash
-    }
-}
-
-pub type GetBlockTimestampResponse = u64;
-
-#[derive(Debug, Clone)]
-pub struct GetTxResponse {
-    /// The transaction.
-    pub transaction: Option<TransactionView>,
-    pub tx_status: TxStatus,
-}
-
-impl Default for GetTxResponse {
-    fn default() -> Self {
-        Self {
-            transaction: None,
-            tx_status: TxStatus::Unknown,
-        }
-    }
-}
-
-impl From<Option<ckb_jsonrpc_types::TransactionWithStatusResponse>> for GetTxResponse {
-    fn from(value: Option<ckb_jsonrpc_types::TransactionWithStatusResponse>) -> Self {
-        match value {
-            Some(response) => Self {
-                transaction: response.transaction.map(|tx| match tx.inner {
-                    ckb_jsonrpc_types::Either::Left(json) => transaction_view_from_json(json),
-                    ckb_jsonrpc_types::Either::Right(_) => {
-                        panic!("bytes response format not used");
-                    }
-                }),
-                tx_status: tx_status_from_json(response.tx_status),
-            },
-            None => Self::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct GetShutdownTxRequest {
-    pub funding_lock_script: packed::Script,
-}
-
-#[derive(Debug, Clone)]
-pub struct GetShutdownTxResponse {
-    /// The transaction.
-    pub transaction: Option<TransactionView>,
-    pub tx_status: TxStatus,
-}
-
-impl Default for GetShutdownTxResponse {
-    fn default() -> Self {
-        Self {
-            transaction: None,
-            tx_status: TxStatus::Unknown,
-        }
-    }
-}
-
-impl From<Option<ckb_jsonrpc_types::TransactionWithStatusResponse>> for GetShutdownTxResponse {
-    fn from(value: Option<ckb_jsonrpc_types::TransactionWithStatusResponse>) -> Self {
-        match value {
-            Some(response) => Self {
-                transaction: response.transaction.map(|tx| match tx.inner {
-                    ckb_jsonrpc_types::Either::Left(json) => transaction_view_from_json(json),
-                    ckb_jsonrpc_types::Either::Right(_) => {
-                        panic!("bytes response format not used");
-                    }
-                }),
-                tx_status: tx_status_from_json(response.tx_status),
-            },
-            None => Self::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct GetCellsRequest {
-    pub search_key: SearchKey,
-    pub order: Order,
-    pub limit: u32,
-    pub after: Option<JsonBytes>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct GetCellsResponse {
-    pub objects: Vec<Cell>,
-    pub last_cursor: JsonBytes,
-}
-
-impl From<Pagination<Cell>> for GetCellsResponse {
-    fn from(value: Pagination<Cell>) -> Self {
-        Self {
-            objects: value.objects,
-            last_cursor: value.last_cursor,
-        }
-    }
 }
 
 #[derive(Debug, AsRefStr)]
@@ -174,21 +57,9 @@ pub enum CkbChainMessage {
     CommitFundingTx(Hash256, u64),
     Sign(FundingTx, RpcReplyPort<Result<FundingTx, FundingError>>),
     SendTx(TransactionView, RpcReplyPort<Result<(), RpcError>>),
-    GetTx(Hash256, RpcReplyPort<Result<GetTxResponse, RpcError>>),
     CreateTxTracer(CkbTxTracer),
     RemoveTxTracers(Hash256),
-    GetBlockTimestamp(
-        GetBlockTimestampRequest,
-        RpcReplyPort<Result<Option<GetBlockTimestampResponse>, RpcError>>,
-    ),
-    GetShutdownTx(
-        GetShutdownTxRequest,
-        RpcReplyPort<Result<Option<GetShutdownTxResponse>, RpcError>>,
-    ),
-    GetCells(
-        GetCellsRequest,
-        RpcReplyPort<Result<GetCellsResponse, RpcError>>,
-    ),
+
     Stop,
 }
 
@@ -325,14 +196,7 @@ impl Actor for CkbChainActor {
                     let _ = reply_port.send(result);
                 }
             }
-            CkbChainMessage::GetTx(tx_hash, reply_port) => {
-                let ckb_client = state.config.ckb_rpc_client();
-                let result = ckb_client.get_transaction(tx_hash.into()).await;
-                if !reply_port.is_closed() {
-                    // ignore error
-                    let _ = reply_port.send(result.map(Into::into));
-                }
-            }
+
             CkbChainMessage::CreateTxTracer(tracer) => {
                 debug!(
                     "[{}] trace transaction {} with {} confs",
@@ -349,28 +213,7 @@ impl Actor for CkbChainActor {
                     .ckb_tx_tracing_actor
                     .send_message(CkbTxTracingMessage::RemoveTracers(tx_hash))?;
             }
-            CkbChainMessage::GetBlockTimestamp(
-                GetBlockTimestampRequest { block_hash },
-                reply_port,
-            ) => {
-                let ckb_client = state.config.ckb_rpc_client();
-                let _ = reply_port.send(
-                    ckb_client
-                        .get_header(block_hash.into())
-                        .await
-                        .map(|x| x.map(|x| x.inner.timestamp.into())),
-                );
-            }
-            CkbChainMessage::GetShutdownTx(request, reply_port) => {
-                let client = state.config.ckb_rpc_client();
-                let response = get_shutdown_tx(&client, request).await;
-                let _ = reply_port.send(response);
-            }
-            CkbChainMessage::GetCells(request, reply_port) => {
-                let client = state.config.ckb_rpc_client();
-                let response = get_cells(&client, request).await;
-                let _ = reply_port.send(response);
-            }
+
             CkbChainMessage::Stop => {
                 myself.stop(Some("stop received".to_string()));
             }
@@ -457,50 +300,4 @@ async fn fund_via_shell(
 ) -> Result<FundingTx, FundingError> {
     // Never called in WASM
     unreachable!();
-}
-
-async fn get_shutdown_tx(
-    client: &CkbRpcAsyncClient,
-    GetShutdownTxRequest {
-        funding_lock_script,
-    }: GetShutdownTxRequest,
-) -> Result<Option<GetShutdownTxResponse>, RpcError> {
-    // query transaction spent the funding cell
-    let search_key = SearchKey {
-        script: funding_lock_script.into(),
-        script_type: ScriptType::Lock,
-        script_search_mode: Some(SearchMode::Exact),
-        with_data: None,
-        filter: None,
-        group_by_transaction: None,
-    };
-    let txs = client
-        .get_transactions(search_key, Order::Desc, 1u32.into(), None)
-        .await?;
-
-    let Some(Tx::Ungrouped(tx)) = txs.objects.first() else {
-        return Ok(None);
-    };
-    if !matches!(tx.io_type, CellType::Input) {
-        return Ok(None);
-    }
-
-    let shutdown_tx_hash: Hash256 = tx.tx_hash.clone().into();
-    let tx_with_status = client.get_transaction(shutdown_tx_hash.into()).await?;
-    Ok(Some(tx_with_status.into()))
-}
-
-async fn get_cells(
-    client: &CkbRpcAsyncClient,
-    GetCellsRequest {
-        search_key,
-        order,
-        limit,
-        after,
-    }: GetCellsRequest,
-) -> Result<GetCellsResponse, RpcError> {
-    client
-        .get_cells(search_key, order, limit.into(), after)
-        .await
-        .map(GetCellsResponse::from)
 }

--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -1,0 +1,190 @@
+use crate::ckb::CkbConfig;
+use ckb_jsonrpc_types::JsonBytes;
+use ckb_sdk::rpc::ckb_indexer::{Cell, CellType, Order, Pagination, ScriptType, SearchKey, Tx};
+use ckb_types::H256;
+
+use ckb_types::{
+    core::{tx_pool::TxStatus, TransactionView},
+    packed::Script,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{ckb::jsonrpc_types_convert::*, fiber::types::Hash256};
+
+#[derive(Debug, Clone)]
+pub struct GetTxResponse {
+    /// The transaction.
+    pub transaction: Option<TransactionView>,
+    pub tx_status: TxStatus,
+}
+
+impl Default for GetTxResponse {
+    fn default() -> Self {
+        Self {
+            transaction: None,
+            tx_status: TxStatus::Unknown,
+        }
+    }
+}
+
+impl From<Option<ckb_jsonrpc_types::TransactionWithStatusResponse>> for GetTxResponse {
+    fn from(value: Option<ckb_jsonrpc_types::TransactionWithStatusResponse>) -> Self {
+        match value {
+            Some(response) => Self {
+                transaction: response.transaction.map(|tx| match tx.inner {
+                    ckb_jsonrpc_types::Either::Left(json) => transaction_view_from_json(json),
+                    ckb_jsonrpc_types::Either::Right(_) => {
+                        panic!("bytes response format not used");
+                    }
+                }),
+                tx_status: tx_status_from_json(response.tx_status),
+            },
+            None => Self::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GetShutdownTxResponse {
+    /// The transaction.
+    pub transaction: Option<TransactionView>,
+    pub tx_status: TxStatus,
+}
+
+impl Default for GetShutdownTxResponse {
+    fn default() -> Self {
+        Self {
+            transaction: None,
+            tx_status: TxStatus::Unknown,
+        }
+    }
+}
+
+impl From<Option<ckb_jsonrpc_types::TransactionWithStatusResponse>> for GetShutdownTxResponse {
+    fn from(value: Option<ckb_jsonrpc_types::TransactionWithStatusResponse>) -> Self {
+        match value {
+            Some(response) => Self {
+                transaction: response.transaction.map(|tx| match tx.inner {
+                    ckb_jsonrpc_types::Either::Left(json) => transaction_view_from_json(json),
+                    ckb_jsonrpc_types::Either::Right(_) => {
+                        panic!("bytes response format not used");
+                    }
+                }),
+                tx_status: tx_status_from_json(response.tx_status),
+            },
+            None => Self::default(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GetCellsResponse {
+    pub objects: Vec<Cell>,
+    pub last_cursor: JsonBytes,
+}
+
+impl From<Pagination<Cell>> for GetCellsResponse {
+    fn from(value: Pagination<Cell>) -> Self {
+        Self {
+            objects: value.objects,
+            last_cursor: value.last_cursor,
+        }
+    }
+}
+
+#[cfg_attr(target_arch="wasm32",async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait CkbChainClient: Send + Sync {
+    async fn get_transaction(&self, hash: H256) -> Result<GetTxResponse, anyhow::Error>;
+    async fn get_cells(
+        &self,
+        search_key: SearchKey,
+        order: Order,
+        limit: u32,
+        after: Option<JsonBytes>,
+    ) -> Result<Pagination<Cell>, anyhow::Error>;
+    async fn get_block_timestamp(&self, block_hash: Hash256) -> Result<Option<u64>, anyhow::Error>;
+    async fn get_shutdown_tx(
+        &self,
+        funding_lock_script: Script,
+    ) -> Result<Option<GetShutdownTxResponse>, anyhow::Error>;
+}
+
+#[derive(Clone)]
+pub struct CkbRpcClient {
+    config: CkbConfig,
+}
+
+impl CkbRpcClient {
+    pub fn new(config: &CkbConfig) -> Self {
+        Self {
+            config: config.clone(),
+        }
+    }
+}
+
+#[cfg_attr(target_arch="wasm32",async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl CkbChainClient for CkbRpcClient {
+    async fn get_transaction(&self, hash: H256) -> Result<GetTxResponse, anyhow::Error> {
+        let client = self.config.ckb_rpc_client();
+        client
+            .get_transaction(hash)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
+    async fn get_cells(
+        &self,
+        search_key: SearchKey,
+        order: Order,
+        limit: u32,
+        after: Option<JsonBytes>,
+    ) -> Result<Pagination<Cell>, anyhow::Error> {
+        let client = self.config.ckb_rpc_client();
+        client
+            .get_cells(search_key, order, limit.into(), after)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn get_block_timestamp(&self, block_hash: Hash256) -> Result<Option<u64>, anyhow::Error> {
+        let client = self.config.ckb_rpc_client();
+        client
+            .get_header(block_hash.into())
+            .await
+            .map(|x| x.map(|x| x.inner.timestamp.into()))
+            .map_err(Into::into)
+    }
+
+    async fn get_shutdown_tx(
+        &self,
+        funding_lock_script: Script,
+    ) -> Result<Option<GetShutdownTxResponse>, anyhow::Error> {
+        let client = self.config.ckb_rpc_client();
+        // query transaction spent the funding cell
+        let search_key = SearchKey {
+            script: funding_lock_script.into(),
+            script_type: ScriptType::Lock,
+            script_search_mode: Some(ckb_sdk::rpc::ckb_indexer::SearchMode::Exact),
+            with_data: None,
+            filter: None,
+            group_by_transaction: None,
+        };
+        let txs = client
+            .get_transactions(search_key, Order::Desc, 1u32.into(), None)
+            .await?;
+
+        let Some(Tx::Ungrouped(tx)) = txs.objects.first() else {
+            return Ok(None);
+        };
+        if !matches!(tx.io_type, CellType::Input) {
+            return Ok(None);
+        }
+
+        let shutdown_tx_hash: Hash256 = tx.tx_hash.clone().into();
+        let tx_with_status = client.get_transaction(shutdown_tx_hash.into()).await?;
+        Ok(Some(tx_with_status.into()))
+    }
+}

--- a/crates/fiber-lib/src/ckb/mod.rs
+++ b/crates/fiber-lib/src/ckb/mod.rs
@@ -4,15 +4,15 @@ mod funding;
 mod jsonrpc_types_convert;
 mod tx_tracing_actor;
 
-pub use actor::{
-    CkbChainActor, CkbChainMessage, GetBlockTimestampRequest, GetBlockTimestampResponse,
-    GetCellsRequest, GetCellsResponse, GetShutdownTxRequest, GetShutdownTxResponse, GetTxResponse,
-};
+pub use actor::{CkbChainActor, CkbChainMessage};
+
+pub use client::{GetCellsResponse, GetShutdownTxResponse, GetTxResponse};
 pub use config::{CkbConfig, DEFAULT_CKB_BASE_DIR_NAME};
 pub use error::{CkbChainError, FundingError};
 pub use funding::{FundingRequest, FundingTx};
 pub use tx_tracing_actor::{CkbTxTracer, CkbTxTracingMask, CkbTxTracingResult};
 
+pub mod client;
 pub mod config;
 pub mod contracts;
 

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -55,6 +55,7 @@ use super::channel::{
     DEFAULT_MAX_TLC_VALUE_IN_FLIGHT,
 };
 use super::config::AnnouncedNodeName;
+use crate::ckb::client::CkbChainClient;
 use ckb_sdk::rpc::ckb_indexer::{Order, ScriptType, SearchKey, SearchMode};
 
 use super::features::FeatureVector;
@@ -72,10 +73,7 @@ use super::{
 };
 use crate::ckb::config::UdtCfgInfos;
 use crate::ckb::contracts::{check_udt_script, get_udt_whitelist, is_udt_type_auto_accept};
-use crate::ckb::{
-    CkbChainMessage, FundingError, FundingRequest, FundingTx, GetCellsRequest,
-    GetShutdownTxRequest, GetShutdownTxResponse,
-};
+use crate::ckb::{CkbChainMessage, FundingError, FundingRequest, FundingTx, GetShutdownTxResponse};
 use crate::fiber::channel::{
     tlc_expiry_delay, AddTlcCommand, AddTlcResponse, ChannelActorState, ChannelEphemeralConfig,
     ChannelInitializationOperation, RetryableTlcOperation, ShutdownCommand, TxCollaborationCommand,
@@ -634,15 +632,16 @@ impl GossipMessageWithPeerId {
     }
 }
 
-pub struct NetworkActor<S> {
+pub struct NetworkActor<S, C> {
     // An event emitter to notify outside observers.
     event_sender: mpsc::Sender<NetworkServiceEvent>,
     chain_actor: ActorRef<CkbChainMessage>,
     store: S,
     network_graph: Arc<RwLock<NetworkGraph<S>>>,
+    chain_client: C,
 }
 
-impl<S> NetworkActor<S>
+impl<S, C> NetworkActor<S, C>
 where
     S: NetworkActorStateStore
         + ChannelActorStateStore
@@ -654,25 +653,28 @@ where
         + Send
         + Sync
         + 'static,
+    C: CkbChainClient + Clone + Send + Sync + 'static,
 {
     pub fn new(
         event_sender: mpsc::Sender<NetworkServiceEvent>,
         chain_actor: ActorRef<CkbChainMessage>,
         store: S,
         network_graph: Arc<RwLock<NetworkGraph<S>>>,
+        chain_client: C,
     ) -> Self {
         Self {
             event_sender,
             chain_actor,
             store: store.clone(),
             network_graph,
+            chain_client,
         }
     }
 
     pub async fn handle_peer_message(
         &self,
         myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         peer_id: PeerId,
         message: FiberMessage,
     ) -> crate::Result<()> {
@@ -753,7 +755,7 @@ where
     pub async fn handle_event(
         &self,
         myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         event: NetworkActorEvent,
     ) -> crate::Result<()> {
         match event {
@@ -997,7 +999,7 @@ where
     pub async fn handle_command(
         &self,
         myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         command: NetworkActorCommand,
     ) -> crate::Result<()> {
         match command {
@@ -2095,22 +2097,15 @@ where
             ChannelState::ChannelReady | ChannelState::ShuttingDown(..)
         ) {
             let channel_id = state.get_id();
-            // check shutdown transactions
-            let request = GetShutdownTxRequest {
-                funding_lock_script,
-            };
-            if let Err(err) = self.chain_actor.call_and_forward(
-                |tx| CkbChainMessage::GetShutdownTx(request, tx),
-                &myself,
-                move |shutdown_tx| {
-                    NetworkActorMessage::Command(NetworkActorCommand::RemoteForceShutdownChannel(
-                        channel_id,
-                        shutdown_tx.unwrap_or_default(),
-                    ))
-                },
-                None,
-            ) {
-                tracing::error!("Failed to call_and_forward chain_actor: {err:?}");
+            match self.chain_client.get_shutdown_tx(funding_lock_script).await {
+                Ok(shutdown_tx) => {
+                    let _ = myself.send_message(NetworkActorMessage::Command(
+                        NetworkActorCommand::RemoteForceShutdownChannel(channel_id, shutdown_tx),
+                    ));
+                }
+                Err(err) => {
+                    tracing::error!("Failed to check shutdown tx: {err:?}");
+                }
             }
         }
     }
@@ -2131,23 +2126,11 @@ where
             return;
         };
 
-        let tx_response = match call_t!(
-            self.chain_actor,
-            CkbChainMessage::GetTx,
-            DEFAULT_CHAIN_ACTOR_TIMEOUT,
-            tx_hash.clone().into()
-        ) {
-            Ok(Ok(response)) => response,
-            Ok(Err(err)) => {
-                error!(
-                    "Failed to load commitment tx {:?} during settlement check: {:?}",
-                    tx_hash, err
-                );
-                return;
-            }
+        let tx_response = match self.chain_client.get_transaction(tx_hash.clone()).await {
+            Ok(response) => response,
             Err(err) => {
                 error!(
-                    "Timeout while loading commitment tx {:?} during settlement check: {:?}",
+                    "Failed to load commitment tx {:?} during settlement check: {:?}",
                     tx_hash, err
                 );
                 return;
@@ -2192,20 +2175,14 @@ where
             filter: None,
             group_by_transaction: None,
         };
-        let request = GetCellsRequest {
-            search_key,
-            order: Order::Desc,
-            limit: 1,
-            after: None,
-        };
 
-        match call_t!(
-            self.chain_actor,
-            CkbChainMessage::GetCells,
-            DEFAULT_CHAIN_ACTOR_TIMEOUT,
-            request
-        ) {
-            Ok(Ok(response)) => {
+        match self
+            .chain_client
+            .get_cells(search_key, Order::Desc, 1, None)
+            .await
+        {
+            Ok(response) => {
+                let response = crate::ckb::GetCellsResponse::from(response);
                 if response.objects.is_empty() {
                     let channel_id = state.get_id();
                     flags.remove(CloseFlags::WAITING_ONCHAIN_SETTLEMENT);
@@ -2214,16 +2191,9 @@ where
                     info!("Channel {channel_id:?} on-chain settlement completed");
                 }
             }
-            Ok(Err(err)) => {
-                error!(
-                    "Failed to check commitment cells for {:?}: {:?}",
-                    state.get_id(),
-                    err
-                );
-            }
             Err(err) => {
                 error!(
-                    "GetCells request timed out for {:?}: {:?}",
+                    "Failed to check commitment cells for {:?}: {:?}",
                     state.get_id(),
                     err
                 );
@@ -2343,7 +2313,7 @@ where
 
     async fn handle_send_onion_packet_command(
         &self,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         command: SendOnionPacketCommand,
     ) -> Result<(), TlcErr> {
         trace!("Entering handle_send_onion_packet_command");
@@ -2413,7 +2383,7 @@ where
 
     fn get_tlc_error(
         &self,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         error: &Error,
         channel_outpoint: &OutPoint,
     ) -> TlcErr {
@@ -2444,7 +2414,7 @@ where
     async fn on_remove_tlc_event(
         &self,
         myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         payment_hash: Hash256,
         attempt_id: Option<u64>,
         reason: RemoveTlcReason,
@@ -2471,7 +2441,7 @@ where
     async fn on_add_tlc_result_event(
         &self,
         myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         payment_hash: Hash256,
         attempt_id: Option<u64>,
         add_tlc_result: Result<(Hash256, u64), (ProcessingChannelError, TlcErr)>,
@@ -2529,7 +2499,7 @@ where
     async fn resume_payment_actor_and_send_command(
         &self,
         myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         payment_hash: Hash256,
         message: PaymentActorMessage,
     ) {
@@ -2552,7 +2522,7 @@ where
     async fn start_payment_actor(
         &self,
         myself: ActorRef<NetworkActorMessage>,
-        state: &mut NetworkActorState<S>,
+        state: &mut NetworkActorState<S, C>,
         payment_hash: Hash256,
         init_command: PaymentActorMessage,
     ) {
@@ -2633,7 +2603,7 @@ where
     }
 }
 
-pub struct NetworkActorState<S> {
+pub struct NetworkActorState<S, C> {
     store: S,
     state_to_be_persisted: PersistentNetworkActorState,
     // The name of the node to be announced to the network, may be empty.
@@ -2669,6 +2639,8 @@ pub struct NetworkActorState<S> {
     pending_channels: HashMap<OutPoint, Hash256>,
     // Used to broadcast and query network info.
     chain_actor: ActorRef<CkbChainMessage>,
+    // Used to query on-chain info.
+    chain_client: C,
     // If the other party funding more than this amount, we will automatically accept the channel.
     open_channel_auto_accept_min_ckb_funding_amount: u64,
     // The default amount of CKB to be funded when auto accepting a channel.
@@ -2788,7 +2760,7 @@ fn generate_channel_actor_name(local_peer_id: &PeerId, remote_peer_id: &PeerId) 
     )
 }
 
-impl<S> NetworkActorState<S>
+impl<S, C> NetworkActorState<S, C>
 where
     S: NetworkActorStateStore
         + ChannelActorStateStore
@@ -2800,6 +2772,7 @@ where
         + Send
         + Sync
         + 'static,
+    C: CkbChainClient + Clone + Send + Sync + 'static,
 {
     pub fn get_or_create_new_node_announcement_message(&mut self) -> NodeAnnouncement {
         let now = now_timestamp_as_millis_u64();
@@ -3062,6 +3035,7 @@ where
     ) -> crate::Result<()> {
         let handler = InFlightCkbTxActor {
             chain_actor: self.chain_actor.clone(),
+            chain_client: self.chain_client.clone(),
             network_actor: self.network.clone(),
             tx_hash,
             tx_kind,
@@ -3088,6 +3062,7 @@ where
 
         let handler = InFlightCkbTxActor {
             chain_actor: self.chain_actor.clone(),
+            chain_client: self.chain_client.clone(),
             network_actor: self.network.clone(),
             tx_hash,
             tx_kind,
@@ -3909,7 +3884,7 @@ pub struct NetworkActorStartArguments {
 
 #[cfg_attr(target_arch="wasm32",async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<S> Actor for NetworkActor<S>
+impl<S, C> Actor for NetworkActor<S, C>
 where
     S: NetworkActorStateStore
         + ChannelActorStateStore
@@ -3921,9 +3896,10 @@ where
         + Send
         + Sync
         + 'static,
+    C: CkbChainClient + Clone + Send + Sync + 'static,
 {
     type Msg = NetworkActorMessage;
-    type State = NetworkActorState<S>;
+    type State = NetworkActorState<S, C>;
     type Arguments = NetworkActorStartArguments;
 
     async fn pre_start(
@@ -3961,6 +3937,7 @@ where
             gossip_config,
             self.store.clone(),
             self.chain_actor.clone(),
+            self.chain_client.clone(),
             myself.get_cell(),
         )
         .await;
@@ -4129,6 +4106,7 @@ where
             to_be_accepted_channels: ToBeAcceptedChannels::new_with_config(&config),
             pending_channels: Default::default(),
             chain_actor,
+            chain_client: self.chain_client.clone(),
             open_channel_auto_accept_min_ckb_funding_amount: config
                 .open_channel_auto_accept_min_ckb_funding_amount(),
             auto_accept_channel_ckb_funding_amount: config.auto_accept_channel_ckb_funding_amount(),
@@ -4413,8 +4391,10 @@ pub async fn start_network<
         + Send
         + Sync
         + 'static,
+    C: CkbChainClient + Clone + Send + Sync + 'static,
 >(
     config: FiberConfig,
+    chain_client: C,
     chain_actor: ActorRef<CkbChainMessage>,
     event_sender: mpsc::Sender<NetworkServiceEvent>,
     tracker: TaskTracker,
@@ -4428,7 +4408,13 @@ pub async fn start_network<
 
     let (actor, _handle) = Actor::spawn_linked(
         Some(format!("Network {}", my_peer_id)),
-        NetworkActor::new(event_sender, chain_actor, store, network_graph),
+        NetworkActor::new(
+            event_sender,
+            chain_actor,
+            store,
+            network_graph,
+            chain_client,
+        ),
         NetworkActorStartArguments {
             config,
             tracker,

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -1,4 +1,4 @@
-use crate::ckb::tests::test_utils::get_tx_from_hash;
+use crate::ckb::client::CkbChainClient;
 use crate::ckb::tests::test_utils::MockChainActorMiddleware;
 use crate::ckb::CkbConfig;
 use crate::ckb::GetTxResponse;
@@ -86,7 +86,9 @@ use crate::fiber::types::Privkey;
 use crate::store::Store;
 use crate::{
     actors::{RootActor, RootActorMessage},
-    ckb::tests::test_utils::{submit_tx, trace_tx, MockChainActor},
+    ckb::tests::test_utils::{
+        submit_tx, trace_tx, MockChainActor, MockChainState, MockCkbChainClient,
+    },
     ckb::CkbChainMessage,
     fiber::graph::NetworkGraph,
     fiber::network::{
@@ -238,9 +240,9 @@ pub struct NetworkNode {
     pub ckb_config: Option<CkbConfig>,
     pub listening_addrs: Vec<MultiAddr>,
     pub network_actor: ActorRef<NetworkActorMessage>,
-    pub ckb_chain_actor: ActorRef<CkbChainMessage>,
     pub network_graph: Arc<TokioRwLock<NetworkGraph<Store>>>,
     pub chain_actor: ActorRef<CkbChainMessage>,
+    pub chain_client: MockCkbChainClient,
     pub mock_chain_actor_middleware: Option<Box<dyn MockChainActorMiddleware>>,
     pub gossip_actor: ActorRef<GossipActorMessage>,
     pub private_key: Privkey,
@@ -1361,8 +1363,8 @@ impl NetworkNode {
             node_name,
             store,
             fiber_config,
-            ckb_config,
             rpc_config,
+            ckb_config,
             mock_chain_actor_middleware,
         } = config;
 
@@ -1371,15 +1373,18 @@ impl NetworkNode {
         let root = get_test_root_actor().await;
         let (event_sender, mut event_receiver) = mpsc::channel(10000);
 
+        let shared_state = Arc::new(std::sync::RwLock::new(MockChainState::new()));
         let chain_actor = Actor::spawn_linked(
             None,
             MockChainActor::new(),
-            mock_chain_actor_middleware.clone(),
+            (mock_chain_actor_middleware.clone(), shared_state.clone()),
             root.get_cell(),
         )
         .await
         .expect("start mock chain actor")
         .0;
+
+        let chain_client = MockCkbChainClient::new(shared_state);
 
         let private_key: Privkey = fiber_config
             .read_or_generate_secret_key()
@@ -1400,6 +1405,7 @@ impl NetworkNode {
                 chain_actor.clone(),
                 store.clone(),
                 network_graph.clone(),
+                chain_client.clone(),
             ),
             NetworkActorStartArguments {
                 config: fiber_config.clone(),
@@ -1504,7 +1510,7 @@ impl NetworkNode {
             channels_tx_map: Default::default(),
             listening_addrs: announced_addrs,
             network_actor,
-            ckb_chain_actor: chain_actor.clone(),
+            chain_client,
             mock_chain_actor_middleware,
             network_graph,
             chain_actor,
@@ -1534,7 +1540,7 @@ impl NetworkNode {
     }
 
     pub fn send_ckb_chain_message(&self, message: CkbChainMessage) {
-        self.ckb_chain_actor
+        self.chain_actor
             .send_message(message)
             .expect("send ckb chain message");
     }
@@ -1767,9 +1773,7 @@ impl NetworkNode {
         &mut self,
         tx_hash: Hash256,
     ) -> Result<GetTxResponse, anyhow::Error> {
-        get_tx_from_hash(self.chain_actor.clone(), tx_hash)
-            .await
-            .map_err(Into::into)
+        self.chain_client.get_transaction(tx_hash.into()).await
     }
 
     pub async fn get_transaction_view_from_hash(
@@ -1848,7 +1852,8 @@ impl NetworkNode {
 }
 
 pub async fn create_mock_chain_actor() -> ActorRef<CkbChainMessage> {
-    Actor::spawn(None, MockChainActor::new(), None)
+    let shared_state = Arc::new(std::sync::RwLock::new(MockChainState::new()));
+    Actor::spawn(None, MockChainActor::new(), (None, shared_state))
         .await
         .expect("start mock chain actor")
         .0

--- a/crates/fiber-wasm/src/lib.rs
+++ b/crates/fiber-wasm/src/lib.rs
@@ -12,6 +12,7 @@ use fnn::{
     actors::RootActor,
     ckb::{
         CkbChainActor,
+        client::CkbRpcClient,
         contracts::{TypeIDResolver, try_init_contracts_context},
     },
     fiber::{KeyPair, graph::NetworkGraph, network::init_chain_hash},
@@ -188,6 +189,7 @@ pub async fn fiber(
             .await
             .map_err(|err| ExitMessage(format!("failed to start ckb actor: {}", err)))?
             .0;
+            let chain_client = CkbRpcClient::new(&ckb_config);
 
             const CHANNEL_SIZE: usize = 4000;
             let (event_sender, mut event_receiver) = mpsc::channel(CHANNEL_SIZE);
@@ -206,6 +208,7 @@ pub async fn fiber(
             info!("Starting fiber");
             let network_actor = start_network(
                 fiber_config.clone(),
+                chain_client,
                 ckb_chain_actor.clone(),
                 event_sender,
                 new_tokio_task_tracker(),


### PR DESCRIPTION
Fiber actors send rpc to Ckb chain through CkbChainActor, which provides a singular interface, but also causes all read/write Rpc calls becomes non-concurrent and single thread. This caused other actors who depends on CkbChainActors are blocked to wait their actor call.

To solve this Issue, we move `GetTx`, `GetCells`, `GetBlockTimestamp`, `GetShutdownTx` these read Rpc calls to a new CkbChainClient interface(it is not a actor), and change fiber actors to read from the CkbChainClient instead of the CkbChainActor.