### PR TITLE
Fix unstable CI test from rand expiry delta

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -727,6 +727,12 @@ where
         } else {
             None
         };
+        error!(
+            "Generating TlcErr from error {:?} to error_code {:?} for channel {}",
+            error,
+            error_code,
+            state.get_id()
+        );
         TlcErr::new_channel_fail(
             error_code,
             state.local_pubkey,
@@ -879,14 +885,20 @@ where
     ) {
         let status = self.get_invoice_status(&invoice);
         let remove_reason = match status {
-            CkbInvoiceStatus::Expired => RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
-                TlcErr::new(TlcErrorCode::InvoiceExpired),
-                &tlc.shared_secret,
-            )),
-            CkbInvoiceStatus::Cancelled => RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
-                TlcErr::new(TlcErrorCode::InvoiceCancelled),
-                &tlc.shared_secret,
-            )),
+            CkbInvoiceStatus::Expired => {
+                error!("payment hash {:?} invoice expired", tlc.payment_hash);
+                RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
+                    TlcErr::new(TlcErrorCode::InvoiceExpired),
+                    &tlc.shared_secret,
+                ))
+            }
+            CkbInvoiceStatus::Cancelled => {
+                error!("payment hash {:?} invoice cancelled", tlc.payment_hash);
+                RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
+                    TlcErr::new(TlcErrorCode::InvoiceCancelled),
+                    &tlc.shared_secret,
+                ))
+            }
             CkbInvoiceStatus::Paid => {
                 // we have already checked invoice status in apply_add_tlc_operation_with_peeled_onion_packet
                 // this maybe happened when process is killed and restart
@@ -1039,7 +1051,6 @@ where
                 .map_err(|err| err.without_shared_secret())?;
         }
 
-        warn!("finished check tlc for peer message: {:?}", &add_tlc.tlc_id);
         Ok(())
     }
 
@@ -1082,6 +1093,10 @@ where
 
                 // ensure tlc expiry is large than the now + final_tlc_minimum_expiry_delta
                 if invoice.is_tlc_expire_too_soon(add_tlc.expiry) {
+                    error!(
+                        "final tlc expiry is too soon for payment hash {:?}: add_tlc.expiry {}",
+                        payment_hash, add_tlc.expiry
+                    );
                     return Err(ProcessingChannelError::IncorrectFinalTlcExpiry);
                 }
             }

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1481,7 +1481,7 @@ where
             .saturating_sub(route.first().map(|r| r.incoming_tlc_expiry).unwrap_or(0))
             / DEFAULT_TLC_EXPIRY_DELTA;
 
-        thread_rng().gen_range(0..max_rand_expiry_num.max(1)) * DEFAULT_TLC_EXPIRY_DELTA
+        thread_rng().gen_range(1..max_rand_expiry_num.max(2)) * DEFAULT_TLC_EXPIRY_DELTA
     }
 
     // A helper function to evaluate whether an edge should be added to the heap of nodes to visit.

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -648,8 +648,7 @@ async fn test_send_payment_with_normal_invoice_workflow() {
         .gen_invoice(NewInvoiceParams {
             amount: 1000,
             description: Some("test invoice".to_string()),
-            final_expiry_delta: Some(DEFAULT_FINAL_TLC_EXPIRY_DELTA),
-            expiry: None,
+            final_expiry_delta: Some(2048),
             ..Default::default()
         })
         .await;
@@ -658,9 +657,6 @@ async fn test_send_payment_with_normal_invoice_workflow() {
     let res = node_0
         .send_payment(SendPaymentCommand {
             invoice: Some(invoice.invoice_address),
-            amount: None,
-            keysend: None,
-            allow_self_payment: false,
             ..Default::default()
         })
         .await;


### PR DESCRIPTION
CI is not stable from unit test `test_send_payment_with_normal_invoice_workflow`

https://github.com/nervosnetwork/fiber/actions/runs/21166588130/job/60872717734?pr=1012

because `rand_tlc_expiry_delta` may have a chance to return 0, and the tlc expiry check failed at here:

https://github.com/chenyukang/fiber/blob/8087a7068abcb21d7a1703ea703ccd7a52fbca3d/crates/fiber-lib/src/fiber/channel.rs#L1095
