### PR TITLE
Fix concurrency issue from forwarding mulitple tlcs with same invoice

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1014,7 +1014,7 @@ where
         // - Extract public key from onion_packet[1..34]
         // - Obtain share secret using DH Key Exchange from the public key
         // and the network private key stored in the network actor state.
-        match add_tlc.onion_packet.clone() {
+        let should_settle = match add_tlc.onion_packet.clone() {
             Some(onion_packet) => {
                 let peeled = onion_packet
                     .peel(
@@ -1026,7 +1026,7 @@ where
                     .map_err(ProcessingChannelError::without_shared_secret)?;
                 let shared_secret = peeled.shared_secret;
                 self.apply_add_tlc_operation_with_peeled_onion_packet(state, add_tlc, peeled)
-                    .map_err(move |err| err.with_shared_secret(shared_secret))?;
+                    .map_err(move |err| err.with_shared_secret(shared_secret))?
             }
             None => {
                 // The TLC is with a NO_SHARED_SECRET and no onion packet.
@@ -1039,14 +1039,18 @@ where
                     )
                     .without_shared_secret());
                 }
+                // allow test code to manually add tlc without onion packet
+                true
             }
-        }
+        };
 
         // we don't need to settle down the tlc if it is not the last hop here,
         // some e2e tests are calling AddTlc manually, so we can not use onion packet to
         // check whether it's the last hop here, maybe need to revisit in future.
-        self.try_to_settle_down_tlc(myself, state, add_tlc.tlc_id)
-            .map_err(|err| err.without_shared_secret())?;
+        if should_settle {
+            self.try_to_settle_down_tlc(myself, state, add_tlc.tlc_id)
+                .map_err(|err| err.without_shared_secret())?;
+        }
 
         warn!("finished check tlc for peer message: {:?}", &add_tlc.tlc_id);
         Ok(())
@@ -1057,9 +1061,10 @@ where
         state: &mut ChannelActorState,
         add_tlc: &TlcInfo,
         peeled_onion_packet: PeeledPaymentOnionPacket,
-    ) -> ProcessingChannelResult {
+    ) -> Result<bool, ProcessingChannelError> {
         let payment_hash = add_tlc.payment_hash;
         let forward_amount = peeled_onion_packet.current.amount;
+        let is_last = peeled_onion_packet.is_last();
 
         let tlc = state
             .tlc_state
@@ -1067,7 +1072,7 @@ where
             .expect("expect tlc");
         tlc.applied_flags = AppliedFlags::ADD;
 
-        if peeled_onion_packet.is_last() {
+        if is_last {
             if forward_amount != add_tlc.amount {
                 return Err(ProcessingChannelError::FinalIncorrectHTLCAmount);
             }
@@ -1210,7 +1215,7 @@ where
                 forward_fee,
             );
         }
-        Ok(())
+        Ok(is_last)
     }
 
     fn store_preimage(&self, payment_hash: Hash256, preimage: Hash256) {
@@ -1925,11 +1930,17 @@ where
 
         match result.add_tlc_result {
             Ok((channel_id, tlc_id)) => {
-                state
-                    .tlc_state
-                    .get_mut(&TLCId::Received(result.tlc_id))
-                    .expect("tlc should exist")
-                    .forwarding_tlc = Some((channel_id, tlc_id));
+                if let Some(tlc) = state.tlc_state.get_mut(&TLCId::Received(result.tlc_id)) {
+                    tlc.forwarding_tlc = Some((channel_id, tlc_id));
+                } else {
+                    // This case should be unreachable because we have fixed the race condition where
+                    // intermediate nodes could settle the TLC locally.
+                    error!(
+                        "TLC {:?} removed while waiting for forwarding result",
+                        result.tlc_id
+                    );
+                    debug_assert!(false, "TLC removed while waiting for forwarding result");
+                }
             }
             Err((ProcessingChannelError::WaitingTlcAck, _)) => {
                 // peer already buffered the tlc, we already removed the forward tlc record

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -16,6 +16,7 @@ use crate::gen_rand_sha256_hash;
 use crate::invoice::CkbInvoice;
 use crate::invoice::Currency;
 use crate::invoice::InvoiceBuilder;
+use crate::invoice::PreimageStore;
 use crate::now_timestamp_as_millis_u64;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::rpc::invoice::NewInvoiceParams;
@@ -6734,4 +6735,101 @@ async fn test_send_payment_two_with_same_invoice() {
         }
     }
     assert_eq!(succeeded_count, 1);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_tlc_removed_while_waiting_for_forwarding_result() {
+    init_tracing();
+    let (nodes, _channels) = create_n_nodes_network_with_params(
+        &[
+            (
+                (0, 1),
+                ChannelParameters::new(MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB),
+            ),
+            (
+                (1, 2),
+                ChannelParameters::new(MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB),
+            ),
+        ],
+        3,
+        Some(gen_rpc_config()),
+    )
+    .await;
+
+    let [node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
+
+    // 1. Successful payment to ensure route and preimage on Node 1 (Router)
+    let amount = 1000000;
+    let preimage = gen_rand_sha256_hash();
+
+    let invoice_params = NewInvoiceParams {
+        amount,
+        payment_preimage: Some(preimage),
+        description: Some("Description".to_string()),
+        ..Default::default()
+    };
+
+    let invoice_result = node_2.gen_invoice(invoice_params).await;
+    let invoice = invoice_result.invoice;
+    let payment_hash = invoice.data.payment_hash;
+    let invoice_address = invoice_result.invoice_address;
+
+    let res = node_0
+        .send_payment(SendPaymentCommand {
+            target_pubkey: Some(node_2.pubkey),
+            amount: Some(amount),
+            payment_hash: Some(payment_hash),
+            invoice: Some(invoice_address.clone()),
+            ..Default::default()
+        })
+        .await;
+    assert!(res.is_ok());
+    node_0.wait_until_success(payment_hash).await;
+
+    // Node 1 should now have the preimage.
+    // Intermediate nodes don't persist preimages by default in this implementation,
+    // but the bug relies on the node having it (possibly from race or other source).
+    // We manually insert it to simulate the condition.
+    if node_1.store.get_preimage(&payment_hash).is_none() {
+        node_1.store.insert_preimage(payment_hash, preimage);
+    }
+    assert!(node_1.store.get_preimage(&payment_hash).is_some());
+
+    // 2. Send duplicate payment with SAME payment hash
+    let res = node_0
+        .send_payment(SendPaymentCommand {
+            target_pubkey: Some(node_2.pubkey),
+            amount: Some(amount),
+            payment_hash: Some(payment_hash),
+            invoice: Some(invoice_address.clone()),
+            ..Default::default()
+        })
+        .await;
+
+    if res.is_ok() {
+        node_0.wait_until_failed(payment_hash).await;
+    }
+
+    // 3. Verify Node 1 is alive by making a fresh payment
+    let invoice_params2 = NewInvoiceParams {
+        amount,
+        description: Some("Fresh Payment".to_string()),
+        ..Default::default()
+    };
+    let invoice_result2 = node_2.gen_invoice(invoice_params2).await;
+    let invoice2 = invoice_result2.invoice;
+    let payment_hash2 = invoice2.data.payment_hash;
+    let invoice_address2 = invoice_result2.invoice_address;
+
+    let res2 = node_0
+        .send_payment(SendPaymentCommand {
+            target_pubkey: Some(node_2.pubkey),
+            amount: Some(amount),
+            invoice: Some(invoice_address2),
+            ..Default::default()
+        })
+        .await;
+    assert!(res2.is_ok());
+    node_0.wait_until_success(payment_hash2).await;
 }


### PR DESCRIPTION
The testcase `test_send_payment_with_same_invoice` is not stable in CI:
https://github.com/nervosnetwork/fiber/actions/runs/21027661329/job/60455914433

panic at old code:
```rust
thread 'tokio-runtime-worker' panicked at crates/fiber-lib/src/fiber/channel.rs:2029:22:
    tlc should exist
```

For scenario A,B,C sending payments with the same invoice, P3 as middle hop, P4 is receiver:

```console
A \
B - --- P3 ----> P4
C /
```

The concurrency issue happened in P3, this is caused by the code path:

```rust
// Old code path
fn apply_add_tlc_operation(...) {
    // 1. register forwarding tlc here
    self.apply_add_tlc_operation_with_peeled_onion_packet(...) 

    // 2. If P3 already got preimage, tlc will be removed here
    self.try_to_settle_down_tlc(...) 
}
```

Then in `handle_forward_tlc_result` expect will panic because TLC is already removed:

```rust
                    state
                    .tlc_state
                    .get_mut(&TLCId::Received(result.tlc_id))
                    .expect("tlc should exist")
                    .forwarding_tlc = Some((channel_id, tlc_id));
```

This PR make sure for non-last hop, `try_to_settle_down_tlc` will not invoked, so even middle hop got preimage for a payment hash, it will not be settled, and will continue waiting for `AddTlcResult`.
