### PR TITLE
payment: avoid `spawn_blocking` on wasm32

### DIFF
--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -1122,6 +1122,7 @@ where
 
     /// Spawn a blocking task to build route
     /// NOTE: build route is a CPU intensive task
+    #[cfg(not(target_arch = "wasm32"))]
     async fn build_route_in_spawn_task(
         &self,
         amount: u128,
@@ -1139,6 +1140,7 @@ where
     }
 
     /// NOTE: `spawn_blocking` is not supported on wasm, so this original implementation of `build_route` will be used on wasm
+    #[cfg(target_arch = "wasm32")]
     async fn build_route(
         &self,
         amount: u128,


### PR DESCRIPTION
`spawn_blocking` will cause a panic on wasm32 since it's unable to create threads on the platform. This PR uses the original implementation of `build_route` on wasm32.