### PR TITLE
Fix unstable invoice CI

### DIFF
--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -57,7 +57,8 @@ pub const MAX_PAYMENT_TLC_EXPIRY_LIMIT: u64 = 14 * 24 * 60 * 60 * 1000; // 2 wee
 /// The minimal value of a tlc. 0 means no minimal value.
 pub const DEFAULT_TLC_MIN_VALUE: u128 = 0;
 
-/// The fee for forwarding peer tlcs. Proportional to the amount of the forwarded tlc. The unit is millionths of the amount. 1000 means 0.1%.
+/// The fee for forwarding peer tlcs. Proportional to the amount of the forwarded tlc.
+/// The unit is millionths of the amount. 1000 means 0.1%.
 pub const DEFAULT_TLC_FEE_PROPORTIONAL_MILLIONTHS: u128 = 1000;
 
 /// Whether to automatically announce the node on startup. false means not announcing.

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -647,6 +647,7 @@ async fn test_send_payment_with_normal_invoice_workflow() {
         .gen_invoice(NewInvoiceParams {
             amount: 1000,
             description: Some("test invoice".to_string()),
+            final_expiry_delta: Some(DEFAULT_FINAL_TLC_EXPIRY_DELTA),
             expiry: None,
             ..Default::default()
         })


### PR DESCRIPTION
Test failed in https://github.com/nervosnetwork/fiber/actions/runs/21000957943/job/60370496700?pr=1012

with error:

```console
TLC expiry 1768407235678 is too soon, current time: 1768407234353, MIN_TLC_EXPIRY_DELTA: 1333
```

because in testing environment, the default final_expiry_delta in new_invoice RPC being too tight (MIN_TLC_EXPIRY_DELTA = ~1.3 seconds).

