### PR TITLE
feat!: remove redundant u64 length header from hop data serialization

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -309,8 +309,8 @@ pub enum NetworkActorCommand {
     ),
     // Send a command to a channel.
     ControlFiberChannel(ChannelCommandWithId),
-    // The first parameter is the peeled onion in binary via `PeeledPaymentOnionPacket::serialize`. `PeeledPaymentOnionPacket::current`
-    // is for the current node.
+    // Send an onion packet to the next hop. The `PeeledPaymentOnionPacket::current` contains
+    // the hop data for the current node.
     SendPaymentOnionPacket(SendOnionPacketCommand, RpcReplyPort<Result<(), TlcErr>>),
     UpdateChannelFunding(Hash256, Transaction, FundingRequest),
     VerifyFundingTx {

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -6,10 +6,11 @@ use crate::{
         gen::{fiber as molecule_fiber, gossip},
         hash_algorithm::HashAlgorithm,
         types::{
-            pack_hop_data, secp256k1_instance, unpack_hop_data, AddTlc, BasicMppPaymentData,
-            BroadcastMessageID, Cursor, Hash256, NodeAnnouncement, NodeId, PaymentHopData,
+            secp256k1_instance, AddTlc, BasicMppPaymentData, BroadcastMessageID, Cursor, Hash256,
+            NodeAnnouncement, NodeId, PaymentHopData, PaymentOnionPacket, PaymentSphinxCodec,
             PeeledPaymentOnionPacket, Privkey, Pubkey, TlcErr, TlcErrData, TlcErrPacket,
             TlcErrorCode, TrampolineHopPayload, TrampolineOnionPacket, NO_SHARED_SECRET,
+            ONION_PACKET_VERSION_V0, ONION_PACKET_VERSION_V1,
         },
         PaymentCustomRecords,
     },
@@ -175,11 +176,6 @@ fn test_peeled_onion_packet() {
     )
     .expect("create peeled packet");
 
-    let serialized = packet.serialize();
-    let deserialized = PeeledPaymentOnionPacket::deserialize(&serialized).expect("deserialize");
-
-    assert_eq!(packet, deserialized);
-
     assert_eq!(packet.current, hops_infos[0].clone().into());
     assert!(!packet.is_last());
 
@@ -234,11 +230,6 @@ fn test_peeled_large_onion_packet() {
         )
         .map_err(|e| format!("create peeled packet error: {}", e))?;
 
-        let serialized = packet.serialize();
-        let deserialized = PeeledPaymentOnionPacket::deserialize(&serialized).expect("deserialize");
-
-        assert_eq!(packet, deserialized);
-
         let mut now = Some(packet);
         for i in 0..hops_infos.len() - 1 {
             let packet = now
@@ -260,11 +251,13 @@ fn test_peeled_large_onion_packet() {
     }
 
     // default PACKET_DATA_LEN is 6500
-    build_onion_packet(39).expect("build onion packet with 39 hops");
-    let res = build_onion_packet(40);
+    // v1 format saves 8 bytes per hop vs v0, allowing more hops
+    // Note: with trampoline_onion field, each hop is slightly larger
+    build_onion_packet(41).expect("build onion packet with 41 hops");
+    let res = build_onion_packet(42);
     assert!(
         res.is_err(),
-        "should fail to build onion packet with 40 hops"
+        "should fail to build onion packet with 42 hops"
     );
 }
 
@@ -385,75 +378,187 @@ fn test_trampoline_onion_packet_multi_hop_peel() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_peeled_onion_packet_deserialize_u64_max_overflow() {
+fn test_unpack_hop_data_v0_empty_input() {
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &[]);
+    assert!(result.is_none(), "Should reject empty input");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_unpack_hop_data_v0_u64_max_overflow() {
+    // v0 format: [u64 BE length header with u64::MAX]
     // Length header is u64::MAX, which would cause overflow when adding HOP_DATA_HEAD_LEN
-    // Input: [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00]
     let malicious_input = [255u8, 255, 255, 255, 255, 255, 255, 255, 0];
-    let result = PeeledPaymentOnionPacket::deserialize(&malicious_input);
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &malicious_input);
     assert!(
-        result.is_err(),
+        result.is_none(),
         "Should reject input with overflow-causing length"
     );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_peeled_onion_packet_deserialize_large_claimed_length() {
-    // Length header claims more data than available
+fn test_unpack_hop_data_v0_large_claimed_length() {
+    // v0 format: [u64 BE length claiming 1000 bytes]
     let mut large_claim = vec![0u8; 16];
-    large_claim[..8].copy_from_slice(&(1000u64).to_be_bytes()); // Claims 1000 bytes
-    let result = PeeledPaymentOnionPacket::deserialize(&large_claim);
+    large_claim[0..8].copy_from_slice(&(1000u64).to_be_bytes());
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &large_claim);
     assert!(
-        result.is_err(),
+        result.is_none(),
         "Should reject input claiming more data than available"
     );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_peeled_onion_packet_deserialize_empty_input() {
-    let result = PeeledPaymentOnionPacket::deserialize(&[]);
-    assert!(result.is_err(), "Should reject empty input");
-}
-
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_peeled_onion_packet_deserialize_short_header() {
-    // Input too short for header (need 8 bytes, only 7 provided)
-    let result = PeeledPaymentOnionPacket::deserialize(&[1, 2, 3, 4, 5, 6, 7]);
+fn test_unpack_hop_data_v0_short_header() {
+    // v0 format needs 8 byte header, only providing 7 bytes
+    let input = [1, 2, 3, 4, 5, 6, 7];
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &input);
     assert!(
-        result.is_err(),
+        result.is_none(),
         "Should reject input shorter than header length"
     );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_peeled_onion_packet_deserialize_exceeds_buffer() {
-    // Large length that exceeds buffer size
-    // Claimed length (6501 + 8 = 6509) far exceeds actual buffer (16 bytes)
+fn test_unpack_hop_data_v0_exceeds_buffer() {
+    // v0 format: claimed length (6501 + 8) far exceeds actual buffer
     let large_len: u64 = 6501;
     let mut large_input = vec![0u8; 16];
-    large_input[..8].copy_from_slice(&large_len.to_be_bytes());
-    let result = PeeledPaymentOnionPacket::deserialize(&large_input);
+    large_input[0..8].copy_from_slice(&large_len.to_be_bytes());
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &large_input);
     assert!(
-        result.is_err(),
+        result.is_none(),
         "Should reject when claimed length exceeds buffer"
     );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_peeled_onion_packet_deserialize_near_max_overflow() {
-    // Near-max value that would overflow with header addition
-    let near_max = (usize::MAX - 7) as u64; // Adding 8 would overflow
+fn test_unpack_hop_data_v0_near_max_overflow() {
+    // v0 format: near-max value that would overflow with header addition
+    let near_max = (usize::MAX - 7) as u64;
     let mut near_max_input = vec![0u8; 16];
-    near_max_input[..8].copy_from_slice(&near_max.to_be_bytes());
-    let result = PeeledPaymentOnionPacket::deserialize(&near_max_input);
+    near_max_input[0..8].copy_from_slice(&near_max.to_be_bytes());
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &near_max_input);
     assert!(
-        result.is_err(),
+        result.is_none(),
         "Should reject near-max length that overflows"
     );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_unpack_hop_data_v1_empty_input() {
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V1, &[]);
+    assert!(result.is_none(), "Should reject empty v1 input");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_unpack_hop_data_v1_short_header() {
+    // v1 format needs 4 byte molecule header, only providing 3 bytes
+    let input = [1, 2, 3];
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V1, &input);
+    assert!(
+        result.is_none(),
+        "Should reject v1 input shorter than molecule header length"
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_unpack_hop_data_v1_large_claimed_length() {
+    // v1 format: molecule u32 LE header claiming 1000 bytes
+    let mut large_claim = vec![0u8; 8];
+    large_claim[0..4].copy_from_slice(&1000u32.to_le_bytes());
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V1, &large_claim);
+    assert!(
+        result.is_none(),
+        "Should reject v1 input claiming more data than available"
+    );
+}
+
+// Tests for PaymentOnionPacket::peel error handling
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_onion_packet_peel_unknown_version() {
+    let secp = Secp256k1::new();
+    let key = gen_rand_fiber_private_key();
+
+    // Create a packet with unknown version (99) in the version byte position
+    // OnionPacket format: [version: 1 byte][public_key: 33 bytes][packet_data][hmac: 32 bytes]
+    let mut data = vec![99u8]; // Unknown version
+    data.extend(vec![0u8; 33 + 100 + 32]); // pubkey + data + hmac (placeholder)
+    let packet = PaymentOnionPacket::new(data);
+    let result = packet.peel(&key, None, &secp);
+    assert!(result.is_err(), "Should reject unknown version in peel");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_onion_packet_peel_wrong_key() {
+    let secp = Secp256k1::new();
+    let correct_key = gen_rand_fiber_private_key();
+    let wrong_key = gen_rand_fiber_private_key();
+
+    let hops_infos = vec![
+        PaymentHopData {
+            amount: 100,
+            expiry: 1000,
+            next_hop: Some(correct_key.pubkey()),
+            funding_tx_hash: Hash256::default(),
+            hash_algorithm: HashAlgorithm::Sha256,
+            payment_preimage: None,
+            custom_records: None,
+            trampoline_onion: None,
+        },
+        PaymentHopData {
+            amount: 100,
+            expiry: 1000,
+            next_hop: None,
+            funding_tx_hash: Hash256::default(),
+            hash_algorithm: HashAlgorithm::Sha256,
+            payment_preimage: None,
+            custom_records: None,
+            trampoline_onion: None,
+        },
+    ];
+    let packet =
+        PeeledPaymentOnionPacket::create(gen_rand_fiber_private_key(), hops_infos, None, &secp)
+            .expect("create packet");
+
+    let next = packet.next.expect("should have next");
+    // Try to peel with wrong key - should fail HMAC verification
+    let result = next.peel(&wrong_key, None, &secp);
+    assert!(result.is_err(), "Should reject peel with wrong key");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_onion_packet_peel_invalid_data() {
+    let secp = Secp256k1::new();
+    let key = gen_rand_fiber_private_key();
+
+    // Create packet with garbage data
+    let garbage = vec![0u8; 100];
+    let packet = PaymentOnionPacket::new(garbage);
+    let result = packet.peel(&key, None, &secp);
+    assert!(result.is_err(), "Should reject invalid packet data");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_onion_packet_peel_empty_data() {
+    let secp = Secp256k1::new();
+    let key = gen_rand_fiber_private_key();
+
+    let packet = PaymentOnionPacket::new(vec![]);
+    let result = packet.peel(&key, None, &secp);
+    assert!(result.is_err(), "Should reject empty packet data");
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -808,10 +913,10 @@ fn test_custom_records_serialize_deserialize() {
     let _deserialized: Custom = bincode::deserialize(&bincode_serialize).expect("deserialize");
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_verify_payment_hop_data() {
-    let hop_data = PaymentHopData {
+/// Creates a canonical PaymentHopData for checksum tests.
+/// This exact data is used to verify format compatibility across versions.
+fn create_checksum_test_hop_data() -> PaymentHopData {
+    PaymentHopData {
         amount: 1000,
         expiry: 1000,
         hash_algorithm: HashAlgorithm::Sha256,
@@ -820,24 +925,71 @@ fn test_verify_payment_hop_data() {
             data: vec![(1, vec![2, 3])].into_iter().collect(),
         }),
         ..Default::default()
-    };
-
-    let data = pack_hop_data(&hop_data);
-    let unpacked: PaymentHopData = unpack_hop_data(&data).expect("unpack error");
-    assert_eq!(hop_data, unpacked);
-
-    let check_sum = hex::encode(blake2b_256(&data));
-
-    // make sure we don't change PaymentHopData format since it's stored in db with encrypted format
-    // do migration with old data version is not workable
-    let expected_check_sum =
-        "7abddd1a352a8191bea7b694973a83d1d21c91ce50b2c657521ac83233103ce4".to_string();
-    if check_sum != expected_check_sum {
-        panic!(
-            "PaymentHopData check sum mismatch, you need compatible with old data version when deserializing, \
-            migration will not work with PaymentHopData"
-        );
     }
+}
+
+/// Test that v0 format (with u64 BE length header) round-trips correctly.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_hop_data_v0_roundtrip() {
+    let hop_data = create_checksum_test_hop_data();
+    let data_v0 = PaymentSphinxCodec::pack_hop_data(ONION_PACKET_VERSION_V0, &hop_data);
+    let unpacked: PaymentHopData =
+        PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &data_v0)
+            .expect("unpack v0 error");
+    assert_eq!(hop_data, unpacked);
+}
+
+/// Test v0 format checksum to ensure backward compatibility.
+/// This checksum must not change since v0 packets may be in-flight in encrypted form.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_hop_data_v0_checksum() {
+    let hop_data = create_checksum_test_hop_data();
+    let data_v0 = PaymentSphinxCodec::pack_hop_data(ONION_PACKET_VERSION_V0, &hop_data);
+    let check_sum = hex::encode(blake2b_256(&data_v0));
+    let expected = "7abddd1a352a8191bea7b694973a83d1d21c91ce50b2c657521ac83233103ce4";
+    assert_eq!(
+        check_sum, expected,
+        "PaymentHopData v0 checksum mismatch - v0 format compatibility broken"
+    );
+}
+
+/// Test that v1 format (molecule data directly, no u64 header) round-trips correctly.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_hop_data_v1_roundtrip() {
+    let hop_data = create_checksum_test_hop_data();
+    let data_v1 = PaymentSphinxCodec::pack_hop_data(ONION_PACKET_VERSION_V1, &hop_data);
+    let unpacked: PaymentHopData =
+        PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V1, &data_v1)
+            .expect("unpack v1 error");
+    assert_eq!(hop_data, unpacked);
+}
+
+/// Test v1 format checksum for consistency verification.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_hop_data_v1_checksum() {
+    let hop_data = create_checksum_test_hop_data();
+    let data_v1 = PaymentSphinxCodec::pack_hop_data(ONION_PACKET_VERSION_V1, &hop_data);
+    let check_sum = hex::encode(blake2b_256(&data_v1));
+    let expected = "6640af3fa9342368dbe2f3a54fa6bc0e17f394a7de8094ec7d4d33571c8c2160";
+    assert_eq!(check_sum, expected, "PaymentHopData v1 checksum mismatch");
+}
+
+/// Test that v1 format is exactly 8 bytes shorter than v0 (no u64 header).
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_payment_hop_data_v1_is_8_bytes_shorter() {
+    let hop_data = create_checksum_test_hop_data();
+    let data_v0 = PaymentSphinxCodec::pack_hop_data(ONION_PACKET_VERSION_V0, &hop_data);
+    let data_v1 = PaymentSphinxCodec::pack_hop_data(ONION_PACKET_VERSION_V1, &hop_data);
+    assert_eq!(
+        data_v0.len(),
+        data_v1.len() + 8,
+        "v1 should be exactly 8 bytes shorter than v0"
+    );
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -4346,7 +4346,7 @@ impl PaymentSphinxCodec {
                 PaymentHopData::deserialize(payload)
             }
             ONION_PACKET_VERSION_V1 => {
-                let len = molecule_data_len(buf)?;
+                let len = molecule_table_data_len(buf)?;
                 if buf.len() < len {
                     return None;
                 }
@@ -4385,7 +4385,7 @@ impl SphinxOnionCodec for PaymentSphinxCodec {
     fn hop_data_len(version: u8, buf: &[u8]) -> Option<usize> {
         match version {
             ONION_PACKET_VERSION_V0 => len_with_u64_header(buf),
-            ONION_PACKET_VERSION_V1 => molecule_data_len(buf),
+            ONION_PACKET_VERSION_V1 => molecule_table_data_len(buf),
             _ => None,
         }
     }
@@ -4537,7 +4537,7 @@ fn len_with_u64_header(buf: &[u8]) -> Option<usize> {
 
 /// Returns the total length from molecule's native u32 LE header.
 /// Used by v1 format (current payment hop data).
-fn molecule_data_len(buf: &[u8]) -> Option<usize> {
+fn molecule_table_data_len(buf: &[u8]) -> Option<usize> {
     if buf.len() < molecule::NUMBER_SIZE {
         return None;
     }

--- a/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md
+++ b/docs/solutions/security-issues/integer-overflow-onion-packet-deserialization.md
@@ -55,15 +55,16 @@ fn get_hop_data_len(buf: &[u8]) -> Option<usize> {
 
 ## Solution
 
-### Fix 1: `get_hop_data_len_v0` Function
+### Fix 1: `len_with_u64_header` Function
 
-**Location**: `crates/fiber-lib/src/fiber/types.rs:4172-4184`
+**Location**: `crates/fiber-lib/src/fiber/types.rs`
 
 The function was refactored to support versioned hop data formats. The v0 format uses the original u64 BE length header:
 
 ```rust
-/// Returns the total length of v0 hop data: u64 BE length + HOP_DATA_HEAD_LEN.
-fn get_hop_data_len_v0(buf: &[u8]) -> Option<usize> {
+/// Returns the total length with u64 BE header: [u64 BE length] + data.
+/// Used by v0 format (Trampoline and legacy payment hop data).
+fn len_with_u64_header(buf: &[u8]) -> Option<usize> {
     if buf.len() < HOP_DATA_HEAD_LEN {
         return None;
     }
@@ -84,58 +85,64 @@ fn get_hop_data_len_v0(buf: &[u8]) -> Option<usize> {
 2. `.ok()?` - Propagates the `None` on conversion failure
 3. `.checked_add(HOP_DATA_HEAD_LEN)` - Returns `None` if addition would overflow
 
-### Fix 2: `deserialize` Method
+### Fix 2: Version Validation in `peel_sphinx_onion`
 
-**Location**: `crates/fiber-lib/src/fiber/types.rs:4069-4079`
+**Location**: `crates/fiber-lib/src/fiber/types.rs`
 
-The deserialize method now includes version validation and uses `checked_add` for overflow protection:
+The onion packet peeling logic now validates version before processing:
 
 ```rust
-// Ensure backward compatibility
-let mut shared_secret = NO_SHARED_SECRET;
-if let (Some(rb_plus_32), Some(rb_plus_packet)) = (
-    read_bytes.checked_add(32),
-    read_bytes.checked_add(PACKET_DATA_LEN),
-) {
-    if data.len() >= rb_plus_32 && data.len() != rb_plus_packet {
-        shared_secret.copy_from_slice(&data[read_bytes..rb_plus_32]);
-        read_bytes = rb_plus_32;
+let version = sphinx_packet.version;
+if !Codec::is_version_allowed(version) {
+    return Err(Error::OnionPacket(OnionPacketError::UnknownVersion(version)));
+}
+```
+
+Additionally, the version-aware unpacking functions (`unpack_hop_data`, `hop_data_len`) now explicitly match known versions and return `None` for unknown versions, preventing silent misparsing:
+
+```rust
+pub(crate) fn unpack_hop_data(version: u8, buf: &[u8]) -> Option<PaymentHopData> {
+    match version {
+        ONION_PACKET_VERSION_V0 => { /* ... */ }
+        ONION_PACKET_VERSION_V1 => { /* ... */ }
+        _ => None,  // Reject unknown versions
     }
 }
 ```
 
 **Why this works:**
 
-- Both `checked_add` calls must succeed before the block executes
-- Defense in depth: protects against edge cases even if `get_hop_data_len` passes
-- Unknown versions are now explicitly rejected before processing
+- Unknown versions are explicitly rejected at the version check
+- Defense in depth: unpacking functions also reject unknown versions
+- Clear error handling prevents silent misparsing of malformed packets
 
 ### Test Coverage Added
 
-**Location**: `crates/fiber-lib/src/fiber/tests/types.rs:291-404`
+**Location**: `crates/fiber-lib/src/fiber/tests/types.rs`
 
-Tests are now organized by version (v0/v1) with separate functions for independent failure tracking:
+Tests are organized by version (v0/v1) with separate functions for independent failure tracking:
 
 | Test Function | Input | Expected |
 |---------------|-------|----------|
-| `test_peeled_onion_packet_deserialize_empty_input` | `[]` | Error (too short) |
-| `test_peeled_onion_packet_deserialize_v0_u64_max_overflow` | `[v0, 0xFF × 8, 0x00]` | Error (overflow) |
-| `test_peeled_onion_packet_deserialize_v0_large_claimed_length` | v0 + 1000 bytes claimed | Error (bounds) |
-| `test_peeled_onion_packet_deserialize_v0_short_header` | v0 + 7 bytes | Error (need 8) |
-| `test_peeled_onion_packet_deserialize_v0_exceeds_buffer` | v0 + 6501 claimed | Error (bounds) |
-| `test_peeled_onion_packet_deserialize_v0_near_max_overflow` | v0 + `usize::MAX - 7` | Error (overflow) |
-| `test_peeled_onion_packet_deserialize_v1_short_header` | v1 + 3 bytes | Error (need 4) |
-| `test_peeled_onion_packet_deserialize_v1_large_claimed_length` | v1 + 1000 bytes claimed | Error (bounds) |
-| `test_peeled_onion_packet_deserialize_unknown_version` | version=2 | Error (unknown) |
+| `test_unpack_hop_data_v0_empty_input` | `[]` | None (too short) |
+| `test_unpack_hop_data_v0_u64_max_overflow` | `[0xFF × 8, 0x00]` | None (overflow) |
+| `test_unpack_hop_data_v0_large_claimed_length` | 1000 bytes claimed | None (bounds) |
+| `test_unpack_hop_data_v0_short_header` | 7 bytes | None (need 8) |
+| `test_unpack_hop_data_v0_exceeds_buffer` | 6501 claimed | None (bounds) |
+| `test_unpack_hop_data_v0_near_max_overflow` | `usize::MAX - 7` | None (overflow) |
+| `test_unpack_hop_data_v1_empty_input` | `[]` | None (too short) |
+| `test_unpack_hop_data_v1_short_header` | 3 bytes | None (need 4) |
+| `test_unpack_hop_data_v1_large_claimed_length` | 1000 bytes claimed | None (bounds) |
+| `test_payment_onion_packet_peel_unknown_version` | version=99 | Error (unknown) |
 
 ```rust
 #[test]
-fn test_peeled_onion_packet_deserialize_v0_u64_max_overflow() {
-    // v0 format: [version=0][u64 BE length header with u64::MAX]
-    let mut malicious_input = vec![ONION_PACKET_VERSION_V0];
-    malicious_input.extend([255u8, 255, 255, 255, 255, 255, 255, 255, 0]);
-    let result = PeeledPaymentOnionPacket::deserialize(&malicious_input);
-    assert!(result.is_err(), "Should reject input with overflow-causing length");
+fn test_unpack_hop_data_v0_u64_max_overflow() {
+    // v0 format: [u64 BE length header with u64::MAX]
+    // Length header is u64::MAX, which would cause overflow when adding HOP_DATA_HEAD_LEN
+    let malicious_input = [255u8, 255, 255, 255, 255, 255, 255, 255, 0];
+    let result = PaymentSphinxCodec::unpack_hop_data(ONION_PACKET_VERSION_V0, &malicious_input);
+    assert!(result.is_none(), "Should reject input with overflow-causing length");
 }
 
 // ... additional version-specific test functions


### PR DESCRIPTION
> [!IMPORTANT]
> This is a stacked PR:
> - #1094
>     - #1095 :point_left:

## Summary

This PR implements version-based hop data serialization to remove the redundant u64 BE length header from onion packets, as described in #1092.

**Note**: This PR depends on #1094 and should be merged after it.

- Add onion packet versioning: v0 uses u64 BE header, v1 uses molecule's native u32 LE length
- Set sphinx packet version when creating onion packets
- Refactor pack/unpack_hop_data into version-specific functions (v0/v1)
- Delete unused `PeeledPaymentOnionPacket::serialize/deserialize` methods
- Update tests to use public interfaces (`peel`, `unpack_hop_data`)
- v1 saves 8 bytes per hop, allowing ~2 more hops per packet (42 vs 40)

**Phase 1 strategy**: Send v1, accept both v0 and v1 for backward compatibility with in-flight packets.

## Test plan

- [x] All existing tests pass
- [x] Added tests for `unpack_hop_data` malicious input handling (v0 and v1)
- [x] Added tests for `PaymentOnionPacket::peel` error handling
- [x] Verified v1 packets can hold more hops (42 vs 40)

Closes #1092
