### PR TITLE
Stop CKB tx tracer when fail to resolve

### DIFF
--- a/crates/fiber-lib/src/ckb/actor.rs
+++ b/crates/fiber-lib/src/ckb/actor.rs
@@ -59,6 +59,7 @@ pub enum CkbChainMessage {
     SendTx(TransactionView, RpcReplyPort<Result<(), RpcError>>),
     CreateTxTracer(CkbTxTracer),
     RemoveTxTracers(Hash256),
+    ReportRejected(Hash256),
 
     Stop,
 }
@@ -212,6 +213,11 @@ impl Actor for CkbChainActor {
                 state
                     .ckb_tx_tracing_actor
                     .send_message(CkbTxTracingMessage::RemoveTracers(tx_hash))?;
+            }
+            CkbChainMessage::ReportRejected(tx_hash) => {
+                state
+                    .ckb_tx_tracing_actor
+                    .send_message(CkbTxTracingMessage::ReportRejected(tx_hash))?;
             }
 
             CkbChainMessage::Stop => {

--- a/crates/fiber-lib/src/ckb/tests/test_utils.rs
+++ b/crates/fiber-lib/src/ckb/tests/test_utils.rs
@@ -655,6 +655,10 @@ impl Actor for MockChainActor {
                 }
             }
 
+            ReportRejected(_) => {
+                // ignore
+            }
+
             Stop => {
                 myself.stop(Some("stop received".to_string()));
             }


### PR DESCRIPTION
## Summary

This PR adds functionality to stop the CKB transaction tracer when a transaction fails to resolve during submission. When a transaction fails to send due to a permanent error (specifically `TransactionFailedToResolve`), it is now reported as rejected to the tracers, allowing them to stop tracking the transaction.

## Changes

- Added `ReportRejected` message to `CkbChainMessage` and `CkbTxTracingMessage` enums
- Implemented `report_rejected` method in `CkbTxTracingState` that reports rejected transactions with the current tip block number
- Added `is_permanent_error` helper function to detect permanent RPC errors (currently checks for error code -301 `TransactionFailedToResolve`)
- Modified error handling in `InFlightCkbTxActor` to detect permanent errors and report them as rejected

## Implementation Details

When a transaction fails to send with a permanent error:
1. The error is detected using `is_permanent_error` which checks for RPC error code -301 (`TransactionFailedToResolve`)
2. A `ReportRejected` message is sent to the chain actor
3. The chain actor forwards it to the tx tracing actor
4. The tracing actor reports the rejection with the current tip block number, triggering callbacks for tracers with the `Rejected` mask

This prevents unnecessary retries and allows tracers to properly handle permanently rejected transactions.
