### PR TITLE
feat: add external wallet signing for channel funding

### DIFF
--- a/crates/fiber-lib/src/ckb/funding/funding_tx.rs
+++ b/crates/fiber-lib/src/ckb/funding/funding_tx.rs
@@ -37,6 +37,41 @@ use tracing::debug;
 // It is the same with the value used in the CKB SDK.
 const KEEP_BLOCK_PERIOD: u64 = 13;
 
+/// Helper function to build the funding cell output for a channel.
+/// This is used by both internal funding and external funding flows.
+fn build_funding_cell_output(
+    request: &FundingRequest,
+    funding_cell_lock_script: &packed::Script,
+) -> Result<(packed::CellOutput, packed::Bytes), FundingError> {
+    match request.udt_type_script {
+        Some(ref udt_type_script) => {
+            // For external funding, we only include local amounts (no remote party yet)
+            let udt_amount = request.local_amount;
+            let ckb_amount = request.local_reserved_ckb_amount;
+
+            let udt_output = packed::CellOutput::new_builder()
+                .capacity(Capacity::shannons(ckb_amount).pack())
+                .type_(Some(udt_type_script.clone()).pack())
+                .lock(funding_cell_lock_script.clone())
+                .build();
+            let mut data = BytesMut::with_capacity(16);
+            data.put(&udt_amount.to_le_bytes()[..]);
+
+            Ok((udt_output, data.freeze().pack()))
+        }
+        None => {
+            let ckb_amount = (request.local_amount as u64)
+                .checked_add(request.local_reserved_ckb_amount)
+                .ok_or(FundingError::OverflowError)?;
+            let ckb_output = packed::CellOutput::new_builder()
+                .capacity(Capacity::shannons(ckb_amount).pack())
+                .lock(funding_cell_lock_script.clone())
+                .build();
+            Ok((ckb_output, packed::Bytes::default()))
+        }
+    }
+}
+
 /// Funding transaction wrapper.
 ///
 /// It includes extra fields to verify the transaction.
@@ -161,11 +196,30 @@ pub struct FundingContext {
 /// will sign the transaction externally with their own wallet.
 #[derive(Clone, Debug)]
 pub struct ExternalFundingContext {
-    pub rpc_url: String,
-    /// The lock script of the cells to use for funding (user's wallet lock script)
-    pub funding_source_lock_script: packed::Script,
     /// The lock script of the funding cell (channel multisig lock)
     pub funding_cell_lock_script: packed::Script,
+}
+
+/// A cell provided by an external wallet for funding a channel.
+/// This contains all the information needed to use the cell as an input.
+#[derive(Clone, Debug)]
+pub struct ExternalFundingCell {
+    /// The out point of the cell (transaction hash + index).
+    pub out_point: packed::OutPoint,
+    /// The cell output (capacity, lock script, type script).
+    pub output: packed::CellOutput,
+    /// The cell data.
+    pub output_data: molecule::bytes::Bytes,
+}
+
+/// A cell dependency provided by an external wallet for funding a channel.
+/// This is needed to unlock the input cells.
+#[derive(Clone, Debug)]
+pub struct ExternalCellDep {
+    /// The out point of the cell dependency.
+    pub out_point: packed::OutPoint,
+    /// The dep type (code or dep_group).
+    pub dep_type: packed::Byte,
 }
 
 #[allow(dead_code)]
@@ -484,73 +538,16 @@ impl FundingTxBuilder {
 }
 
 /// Builder for unsigned funding transactions for external signing.
-/// This is similar to FundingTxBuilder but does not sign the transaction.
+/// This builder uses cells provided by the external wallet instead of collecting them.
 #[allow(dead_code)]
 struct ExternalFundingTxBuilder {
     funding_tx: FundingTx,
     request: FundingRequest,
     context: ExternalFundingContext,
-}
-
-#[cfg_attr(target_arch="wasm32",async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl TxBuilder for ExternalFundingTxBuilder {
-    async fn build_base_async(
-        &self,
-        cell_collector: &mut dyn CellCollector,
-        _cell_dep_resolver: &dyn CellDepResolver,
-        _header_dep_resolver: &dyn HeaderDepResolver,
-        _tx_dep_provider: &dyn TransactionDependencyProvider,
-    ) -> Result<TransactionView, TxBuilderError> {
-        let (funding_cell_output, funding_cell_output_data) = self
-            .build_funding_cell()
-            .map_err(|err| TxBuilderError::Other(err.into()))?;
-
-        let mut inputs = vec![];
-        let mut cell_deps = HashSet::new();
-
-        // Funding cell does not need new cell deps and header deps. The type script deps will be added with inputs.
-        let mut outputs: Vec<packed::CellOutput> = vec![funding_cell_output];
-        let mut outputs_data: Vec<packed::Bytes> = vec![funding_cell_output_data];
-
-        if let Some(ref tx) = self.funding_tx.tx {
-            inputs = tx.inputs().into_iter().collect();
-            cell_deps = tx.cell_deps().into_iter().collect();
-        }
-        self.build_udt_inputs_outputs(
-            cell_collector,
-            &mut inputs,
-            &mut outputs,
-            &mut outputs_data,
-            &mut cell_deps,
-        )
-        .await?;
-        if let Some(ref tx) = self.funding_tx.tx {
-            for (i, output) in tx.outputs().into_iter().enumerate().skip(1) {
-                outputs.push(output.clone());
-                outputs_data.push(tx.outputs_data().get(i).unwrap_or_default().clone());
-            }
-        }
-
-        let builder = match self.funding_tx.tx {
-            Some(ref tx) => tx.as_advanced_builder(),
-            None => packed::Transaction::default().as_advanced_builder(),
-        };
-
-        // set a placeholder_witness for calculating transaction fee according to transaction size
-        let placeholder_witness = packed::WitnessArgs::new_builder()
-            .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 170])).pack())
-            .build();
-
-        let tx_builder = builder
-            .set_inputs(inputs)
-            .set_outputs(outputs)
-            .set_outputs_data(outputs_data)
-            .set_cell_deps(cell_deps.into_iter().collect())
-            .set_witnesses(vec![placeholder_witness.as_bytes().pack()]);
-        let tx = tx_builder.build();
-        Ok(tx)
-    }
+    /// Cells provided by the external wallet
+    funding_cells: Vec<ExternalFundingCell>,
+    /// Cell dependencies provided by the external wallet for unlocking the input cells
+    funding_cell_deps: Vec<ExternalCellDep>,
 }
 
 impl ExternalFundingTxBuilder {
@@ -611,188 +608,195 @@ impl ExternalFundingTxBuilder {
         }
     }
 
-    async fn build_udt_inputs_outputs(
-        &self,
-        cell_collector: &mut dyn CellCollector,
-        inputs: &mut Vec<CellInput>,
-        outputs: &mut Vec<packed::CellOutput>,
-        outputs_data: &mut Vec<packed::Bytes>,
-        cell_deps: &mut HashSet<packed::CellDep>,
-    ) -> Result<(), TxBuilderError> {
-        let udt_amount = self.request.local_amount;
-        // return early if we don't need to build UDT cell
-        if self.request.udt_type_script.is_none() || udt_amount == 0 {
-            return Ok(());
-        }
-
-        let udt_type_script = self.request.udt_type_script.clone().ok_or_else(|| {
-            TxBuilderError::InvalidParameter(anyhow!("UDT type script not configured"))
-        })?;
-        let owner = self.context.funding_source_lock_script.clone();
-        let mut found_udt_amount: u128 = 0;
-
-        let mut query = CellQueryOptions::new_lock(owner.clone());
-        query.script_search_mode = Some(SearchMode::Exact);
-        query.secondary_script = Some(udt_type_script.clone());
-        query.data_len_range = Some(ValueRangeOption::new_min(16));
-
-        loop {
-            // each query will found at most one cell because of `min_total_capacity == 1` in CellQueryOptions
-            let (udt_cells, _) = cell_collector
-                .collect_live_cells_async(&query, true)
-                .await?;
-            if udt_cells.is_empty() {
-                break;
-            }
-            for cell in udt_cells.iter() {
-                let mut amount_bytes = [0u8; 16];
-                amount_bytes.copy_from_slice(&cell.output_data.as_ref()[0..16]);
-                let cell_udt_amount = u128::from_le_bytes(amount_bytes);
-                let ckb_amount: u64 = cell.output.capacity().unpack();
-                debug!(
-                    "found udt cell ckb_amount: {:?} udt_amount: {:?} cell: {:?}",
-                    ckb_amount, cell_udt_amount, cell
-                );
-
-                found_udt_amount = found_udt_amount
-                    .checked_add(cell_udt_amount)
-                    .ok_or_else(|| TxBuilderError::Other(anyhow!("UDT amount overflow")))?;
-
-                inputs.push(CellInput::new(cell.out_point.clone(), 0));
-
-                if found_udt_amount >= udt_amount {
-                    let change_amount = found_udt_amount - udt_amount;
-                    if change_amount > 0 {
-                        let change_output_data: Bytes = change_amount.to_le_bytes().pack();
-                        let dummy_output = CellOutput::new_builder()
-                            .lock(owner)
-                            .type_(Some(udt_type_script.clone()).pack())
-                            .build();
-                        let required_capacity = dummy_output
-                            .occupied_capacity(
-                                Capacity::bytes(change_output_data.len())
-                                    .map_err(|err| TxBuilderError::Other(err.into()))?,
-                            )
-                            .map_err(|err| TxBuilderError::Other(err.into()))?
-                            .pack();
-                        let change_output = dummy_output
-                            .as_builder()
-                            .capacity(required_capacity)
-                            .build();
-
-                        outputs.push(change_output);
-                        outputs_data.push(change_output_data);
-                    }
-
-                    debug!("find proper UDT owner cells: {:?}", inputs);
-                    // we need to filter the cell deps by the contracts_context
-                    let udt_cell_deps = get_udt_cell_deps(&udt_type_script)
-                        .await
-                        .map_err(|_| TxBuilderError::ResolveCellDepFailed(udt_type_script))?;
-                    for cell_dep in udt_cell_deps {
-                        cell_deps.insert(cell_dep);
-                    }
-                    return Ok(());
-                }
-            }
-        }
-        Err(TxBuilderError::Other(anyhow!(
-            "can not find enough UDT owner cells for funding transaction"
-        )))
-    }
-
-    /// Build an unsigned funding transaction for external signing.
-    /// This collects cells, balances capacity, but does NOT sign the transaction.
+    /// Build an unsigned funding transaction for external signing using provided cells.
+    /// This does NOT require any CKB RPC calls - all cells are provided by the external wallet.
     async fn build(
         self,
         live_cells_exclusion_map: &mut LiveCellsExclusionMap,
     ) -> Result<FundingTx, FundingError> {
-        // Build ScriptUnlocker (with empty keys since we won't sign)
-        let signer = SecpCkbRawKeySigner::new_with_secret_keys(vec![]);
-        let sighash_unlocker = SecpSighashUnlocker::from(Box::new(signer) as Box<_>);
-        let sighash_script_id = ScriptId::new_type(SIGHASH_TYPE_HASH.clone());
-        let mut unlockers = HashMap::default();
-        unlockers.insert(
-            sighash_script_id,
-            Box::new(sighash_unlocker) as Box<dyn ScriptUnlocker>,
-        );
+        let (funding_cell_output, funding_cell_output_data) = self.build_funding_cell()?;
 
-        let sender = self.context.funding_source_lock_script.clone();
-        // Build CapacityBalancer
-        let placeholder_witness = packed::WitnessArgs::new_builder()
-            .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 170])).pack())
-            .build();
+        let mut inputs: Vec<CellInput> = vec![];
+        let mut cell_deps = HashSet::new();
+        let mut outputs: Vec<packed::CellOutput> = vec![funding_cell_output];
+        let mut outputs_data: Vec<packed::Bytes> = vec![funding_cell_output_data];
 
-        let balancer = CapacityBalancer::new_simple(
-            sender.clone(),
-            placeholder_witness,
-            self.request.funding_fee_rate,
-        );
-
-        let ckb_client = new_ckb_rpc_async_client(&self.context.rpc_url);
-        let cell_dep_resolver = {
-            match ckb_client.get_block_by_number(0.into()).await? {
-                Some(genesis_block) => {
-                    match DefaultCellDepResolver::from_genesis_async(&BlockView::from(
-                        genesis_block,
-                    ))
-                    .await
-                    .ok()
-                    {
-                        Some(ret) => ret,
-                        None => {
-                            return Err(FundingError::CkbTxBuilderError(
-                                TxBuilderError::ResolveCellDepFailed(sender),
-                            ))
-                        }
-                    }
-                }
-                None => {
-                    return Err(FundingError::CkbTxBuilderError(
-                        TxBuilderError::ResolveCellDepFailed(sender),
-                    ))
-                }
+        // Add inputs and cell deps from existing funding tx if any (from remote party)
+        if let Some(ref tx) = self.funding_tx.tx {
+            inputs = tx.inputs().into_iter().collect();
+            cell_deps = tx.cell_deps().into_iter().collect();
+            // Add outputs from the existing tx (skip the first which is the funding cell)
+            for (i, output) in tx.outputs().into_iter().enumerate().skip(1) {
+                outputs.push(output.clone());
+                outputs_data.push(tx.outputs_data().get(i).unwrap_or_default().clone());
             }
+        }
+
+        // Calculate total capacity from provided funding cells
+        let mut total_input_capacity: u64 = 0;
+        let mut total_input_udt_amount: u128 = 0;
+
+        // Get the change lock script from the first funding cell (all cells should have the same lock)
+        let change_lock_script = if let Some(first_cell) = self.funding_cells.first() {
+            first_cell.output.lock()
+        } else {
+            return Err(FundingError::CkbTxBuilderError(
+                ckb_sdk::tx_builder::TxBuilderError::InvalidParameter(anyhow!(
+                    "No funding cells provided"
+                )),
+            ));
         };
 
-        let header_dep_resolver = DefaultHeaderDepResolver::new(&self.context.rpc_url);
-        let mut cell_collector = new_default_cell_collector(&self.context.rpc_url);
-        let tx_dep_provider = DefaultTransactionDependencyProvider::new(&self.context.rpc_url, 10);
+        // Add inputs from provided funding cells
+        for cell in &self.funding_cells {
+            let capacity: u64 = cell.output.capacity().unpack();
+            total_input_capacity = total_input_capacity
+                .checked_add(capacity)
+                .ok_or(FundingError::OverflowError)?;
 
-        let tip_block_number: u64 = ckb_client.get_tip_block_number().await?.into();
-        live_cells_exclusion_map.truncate(tip_block_number);
-        live_cells_exclusion_map
-            .apply(&mut cell_collector)
-            .map_err(|err| FundingError::CkbTxBuilderError(TxBuilderError::Other(err.into())))?;
+            // If this is a UDT channel, check for UDT amount in cell data
+            if self.request.udt_type_script.is_some() && cell.output_data.len() >= 16 {
+                let mut amount_bytes = [0u8; 16];
+                amount_bytes.copy_from_slice(&cell.output_data[0..16]);
+                let cell_udt_amount = u128::from_le_bytes(amount_bytes);
+                total_input_udt_amount = total_input_udt_amount
+                    .checked_add(cell_udt_amount)
+                    .ok_or(FundingError::OverflowError)?;
+            }
 
-        // Build the balanced transaction but don't unlock/sign it.
-        // We use build_unlocked which adds inputs for capacity and sets up witnesses,
-        // but since we use an empty signer, the signatures will be placeholders.
-        // The user will replace these placeholders with real signatures.
-        #[cfg(not(target_arch = "wasm32"))]
-        let (tx, _) = self.build_unlocked(
-            &mut cell_collector,
-            &cell_dep_resolver,
-            &header_dep_resolver,
-            &tx_dep_provider,
-            &balancer,
-            &unlockers,
-        )?;
-        #[cfg(target_arch = "wasm32")]
-        let (tx, _) = self
-            .build_unlocked_async(
-                &mut cell_collector,
-                &cell_dep_resolver,
-                &header_dep_resolver,
-                &tx_dep_provider,
-                &balancer,
-                &unlockers,
-            )
-            .await?;
+            inputs.push(CellInput::new(cell.out_point.clone(), 0));
+        }
+
+        // Add cell deps provided by external wallet for unlocking the input cells
+        for cell_dep in &self.funding_cell_deps {
+            let dep = packed::CellDep::new_builder()
+                .out_point(cell_dep.out_point.clone())
+                .dep_type(cell_dep.dep_type.clone())
+                .build();
+            cell_deps.insert(dep);
+        }
+
+        // For UDT channels, handle UDT change output
+        if let Some(ref udt_type_script) = self.request.udt_type_script {
+            if total_input_udt_amount > self.request.local_amount {
+                let change_udt_amount = total_input_udt_amount - self.request.local_amount;
+                let change_output_data: Bytes = change_udt_amount.to_le_bytes().pack();
+                let dummy_output = CellOutput::new_builder()
+                    .lock(change_lock_script.clone())
+                    .type_(Some(udt_type_script.clone()).pack())
+                    .build();
+                let required_capacity = dummy_output
+                    .occupied_capacity(
+                        Capacity::bytes(change_output_data.len())
+                            .map_err(|err| FundingError::CkbTxBuilderError(ckb_sdk::tx_builder::TxBuilderError::Other(err.into())))?,
+                    )
+                    .map_err(|err| FundingError::CkbTxBuilderError(ckb_sdk::tx_builder::TxBuilderError::Other(err.into())))?
+                    .pack();
+                let change_output = dummy_output
+                    .as_builder()
+                    .capacity(required_capacity)
+                    .build();
+
+                outputs.push(change_output);
+                outputs_data.push(change_output_data);
+            } else if total_input_udt_amount < self.request.local_amount {
+                return Err(FundingError::CkbTxBuilderError(
+                    ckb_sdk::tx_builder::TxBuilderError::Other(anyhow!(
+                        "Insufficient UDT amount: required {}, provided {}",
+                        self.request.local_amount,
+                        total_input_udt_amount
+                    )),
+                ));
+            }
+
+            // Add UDT cell deps
+            let udt_cell_deps = get_udt_cell_deps(udt_type_script)
+                .await
+                .map_err(|_| FundingError::CkbTxBuilderError(
+                    ckb_sdk::tx_builder::TxBuilderError::ResolveCellDepFailed(udt_type_script.clone())
+                ))?;
+            for cell_dep in udt_cell_deps {
+                cell_deps.insert(cell_dep);
+            }
+        }
+
+        // Calculate required capacity for outputs
+        let mut total_output_capacity: u64 = 0;
+        for output in &outputs {
+            let capacity: u64 = output.capacity().unpack();
+            total_output_capacity = total_output_capacity
+                .checked_add(capacity)
+                .ok_or(FundingError::OverflowError)?;
+        }
+
+        // Estimate transaction size for fee calculation
+        // Each input needs a witness placeholder (65 bytes for secp256k1 signature)
+        let witness_count = inputs.len();
+        let estimated_tx_size = {
+            // Base transaction size + inputs + outputs + witnesses
+            let base_size = 100; // Approximate base size
+            let input_size = inputs.len() * 44; // Each input ~44 bytes
+            let output_size: usize = outputs.iter().map(|o| o.as_bytes().len() + 8).sum(); // Output + data length
+            let witness_size = witness_count * 170; // Placeholder witness size
+            base_size + input_size + output_size + witness_size
+        };
+
+        let fee = (estimated_tx_size as u64 * self.request.funding_fee_rate) / 1000;
+
+        // Calculate change
+        let required_capacity = total_output_capacity
+            .checked_add(fee)
+            .ok_or(FundingError::OverflowError)?;
+
+        if total_input_capacity < required_capacity {
+            return Err(FundingError::CkbTxBuilderError(
+                ckb_sdk::tx_builder::TxBuilderError::Other(anyhow!(
+                    "Insufficient capacity: required {} (outputs: {}, fee: {}), provided {}",
+                    required_capacity,
+                    total_output_capacity,
+                    fee,
+                    total_input_capacity
+                )),
+            ));
+        }
+
+        let change_capacity = total_input_capacity - required_capacity;
+        const MIN_CHANGE_CAPACITY: u64 = 61_00000000; // 61 CKB minimum for a cell
+
+        if change_capacity >= MIN_CHANGE_CAPACITY {
+            // Add change output
+            let change_output = packed::CellOutput::new_builder()
+                .capacity(Capacity::shannons(change_capacity).pack())
+                .lock(change_lock_script)
+                .build();
+            outputs.push(change_output);
+            outputs_data.push(packed::Bytes::default());
+        } else if change_capacity > 0 {
+            // Change is too small, add it to fee (dust)
+            debug!("Change {} is too small, adding to fee", change_capacity);
+        }
+
+        // Build placeholder witnesses
+        let placeholder_witness = packed::WitnessArgs::new_builder()
+            .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 65])).pack())
+            .build();
+        let witnesses: Vec<packed::Bytes> = (0..inputs.len())
+            .map(|_| placeholder_witness.as_bytes().pack())
+            .collect();
+
+        // Build the transaction
+        let tx = packed::Transaction::default()
+            .as_advanced_builder()
+            .set_inputs(inputs)
+            .set_outputs(outputs)
+            .set_outputs_data(outputs_data)
+            .set_cell_deps(cell_deps.into_iter().collect())
+            .set_witnesses(witnesses)
+            .build();
 
         let old_tx_hash = self.funding_tx.tx.as_ref().map(|tx| tx.hash());
         let mut funding_tx = self.funding_tx;
-        debug!("built unsigned funding tx: {:?}", tx);
+        debug!("built unsigned funding tx for external signing: {:?}", tx.hash());
 
         funding_tx.update_for_self(tx);
 
@@ -837,24 +841,68 @@ impl FundingTx {
         builder.build(live_cells_exclusion_map).await
     }
 
-    /// Build an unsigned funding transaction for external signing.
+    /// Add the funding cell output to a transaction provided by an external wallet.
     ///
-    /// This method collects cells from the user's wallet (identified by
-    /// `funding_source_lock_script`), builds a balanced transaction with
-    /// proper inputs and outputs, but does NOT sign it. The user is expected
-    /// to sign this transaction externally with their own wallet.
-    pub async fn build_unsigned_for_external_funding(
+    /// The external wallet (e.g., CCC) has already constructed a transaction with:
+    /// - inputs: The cells to be consumed
+    /// - cell_deps: The dependencies needed to unlock those inputs
+    /// - outputs: Change outputs (optional)
+    /// - witnesses: Placeholder witnesses
+    ///
+    /// This method adds the funding cell output (2-of-2 multisig) as the first output.
+    /// The caller (external wallet) will then sign the complete transaction.
+    pub async fn add_funding_output(
         self,
         request: FundingRequest,
-        context: ExternalFundingContext,
+        funding_cell_lock_script: packed::Script,
         live_cells_exclusion_map: &mut LiveCellsExclusionMap,
     ) -> Result<Self, FundingError> {
-        let builder = ExternalFundingTxBuilder {
-            funding_tx: self,
-            request,
-            context,
-        };
-        builder.build(live_cells_exclusion_map).await
+        let tx = self.tx.ok_or_else(|| {
+            FundingError::CkbTxBuilderError(ckb_sdk::tx_builder::TxBuilderError::InvalidParameter(
+                anyhow!("No transaction provided by external wallet"),
+            ))
+        })?;
+
+        // Build the funding cell output
+        let (funding_cell_output, funding_cell_output_data) =
+            build_funding_cell_output(&request, &funding_cell_lock_script)?;
+
+        // Get existing transaction components
+        let inputs: Vec<_> = tx.inputs().into_iter().collect();
+        let cell_deps: Vec<_> = tx.cell_deps().into_iter().collect();
+        let witnesses: Vec<_> = tx.witnesses().into_iter().collect();
+
+        // Build new outputs list: funding output first, then existing outputs
+        let mut outputs: Vec<packed::CellOutput> = vec![funding_cell_output];
+        let mut outputs_data: Vec<packed::Bytes> = vec![funding_cell_output_data];
+
+        // Add existing outputs from the transaction (change outputs, etc.)
+        for (i, output) in tx.outputs().into_iter().enumerate() {
+            outputs.push(output);
+            outputs_data.push(tx.outputs_data().get(i).unwrap_or_default());
+        }
+
+        // Rebuild the transaction with the funding output added
+        let new_tx = packed::Transaction::default()
+            .as_advanced_builder()
+            .set_inputs(inputs)
+            .set_outputs(outputs)
+            .set_outputs_data(outputs_data)
+            .set_cell_deps(cell_deps)
+            .set_witnesses(witnesses)
+            .build();
+
+        let old_tx_hash = Some(tx.hash());
+        let funding_tx = FundingTx { tx: Some(new_tx) };
+        debug!("Added funding output to external tx: {:?}", funding_tx.tx.as_ref().map(|t| t.hash()));
+
+        // Update exclusion map
+        if let Some(tx_hash) = old_tx_hash {
+            live_cells_exclusion_map.remove(&tx_hash);
+        }
+        live_cells_exclusion_map.add_funding_tx(&funding_tx);
+
+        Ok(funding_tx)
     }
 
     pub async fn sign(

--- a/crates/fiber-lib/src/ckb/funding/mod.rs
+++ b/crates/fiber-lib/src/ckb/funding/mod.rs
@@ -1,4 +1,5 @@
 mod funding_tx;
 
-pub(crate) use funding_tx::{FundingContext, LiveCellsExclusionMap};
+#[allow(unused_imports)]
+pub(crate) use funding_tx::{ExternalFundingContext, FundingContext, LiveCellsExclusionMap};
 pub use funding_tx::{FundingRequest, FundingTx};

--- a/crates/fiber-lib/src/ckb/funding/mod.rs
+++ b/crates/fiber-lib/src/ckb/funding/mod.rs
@@ -2,4 +2,4 @@ mod funding_tx;
 
 #[allow(unused_imports)]
 pub(crate) use funding_tx::{ExternalFundingContext, FundingContext, LiveCellsExclusionMap};
-pub use funding_tx::{FundingRequest, FundingTx};
+pub use funding_tx::{ExternalCellDep, ExternalFundingCell, FundingRequest, FundingTx};

--- a/crates/fiber-lib/src/ckb/mod.rs
+++ b/crates/fiber-lib/src/ckb/mod.rs
@@ -9,7 +9,7 @@ pub use actor::{CkbChainActor, CkbChainMessage};
 pub use client::{GetCellsResponse, GetShutdownTxResponse, GetTxResponse};
 pub use config::{CkbConfig, DEFAULT_CKB_BASE_DIR_NAME};
 pub use error::{CkbChainError, FundingError};
-pub use funding::{FundingRequest, FundingTx};
+pub use funding::{ExternalCellDep, ExternalFundingCell, FundingRequest, FundingTx};
 pub use tx_tracing_actor::{CkbTxTracer, CkbTxTracingMask, CkbTxTracingResult};
 
 pub mod client;

--- a/crates/fiber-lib/src/ckb/tests/test_utils.rs
+++ b/crates/fiber-lib/src/ckb/tests/test_utils.rs
@@ -655,6 +655,13 @@ impl Actor for MockChainActor {
                 }
             }
 
+            BuildUnsignedFundingTx { reply, .. } => {
+                // Mock implementation: return an error for now as this is for external funding
+                let _ = reply.send(Err(FundingError::CkbTxBuilderError(TxBuilderError::Other(
+                    anyhow!("BuildUnsignedFundingTx not implemented in mock"),
+                ))));
+            }
+
             Stop => {
                 myself.stop(Some("stop received".to_string()));
             }

--- a/crates/fiber-lib/src/ckb/tests/test_utils.rs
+++ b/crates/fiber-lib/src/ckb/tests/test_utils.rs
@@ -655,10 +655,10 @@ impl Actor for MockChainActor {
                 }
             }
 
-            BuildUnsignedFundingTx { reply, .. } => {
+            BuildFundingTxFromExternal { reply, .. } => {
                 // Mock implementation: return an error for now as this is for external funding
                 let _ = reply.send(Err(FundingError::CkbTxBuilderError(TxBuilderError::Other(
-                    anyhow!("BuildUnsignedFundingTx not implemented in mock"),
+                    anyhow!("BuildFundingTxFromExternal not implemented in mock"),
                 ))));
             }
 

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -177,6 +177,12 @@ pub enum ChannelCommand {
     BroadcastChannelUpdate(),
     Update(UpdateCommand, RpcReplyPort<Result<(), String>>),
     NotifyEvent(ChannelEvent),
+    /// Set the unsigned funding transaction for external funding channels.
+    /// This is called after the peer accepts the channel.
+    SetUnsignedFundingTx(Transaction),
+    /// Submit the signed funding transaction for external funding channels.
+    /// The user has signed the transaction with their wallet.
+    SubmitExternalFundingTx(Transaction, RpcReplyPort<Result<Hash256, String>>),
     #[cfg(any(test, feature = "bench"))]
     ReloadState(ReloadParams),
 }
@@ -193,6 +199,8 @@ impl Display for ChannelCommand {
             ChannelCommand::BroadcastChannelUpdate() => write!(f, "BroadcastChannelUpdate"),
             ChannelCommand::Update(_, _) => write!(f, "Update"),
             ChannelCommand::NotifyEvent(event) => write!(f, "NotifyEvent [{:?}]", event),
+            ChannelCommand::SetUnsignedFundingTx(_) => write!(f, "SetUnsignedFundingTx"),
+            ChannelCommand::SubmitExternalFundingTx(_, _) => write!(f, "SubmitExternalFundingTx"),
             #[cfg(any(test, feature = "bench"))]
             ChannelCommand::ReloadState(_) => write!(f, "ReloadState"),
         }
@@ -332,6 +340,25 @@ pub struct AcceptChannelParameter {
     pub max_tlc_number_in_flight: u64,
 }
 
+/// Parameters for opening a channel with external funding.
+/// The user will sign the funding transaction with their own wallet.
+pub struct OpenChannelWithExternalFundingParameter {
+    pub funding_amount: u128,
+    pub seed: [u8; 32],
+    pub tlc_info: ChannelTlcInfo,
+    pub public_channel_info: Option<PublicChannelInfo>,
+    pub funding_udt_type_script: Option<Script>,
+    pub shutdown_script: Script,
+    /// The lock script that controls the funding cells (user's wallet lock script).
+    pub funding_lock_script: Script,
+    pub channel_id_sender: oneshot::Sender<Hash256>,
+    pub commitment_fee_rate: Option<u64>,
+    pub commitment_delay_epoch: Option<EpochNumberWithFraction>,
+    pub funding_fee_rate: Option<u64>,
+    pub max_tlc_value_in_flight: u128,
+    pub max_tlc_number_in_flight: u64,
+}
+
 // Ephemeral config for channel which does not need to persist.
 #[derive(Clone, Debug)]
 pub struct ChannelEphemeralConfig {
@@ -359,6 +386,9 @@ pub enum ChannelInitializationOperation {
     AcceptChannel(AcceptChannelParameter),
     /// Reestablish a channel with given channel id.
     ReestablishChannel(Hash256),
+    /// To open a new channel with external funding - the user will sign
+    /// the funding transaction with their own wallet instead of the node.
+    OpenChannelWithExternalFunding(OpenChannelWithExternalFundingParameter),
 }
 
 pub struct ChannelInitializationParameter {
@@ -468,22 +498,48 @@ where
                 state.handle_accept_channel_message(accept_channel)?;
                 let old_id = state.get_id();
                 state.fill_in_channel_id();
-                self.network
-                    .send_message(NetworkActorMessage::new_event(
-                        NetworkActorEvent::ChannelAccepted(
-                            state.get_remote_peer_id(),
-                            state.get_id(),
-                            old_id,
-                            state.to_local_amount,
-                            state.to_remote_amount,
-                            state.get_funding_lock_script(),
-                            state.funding_udt_type_script.clone(),
-                            state.local_reserved_ckb_amount,
-                            state.remote_reserved_ckb_amount,
-                            state.funding_fee_rate,
-                        ),
-                    ))
-                    .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+
+                if state.external_funding {
+                    // For external funding, send a different event and transition to AwaitingExternalFunding
+                    self.network
+                        .send_message(NetworkActorMessage::new_event(
+                            NetworkActorEvent::ChannelAcceptedForExternalFunding {
+                                peer_id: state.get_remote_peer_id(),
+                                new_channel_id: state.get_id(),
+                                old_channel_id: old_id,
+                                funding_amount: state.to_local_amount,
+                                remote_funding_amount: state.to_remote_amount,
+                                funding_source_lock_script: state
+                                    .external_funding_lock_script
+                                    .clone()
+                                    .expect("external_funding_lock_script should be set"),
+                                funding_cell_lock_script: state.get_funding_lock_script(),
+                                funding_udt_type_script: state.funding_udt_type_script.clone(),
+                                local_reserved_ckb_amount: state.local_reserved_ckb_amount,
+                                remote_reserved_ckb_amount: state.remote_reserved_ckb_amount,
+                                funding_fee_rate: state.funding_fee_rate,
+                            },
+                        ))
+                        .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+                } else {
+                    // Normal flow: send ChannelAccepted to start funding collaboration
+                    self.network
+                        .send_message(NetworkActorMessage::new_event(
+                            NetworkActorEvent::ChannelAccepted(
+                                state.get_remote_peer_id(),
+                                state.get_id(),
+                                old_id,
+                                state.to_local_amount,
+                                state.to_remote_amount,
+                                state.get_funding_lock_script(),
+                                state.funding_udt_type_script.clone(),
+                                state.local_reserved_ckb_amount,
+                                state.remote_reserved_ckb_amount,
+                                state.funding_fee_rate,
+                            ),
+                        ))
+                        .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+                }
                 Ok(())
             }
             FiberChannelMessage::TxUpdate(tx) => {
@@ -2148,6 +2204,40 @@ where
                 Ok(())
             }
             ChannelCommand::NotifyEvent(event) => self.handle_event(myself, state, event).await,
+            ChannelCommand::SetUnsignedFundingTx(tx) => {
+                // Store the unsigned funding transaction for external funding channels.
+                // This is called when the peer accepts the channel.
+                if !state.external_funding {
+                    return Err(ProcessingChannelError::InvalidState(
+                        "SetUnsignedFundingTx can only be used for external funding channels"
+                            .to_string(),
+                    ));
+                }
+                debug!(
+                    "Storing unsigned funding tx for external funding channel {:?}: {:?}",
+                    state.get_id(),
+                    tx.calc_tx_hash()
+                );
+                state.unsigned_funding_tx = Some(tx);
+                // Transition to AwaitingExternalFunding state
+                state.update_state(ChannelState::AwaitingExternalFunding);
+                Ok(())
+            }
+            ChannelCommand::SubmitExternalFundingTx(signed_tx, reply) => {
+                match self
+                    .handle_submit_external_funding_tx(myself, state, signed_tx)
+                    .await
+                {
+                    Ok(tx_hash) => {
+                        let _ = reply.send(Ok(tx_hash));
+                        Ok(())
+                    }
+                    Err(err) => {
+                        let _ = reply.send(Err(err.to_string()));
+                        Err(err)
+                    }
+                }
+            }
             #[cfg(any(test, feature = "bench"))]
             ChannelCommand::ReloadState(reload_params) => {
                 let private_key = state.private_key.clone();
@@ -2164,6 +2254,133 @@ where
                 Ok(())
             }
         }
+    }
+
+    /// Handle the submission of a signed funding transaction for external funding channels.
+    /// This validates the signed tx, stores it, and initiates the commitment exchange with the peer.
+    async fn handle_submit_external_funding_tx(
+        &self,
+        myself: &ActorRef<ChannelActorMessage>,
+        state: &mut ChannelActorState,
+        signed_tx: Transaction,
+    ) -> Result<Hash256, ProcessingChannelError> {
+        // Validate channel is in AwaitingExternalFunding state
+        if state.state != ChannelState::AwaitingExternalFunding {
+            return Err(ProcessingChannelError::InvalidState(format!(
+                "Expected channel in AwaitingExternalFunding state, but got {:?}",
+                state.state
+            )));
+        }
+
+        // Validate the channel is using external funding
+        if !state.external_funding {
+            return Err(ProcessingChannelError::InvalidState(
+                "Channel is not configured for external funding".to_string(),
+            ));
+        }
+
+        // Get the unsigned funding tx for comparison
+        let unsigned_tx = state.unsigned_funding_tx.as_ref().ok_or_else(|| {
+            ProcessingChannelError::InvalidState(
+                "Unsigned funding transaction not found".to_string(),
+            )
+        })?;
+
+        // Validate that the signed tx has the same structure as the unsigned tx
+        // (same inputs and outputs, just with witnesses added)
+        let unsigned_view = unsigned_tx.clone().into_view();
+        let signed_view = signed_tx.clone().into_view();
+
+        // Check inputs match
+        if unsigned_view.inputs().len() != signed_view.inputs().len() {
+            return Err(ProcessingChannelError::InvalidParameter(format!(
+                "Input count mismatch: unsigned has {}, signed has {}",
+                unsigned_view.inputs().len(),
+                signed_view.inputs().len()
+            )));
+        }
+
+        for (i, (unsigned_input, signed_input)) in unsigned_view
+            .inputs()
+            .into_iter()
+            .zip(signed_view.inputs().into_iter())
+            .enumerate()
+        {
+            if unsigned_input.previous_output() != signed_input.previous_output() {
+                return Err(ProcessingChannelError::InvalidParameter(format!(
+                    "Input {} previous_output mismatch",
+                    i
+                )));
+            }
+        }
+
+        // Check outputs match
+        if unsigned_view.outputs().len() != signed_view.outputs().len() {
+            return Err(ProcessingChannelError::InvalidParameter(format!(
+                "Output count mismatch: unsigned has {}, signed has {}",
+                unsigned_view.outputs().len(),
+                signed_view.outputs().len()
+            )));
+        }
+
+        for (i, (unsigned_output, signed_output)) in unsigned_view
+            .outputs()
+            .into_iter()
+            .zip(signed_view.outputs().into_iter())
+            .enumerate()
+        {
+            if unsigned_output.as_slice() != signed_output.as_slice() {
+                return Err(ProcessingChannelError::InvalidParameter(format!(
+                    "Output {} mismatch",
+                    i
+                )));
+            }
+        }
+
+        // Check outputs_data match
+        if unsigned_view.outputs_data().len() != signed_view.outputs_data().len() {
+            return Err(ProcessingChannelError::InvalidParameter(format!(
+                "Outputs data count mismatch: unsigned has {}, signed has {}",
+                unsigned_view.outputs_data().len(),
+                signed_view.outputs_data().len()
+            )));
+        }
+
+        for (i, (unsigned_data, signed_data)) in unsigned_view
+            .outputs_data()
+            .into_iter()
+            .zip(signed_view.outputs_data().into_iter())
+            .enumerate()
+        {
+            if unsigned_data.as_slice() != signed_data.as_slice() {
+                return Err(ProcessingChannelError::InvalidParameter(format!(
+                    "Output data {} mismatch",
+                    i
+                )));
+            }
+        }
+
+        let tx_hash: Hash256 = signed_view.hash().into();
+        debug!(
+            "Validated signed funding tx for external funding channel {:?}: {:?}",
+            state.get_id(),
+            tx_hash
+        );
+
+        // Store the signed funding tx
+        state.funding_tx = Some(signed_tx);
+
+        // Transition to CollaboratingFundingTx state with COLLABORATION_COMPLETED flag
+        // since we already have the complete funding tx from external signing
+        state.update_state(ChannelState::CollaboratingFundingTx(
+            CollaboratingFundingTxFlags::COLLABORATION_COMPLETED,
+        ));
+
+        // Increment commitment number and start the commitment signed exchange
+        state.increment_local_commitment_number();
+        self.handle_commitment_signed_command(myself, state).await?;
+
+        Ok(tx_hash)
     }
 
     pub async fn handle_event(
@@ -2659,6 +2876,144 @@ where
                     ))
                     .expect(ASSUME_NETWORK_ACTOR_ALIVE);
 
+                channel
+            }
+            ChannelInitializationOperation::OpenChannelWithExternalFunding(
+                OpenChannelWithExternalFundingParameter {
+                    funding_amount,
+                    seed,
+                    tlc_info,
+                    public_channel_info,
+                    funding_udt_type_script,
+                    shutdown_script,
+                    funding_lock_script,
+                    channel_id_sender,
+                    commitment_fee_rate,
+                    commitment_delay_epoch,
+                    funding_fee_rate,
+                    max_tlc_number_in_flight,
+                    max_tlc_value_in_flight,
+                },
+            ) => {
+                let public = public_channel_info.is_some();
+                let peer_id = self.get_remote_peer_id();
+                info!(
+                    "Trying to open a channel with external funding to {:?}",
+                    &peer_id
+                );
+
+                let commitment_fee_rate =
+                    commitment_fee_rate.unwrap_or(DEFAULT_COMMITMENT_FEE_RATE);
+                let funding_fee_rate = funding_fee_rate.unwrap_or(DEFAULT_FEE_RATE);
+
+                let (to_local_amount, reserved_ckb_amount) = get_funding_and_reserved_amount(
+                    funding_amount,
+                    &shutdown_script,
+                    &funding_udt_type_script,
+                )?;
+
+                let mut channel = ChannelActorState::new_outbound_channel(
+                    public_channel_info,
+                    &seed,
+                    self.get_local_pubkey(),
+                    self.get_remote_pubkey(),
+                    to_local_amount,
+                    reserved_ckb_amount,
+                    commitment_fee_rate,
+                    commitment_delay_epoch
+                        .unwrap_or(EpochNumberWithFraction::new(
+                            DEFAULT_COMMITMENT_DELAY_EPOCHS,
+                            0,
+                            1,
+                        ))
+                        .full_value(),
+                    funding_fee_rate,
+                    funding_udt_type_script.clone(),
+                    shutdown_script.clone(),
+                    max_tlc_value_in_flight,
+                    max_tlc_number_in_flight,
+                    tlc_info,
+                    self.network.clone(),
+                    args.private_key.clone(),
+                );
+
+                // Mark this channel as using external funding
+                channel.external_funding = true;
+                channel.external_funding_lock_script = Some(funding_lock_script);
+
+                check_open_channel_parameters(
+                    &channel.funding_udt_type_script,
+                    &channel.local_shutdown_script,
+                    channel.local_reserved_ckb_amount,
+                    channel.funding_fee_rate,
+                    channel.commitment_fee_rate,
+                    channel.commitment_delay_epoch,
+                    channel.local_constraints.max_tlc_number_in_flight,
+                )?;
+
+                let channel_flags = if public {
+                    ChannelFlags::PUBLIC
+                } else {
+                    ChannelFlags::empty()
+                };
+                let channel_announcement_nonce = if public {
+                    Some(channel.get_channel_announcement_musig2_pubnonce())
+                } else {
+                    None
+                };
+                let commitment_number = 1; // The first commitment number is 1, as 0 is reserved for the initial state.
+                let message = FiberMessage::ChannelInitialization(OpenChannel {
+                    chain_hash: get_chain_hash(),
+                    channel_id: channel.get_id(),
+                    funding_udt_type_script,
+                    funding_amount: channel.to_local_amount,
+                    shutdown_script,
+                    reserved_ckb_amount: channel.local_reserved_ckb_amount,
+                    funding_fee_rate,
+                    commitment_fee_rate,
+                    commitment_delay_epoch: channel.commitment_delay_epoch,
+                    max_tlc_value_in_flight: channel.local_constraints.max_tlc_value_in_flight,
+                    max_tlc_number_in_flight: channel.local_constraints.max_tlc_number_in_flight,
+                    channel_flags,
+                    first_per_commitment_point: channel
+                        .signer
+                        .get_commitment_point(commitment_number),
+                    second_per_commitment_point: channel
+                        .signer
+                        .get_commitment_point(commitment_number + 1),
+                    funding_pubkey: channel.get_local_channel_public_keys().funding_pubkey,
+                    tlc_basepoint: channel.get_local_channel_public_keys().tlc_base_key,
+                    next_commitment_nonce: channel.get_commitment_nonce(),
+                    next_revocation_nonce: channel.get_init_revocation_nonce(),
+                    channel_announcement_nonce,
+                });
+
+                debug!(
+                    "Created OpenChannel message (external funding) to {:?}: {:?}",
+                    &peer_id, &message
+                );
+                self.network
+                    .send_message(NetworkActorMessage::new_command(
+                        NetworkActorCommand::SendFiberMessage(FiberMessageWithPeerId {
+                            peer_id: peer_id.clone(),
+                            message,
+                        }),
+                    ))
+                    .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+
+                // Same initial state as regular OpenChannel - we're still negotiating
+                channel.update_state(ChannelState::NegotiatingFunding(
+                    NegotiatingFundingFlags::OUR_INIT_SENT,
+                ));
+                debug!(
+                    "Channel with external funding to peer {:?} with id {:?} created",
+                    &peer_id,
+                    &channel.get_id()
+                );
+
+                channel_id_sender
+                    .send(channel.get_id())
+                    .expect("Receive not dropped");
                 channel
             }
         };
@@ -3725,6 +4080,17 @@ pub struct ChannelActorState {
     // signing key
     #[serde(skip)]
     pub private_key: Option<Privkey>,
+
+    // Whether this channel uses external funding (user signs funding tx with their own wallet)
+    pub external_funding: bool,
+
+    // The lock script used for external funding (user's wallet lock script)
+    #[serde_as(as = "Option<EntityHex>")]
+    pub external_funding_lock_script: Option<Script>,
+
+    // The unsigned funding transaction for external funding (before user signs it)
+    #[serde_as(as = "Option<EntityHex>")]
+    pub unsigned_funding_tx: Option<Transaction>,
 }
 
 #[serde_as]
@@ -4018,6 +4384,9 @@ enum CommitmentSignedFlags {
 pub enum ChannelState {
     /// We are negotiating the parameters required for the channel prior to funding it.
     NegotiatingFunding(NegotiatingFundingFlags),
+    /// We're waiting for the user to sign and submit the funding transaction externally.
+    /// This state is used when the channel is opened with external funding.
+    AwaitingExternalFunding,
     /// We're collaborating with the other party on the funding transaction.
     CollaboratingFundingTx(CollaboratingFundingTxFlags),
     /// We have collaborated over the funding and are now waiting for CommitmentSigned messages.
@@ -4050,6 +4419,7 @@ impl ChannelState {
     fn can_abort_funding(&self) -> bool {
         match self {
             ChannelState::NegotiatingFunding(_)
+            | ChannelState::AwaitingExternalFunding
             | ChannelState::CollaboratingFundingTx(_)
             | ChannelState::SigningCommitment(_) => true,
             ChannelState::AwaitingTxSignatures(flags)
@@ -4647,6 +5017,9 @@ impl ChannelActorState {
             pending_notify_settle_tlcs: vec![],
             ephemeral_config: Default::default(),
             private_key: Some(private_key),
+            external_funding: false,
+            external_funding_lock_script: None,
+            unsigned_funding_tx: None,
         };
         if let Some(nonce) = remote_channel_announcement_nonce {
             state.update_remote_channel_announcement_nonce(&nonce);
@@ -4729,6 +5102,9 @@ impl ChannelActorState {
             pending_notify_settle_tlcs: vec![],
             ephemeral_config: Default::default(),
             private_key: Some(private_key),
+            external_funding: false,
+            external_funding_lock_script: None,
+            unsigned_funding_tx: None,
         };
         state.log_ack_state("[ack] new_outbound_channel");
         state
@@ -6771,7 +7147,8 @@ impl ChannelActorState {
         match self.state {
             ChannelState::NegotiatingFunding(_)
             | ChannelState::CollaboratingFundingTx(_)
-            | ChannelState::SigningCommitment(_) => {
+            | ChannelState::SigningCommitment(_)
+            | ChannelState::AwaitingExternalFunding => {
                 // Abort funding. It's better to resume the funding workflow, but it will make the code more complex.
                 // Consider refactoring the code to better support restarting in the future.
                 myself
@@ -7622,7 +7999,8 @@ impl ChannelActorState {
         match self.state {
             ChannelState::NegotiatingFunding(_)
             | ChannelState::CollaboratingFundingTx(_)
-            | ChannelState::SigningCommitment(_) => true,
+            | ChannelState::SigningCommitment(_)
+            | ChannelState::AwaitingExternalFunding => true,
             // Once we have sent the signature, the peer may succeed to submit
             // the funding tx on-chain.The best solution is waiting for the
             // confirmations or spending any input of the funding tx.

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -90,6 +90,9 @@ pub const DEFAULT_MIN_OUTBOUND_PEERS: usize = 8;
 /// Funding timeout in seconds since the channel is created.
 pub const DEFAULT_FUNDING_TIMEOUT_SECONDS: u64 = 60 * 60 * 24; // 1 day
 
+/// External funding timeout in seconds (how long to wait for user to submit signed funding tx).
+pub const DEFAULT_EXTERNAL_FUNDING_TIMEOUT_SECONDS: u64 = 60 * 5; // 5 minutes
+
 /// The interval to maintain the gossip network, in milli-seconds.
 #[cfg(not(any(test, feature = "bench")))]
 pub const DEFAULT_GOSSIP_STORE_MAINTENANCE_INTERVAL_MS: u64 = 20 * 1000;

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -78,8 +78,8 @@ use crate::ckb::contracts::{check_udt_script, get_udt_whitelist, is_udt_type_aut
 use crate::ckb::{CkbChainMessage, FundingError, FundingRequest, FundingTx, GetShutdownTxResponse};
 use crate::fiber::channel::{
     tlc_expiry_delay, AddTlcCommand, AddTlcResponse, ChannelActorState, ChannelEphemeralConfig,
-    ChannelInitializationOperation, RetryableTlcOperation, ShutdownCommand, TxCollaborationCommand,
-    TxUpdateCommand,
+    ChannelInitializationOperation, OpenChannelWithExternalFundingParameter, RetryableTlcOperation,
+    ShutdownCommand, TxCollaborationCommand, TxUpdateCommand,
 };
 use crate::fiber::channel::{
     AwaitingTxSignaturesFlags, ShuttingDownFlags, MAX_TLC_NUMBER_IN_FLIGHT,
@@ -358,6 +358,19 @@ pub enum NetworkActorCommand {
     NodeInfo((), RpcReplyPort<Result<NodeInfoResponse, String>>),
     ListPeers((), RpcReplyPort<Result<Vec<PeerInfo>, String>>),
 
+    // Open a channel with external funding - the funding transaction will be returned
+    // for the user to sign with their own wallet.
+    OpenChannelWithExternalFunding(
+        OpenChannelWithExternalFundingCommand,
+        RpcReplyPort<Result<OpenChannelWithExternalFundingResponse, String>>,
+    ),
+    // Submit a signed funding transaction for external funding.
+    SubmitSignedFundingTx {
+        channel_id: Hash256,
+        signed_tx: Transaction,
+        reply: RpcReplyPort<Result<Hash256, String>>,
+    },
+
     #[cfg(any(debug_assertions, feature = "bench"))]
     UpdateFeatures(FeatureVector),
 }
@@ -377,6 +390,29 @@ pub struct OpenChannelCommand {
     pub funding_amount: u128,
     pub public: bool,
     pub shutdown_script: Option<Script>,
+    pub funding_udt_type_script: Option<Script>,
+    pub commitment_fee_rate: Option<u64>,
+    pub commitment_delay_epoch: Option<EpochNumberWithFraction>,
+    pub funding_fee_rate: Option<u64>,
+    pub tlc_expiry_delta: Option<u64>,
+    pub tlc_min_value: Option<u128>,
+    pub tlc_fee_proportional_millionths: Option<u128>,
+    pub max_tlc_value_in_flight: Option<u128>,
+    pub max_tlc_number_in_flight: Option<u64>,
+}
+
+/// Command to open a channel with external funding.
+/// Similar to OpenChannelCommand, but the user will sign the funding transaction
+/// with their own wallet instead of having the node sign automatically.
+#[derive(Debug)]
+pub struct OpenChannelWithExternalFundingCommand {
+    pub peer_id: PeerId,
+    pub funding_amount: u128,
+    pub public: bool,
+    /// Required for external funding - the script to receive funds when channel closes.
+    pub shutdown_script: Script,
+    /// The lock script that controls the funding cells (user's wallet lock script).
+    pub funding_lock_script: Script,
     pub funding_udt_type_script: Option<Script>,
     pub commitment_fee_rate: Option<u64>,
     pub commitment_delay_epoch: Option<EpochNumberWithFraction>,
@@ -427,6 +463,15 @@ pub struct AcceptChannelCommand {
     pub min_tlc_value: Option<u128>,
     pub tlc_fee_proportional_millionths: Option<u128>,
     pub tlc_expiry_delta: Option<u64>,
+}
+
+/// Response for opening a channel with external funding.
+#[derive(Debug, Clone)]
+pub struct OpenChannelWithExternalFundingResponse {
+    /// The temporary channel ID.
+    pub channel_id: Hash256,
+    /// The unsigned funding transaction for the user to sign.
+    pub unsigned_funding_tx: Transaction,
 }
 
 impl NetworkActorMessage {
@@ -548,6 +593,23 @@ pub enum NetworkActorEvent {
         u64,
         u64,
     ),
+    /// A channel with external funding has been accepted.
+    /// This is used when the user wants to sign the funding transaction themselves.
+    ChannelAcceptedForExternalFunding {
+        peer_id: PeerId,
+        new_channel_id: Hash256,
+        old_channel_id: Hash256,
+        funding_amount: u128,
+        remote_funding_amount: u128,
+        /// The lock script of the user's wallet, used to collect input cells.
+        funding_source_lock_script: Script,
+        /// The 2-of-2 multisig lock script for the funding cell output.
+        funding_cell_lock_script: Script,
+        funding_udt_type_script: Option<Script>,
+        local_reserved_ckb_amount: u64,
+        remote_reserved_ckb_amount: u64,
+        funding_fee_rate: u64,
+    },
     /// A channel is ready to use.
     ChannelReady(Hash256, PeerId, OutPoint),
     /// A channel is going to be closed, waiting the closing transaction to be broadcasted and confirmed.
@@ -1006,6 +1068,159 @@ where
                         self.store.insert_channel_actor_state(actor_state);
                         info!("Channel {channel_id:?} on-chain settlement completed");
                     }
+                }
+            }
+            NetworkActorEvent::ChannelAcceptedForExternalFunding {
+                peer_id,
+                new_channel_id,
+                old_channel_id,
+                funding_amount,
+                remote_funding_amount,
+                funding_source_lock_script,
+                funding_cell_lock_script,
+                funding_udt_type_script,
+                local_reserved_ckb_amount,
+                remote_reserved_ckb_amount,
+                funding_fee_rate,
+            } => {
+                assert_ne!(
+                    new_channel_id, old_channel_id,
+                    "new and old channel id must be different"
+                );
+
+                // Update channel mapping
+                if let Some(session) = state.get_peer_session(&peer_id) {
+                    if let Some(channel) = state.channels.remove(&old_channel_id) {
+                        debug!(
+                            "Channel accepted for external funding: {:?} -> {:?}",
+                            old_channel_id, new_channel_id
+                        );
+                        state.channels.insert(new_channel_id, channel);
+                        if let Some(set) = state.session_channels_map.get_mut(&session) {
+                            set.remove(&old_channel_id);
+                            set.insert(new_channel_id);
+                        }
+                    }
+                }
+
+                // Get the pending reply - it could be under old_channel_id or new_channel_id
+                let reply = state
+                    .pending_external_funding_replies
+                    .remove(&old_channel_id)
+                    .or_else(|| {
+                        state
+                            .pending_external_funding_replies
+                            .remove(&new_channel_id)
+                    });
+
+                if let Some(reply) = reply {
+                    // Build the unsigned funding transaction
+                    let request = FundingRequest {
+                        script: funding_source_lock_script.clone(),
+                        udt_type_script: funding_udt_type_script,
+                        local_amount: funding_amount,
+                        remote_amount: remote_funding_amount,
+                        funding_fee_rate,
+                        local_reserved_ckb_amount,
+                        remote_reserved_ckb_amount,
+                    };
+
+                    let funding_tx = FundingTx::new();
+
+                    // Create a oneshot channel for the reply
+                    let (send, recv) = oneshot::channel::<Result<FundingTx, FundingError>>();
+                    let rpc_reply = RpcReplyPort::from(send);
+
+                    // Send the message to build the unsigned funding tx
+                    let _ =
+                        state
+                            .chain_actor
+                            .send_message(CkbChainMessage::BuildUnsignedFundingTx {
+                                funding_tx,
+                                request,
+                                funding_source_lock_script: funding_source_lock_script.into(),
+                                funding_cell_lock_script: funding_cell_lock_script.into(),
+                                reply: rpc_reply,
+                            });
+
+                    // Wait for the result
+                    match tokio::time::timeout(
+                        Duration::from_millis(DEFAULT_CHAIN_ACTOR_TIMEOUT),
+                        recv,
+                    )
+                    .await
+                    {
+                        Ok(Ok(Ok(built_tx))) => {
+                            if let Some(tx) = built_tx.into_inner() {
+                                debug!(
+                                    "Built unsigned funding tx for external funding channel {:?}: {:?}",
+                                    new_channel_id,
+                                    tx.hash()
+                                );
+
+                                // Store the unsigned tx in the channel actor state
+                                if let Err(e) = state
+                                    .send_command_to_channel(
+                                        new_channel_id,
+                                        ChannelCommand::SetUnsignedFundingTx(tx.data()),
+                                    )
+                                    .await
+                                {
+                                    error!(
+                                        "Failed to store unsigned funding tx in channel: {:?}",
+                                        e
+                                    );
+                                    let _ = reply.send(Err(format!(
+                                        "Failed to store unsigned funding tx: {}",
+                                        e
+                                    )));
+                                    return Ok(());
+                                }
+
+                                // Send the response
+                                let _ = reply.send(Ok(OpenChannelWithExternalFundingResponse {
+                                    channel_id: new_channel_id,
+                                    unsigned_funding_tx: tx.data(),
+                                }));
+                            } else {
+                                error!(
+                                    "Built funding tx is empty for channel {:?}",
+                                    new_channel_id
+                                );
+                                let _ = reply
+                                    .send(Err("Failed to build unsigned funding tx: empty result"
+                                        .to_string()));
+                            }
+                        }
+                        Ok(Ok(Err(e))) => {
+                            error!(
+                                "Failed to build unsigned funding tx for channel {:?}: {:?}",
+                                new_channel_id, e
+                            );
+                            let _ = reply
+                                .send(Err(format!("Failed to build unsigned funding tx: {}", e)));
+                        }
+                        Ok(Err(e)) => {
+                            error!(
+                                "Channel recv error for channel {:?}: {:?}",
+                                new_channel_id, e
+                            );
+                            let _ = reply.send(Err(format!("Channel recv error: {}", e)));
+                        }
+                        Err(_) => {
+                            error!(
+                                "Timeout waiting for unsigned funding tx for channel {:?}",
+                                new_channel_id
+                            );
+                            let _ = reply
+                                .send(Err("Timeout waiting for unsigned funding tx".to_string()));
+                        }
+                    }
+                } else {
+                    warn!(
+                        "No pending reply found for external funding channel {:?} (old: {:?})",
+                        new_channel_id, old_channel_id
+                    );
                 }
             }
         }
@@ -2109,6 +2324,59 @@ where
                     ))
                     .expect(ASSUME_NETWORK_MYSELF_ALIVE);
             }
+            NetworkActorCommand::OpenChannelWithExternalFunding(open_channel, reply) => {
+                debug!(
+                    "OpenChannelWithExternalFunding request: peer_id={:?}, funding_amount={:?}",
+                    open_channel.peer_id, open_channel.funding_amount
+                );
+                match state
+                    .create_outbound_channel_with_external_funding(open_channel)
+                    .await
+                {
+                    Ok((_channel_actor, temp_channel_id)) => {
+                        // Channel is now in NegotiatingFunding state waiting for AcceptChannel.
+                        // Store the reply port - we'll send the response when the peer accepts
+                        // and we build the unsigned funding tx.
+                        state
+                            .pending_external_funding_replies
+                            .insert(temp_channel_id, reply);
+                        debug!(
+                            "Stored pending reply for external funding channel {:?}",
+                            temp_channel_id
+                        );
+                    }
+                    Err(err) => {
+                        error!("Failed to create channel with external funding: {:?}", err);
+                        let _ = reply.send(Err(err.to_string()));
+                    }
+                }
+            }
+            NetworkActorCommand::SubmitSignedFundingTx {
+                channel_id,
+                signed_tx,
+                reply,
+            } => {
+                debug!(
+                    "SubmitSignedFundingTx request: channel_id={:?}, tx_hash={:?}",
+                    channel_id,
+                    signed_tx.calc_tx_hash()
+                );
+
+                // Forward the command to the channel actor
+                if let Err(e) = state
+                    .send_command_to_channel(
+                        channel_id,
+                        ChannelCommand::SubmitExternalFundingTx(signed_tx, reply),
+                    )
+                    .await
+                {
+                    error!(
+                        "Failed to send SubmitExternalFundingTx command to channel {:?}: {:?}",
+                        channel_id, e
+                    );
+                    // Note: reply is already moved to the channel command, can't send error here
+                }
+            }
         };
         Ok(())
     }
@@ -2688,6 +2956,12 @@ pub struct NetworkActorState<S, C> {
 
     // Inflight payment actors
     inflight_payments: HashMap<Hash256, ActorRef<PaymentActorMessage>>,
+
+    // Pending replies for external funding channel requests.
+    // When a user requests to open a channel with external funding, we store the reply port here
+    // until the peer accepts the channel and we build the unsigned funding tx.
+    pending_external_funding_replies:
+        HashMap<Hash256, RpcReplyPort<Result<OpenChannelWithExternalFundingResponse, String>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -2935,6 +3209,107 @@ where
                     max_tlc_number_in_flight: max_tlc_number_in_flight
                         .unwrap_or(MAX_TLC_NUMBER_IN_FLIGHT),
                 }),
+                ephemeral_config: self.channel_ephemeral_config.clone(),
+                private_key: self.private_key.clone(),
+            },
+            network.clone().get_cell(),
+        )
+        .await
+        .map_err(|e| ProcessingChannelError::SpawnErr(e.to_string()))?
+        .0;
+        let temp_channel_id = rx.await.expect("msg received");
+        self.on_channel_created(temp_channel_id, &peer_id, channel.clone());
+        Ok((channel, temp_channel_id))
+    }
+
+    /// Create an outbound channel with external funding.
+    /// Similar to create_outbound_channel, but the user will sign the funding transaction
+    /// with their own wallet.
+    pub async fn create_outbound_channel_with_external_funding(
+        &mut self,
+        command: OpenChannelWithExternalFundingCommand,
+    ) -> Result<(ActorRef<ChannelActorMessage>, Hash256), ProcessingChannelError> {
+        let store = self.store.clone();
+        let network = self.network.clone();
+        let OpenChannelWithExternalFundingCommand {
+            peer_id,
+            funding_amount,
+            public,
+            shutdown_script,
+            funding_lock_script,
+            funding_udt_type_script,
+            commitment_fee_rate,
+            commitment_delay_epoch,
+            funding_fee_rate,
+            tlc_expiry_delta,
+            tlc_min_value,
+            tlc_fee_proportional_millionths,
+            max_tlc_value_in_flight,
+            max_tlc_number_in_flight,
+        } = command;
+
+        self.check_feature_compatibility(&peer_id)?;
+
+        let remote_pubkey =
+            self.get_peer_pubkey(&peer_id)
+                .ok_or(ProcessingChannelError::InvalidParameter(format!(
+                    "Peer {:?} pubkey not found",
+                    &peer_id
+                )))?;
+
+        if let Some(udt_type_script) = funding_udt_type_script.as_ref() {
+            if !check_udt_script(udt_type_script) {
+                return Err(ProcessingChannelError::InvalidParameter(
+                    "Invalid UDT type script".to_string(),
+                ));
+            }
+        }
+
+        if tlc_expiry_delta.is_some_and(|d| d < MIN_TLC_EXPIRY_DELTA) {
+            return Err(ProcessingChannelError::InvalidParameter(format!(
+                "TLC expiry delta is too small, expect larger than {}, got {}",
+                MIN_TLC_EXPIRY_DELTA,
+                tlc_expiry_delta.unwrap()
+            )));
+        }
+
+        let tlc_expiry_delta = tlc_expiry_delta.unwrap_or(self.tlc_expiry_delta);
+        let commitment_delay_epochs = commitment_delay_epoch.map_or_else(
+            || EpochNumberWithFraction::new(DEFAULT_COMMITMENT_DELAY_EPOCHS, 0, 1).full_value(),
+            |epochs| epochs.full_value(),
+        );
+        check_tlc_delta_with_epochs(tlc_expiry_delta, commitment_delay_epochs)?;
+
+        let seed = self.generate_channel_seed();
+        let (tx, rx) = oneshot::channel::<Hash256>();
+        let channel = Actor::spawn_linked(
+            Some(generate_channel_actor_name(&self.peer_id, &peer_id)),
+            ChannelActor::new(self.get_public_key(), remote_pubkey, network.clone(), store),
+            ChannelInitializationParameter {
+                operation: ChannelInitializationOperation::OpenChannelWithExternalFunding(
+                    OpenChannelWithExternalFundingParameter {
+                        funding_amount,
+                        seed,
+                        tlc_info: ChannelTlcInfo::new(
+                            tlc_min_value.unwrap_or(self.tlc_min_value),
+                            tlc_expiry_delta,
+                            tlc_fee_proportional_millionths
+                                .unwrap_or(self.tlc_fee_proportional_millionths),
+                        ),
+                        public_channel_info: public.then_some(PublicChannelInfo::new()),
+                        funding_udt_type_script,
+                        shutdown_script,
+                        funding_lock_script,
+                        channel_id_sender: tx,
+                        commitment_fee_rate,
+                        commitment_delay_epoch,
+                        funding_fee_rate,
+                        max_tlc_value_in_flight: max_tlc_value_in_flight
+                            .unwrap_or(DEFAULT_MAX_TLC_VALUE_IN_FLIGHT),
+                        max_tlc_number_in_flight: max_tlc_number_in_flight
+                            .unwrap_or(MAX_TLC_NUMBER_IN_FLIGHT),
+                    },
+                ),
                 ephemeral_config: self.channel_ephemeral_config.clone(),
                 private_key: self.private_key.clone(),
             },
@@ -4148,6 +4523,7 @@ where
                 funding_timeout_seconds: config.funding_timeout_seconds,
             },
             inflight_payments: Default::default(),
+            pending_external_funding_replies: Default::default(),
         };
 
         let node_announcement = state.get_or_create_new_node_announcement_message();

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -25,6 +25,8 @@ You may refer to the e2e test cases in the `tests/bruno/e2e` directory for examp
         * [Method `list_channels`](#channel-list_channels)
         * [Method `shutdown_channel`](#channel-shutdown_channel)
         * [Method `update_channel`](#channel-update_channel)
+        * [Method `open_channel_with_external_funding`](#channel-open_channel_with_external_funding)
+        * [Method `submit_signed_funding_tx`](#channel-submit_signed_funding_tx)
     * [Module Dev](#module-dev)
         * [Method `commitment_signed`](#dev-commitment_signed)
         * [Method `add_tlc`](#dev-add_tlc)
@@ -342,6 +344,80 @@ Updates a channel.
 ##### Returns
 
 * None
+
+---
+
+
+
+<a id="channel-open_channel_with_external_funding"></a>
+#### Method `open_channel_with_external_funding`
+
+Opens a channel with external funding. The node will negotiate the channel with the peer,
+ but the user must sign the funding transaction themselves using their own wallet.
+
+ This is useful when the user wants to fund a channel from an external wallet
+ rather than having the node sign with its internal key.
+
+ Returns an unsigned funding transaction that the user must sign and submit
+ using `submit_signed_funding_tx`.
+
+##### Params
+
+* `peer_id` - <em>`PeerId`</em>, The peer ID to open a channel with, the peer must be connected through the [connect_peer](#peer-connect_peer) rpc first.
+* `funding_amount` - <em>`u128`</em>, The amount of CKB or UDT to fund the channel with.
+* `public` - <em>`Option<bool>`</em>, Whether this is a public channel (will be broadcasted to network, and can be used to forward TLCs), an optional parameter, default value is true.
+* `funding_udt_type_script` - <em>`Option<Script>`</em>, The type script of the UDT to fund the channel with, an optional parameter.
+* `shutdown_script` - <em>`Script`</em>, The script used to receive the channel balance when the channel is closed. This is REQUIRED for external funding.
+* `funding_lock_script` - <em>`Script`</em>, The lock script that controls the funding cells. The node will collect cells with this lock script
+ to build the funding transaction. The user must be able to sign for this lock script.
+* `commitment_delay_epoch` - <em>`Option<EpochNumberWithFraction>`</em>, The delay time for the commitment transaction, must be an [EpochNumberWithFraction](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0017-tx-valid-since/e-i-l-encoding.png) in u64 format, an optional parameter, default value is 1 epoch, which is 4 hours.
+* `commitment_fee_rate` - <em>`Option<u64>`</em>, The fee rate for the commitment transaction, an optional parameter.
+* `funding_fee_rate` - <em>`Option<u64>`</em>, The fee rate for the funding transaction, an optional parameter.
+* `tlc_expiry_delta` - <em>`Option<u64>`</em>, The expiry delta to forward a tlc, in milliseconds, default to 4 hours, which is 4 * 60 * 60 * 1000 milliseconds
+ Expect it >= 2/3 commitment_delay_epoch.
+ This parameter can be updated with rpc `update_channel` later.
+* `tlc_min_value` - <em>`Option<u128>`</em>, The minimum value for a TLC our side can send,
+ an optional parameter, default is 0, which means we can send any TLC is larger than 0.
+ This parameter can be updated with rpc `update_channel` later.
+* `tlc_fee_proportional_millionths` - <em>`Option<u128>`</em>, The fee proportional millionths for a TLC, proportional to the amount of the forwarded tlc.
+ The unit is millionths of the amount. default is 1000 which means 0.1%.
+ This parameter can be updated with rpc `update_channel` later.
+* `max_tlc_value_in_flight` - <em>`Option<u128>`</em>, The maximum value in flight for TLCs, an optional parameter.
+ This parameter can not be updated after channel is opened.
+* `max_tlc_number_in_flight` - <em>`Option<u64>`</em>, The maximum number of TLCs that can be accepted, an optional parameter, default is 125
+ This parameter can not be updated after channel is opened.
+
+##### Returns
+
+* `temporary_channel_id` - <em>[Hash256](#type-hash256)</em>, The temporary channel ID of the channel being opened.
+ Use this ID to submit the signed funding transaction.
+* `unsigned_funding_tx` - <em>`ckb_jsonrpc_types::Transaction`</em>, The unsigned funding transaction that needs to be signed.
+ The user should sign this transaction with their wallet and submit it
+ using `submit_signed_funding_tx`.
+
+---
+
+
+
+<a id="channel-submit_signed_funding_tx"></a>
+#### Method `submit_signed_funding_tx`
+
+Submits a signed funding transaction for an externally funded channel.
+
+ After calling `open_channel_with_external_funding`, the user signs the returned
+ unsigned transaction with their wallet and submits it here.
+
+##### Params
+
+* `channel_id` - <em>[Hash256](#type-hash256)</em>, The temporary channel ID returned from `open_channel_with_external_funding`.
+* `signed_funding_tx` - <em>`ckb_jsonrpc_types::Transaction`</em>, The signed funding transaction. This must be the same transaction structure
+ that was returned from `open_channel_with_external_funding`, but with valid
+ witnesses (signatures) added.
+
+##### Returns
+
+* `channel_id` - <em>[Hash256](#type-hash256)</em>, The channel ID (may be updated from temporary to final after peer exchange).
+* `funding_tx_hash` - <em>`H256`</em>, The hash of the funding transaction that was submitted.
 
 ---
 
@@ -1154,6 +1230,7 @@ The state of a channel
 #### Enum with values of
 
 * `NegotiatingFunding` - <em>`NegotiatingFundingFlags`</em>, We are negotiating the parameters required for the channel prior to funding it.
+* `AwaitingExternalFunding` - We're waiting for the user to sign and submit the funding transaction externally.
 * `CollaboratingFundingTx` - <em>`CollaboratingFundingTxFlags`</em>, We're collaborating with the other party on the funding transaction.
 * `SigningCommitment` - <em>`SigningCommitmentFlags`</em>, We have collaborated over the funding and are now waiting for CommitmentSigned messages.
 * `AwaitingTxSignatures` - <em>`AwaitingTxSignaturesFlags`</em>, We've received and sent `commitment_signed` and are now waiting for both

--- a/crates/fiber-lib/src/rpc/channel.rs
+++ b/crates/fiber-lib/src/rpc/channel.rs
@@ -7,7 +7,7 @@ use crate::fiber::{
         CollaboratingFundingTxFlags, NegotiatingFundingFlags, ShutdownCommand, ShuttingDownFlags,
         SigningCommitmentFlags, UpdateCommand,
     },
-    network::{AcceptChannelCommand, OpenChannelCommand},
+    network::{AcceptChannelCommand, OpenChannelCommand, OpenChannelWithExternalFundingCommand},
     serde_utils::{U128Hex, U64Hex},
     types::Hash256,
     NetworkActorCommand, NetworkActorMessage,
@@ -16,7 +16,7 @@ use crate::{handle_actor_call, log_and_error};
 use ckb_jsonrpc_types::{EpochNumberWithFraction, Script};
 use ckb_types::{
     core::{EpochNumberWithFraction as EpochNumberWithFractionCore, FeeRate},
-    packed::OutPoint,
+    packed::{self, OutPoint},
     prelude::{IntoTransactionView, Unpack},
     H256,
 };
@@ -183,6 +183,8 @@ pub struct ListChannelsResult {
 pub enum ChannelState {
     /// We are negotiating the parameters required for the channel prior to funding it.
     NegotiatingFunding(NegotiatingFundingFlags),
+    /// We're waiting for the user to sign and submit the funding transaction externally.
+    AwaitingExternalFunding,
     /// We're collaborating with the other party on the funding transaction.
     CollaboratingFundingTx(CollaboratingFundingTxFlags),
     /// We have collaborated over the funding and are now waiting for CommitmentSigned messages.
@@ -206,6 +208,7 @@ impl From<RawChannelState> for ChannelState {
     fn from(state: RawChannelState) -> Self {
         match state {
             RawChannelState::NegotiatingFunding(flags) => ChannelState::NegotiatingFunding(flags),
+            RawChannelState::AwaitingExternalFunding => ChannelState::AwaitingExternalFunding,
             RawChannelState::CollaboratingFundingTx(flags) => {
                 ChannelState::CollaboratingFundingTx(flags)
             }
@@ -338,6 +341,108 @@ pub struct UpdateChannelParams {
     pub tlc_fee_proportional_millionths: Option<u128>,
 }
 
+/// Parameters for opening a channel with external funding.
+/// This allows end-users to open channels by signing the funding transaction
+/// with their own wallet instead of having the node sign automatically.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct OpenChannelWithExternalFundingParams {
+    /// The peer ID to open a channel with, the peer must be connected through the [connect_peer](#peer-connect_peer) rpc first.
+    #[serde_as(as = "DisplayFromStr")]
+    pub peer_id: PeerId,
+
+    /// The amount of CKB or UDT to fund the channel with.
+    #[serde_as(as = "U128Hex")]
+    pub funding_amount: u128,
+
+    /// Whether this is a public channel (will be broadcasted to network, and can be used to forward TLCs), an optional parameter, default value is true.
+    pub public: Option<bool>,
+
+    /// The type script of the UDT to fund the channel with, an optional parameter.
+    pub funding_udt_type_script: Option<Script>,
+
+    /// The script used to receive the channel balance when the channel is closed. This is REQUIRED for external funding.
+    pub shutdown_script: Script,
+
+    /// The lock script that controls the funding cells. The node will collect cells with this lock script
+    /// to build the funding transaction. The user must be able to sign for this lock script.
+    pub funding_lock_script: Script,
+
+    /// The delay time for the commitment transaction, must be an [EpochNumberWithFraction](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0017-tx-valid-since/e-i-l-encoding.png) in u64 format, an optional parameter, default value is 1 epoch, which is 4 hours.
+    pub commitment_delay_epoch: Option<EpochNumberWithFraction>,
+
+    /// The fee rate for the commitment transaction, an optional parameter.
+    #[serde_as(as = "Option<U64Hex>")]
+    pub commitment_fee_rate: Option<u64>,
+
+    /// The fee rate for the funding transaction, an optional parameter.
+    #[serde_as(as = "Option<U64Hex>")]
+    pub funding_fee_rate: Option<u64>,
+
+    /// The expiry delta to forward a tlc, in milliseconds, default to 4 hours, which is 4 * 60 * 60 * 1000 milliseconds
+    /// Expect it >= 2/3 commitment_delay_epoch.
+    /// This parameter can be updated with rpc `update_channel` later.
+    #[serde_as(as = "Option<U64Hex>")]
+    pub tlc_expiry_delta: Option<u64>,
+
+    /// The minimum value for a TLC our side can send,
+    /// an optional parameter, default is 0, which means we can send any TLC is larger than 0.
+    /// This parameter can be updated with rpc `update_channel` later.
+    #[serde_as(as = "Option<U128Hex>")]
+    pub tlc_min_value: Option<u128>,
+
+    /// The fee proportional millionths for a TLC, proportional to the amount of the forwarded tlc.
+    /// The unit is millionths of the amount. default is 1000 which means 0.1%.
+    /// This parameter can be updated with rpc `update_channel` later.
+    #[serde_as(as = "Option<U128Hex>")]
+    pub tlc_fee_proportional_millionths: Option<u128>,
+
+    /// The maximum value in flight for TLCs, an optional parameter.
+    /// This parameter can not be updated after channel is opened.
+    #[serde_as(as = "Option<U128Hex>")]
+    pub max_tlc_value_in_flight: Option<u128>,
+
+    /// The maximum number of TLCs that can be accepted, an optional parameter, default is 125
+    /// This parameter can not be updated after channel is opened.
+    #[serde_as(as = "Option<U64Hex>")]
+    pub max_tlc_number_in_flight: Option<u64>,
+}
+
+/// Result of opening a channel with external funding.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OpenChannelWithExternalFundingResult {
+    /// The temporary channel ID of the channel being opened.
+    /// Use this ID to submit the signed funding transaction.
+    pub temporary_channel_id: Hash256,
+
+    /// The unsigned funding transaction that needs to be signed.
+    /// The user should sign this transaction with their wallet and submit it
+    /// using `submit_signed_funding_tx`.
+    pub unsigned_funding_tx: ckb_jsonrpc_types::Transaction,
+}
+
+/// Parameters for submitting a signed funding transaction for external funding.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SubmitSignedFundingTxParams {
+    /// The temporary channel ID returned from `open_channel_with_external_funding`.
+    pub channel_id: Hash256,
+
+    /// The signed funding transaction. This must be the same transaction structure
+    /// that was returned from `open_channel_with_external_funding`, but with valid
+    /// witnesses (signatures) added.
+    pub signed_funding_tx: ckb_jsonrpc_types::Transaction,
+}
+
+/// Result of submitting a signed funding transaction.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SubmitSignedFundingTxResult {
+    /// The channel ID (may be updated from temporary to final after peer exchange).
+    pub channel_id: Hash256,
+
+    /// The hash of the funding transaction that was submitted.
+    pub funding_tx_hash: H256,
+}
+
 /// RPC module for channel management.
 #[cfg(not(target_arch = "wasm32"))]
 #[rpc(server)]
@@ -376,6 +481,30 @@ trait ChannelRpc {
     /// Updates a channel.
     #[method(name = "update_channel")]
     async fn update_channel(&self, params: UpdateChannelParams) -> Result<(), ErrorObjectOwned>;
+
+    /// Opens a channel with external funding. The node will negotiate the channel with the peer,
+    /// but the user must sign the funding transaction themselves using their own wallet.
+    ///
+    /// This is useful when the user wants to fund a channel from an external wallet
+    /// rather than having the node sign with its internal key.
+    ///
+    /// Returns an unsigned funding transaction that the user must sign and submit
+    /// using `submit_signed_funding_tx`.
+    #[method(name = "open_channel_with_external_funding")]
+    async fn open_channel_with_external_funding(
+        &self,
+        params: OpenChannelWithExternalFundingParams,
+    ) -> Result<OpenChannelWithExternalFundingResult, ErrorObjectOwned>;
+
+    /// Submits a signed funding transaction for an externally funded channel.
+    ///
+    /// After calling `open_channel_with_external_funding`, the user signs the returned
+    /// unsigned transaction with their wallet and submits it here.
+    #[method(name = "submit_signed_funding_tx")]
+    async fn submit_signed_funding_tx(
+        &self,
+        params: SubmitSignedFundingTxParams,
+    ) -> Result<SubmitSignedFundingTxResult, ErrorObjectOwned>;
 }
 
 pub struct ChannelRpcServerImpl<S> {
@@ -435,6 +564,22 @@ where
     /// Updates a channel.
     async fn update_channel(&self, params: UpdateChannelParams) -> Result<(), ErrorObjectOwned> {
         self.update_channel(params).await
+    }
+
+    /// Opens a channel with external funding.
+    async fn open_channel_with_external_funding(
+        &self,
+        params: OpenChannelWithExternalFundingParams,
+    ) -> Result<OpenChannelWithExternalFundingResult, ErrorObjectOwned> {
+        self.open_channel_with_external_funding(params).await
+    }
+
+    /// Submits a signed funding transaction for an externally funded channel.
+    async fn submit_signed_funding_tx(
+        &self,
+        params: SubmitSignedFundingTxParams,
+    ) -> Result<SubmitSignedFundingTxResult, ErrorObjectOwned> {
+        self.submit_signed_funding_tx(params).await
     }
 }
 impl<S> ChannelRpcServerImpl<S>
@@ -637,5 +782,64 @@ where
             ))
         };
         handle_actor_call!(self.actor, message, params)
+    }
+
+    /// Opens a channel with external funding.
+    pub async fn open_channel_with_external_funding(
+        &self,
+        params: OpenChannelWithExternalFundingParams,
+    ) -> Result<OpenChannelWithExternalFundingResult, ErrorObjectOwned> {
+        let message = |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::OpenChannelWithExternalFunding(
+                OpenChannelWithExternalFundingCommand {
+                    peer_id: params.peer_id.clone(),
+                    funding_amount: params.funding_amount,
+                    public: params.public.unwrap_or(true),
+                    shutdown_script: params.shutdown_script.clone().into(),
+                    funding_lock_script: params.funding_lock_script.clone().into(),
+                    commitment_delay_epoch: params
+                        .commitment_delay_epoch
+                        .map(|e| EpochNumberWithFractionCore::from_full_value(e.value())),
+                    funding_udt_type_script: params
+                        .funding_udt_type_script
+                        .clone()
+                        .map(|s| s.into()),
+                    commitment_fee_rate: params.commitment_fee_rate,
+                    funding_fee_rate: params.funding_fee_rate,
+                    tlc_expiry_delta: params.tlc_expiry_delta,
+                    tlc_min_value: params.tlc_min_value,
+                    tlc_fee_proportional_millionths: params.tlc_fee_proportional_millionths,
+                    max_tlc_value_in_flight: params.max_tlc_value_in_flight,
+                    max_tlc_number_in_flight: params.max_tlc_number_in_flight,
+                },
+                rpc_reply,
+            ))
+        };
+        handle_actor_call!(self.actor, message, params).map(|response| {
+            OpenChannelWithExternalFundingResult {
+                temporary_channel_id: response.channel_id,
+                unsigned_funding_tx: response.unsigned_funding_tx.into(),
+            }
+        })
+    }
+
+    /// Submits a signed funding transaction for an externally funded channel.
+    pub async fn submit_signed_funding_tx(
+        &self,
+        params: SubmitSignedFundingTxParams,
+    ) -> Result<SubmitSignedFundingTxResult, ErrorObjectOwned> {
+        let channel_id = params.channel_id;
+        let signed_tx: packed::Transaction = params.signed_funding_tx.clone().into();
+        let message = |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::SubmitSignedFundingTx {
+                channel_id,
+                signed_tx: signed_tx.clone(),
+                reply: rpc_reply,
+            })
+        };
+        handle_actor_call!(self.actor, message, params).map(|tx_hash| SubmitSignedFundingTxResult {
+            channel_id,
+            funding_tx_hash: tx_hash.into(),
+        })
     }
 }

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -559,6 +559,9 @@ fn test_channel_actor_state_store() {
         pending_notify_settle_tlcs: vec![],
         ephemeral_config: Default::default(),
         private_key: None,
+        external_funding: false,
+        external_funding_lock_script: None,
+        unsigned_funding_tx: None,
     };
 
     let bincode_encoded = bincode::serialize(&state).unwrap();
@@ -681,6 +684,9 @@ fn test_serde_channel_actor_state_ciborium() {
         pending_notify_settle_tlcs: vec![],
         ephemeral_config: Default::default(),
         private_key: None,
+        external_funding: false,
+        external_funding_lock_script: None,
+        unsigned_funding_tx: None,
     };
 
     let mut serialized = Vec::new();

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -560,7 +560,7 @@ fn test_channel_actor_state_store() {
         ephemeral_config: Default::default(),
         private_key: None,
         external_funding: false,
-        external_funding_lock_script: None,
+        external_funding_tx: None,
         unsigned_funding_tx: None,
     };
 
@@ -685,7 +685,7 @@ fn test_serde_channel_actor_state_ciborium() {
         ephemeral_config: Default::default(),
         private_key: None,
         external_funding: false,
-        external_funding_lock_script: None,
+        external_funding_tx: None,
         unsigned_funding_tx: None,
     };
 


### PR DESCRIPTION
Implement RPC endpoints that allow users to open payment channels by signing funding transactions with their own external wallets, instead of having the node automatically sign with its private key.

New RPC methods:
- open_channel_with_external_funding: negotiates channel with peer and returns unsigned funding tx for user to sign externally
- submit_signed_funding_tx: accepts signed tx and completes channel opening

Key changes:
- Add AwaitingExternalFunding channel state for channels waiting for user signature
- Add ExternalFundingTxBuilder to build unsigned funding transactions
- Add BuildUnsignedFundingTx message to CKB chain actor
- Add timeout mechanism for external funding (reuses existing funding timeout)
- Update RPC documentation with new endpoints