### PR TITLE
Add a up bound limit for payment fee

### DIFF
--- a/crates/fiber-lib/src/fiber/fee.rs
+++ b/crates/fiber-lib/src/fiber/fee.rs
@@ -112,9 +112,10 @@ pub(crate) fn calculate_shutdown_tx_fee(
     fee_rate.fee(tx_size).as_u64()
 }
 
-pub(crate) fn calculate_tlc_forward_fee(
+pub(crate) fn calculate_fee_with_base(
     amount: u128,
     fee_proportational_millionths: u128,
+    base: u128,
 ) -> Result<u128, String> {
     let fee = fee_proportational_millionths
         .checked_mul(amount)
@@ -124,13 +125,20 @@ pub(crate) fn calculate_tlc_forward_fee(
                 fee_proportational_millionths, amount
             )
         })?;
-    let base_fee = fee / 1_000_000;
-    let remainder = fee % 1_000_000;
+    let base_fee = fee / base;
+    let remainder = fee % base;
     if remainder > 0 {
         Ok(base_fee + 1)
     } else {
         Ok(base_fee)
     }
+}
+
+pub(crate) fn calculate_tlc_forward_fee(
+    amount: u128,
+    fee_proportational_millionths: u128,
+) -> Result<u128, String> {
+    calculate_fee_with_base(amount, fee_proportational_millionths, 1_000_000)
 }
 
 pub(crate) fn check_open_channel_parameters(

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -2017,8 +2017,8 @@ where
             // this can help us early return if the payment is not possible to be sent
             // otherwise when PathFind error is returned, we need to retry with half amount
             error!(
-                "no path found from {:?} to {:?} for amount: {:?}",
-                source, target, amount
+                "no path found from {:?} to {:?} for amount: {:?} max_fee_amount: {:?}",
+                source, target, amount, max_fee_amount
             );
             return Err(PathFindError::NoPathFound);
         }

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -41,6 +41,9 @@ use strum::AsRefStr;
 use tokio::sync::RwLock;
 use tracing::{debug, error, instrument, warn};
 
+const DEFAULT_MAX_FEE_RATE: u64 = 5;
+const MAX_FEE_RATE_DENOMINATOR: u128 = 1000;
+
 /// The status of a payment, will update as the payment progresses.
 /// The transfer path for payment status is `Created -> Inflight -> Success | Failed`.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
@@ -290,11 +293,38 @@ impl SendPaymentData {
             return Err("amount must be greater than 0".to_string());
         }
 
-        let max_fee_amount = command.max_fee_amount.unwrap_or(0);
-        if amount.checked_add(max_fee_amount).is_none() {
+        let max_fee_rate = command.max_fee_rate.unwrap_or(DEFAULT_MAX_FEE_RATE);
+        let max_fee_amount_by_rate =
+            amount
+                .checked_mul(u128::from(max_fee_rate))
+                .ok_or_else(|| {
+                    format!(
+                        "amount * max_fee_rate overflow: amount = {}, max_fee_rate = {}",
+                        amount, max_fee_rate
+                    )
+                })?
+                / MAX_FEE_RATE_DENOMINATOR;
+        let max_fee_amount_by_rate = if max_fee_amount_by_rate == 0 {
+            amount
+        } else {
+            max_fee_amount_by_rate
+        };
+
+        let max_fee_amount = match command.max_fee_amount {
+            Some(max_fee_amount) => Some(max_fee_amount.min(max_fee_amount_by_rate)),
+            None => Some(max_fee_amount_by_rate),
+        };
+
+        error!(
+            "now get : {:?} command.max_fee_amount: {:?} command.max_fee_rate: {:?} amount: {:?}",
+            max_fee_amount, command.max_fee_amount, command.max_fee_rate, amount
+        );
+
+        if amount.checked_add(max_fee_amount.unwrap_or(0)).is_none() {
             return Err(format!(
                 "amount + max_fee_amount overflow: amount = {}, max_fee_amount = {}",
-                amount, max_fee_amount
+                amount,
+                max_fee_amount.unwrap_or(0)
             ));
         }
 
@@ -355,7 +385,7 @@ impl SendPaymentData {
             final_tlc_expiry_delta,
             tlc_expiry_limit,
             timeout: command.timeout,
-            max_fee_amount: command.max_fee_amount,
+            max_fee_amount,
             max_parts: command.max_parts,
             keysend,
             udt_type_script,
@@ -860,8 +890,10 @@ pub struct SendPaymentCommand {
     pub tlc_expiry_limit: Option<u64>,
     // the payment timeout in seconds, if the payment is not completed within this time, it will be cancelled
     pub timeout: Option<u64>,
-    // the maximum fee amounts in shannons that the sender is willing to pay, default is 1000 shannons CKB.
+    // the maximum fee amounts in shannons that the sender is willing to pay, default is 0.5% * amount.
     pub max_fee_amount: Option<u128>,
+    // the maximum fee rate per thousand (‰), default is 5 (0.5%).
+    pub max_fee_rate: Option<u64>,
     // max parts for the payment, only used for multi-part payments
     pub max_parts: Option<u64>,
     // keysend payment, default is false

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -5488,6 +5488,7 @@ async fn test_send_payment_will_fail_with_invoice_not_generated_by_target() {
         .send_payment(SendPaymentCommand {
             target_pubkey: Some(target_pubkey),
             amount: Some(100),
+            max_fee_rate: Some(1000),
             invoice: Some(invoice.clone()),
             ..Default::default()
         })
@@ -5537,6 +5538,7 @@ async fn test_send_payment_will_succeed_with_valid_invoice() {
         .send_payment(SendPaymentCommand {
             target_pubkey: Some(target_pubkey),
             amount: Some(100),
+            max_fee_rate: Some(1000),
             invoice: Some(ckb_invoice.to_string()),
             ..Default::default()
         })
@@ -5605,6 +5607,7 @@ async fn test_send_payment_will_fail_with_no_invoice_preimage() {
         .send_payment(SendPaymentCommand {
             target_pubkey: Some(target_pubkey),
             amount: Some(100),
+            max_fee_rate: Some(1000),
             invoice: Some(ckb_invoice.to_string()),
             ..Default::default()
         })
@@ -5688,6 +5691,7 @@ async fn test_send_payment_will_fail_with_cancelled_invoice() {
         .send_payment(SendPaymentCommand {
             target_pubkey: Some(target_pubkey),
             amount: Some(100),
+            max_fee_rate: Some(1000),
             invoice: Some(ckb_invoice.to_string()),
             ..Default::default()
         })

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -618,9 +618,8 @@ async fn test_send_payment_for_pay_self_with_invoice() {
     let res = node_0
         .send_payment(SendPaymentCommand {
             invoice: Some(invoice.invoice_address),
-            amount: None,
-            keysend: None,
             allow_self_payment: true,
+            max_fee_rate: Some(1000),
             ..Default::default()
         })
         .await;
@@ -5167,6 +5166,7 @@ async fn test_send_payment_invoice_cancel_multiple_ops() {
             .send_payment(SendPaymentCommand {
                 invoice: Some(invoice.to_string()),
                 amount: invoice.amount,
+                max_fee_rate: Some(1000),
                 allow_self_payment: true,
                 ..Default::default()
             })

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -292,9 +292,10 @@ async fn test_send_payment_with_tool_large_fee_and_amount() {
         })
         .await;
 
-    assert!(res.is_err());
-    assert!(res.unwrap_err().to_string().contains("max_fee_amount"));
-    assert_eq!(node_0.get_inflight_payment_count().await, 0);
+    // will succeed because of default max_fee_rate is 0.5%
+    assert!(res.is_ok());
+    let payment_hash = res.unwrap().payment_hash;
+    node_0.wait_until_success(payment_hash).await;
 }
 
 #[tokio::test]
@@ -341,7 +342,14 @@ async fn test_send_payment_fee_rate() {
     node_0.submit_tx(funding_tx_1).await;
 
     let res = node_0
-        .send_payment_keysend(&node_2, 10_000_000, false)
+        .send_payment(SendPaymentCommand {
+            target_pubkey: Some(node_2.pubkey),
+            amount: Some(10_000_000),
+            keysend: Some(true),
+            // use a high max fee rate to make sure payment success
+            max_fee_rate: Some(5000),
+            ..Default::default()
+        })
         .await;
     assert!(res.is_ok(), "Send payment failed: {:?}", res);
     let res = res.unwrap();
@@ -356,7 +364,16 @@ async fn test_send_payment_fee_rate() {
     node_0.wait_until_success(payment_hash).await;
     assert_eq!(node_0.get_inflight_payment_count().await, 0);
 
-    let res = node_2.send_payment_keysend(&node_0, 1_000_000, false).await;
+    let res = node_2
+        .send_payment(SendPaymentCommand {
+            target_pubkey: Some(node_0.pubkey),
+            amount: Some(1_000_000),
+            keysend: Some(true),
+            // use a high max fee rate to make sure payment success
+            max_fee_rate: Some(5000),
+            ..Default::default()
+        })
+        .await;
     assert!(res.is_ok(), "Send payment failed: {:?}", res);
     let res = res.unwrap();
     assert!(res.fee > 0);
@@ -5208,19 +5225,8 @@ async fn test_send_payment_no_preimage_invoice_will_make_payment_failed() {
             .send_payment(SendPaymentCommand {
                 invoice: Some(invoice.to_string()),
                 amount: invoice.amount,
-                target_pubkey: None,
                 allow_self_payment: true,
-                payment_hash: None,
-                final_tlc_expiry_delta: None,
-                tlc_expiry_limit: None,
-                timeout: None,
-                max_fee_amount: None,
-                max_parts: None,
-                keysend: None,
-                udt_type_script: None,
-                dry_run: false,
-                hop_hints: None,
-                custom_records: None,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -5551,14 +5557,14 @@ async fn test_send_payment_with_reverse_channel_of_capaicity_not_enough() {
     let _span = tracing::info_span!("node", node = "test").entered();
     let (nodes, channels) = create_n_nodes_network(
         &[
-            ((0, 1), (16 + MIN_RESERVED_CKB, MIN_RESERVED_CKB)),
-            ((1, 2), (17 + MIN_RESERVED_CKB, MIN_RESERVED_CKB)),
+            ((0, 1), (160000 + MIN_RESERVED_CKB, MIN_RESERVED_CKB)),
+            ((1, 2), (170000 + MIN_RESERVED_CKB, MIN_RESERVED_CKB)),
             // path finding algorighm will choose this channel firstly,
             // since it has more capacity than the above two channels,
             // but there capacity from 1->2 is not enough for the payment
             // so the first payment will retry two times,
             // and the following payments will only retry once
-            ((2, 1), (18 + MIN_RESERVED_CKB, MIN_RESERVED_CKB)),
+            ((2, 1), (180000 + MIN_RESERVED_CKB, MIN_RESERVED_CKB)),
         ],
         3,
     )
@@ -5581,7 +5587,14 @@ async fn test_send_payment_with_reverse_channel_of_capaicity_not_enough() {
 
     let count = 5;
     for _i in 0..count {
-        let payment = nodes[0].send_payment_keysend(&nodes[2], 1, false).await;
+        let payment = nodes[0]
+            .send_payment(SendPaymentCommand {
+                target_pubkey: Some(nodes[2].pubkey),
+                amount: Some(30000),
+                keysend: Some(true),
+                ..Default::default()
+            })
+            .await;
         let payment_hash = payment.unwrap().payment_hash;
         nodes[0].wait_until_success(payment_hash).await;
         let session = nodes[0].get_payment_session(payment_hash).unwrap();
@@ -6404,8 +6417,7 @@ async fn test_network_with_hops_max_number_limit() {
             target_pubkey: Some(nodes[14].pubkey), // can not make a payment with 14 hops
             amount: Some(1000),
             keysend: Some(true),
-            allow_self_payment: false,
-            dry_run: false,
+            max_fee_rate: Some(1000),
             tlc_expiry_limit: Some(DEFAULT_TLC_EXPIRY_DELTA * 12 + DEFAULT_FINAL_TLC_EXPIRY_DELTA), // 13 hops limit
             ..Default::default()
         })
@@ -6419,8 +6431,7 @@ async fn test_network_with_hops_max_number_limit() {
             target_pubkey: Some(nodes[13].pubkey),
             amount: Some(1000),
             keysend: Some(true),
-            allow_self_payment: false,
-            dry_run: false,
+            max_fee_rate: Some(1000),
             tlc_expiry_limit: Some(DEFAULT_TLC_EXPIRY_DELTA * 12 + DEFAULT_FINAL_TLC_EXPIRY_DELTA), // 13 hops limit
             ..Default::default()
         })
@@ -6434,8 +6445,7 @@ async fn test_network_with_hops_max_number_limit() {
             target_pubkey: Some(nodes[13].pubkey),
             amount: Some(1000),
             keysend: Some(true),
-            allow_self_payment: false,
-            dry_run: false,
+            max_fee_rate: Some(1000),
             tlc_expiry_limit: Some(15 * 24 * 60 * 60 * 1000), // 15 days
             ..Default::default()
         })
@@ -6470,8 +6480,7 @@ async fn test_network_with_relay_remove_will_be_ok() {
             target_pubkey: Some(nodes[5].pubkey),
             amount: Some(1000),
             keysend: Some(true),
-            allow_self_payment: false,
-            dry_run: false,
+            max_fee_rate: Some(1000),
             tlc_expiry_limit: Some(DEFAULT_TLC_EXPIRY_DELTA * 10 + DEFAULT_FINAL_TLC_EXPIRY_DELTA),
             ..Default::default()
         })
@@ -6832,4 +6841,41 @@ async fn test_tlc_removed_while_waiting_for_forwarding_result() {
         .await;
     assert!(res2.is_ok());
     node_0.wait_until_success(payment_hash2).await;
+}
+
+#[tokio::test]
+async fn test_send_payment_max_fee_rate_limit() {
+    let payment_data = SendPaymentData::new(SendPaymentCommand {
+        target_pubkey: Some(gen_rand_fiber_public_key()),
+        amount: Some(1000),
+        keysend: Some(true),
+        ..Default::default()
+    })
+    .expect("payment data ok");
+
+    assert_eq!(payment_data.max_fee_amount, Some(5));
+
+    let payment_data = SendPaymentData::new(SendPaymentCommand {
+        target_pubkey: Some(gen_rand_fiber_public_key()),
+        amount: Some(1000),
+        keysend: Some(true),
+        max_fee_rate: Some(10),
+        max_fee_amount: Some(6),
+        ..Default::default()
+    })
+    .expect("payment data ok");
+
+    assert_eq!(payment_data.max_fee_amount, Some(6));
+
+    let payment_data = SendPaymentData::new(SendPaymentCommand {
+        target_pubkey: Some(gen_rand_fiber_public_key()),
+        amount: Some(1000),
+        keysend: Some(true),
+        max_fee_rate: Some(10),
+        max_fee_amount: Some(20),
+        ..Default::default()
+    })
+    .expect("payment data ok");
+
+    assert_eq!(payment_data.max_fee_amount, Some(10));
 }

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -657,7 +657,9 @@ Sends a payment to a peer.
  this is also the default value for the payment if this parameter is not provided
 * `invoice` - <em>`Option<String>`</em>, the encoded invoice to send to the recipient
 * `timeout` - <em>`Option<u64>`</em>, the payment timeout in seconds, if the payment is not completed within this time, it will be cancelled
-* `max_fee_amount` - <em>`Option<u128>`</em>, the maximum fee amounts in shannons that the sender is willing to pay
+* `max_fee_amount` - <em>`Option<u128>`</em>, the maximum fee amounts in shannons that the sender is willing to pay,
+ default is 0.5% * amount
+* `max_fee_rate` - <em>`Option<u64>`</em>, the maximum fee rate per thousand (‰), default is 5 (0.5%)
 * `max_parts` - <em>`Option<u64>`</em>, max parts for the payment, only used for multi-part payments
 * `keysend` - <em>`Option<bool>`</em>, keysend payment
 * `udt_type_script` - <em>`Option<Script>`</em>, udt type script for the payment

--- a/crates/fiber-lib/src/rpc/payment.rs
+++ b/crates/fiber-lib/src/rpc/payment.rs
@@ -127,9 +127,14 @@ pub struct SendPaymentCommandParams {
     #[serde_as(as = "Option<U64Hex>")]
     pub timeout: Option<u64>,
 
-    /// the maximum fee amounts in shannons that the sender is willing to pay
+    /// the maximum fee amounts in shannons that the sender is willing to pay,
+    /// default is 0.5% * amount
     #[serde_as(as = "Option<U128Hex>")]
     pub max_fee_amount: Option<u128>,
+
+    /// the maximum fee rate per thousand (‰), default is 5 (0.5%)
+    #[serde_as(as = "Option<U64Hex>")]
+    pub max_fee_rate: Option<u64>,
 
     /// max parts for the payment, only used for multi-part payments
     #[serde_as(as = "Option<U64Hex>")]
@@ -383,6 +388,7 @@ where
                     invoice: params.invoice.clone(),
                     timeout: params.timeout,
                     max_fee_amount: params.max_fee_amount,
+                    max_fee_rate: params.max_fee_rate,
                     max_parts: params.max_parts,
                     keysend: params.keysend,
                     udt_type_script: params.udt_type_script.clone().map(|s| s.into()),

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -902,6 +902,8 @@ impl NetworkNode {
             target_pubkey: Some(recipient.pubkey),
             amount: Some(amount),
             keysend: Some(true),
+            // set a max fee rate to avoid test failure due to fee rate fluctuation
+            max_fee_rate: Some(1000),
             allow_self_payment: false,
             dry_run,
             ..Default::default()


### PR DESCRIPTION
## 1. Parameter Specification

* **RPC Interface**: `send_payment`
* **New Parameter**: `max_fee_rate`
* **Default Value**: `5` (represents **0.5%**), if this field is not specified, there will also a hardcoded default `5` for it.

## 2. Validation Logic for `max_fee_amount`
The maximum fee limit for a payment should be determined using the following logic:

* **Case 1: `max_fee_amount` is not provided in the RPC**
If the user does not specify a fixed amount, the limit defaults to the rate-based calculation:

$$
Fee Limit = 0.5\\% \times amount
$$

* **Case 2: Both `max_fee_rate` and `max_fee_amount` are provided**
If both constraints are set, the system must enforce the stricter (lower) limit:

$$
Fee Limit = \min(max\\_fee\\_rate \times amount, rpc.max\\_fee\\_amount)
$$

