### PR TITLE
use forward! for fiber outgoing payments

### DIFF
--- a/crates/fiber-lib/src/cch/actions/mod.rs
+++ b/crates/fiber-lib/src/cch/actions/mod.rs
@@ -34,19 +34,20 @@ impl ActionDispatcher {
         cch_actor_ref: &ActorRef<CchMessage>,
         order: &CchOrder,
         action: CchOrderAction,
+        retry_count: u32,
     ) -> Option<Box<dyn ActionExecutor>> {
         match action {
             CchOrderAction::TrackIncomingInvoice => {
-                TrackIncomingInvoiceDispatcher::dispatch(state, cch_actor_ref, order)
+                TrackIncomingInvoiceDispatcher::dispatch(state, cch_actor_ref, order, retry_count)
             }
             CchOrderAction::SendOutgoingPayment => {
-                SendOutgoingPaymentDispatcher::dispatch(state, cch_actor_ref, order)
+                SendOutgoingPaymentDispatcher::dispatch(state, cch_actor_ref, order, retry_count)
             }
             CchOrderAction::TrackOutgoingPayment => {
-                TrackOutgoingPaymentDispatcher::dispatch(state, cch_actor_ref, order)
+                TrackOutgoingPaymentDispatcher::dispatch(state, cch_actor_ref, order, retry_count)
             }
             CchOrderAction::SettleIncomingInvoice => {
-                SettleIncomingInvoiceDispatcher::dispatch(state, cch_actor_ref, order)
+                SettleIncomingInvoiceDispatcher::dispatch(state, cch_actor_ref, order, retry_count)
             }
         }
     }
@@ -89,8 +90,9 @@ impl ActionDispatcher {
         cch_actor_ref: &ActorRef<CchMessage>,
         order: &CchOrder,
         action: CchOrderAction,
+        retry_count: u32,
     ) -> Result<()> {
-        if let Some(executor) = Self::dispatch(state, cch_actor_ref, order, action) {
+        if let Some(executor) = Self::dispatch(state, cch_actor_ref, order, action, retry_count) {
             return executor.execute().await;
         }
         Ok(())

--- a/crates/fiber-lib/src/cch/actions/settle_incoming_invoice.rs
+++ b/crates/fiber-lib/src/cch/actions/settle_incoming_invoice.rs
@@ -129,6 +129,7 @@ impl SettleIncomingInvoiceDispatcher {
         state: &CchState<S>,
         cch_actor_ref: &ActorRef<CchMessage>,
         order: &CchOrder,
+        _retry_count: u32,
     ) -> Option<Box<dyn ActionExecutor>> {
         if !Self::should_dispatch(order) {
             return None;

--- a/crates/fiber-lib/src/cch/actions/track_incoming_invoice.rs
+++ b/crates/fiber-lib/src/cch/actions/track_incoming_invoice.rs
@@ -40,6 +40,7 @@ impl TrackIncomingInvoiceDispatcher {
         state: &CchState<S>,
         _cch_actor_ref: &ActorRef<CchMessage>,
         order: &CchOrder,
+        _retry_count: u32,
     ) -> Option<Box<dyn ActionExecutor>> {
         if !Self::should_dispatch(order) {
             return None;

--- a/crates/fiber-lib/src/cch/actions/track_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/track_outgoing_payment.rs
@@ -9,6 +9,7 @@ impl TrackOutgoingPaymentDispatcher {
         _state: &CchState<S>,
         _cch_actor_ref: &ActorRef<CchMessage>,
         _order: &CchOrder,
+        _retry_count: u32,
     ) -> Option<Box<dyn ActionExecutor>> {
         // `CchActor` will track all fiber payments, so there's nothing to do here to track a single payment.
         None


### PR DESCRIPTION
fixes #1071

I’m unsure about this change: previously the result wasn’t always forwarded to cch actor (there is a fallback retry mechanism), but now (if I understand correctly) forward! will always relay the mapped message—only a fatal actor error would stop it. I added an oneshot to surface transient errors and a Noop message for cch actor to avoid unintended state changes. Please confirm this is acceptable.