### PR TITLE
Refactory: Use LocalSigner to manage secretkeys.

### DIFF
--- a/crates/fiber-lib/src/ckb/actor.rs
+++ b/crates/fiber-lib/src/ckb/actor.rs
@@ -14,6 +14,7 @@ use crate::{
 
 use super::{
     funding::{FundingContext, LiveCellsExclusionMap},
+    signer::LocalSigner,
     tx_tracing_actor::{
         CkbTxTracer, CkbTxTracingActor, CkbTxTracingArguments, CkbTxTracingMessage,
     },
@@ -28,7 +29,7 @@ const ACTOR_HANDLE_WARN_THRESHOLD_MS: u64 = 15_000;
 pub struct CkbChainState {
     config: CkbConfig,
     ckb_tx_tracing_actor: ActorRef<CkbTxTracingMessage>,
-    secret_key: secp256k1::SecretKey,
+    signer: LocalSigner,
     funding_source_lock_script: packed::Script,
     live_cells_exclusion_map: LiveCellsExclusionMap,
 }
@@ -76,11 +77,9 @@ impl Actor for CkbChainActor {
         config: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
         let secret_key = config.read_secret_key()?;
-        let secp = secp256k1::Secp256k1::new();
-        let pub_key = secret_key.public_key(&secp);
-        let pub_key_hash = ckb_hash::blake2b_256(pub_key.serialize());
+        let signer = LocalSigner::new(secret_key);
         let funding_source_lock_script =
-            get_script_by_contract(Contract::Secp256k1Lock, &pub_key_hash[0..20]);
+            get_script_by_contract(Contract::Secp256k1Lock, signer.pubkey_hash());
         let ckb_tx_tracing_actor = Actor::spawn_linked(
             Some(format!(
                 "{}/ckb-tx-tracing",
@@ -97,7 +96,7 @@ impl Actor for CkbChainActor {
         .0;
         Ok(CkbChainState {
             config,
-            secret_key,
+            signer,
             funding_source_lock_script,
             ckb_tx_tracing_actor,
             live_cells_exclusion_map: Default::default(),
@@ -154,9 +153,8 @@ impl Actor for CkbChainActor {
             }
             CkbChainMessage::Sign(tx, reply_port) => {
                 if !reply_port.is_closed() {
-                    let secret_key = state.secret_key;
                     let rpc_url = state.config.rpc_url.clone();
-                    let result = tx.sign(secret_key, rpc_url).await;
+                    let result = state.signer.sign_funding_tx(tx, rpc_url).await;
                     if !reply_port.is_closed() {
                         // ignore error
                         let _ = reply_port.send(result);
@@ -232,7 +230,7 @@ impl Actor for CkbChainActor {
 impl CkbChainState {
     fn build_funding_context(&self, funding_cell_lock_script: packed::Script) -> FundingContext {
         FundingContext {
-            secret_key: self.secret_key,
+            signer: self.signer.clone(),
             rpc_url: self.config.rpc_url.clone(),
             funding_source_lock_script: self.funding_source_lock_script.clone(),
             funding_cell_lock_script,

--- a/crates/fiber-lib/src/ckb/funding/funding_tx.rs
+++ b/crates/fiber-lib/src/ckb/funding/funding_tx.rs
@@ -1,4 +1,4 @@
-use super::super::FundingError;
+use super::super::{signer::LocalSigner, FundingError};
 use crate::{
     ckb::{
         config::{new_ckb_rpc_async_client, new_default_cell_collector},
@@ -150,7 +150,7 @@ pub struct FundingRequest {
 // TODO: trace locked cells
 #[derive(Clone, Debug)]
 pub struct FundingContext {
-    pub secret_key: secp256k1::SecretKey,
+    pub signer: LocalSigner,
     pub rpc_url: String,
     pub funding_source_lock_script: packed::Script,
     pub funding_cell_lock_script: packed::Script,

--- a/crates/fiber-lib/src/ckb/mod.rs
+++ b/crates/fiber-lib/src/ckb/mod.rs
@@ -2,6 +2,7 @@ mod actor;
 mod error;
 mod funding;
 mod jsonrpc_types_convert;
+pub mod signer;
 mod tx_tracing_actor;
 
 pub use actor::{CkbChainActor, CkbChainMessage};
@@ -10,6 +11,7 @@ pub use client::{GetCellsResponse, GetShutdownTxResponse, GetTxResponse};
 pub use config::{CkbConfig, DEFAULT_CKB_BASE_DIR_NAME};
 pub use error::{CkbChainError, FundingError};
 pub use funding::{FundingRequest, FundingTx};
+pub use signer::LocalSigner;
 pub use tx_tracing_actor::{CkbTxTracer, CkbTxTracingMask, CkbTxTracingResult};
 
 pub mod client;

--- a/crates/fiber-lib/src/ckb/signer.rs
+++ b/crates/fiber-lib/src/ckb/signer.rs
@@ -1,0 +1,208 @@
+//! Local signer implementation for CKB transactions.
+//!
+//! This module provides a minimal encapsulation of the secret key used for signing
+//! CKB transactions. It caches derived values (public key, pubkey hash) to avoid
+//! repeated computation.
+
+use ckb_sdk::{
+    constants::SIGHASH_TYPE_HASH,
+    traits::{DefaultTransactionDependencyProvider, SecpCkbRawKeySigner},
+    tx_builder::unlock_tx_async,
+    unlock::{ScriptUnlocker, SecpSighashUnlocker},
+    util::blake160,
+    ScriptId,
+};
+use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
+use std::collections::HashMap;
+
+use super::{FundingError, FundingTx};
+
+/// A local signer that holds a secret key and provides signing capabilities.
+///
+/// This is a minimal encapsulation that:
+/// - Caches derived values (pubkey, pubkey_hash) to avoid repeated computation
+/// - Provides a consistent interface for signing operations
+/// - Does not introduce traits, async, or RPC dependencies
+#[derive(Clone)]
+pub struct LocalSigner {
+    secret_key: SecretKey,
+    pubkey: PublicKey,
+    /// blake160(pubkey.serialize()) - used for lock script args
+    pubkey_hash: [u8; 20],
+}
+
+impl LocalSigner {
+    /// Create a new LocalSigner from a secret key.
+    ///
+    /// This computes and caches the public key and its blake160 hash.
+    pub fn new(secret_key: SecretKey) -> Self {
+        let secp = Secp256k1::new();
+        let pubkey = secret_key.public_key(&secp);
+        let pubkey_hash = blake160(pubkey.serialize().as_ref()).0;
+        Self {
+            secret_key,
+            pubkey,
+            pubkey_hash,
+        }
+    }
+
+    /// Get the public key.
+    pub fn pubkey(&self) -> &PublicKey {
+        &self.pubkey
+    }
+
+    /// Get the blake160 hash of the public key (20 bytes).
+    ///
+    /// This is commonly used as lock script args for secp256k1-sighash lock.
+    pub fn pubkey_hash(&self) -> &[u8; 20] {
+        &self.pubkey_hash
+    }
+
+    /// Sign a 32-byte message and return a 65-byte recoverable signature.
+    ///
+    /// The signature format is: [r (32 bytes) | s (32 bytes) | recovery_id (1 byte)]
+    ///
+    /// This is the low-level signing API. Callers are responsible for computing
+    /// the message (e.g., CKB sighash or Fiber's compute_tx_message).
+    pub fn sign_recoverable(&self, message: &[u8; 32]) -> [u8; 65] {
+        let secp = Secp256k1::new();
+        let msg = Message::from_digest(*message);
+        let signature = secp.sign_ecdsa_recoverable(&msg, &self.secret_key);
+        let (recov_id, data) = signature.serialize_compact();
+
+        let mut signature_bytes = [0u8; 65];
+        signature_bytes[0..64].copy_from_slice(&data[0..64]);
+        signature_bytes[64] = recov_id.to_i32() as u8;
+        signature_bytes
+    }
+
+    /// Sign a funding transaction using the signer's secret key.
+    ///
+    /// This method encapsulates the signing logic to avoid exposing the secret key
+    /// directly to callers. It uses CKB SDK's `unlock_tx_async` internally.
+    pub async fn sign_funding_tx(
+        &self,
+        mut tx: FundingTx,
+        rpc_url: String,
+    ) -> Result<FundingTx, FundingError> {
+        // Convert between different versions of secp256k1.
+        // This app requires 0.28 because of:
+        // ```
+        // #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+        // pub struct Signature(pub Secp256k1Signature);
+        // ```
+        //
+        // However, ckb-sdk-rust still uses 0.24.
+        //
+        // It's complex to use map_err and return an error as well because secp256k1 used by ckb sdk is not public.
+        // Expect is OK here since the secret key is valid and can be parsed in both versions.
+        let signer = SecpCkbRawKeySigner::new_with_secret_keys(vec![std::str::FromStr::from_str(
+            hex::encode(self.secret_key.as_ref()).as_ref(),
+        )
+        .expect("convert secret key between different secp256k1 versions")]);
+        let sighash_unlocker = SecpSighashUnlocker::from(Box::new(signer) as Box<_>);
+        let sighash_script_id = ScriptId::new_type(SIGHASH_TYPE_HASH.clone());
+        let mut unlockers = HashMap::default();
+        unlockers.insert(
+            sighash_script_id,
+            Box::new(sighash_unlocker) as Box<dyn ScriptUnlocker>,
+        );
+        let inner_tx = tx.take().ok_or(FundingError::AbsentTx)?;
+        let tx_dep_provider = DefaultTransactionDependencyProvider::new(&rpc_url, 10);
+
+        let (signed_tx, _) = unlock_tx_async(inner_tx, &tx_dep_provider, &unlockers).await?;
+        tx.update_for_self(signed_tx);
+        Ok(tx)
+    }
+
+    /// Get the secret key (test only).
+    ///
+    /// This method is only available in test builds for test setup purposes.
+    /// Production code should use higher-level APIs like `sign_recoverable()`.
+    #[cfg(test)]
+    pub(crate) fn secret_key(&self) -> &SecretKey {
+        &self.secret_key
+    }
+
+    /// Get the X-only public key.
+    ///
+    /// This is useful for creating channel announcements and other protocol messages.
+    pub fn x_only_pub_key(&self) -> secp256k1::XOnlyPublicKey {
+        let secp = Secp256k1::new();
+        let keypair = secp256k1::Keypair::from_secret_key(&secp, &self.secret_key);
+        secp256k1::XOnlyPublicKey::from_keypair(&keypair).0
+    }
+}
+
+impl std::fmt::Debug for LocalSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalSigner")
+            .field("pubkey", &self.pubkey)
+            .field("pubkey_hash", &hex::encode(self.pubkey_hash))
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_local_signer_creation() {
+        // Use a fixed test secret key
+        let secret_key_bytes = [1u8; 32];
+        let secret_key = SecretKey::from_slice(&secret_key_bytes).unwrap();
+
+        let signer = LocalSigner::new(secret_key);
+
+        // Verify pubkey is derived correctly
+        let secp = Secp256k1::new();
+        let expected_pubkey = secret_key.public_key(&secp);
+        assert_eq!(signer.pubkey(), &expected_pubkey);
+
+        // Verify pubkey_hash is 20 bytes
+        assert_eq!(signer.pubkey_hash().len(), 20);
+    }
+
+    #[test]
+    fn test_sign_recoverable() {
+        let secret_key_bytes = [42u8; 32];
+        let secret_key = SecretKey::from_slice(&secret_key_bytes).unwrap();
+        let signer = LocalSigner::new(secret_key);
+
+        let message = [0xab; 32];
+        let signature = signer.sign_recoverable(&message);
+
+        // Signature should be 65 bytes
+        assert_eq!(signature.len(), 65);
+
+        // Verify the signature is deterministic
+        let signature2 = signer.sign_recoverable(&message);
+        assert_eq!(signature, signature2);
+    }
+
+    #[test]
+    fn test_signature_matches_direct_signing() {
+        // Verify that LocalSigner produces the same signature as direct secp256k1 signing
+        let secret_key_bytes = [99u8; 32];
+        let secret_key = SecretKey::from_slice(&secret_key_bytes).unwrap();
+        let signer = LocalSigner::new(secret_key);
+
+        let message = [0x12; 32];
+
+        // Sign using LocalSigner
+        let signer_sig = signer.sign_recoverable(&message);
+
+        // Sign directly using secp256k1
+        let secp = Secp256k1::new();
+        let msg = Message::from_digest(message);
+        let direct_sig = secp.sign_ecdsa_recoverable(&msg, &secret_key);
+        let (recov_id, data) = direct_sig.serialize_compact();
+        let mut direct_sig_bytes = [0u8; 65];
+        direct_sig_bytes[0..64].copy_from_slice(&data[0..64]);
+        direct_sig_bytes[64] = recov_id.to_i32() as u8;
+
+        // They should be identical
+        assert_eq!(signer_sig, direct_sig_bytes);
+    }
+}

--- a/crates/fiber-lib/src/ckb/signer.rs
+++ b/crates/fiber-lib/src/ckb/signer.rs
@@ -92,7 +92,7 @@ impl LocalSigner {
         // pub struct Signature(pub Secp256k1Signature);
         // ```
         //
-        // However, ckb-sdk-rust still uses 0.24.
+        // However, ckb-sdk-rust still uses 0.30 .
         //
         // It's complex to use map_err and return an error as well because secp256k1 used by ckb sdk is not public.
         // Expect is OK here since the secret key is valid and can be parsed in both versions.

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -316,9 +316,8 @@ impl Privkey {
         let message = secp256k1::Message::from_digest(message);
         let sig = secp256k1_instance.sign_schnorr(&message, &keypair);
         trace!(
-            "Schnorr signing message {:?} with private key {:?} (pub key {:?}), Signature: {:?}",
+            "Schnorr signing message {:?} (pub key {:?}), Signature: {:?}",
             message,
-            keypair.secret_key(),
             keypair.public_key(),
             &sig
         );

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -1,3 +1,4 @@
+use crate::ckb::signer::LocalSigner;
 use crate::fiber::channel::*;
 use crate::fiber::config::AnnouncedNodeName;
 use crate::fiber::features::FeatureVector;
@@ -38,7 +39,6 @@ use musig2::secp::MaybeScalar;
 #[cfg(not(target_arch = "wasm32"))]
 use musig2::CompactSignature;
 use musig2::SecNonce;
-use crate::ckb::signer::LocalSigner;
 use secp256k1::{Keypair, Secp256k1};
 use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -21,7 +21,7 @@ use ckb_types::{
 };
 use molecule::prelude::Entity;
 use ractor::{Actor, ActorProcessingErr, ActorRef};
-use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
+use secp256k1::{Message, Secp256k1, SecretKey};
 use strum::AsRefStr;
 use tracing::{debug, error, info, warn};
 
@@ -29,6 +29,7 @@ use crate::{
     ckb::{
         config::{new_default_cell_collector, CKB_RPC_TIMEOUT},
         contracts::{get_cell_deps_sync, get_script_by_contract, Contract},
+        signer::LocalSigner,
         CkbConfig,
     },
     fiber::{
@@ -82,7 +83,7 @@ pub enum WatchtowerMessage {
 
 pub struct WatchtowerState {
     config: CkbConfig,
-    secret_key: SecretKey,
+    signer: LocalSigner,
     /// is periodic check running
     periodic_check_running: Arc<AtomicBool>,
 }
@@ -102,9 +103,10 @@ where
         config: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
         let secret_key = config.read_secret_key()?;
+        let signer = LocalSigner::new(secret_key);
         Ok(Self::State {
             config,
-            secret_key,
+            signer,
             periodic_check_running: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -191,15 +193,15 @@ where
                 // Spawn the periodic check task
                 let store = self.store.clone();
                 let node_id = self.node_id.clone();
-                let secret_key = state.secret_key;
                 let rpc_url = state.config.rpc_url.clone();
                 let periodic_check_running = state.periodic_check_running.clone();
+                let signer = state.signer.clone();
                 tokio::task::spawn_blocking(move || {
                     // Use RAII guard to ensure flag is reset even on panic
                     let _guard = PeriodicCheckGuard(periodic_check_running);
                     info!("PeriodicCheck started");
                     let start = now_timestamp_as_millis_u64();
-                    run_periodic_check(store, node_id, secret_key, rpc_url);
+                    run_periodic_check(store, node_id, signer, rpc_url);
                     let elapsed = now_timestamp_as_millis_u64().saturating_sub(start);
                     info!("PeriodicCheck finished elapsed: {}ms", elapsed);
                 });
@@ -218,7 +220,7 @@ impl Drop for PeriodicCheckGuard {
     }
 }
 
-fn run_periodic_check<S>(store: S, node_id: NodeId, secret_key: SecretKey, rpc_url: String)
+fn run_periodic_check<S>(store: S, node_id: NodeId, signer: LocalSigner, rpc_url: String)
 where
     S: WatchtowerStore + Send + Sync + 'static,
 {
@@ -294,7 +296,7 @@ where
                                                                                     first_commitment_tx_out_point,
                                                                                     revocation_data,
                                                                                     x_only_aggregated_pubkey,
-                                                                                    secret_key,
+                                                                                    &signer,
                                                                                     &mut cell_collector,
                                                                                 ) {
                                                                                     Ok(tx) => {
@@ -330,7 +332,7 @@ where
                                                                 ckb_client,
                                                                 channel_data,
                                                                 true,
-                                                                secret_key,
+                                                                &signer,
                                                                 &mut cell_collector,
                                                                 &store,
                                                                 node_id.clone(),
@@ -344,7 +346,7 @@ where
                                                         ckb_client,
                                                         channel_data,
                                                         false,
-                                                        secret_key,
+                                                        &signer,
                                                         &mut cell_collector,
                                                         &store,
                                                         node_id.clone(),
@@ -387,7 +389,7 @@ fn build_revocation_tx(
     commitment_tx_out_point: OutPoint,
     revocation_data: RevocationData,
     x_only_aggregated_pubkey: [u8; 32],
-    secret_key: SecretKey,
+    signer: &LocalSigner,
     cell_collector: &mut DefaultCellCollector,
 ) -> Result<TransactionView, Box<dyn std::error::Error>> {
     let witness = [
@@ -399,9 +401,8 @@ fn build_revocation_tx(
     ]
     .concat();
 
-    let pubkey = PublicKey::from_secret_key(&Secp256k1::new(), &secret_key);
-    let args = blake160(pubkey.serialize().as_ref());
-    let fee_provider_lock_script = get_script_by_contract(Contract::Secp256k1Lock, args.as_bytes());
+    let args = signer.pubkey_hash();
+    let fee_provider_lock_script = get_script_by_contract(Contract::Secp256k1Lock, args);
 
     let change_output = CellOutput::new_builder()
         .lock(fee_provider_lock_script.clone())
@@ -466,7 +467,7 @@ fn build_revocation_tx(
                 .set_outputs(vec![revocation_data.output, new_change_output])
                 .build();
 
-            let tx = sign_tx(tx, secret_key)?;
+            let tx = sign_tx(tx, signer)?;
             return Ok(tx);
         }
     }
@@ -481,7 +482,7 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
     ckb_client: CkbRpcClient,
     channel_data: ChannelData,
     for_remote: bool,
-    secret_key: SecretKey,
+    signer: &LocalSigner,
     cell_collector: &mut DefaultCellCollector,
     store: &S,
     self_node_id: NodeId,
@@ -630,7 +631,7 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
                         for_remote,
                         channel_data.clone(),
                         settlement_witness,
-                        secret_key,
+                        signer,
                         cell_collector,
                         store,
                     ) {
@@ -792,7 +793,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
     for_remote: bool,
     channel_data: ChannelData,
     settlement_witness: Option<SettlementWitness>,
-    secret_key: SecretKey,
+    signer: &LocalSigner,
     cell_collector: &mut DefaultCellCollector,
     store: &S,
 ) -> Result<Option<TransactionView>, Box<dyn std::error::Error>> {
@@ -842,9 +843,8 @@ fn build_settlement_tx<S: WatchtowerStore>(
         channel_data.local_settlement_data.clone()
     };
 
-    let pubkey = PublicKey::from_secret_key(&Secp256k1::new(), &secret_key);
-    let args = blake160(pubkey.serialize().as_ref());
-    let fee_provider_lock_script = get_script_by_contract(Contract::Secp256k1Lock, args.as_bytes());
+    let fee_provider_lock_script =
+        get_script_by_contract(Contract::Secp256k1Lock, signer.pubkey_hash());
     let change_output = CellOutput::new_builder()
         .lock(fee_provider_lock_script.clone())
         .build();
@@ -1276,8 +1276,12 @@ fn build_settlement_tx<S: WatchtowerStore>(
                     vec![new_commitment_output, adjusted_settlement_output]
                 };
                 let tx = tx_builder.set_outputs(outputs).build();
-                let tx =
-                    sign_tx_with_settlement(tx, secret_key, unlock_key.0, unlock.with_preimage)?;
+                let tx = sign_tx_with_settlement(
+                    tx,
+                    signer,
+                    unlock_key.0,
+                    unlock.with_preimage,
+                )?;
                 return Ok(Some(tx));
             }
         }
@@ -1462,8 +1466,12 @@ fn build_settlement_tx<S: WatchtowerStore>(
                     .set_outputs(outputs)
                     .set_outputs_data(outputs_data)
                     .build();
-                let tx =
-                    sign_tx_with_settlement(tx, secret_key, unlock_key.0, unlock.with_preimage)?;
+                let tx = sign_tx_with_settlement(
+                    tx,
+                    signer,
+                    unlock_key.0,
+                    unlock.with_preimage,
+                )?;
                 return Ok(Some(tx));
             }
         }
@@ -1474,7 +1482,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
 
 fn sign_tx(
     tx: TransactionView,
-    secret_key: SecretKey,
+    signer: &LocalSigner,
 ) -> Result<TransactionView, Box<dyn std::error::Error>> {
     let tx = tx.data();
     let witness = tx.witnesses().get(1).expect("get witness at index 1");
@@ -1482,15 +1490,10 @@ fn sign_tx(
     blake2b.update(tx.calc_tx_hash().as_slice());
     blake2b.update(&(witness.item_count() as u64).to_le_bytes());
     blake2b.update(&witness.raw_data());
-    let mut message = vec![0u8; 32];
+    let mut message = [0u8; 32];
     blake2b.finalize(&mut message);
-    let secp256k1_message = Message::from_digest_slice(&message)?;
-    let secp256k1 = Secp256k1::new();
-    let signature = secp256k1.sign_ecdsa_recoverable(&secp256k1_message, &secret_key);
-    let (recov_id, data) = signature.serialize_compact();
-    let mut signature_bytes = [0u8; 65];
-    signature_bytes[0..64].copy_from_slice(&data[0..64]);
-    signature_bytes[64] = recov_id.to_i32() as u8;
+
+    let signature_bytes = signer.sign_recoverable(&message);
 
     let witness = WitnessArgs::new_builder()
         .lock(Some(ckb_types::bytes::Bytes::from(signature_bytes.to_vec())).pack())
@@ -1505,7 +1508,7 @@ fn sign_tx(
 
 fn sign_tx_with_settlement(
     tx: TransactionView,
-    change_secret_key: SecretKey,
+    change_signer: &LocalSigner,
     settlement_secret_key: SecretKey,
     with_preimage: bool,
 ) -> Result<TransactionView, Box<dyn std::error::Error>> {
@@ -1539,15 +1542,9 @@ fn sign_tx_with_settlement(
     blake2b.update(tx.hash().as_slice());
     blake2b.update(&(witness.item_count() as u64).to_le_bytes());
     blake2b.update(&witness.raw_data());
-    let mut message = vec![0u8; 32];
+    let mut message = [0u8; 32];
     blake2b.finalize(&mut message);
-    let secp256k1_message = Message::from_digest_slice(&message)?;
-    let secp256k1 = Secp256k1::new();
-    let signature = secp256k1.sign_ecdsa_recoverable(&secp256k1_message, &change_secret_key);
-    let (recov_id, data) = signature.serialize_compact();
-    let mut signature_bytes = [0u8; 65];
-    signature_bytes[0..64].copy_from_slice(&data[0..64]);
-    signature_bytes[64] = recov_id.to_i32() as u8;
+    let signature_bytes = change_signer.sign_recoverable(&message);
     let change_witness = WitnessArgs::new_builder()
         .lock(Some(ckb_types::bytes::Bytes::from(signature_bytes.to_vec())).pack())
         .build()

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -1276,12 +1276,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
                     vec![new_commitment_output, adjusted_settlement_output]
                 };
                 let tx = tx_builder.set_outputs(outputs).build();
-                let tx = sign_tx_with_settlement(
-                    tx,
-                    signer,
-                    unlock_key.0,
-                    unlock.with_preimage,
-                )?;
+                let tx = sign_tx_with_settlement(tx, signer, unlock_key.0, unlock.with_preimage)?;
                 return Ok(Some(tx));
             }
         }
@@ -1466,12 +1461,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
                     .set_outputs(outputs)
                     .set_outputs_data(outputs_data)
                     .build();
-                let tx = sign_tx_with_settlement(
-                    tx,
-                    signer,
-                    unlock_key.0,
-                    unlock.with_preimage,
-                )?;
+                let tx = sign_tx_with_settlement(tx, signer, unlock_key.0, unlock.with_preimage)?;
                 return Ok(Some(tx));
             }
         }


### PR DESCRIPTION
This PR centralizes private key handling and signing behind `LocalSigner`, ensuring the `secret_key` is never passed around or accessed directly across the codebase. This significantly reduces the private key exposure surface and the risk of accidental misuse. 

In addition, it establishes a stable signing interface to prepare for the WASM build, where signing will be delegated to third-party wallets (signature-only, no private key input).