### PR TITLE
perf: use secp256k1 global-context feature to avoid repeated context creation

### DIFF
--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -46,7 +46,7 @@ ractor = { "git" = "https://github.com/officeyutong/ractor", branch = "use-non-s
 rand = "0.8.5"
 regex = "1.10.5"
 scrypt = "0.11"
-secp256k1 = { version = "0.30.0", features = ["serde", "recovery", "rand"] }
+secp256k1 = { version = "0.30.0", features = ["serde", "recovery", "rand", "global-context"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_with = { version = "3.7.0", features = ["macros", "base64"] }

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -5,7 +5,7 @@ use ractor::{
     call, port::OutputPortSubscriberTrait as _, Actor, ActorProcessingErr, ActorRef, OutputPort,
     RpcReplyPort,
 };
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use secp256k1::{PublicKey, SecretKey, SECP256K1};
 use serde::Deserialize;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -468,9 +468,7 @@ impl<S: CchOrderStore> CchState<S> {
             .final_expiry_delta(self.config.ckb_final_tlc_expiry_delta_seconds * 1000)
             .udt_type_script(wrapped_btc_type_script.clone().into())
             .payee_pub_key(self.node_keypair.0)
-            .build_with_sign(|hash| {
-                Secp256k1::new().sign_ecdsa_recoverable(hash, &self.node_keypair.1)
-            })?;
+            .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, &self.node_keypair.1))?;
 
         let message = {
             let invoice = invoice.clone();

--- a/crates/fiber-lib/src/ckb/config.rs
+++ b/crates/fiber-lib/src/ckb/config.rs
@@ -21,7 +21,7 @@ use serde_with::serde_as;
 use std::fs;
 #[cfg(not(target_arch = "wasm32"))]
 use tracing::info;
-use {ckb_hash::blake2b_256, secp256k1::Secp256k1};
+use {ckb_hash::blake2b_256, secp256k1::SECP256K1};
 
 use std::{path::PathBuf, str::FromStr};
 
@@ -149,8 +149,7 @@ impl CkbConfig {
 
     pub fn get_default_funding_lock_script(&self) -> Result<Script> {
         let secret_key = self.read_secret_key()?;
-        let secp = Secp256k1::new();
-        let pubkey_hash = blake2b_256(secret_key.public_key(&secp).serialize());
+        let pubkey_hash = blake2b_256(secret_key.public_key(SECP256K1).serialize());
         Ok(get_script_by_contract(
             Contract::Secp256k1Lock,
             &pubkey_hash[0..20],

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -74,7 +74,7 @@ use ractor::{
     concurrency::{Duration, JoinHandle},
     Actor, ActorProcessingErr, ActorRef, MessagingErr, RpcReplyPort,
 };
-use secp256k1::{Secp256k1, XOnlyPublicKey};
+use secp256k1::{XOnlyPublicKey, SECP256K1};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -1029,7 +1029,7 @@ where
                     .peel(
                         state.private_key(),
                         Some(add_tlc.payment_hash.as_ref()),
-                        &Secp256k1::new(),
+                        SECP256K1,
                     )
                     .map_err(|err| ProcessingChannelError::PeelingOnionPacketError(err.to_string()))
                     .map_err(ProcessingChannelError::without_shared_secret)?;
@@ -1100,11 +1100,7 @@ where
                 .expect("trampoline_onion present");
 
             let peeled_trampoline = TrampolineOnionPacket::new(trampoline_bytes.to_vec())
-                .peel(
-                    state.private_key(),
-                    Some(payment_hash.as_ref()),
-                    &Secp256k1::new(),
-                )
+                .peel(state.private_key(), Some(payment_hash.as_ref()), SECP256K1)
                 .map_err(|err| {
                     ProcessingChannelError::PeelingOnionPacketError(format!(
                         "Failed to peel trampoline onion packet: {err}"

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -1,4 +1,5 @@
 use core::panic;
+use secp256k1::SECP256K1;
 use std::{
     cmp::max,
     collections::{HashMap, HashSet},
@@ -37,7 +38,7 @@ use tracing::{debug, error, info, trace, warn};
 use crate::fiber::network::DEFAULT_CHAIN_ACTOR_TIMEOUT;
 use crate::{
     ckb::{client::CkbChainClient, CkbChainMessage, GetTxResponse},
-    fiber::{network::MAX_SERVICE_PROTOCOAL_DATA_SIZE, types::secp256k1_instance},
+    fiber::network::MAX_SERVICE_PROTOCOAL_DATA_SIZE,
     now_timestamp_as_millis_u64, unwrap_or_return,
     utils::actor::ActorHandleLogGuard,
     Error,
@@ -2343,7 +2344,7 @@ async fn verify_channel_announcement<S: GossipMessageStore>(
     }
 
     if let Err(err) =
-        secp256k1_instance().verify_schnorr(ckb_signature, &message, &channel_announcement.ckb_key)
+        SECP256K1.verify_schnorr(ckb_signature, &message, &channel_announcement.ckb_key)
     {
         return Err(Error::InvalidParameter(format!(
             "Channel announcement message signature verification failed for ckb: {:?}, message: {:?}, signature: {:?}, pubkey: {:?}, error: {:?}",

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -30,7 +30,7 @@ use crate::now_timestamp_as_millis_u64;
 use ckb_types::packed::{OutPoint, Script};
 use parking_lot::Mutex;
 use rand::{thread_rng, Rng};
-use secp256k1::Secp256k1;
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::{HashMap, HashSet};
@@ -1480,7 +1480,6 @@ where
 
         let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
         let mut trampoline_path: Vec<Pubkey> = hops.to_vec();
-        let secp = Secp256k1::new();
 
         trampoline_path.push(target);
         let trampoline_onion = TrampolineOnionPacket::create(
@@ -1488,7 +1487,7 @@ where
             trampoline_path,
             payloads,
             Some(payment_data.payment_hash.as_ref().to_vec()),
-            &secp,
+            SECP256K1,
         )
         .map_err(|_| PathFindError::NoPathFound)?
         .into_bytes();

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -12,7 +12,7 @@ use ractor::{
     call_t, Actor, ActorCell, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent,
 };
 use rand::seq::{IteratorRandom, SliceRandom};
-use secp256k1::Secp256k1;
+use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::borrow::Cow;
@@ -2474,11 +2474,7 @@ where
             })?;
         let udt_type_script = prev_channel_state.funding_udt_type_script.clone();
         let peeled_trampoline = trampoline_packet
-            .peel(
-                &state.private_key,
-                Some(payment_hash.as_ref()),
-                &Secp256k1::new(),
-            )
+            .peel(&state.private_key, Some(payment_hash.as_ref()), SECP256K1)
             .map_err(|_| {
                 TlcErr::new_node_fail(TlcErrorCode::TemporaryNodeFailure, state.get_public_key())
             })?;

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -45,7 +45,7 @@ use ckb_types::{
 use musig2::secp::Point;
 use musig2::KeyAggContext;
 use ractor::call;
-use secp256k1::Secp256k1;
+use secp256k1::SECP256K1;
 use std::collections::HashSet;
 use std::time::Duration;
 use tracing::{debug, error};
@@ -960,7 +960,6 @@ async fn test_network_send_previous_tlc_error() {
         create_nodes_with_established_channel(node_a_funding_amount, node_b_funding_amount, true)
             .await;
 
-    let secp = Secp256k1::new();
     let keys: Vec<Privkey> = std::iter::repeat_with(gen_rand_fiber_private_key)
         .take(1)
         .collect();
@@ -983,7 +982,7 @@ async fn test_network_send_previous_tlc_error() {
         gen_rand_fiber_private_key(),
         hops_infos.clone(),
         Some(generated_payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -1056,7 +1055,6 @@ async fn test_network_send_previous_tlc_error_with_limit_amount_error() {
         create_nodes_with_established_channel(node_a_funding_amount, node_b_funding_amount, true)
             .await;
 
-    let secp = Secp256k1::new();
     let keys: Vec<Privkey> = std::iter::repeat_with(gen_rand_fiber_private_key)
         .take(1)
         .collect();
@@ -1079,7 +1077,7 @@ async fn test_network_send_previous_tlc_error_with_limit_amount_error() {
         gen_rand_fiber_private_key(),
         hops_infos.clone(),
         Some(generated_payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -21,7 +21,7 @@ use ckb_types::{
     packed::{OutPoint, Script},
     prelude::Entity,
 };
-use secp256k1::{PublicKey, SecretKey, XOnlyPublicKey};
+use secp256k1::{PublicKey, SecretKey, XOnlyPublicKey, SECP256K1};
 use tracing::debug;
 
 use crate::{
@@ -793,7 +793,6 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
         .expect("trampoline payload should be present")
         .to_vec();
 
-    let secp = secp256k1::Secp256k1::new();
     let assoc = Some(payment_hash.as_ref());
 
     // Peel inner trampoline onion hop-by-hop and validate the chain.
@@ -801,7 +800,7 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[2]),
             assoc,
-            &secp,
+            SECP256K1,
         )
         .expect("peel t1");
     assert!(matches!(
@@ -816,7 +815,7 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[3]),
             assoc,
-            &secp,
+            SECP256K1,
         )
         .expect("peel t2");
     assert!(matches!(
@@ -831,7 +830,7 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[4]),
             assoc,
-            &secp,
+            SECP256K1,
         )
         .expect("peel t3");
     assert!(matches!(
@@ -846,7 +845,7 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[5]),
             assoc,
-            &secp,
+            SECP256K1,
         )
         .expect("peel final");
     assert!(matches!(
@@ -872,7 +871,7 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[2]),
             assoc,
-            &secp,
+            SECP256K1,
         )
         .expect("peel short t1");
     assert!(matches!(
@@ -1072,7 +1071,6 @@ fn test_graph_trampoline_routing_fee_fields_match_precompute() {
         exp_build_max_fee_amounts[idx] = fees.get(idx).copied().unwrap_or(0);
     }
 
-    let secp = secp256k1::Secp256k1::new();
     let assoc = Some(payment_hash.as_ref());
     let trampoline_bytes = route
         .last()
@@ -1086,7 +1084,7 @@ fn test_graph_trampoline_routing_fee_fields_match_precompute() {
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[2]),
             assoc,
-            &secp,
+            SECP256K1,
         )
         .expect("peel t1");
     match peeled1.current {
@@ -1109,7 +1107,7 @@ fn test_graph_trampoline_routing_fee_fields_match_precompute() {
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[3]),
             assoc,
-            &secp,
+            SECP256K1,
         )
         .expect("peel t2");
     match peeled2.current {
@@ -1132,7 +1130,7 @@ fn test_graph_trampoline_routing_fee_fields_match_precompute() {
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[4]),
             assoc,
-            &secp,
+            SECP256K1,
         )
         .expect("peel t3");
     match peeled3.current {

--- a/crates/fiber-lib/src/fiber/tests/mpp.rs
+++ b/crates/fiber-lib/src/fiber/tests/mpp.rs
@@ -1,4 +1,4 @@
-use secp256k1::Secp256k1;
+use secp256k1::SECP256K1;
 use std::{collections::HashMap, time::Duration};
 use tracing::debug;
 
@@ -516,7 +516,6 @@ async fn test_mpp_tlc_set() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records);
@@ -542,7 +541,7 @@ async fn test_mpp_tlc_set() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -654,7 +653,6 @@ async fn test_mpp_tlc_set_with_insufficient_total_amount() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     // set total amount to 20000000000, but pay only 10000000000
     let record = BasicMppPaymentData::new(payment_secret, 20000000000);
@@ -681,7 +679,7 @@ async fn test_mpp_tlc_set_with_insufficient_total_amount() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -790,7 +788,6 @@ async fn test_mpp_tlc_set_with_only_1_tlc() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 10000000000);
     record.write(&mut custom_records);
@@ -816,7 +813,7 @@ async fn test_mpp_tlc_set_with_only_1_tlc() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -892,7 +889,6 @@ async fn test_mpp_tlc_set_with_only_1_tlc_without_payment_data() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let hops_infos = vec![
         PaymentHopData {
             amount: 10000000000,
@@ -913,7 +909,7 @@ async fn test_mpp_tlc_set_with_only_1_tlc_without_payment_data() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -989,7 +985,6 @@ async fn test_mpp_tlc_set_total_amount_mismatch() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     // the total amount should be 20000000000, but we set 10000000000 here
     let record = BasicMppPaymentData::new(payment_secret, 10000000000);
@@ -1017,7 +1012,7 @@ async fn test_mpp_tlc_set_total_amount_mismatch() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -1139,8 +1134,6 @@ async fn test_mpp_tlc_set_total_amount_should_be_consistent() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
-
     // Tlc 1 is set to 20000000000, but tlc2 is set to 20000000001
     // both should valid since there are greater than invoice amount
     // but payment will fail because the total_amount is inconsistent
@@ -1177,7 +1170,7 @@ async fn test_mpp_tlc_set_total_amount_should_be_consistent() {
             source_node.get_private_key().clone(),
             hops_infos.clone(),
             Some(payment_hash.as_ref().to_vec()),
-            &secp,
+            SECP256K1,
         )
         .expect("create peeled packet")
     };
@@ -1315,7 +1308,6 @@ async fn test_mpp_tlc_set_payment_secret_mismatch() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     // set the payment secret to a random value
     let record = BasicMppPaymentData::new(gen_rand_sha256_hash(), 20000000000);
@@ -1342,7 +1334,7 @@ async fn test_mpp_tlc_set_payment_secret_mismatch() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -1467,7 +1459,6 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 30000000000);
     record.write(&mut custom_records);
@@ -1493,7 +1484,7 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -1679,7 +1670,6 @@ async fn test_mpp_tlc_set_timeout() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records);
@@ -1705,7 +1695,7 @@ async fn test_mpp_tlc_set_timeout() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -1855,7 +1845,6 @@ async fn test_mpp_tlc_set_without_payment_data() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     // We leave payment_data in the custom_records as none
     let hops_infos = vec![
         PaymentHopData {
@@ -1877,7 +1866,7 @@ async fn test_mpp_tlc_set_without_payment_data() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -2513,7 +2502,6 @@ async fn test_mpp_tlc_set_without_invoice_should_not_be_accepted() {
         let payment_secret = gen_rand_sha256_hash();
         let hash_algorithm = HashAlgorithm::CkbHash;
 
-        let secp = Secp256k1::new();
         let mut custom_records = PaymentCustomRecords::default();
         let record = BasicMppPaymentData::new(payment_secret, 20000000000);
         record.write(&mut custom_records);
@@ -2541,7 +2529,7 @@ async fn test_mpp_tlc_set_without_invoice_should_not_be_accepted() {
             source_node.get_private_key().clone(),
             hops_infos.clone(),
             Some(payment_hash.as_ref().to_vec()),
-            &secp,
+            SECP256K1,
         )
         .expect("create peeled packet");
 
@@ -2679,7 +2667,6 @@ async fn test_mpp_tlc_with_invoice_not_allow_mpp_should_not_be_accepted() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 20000000000);
     record.write(&mut custom_records);
@@ -2705,7 +2692,7 @@ async fn test_mpp_tlc_with_invoice_not_allow_mpp_should_not_be_accepted() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 

--- a/crates/fiber-lib/src/fiber/tests/path.rs
+++ b/crates/fiber-lib/src/fiber/tests/path.rs
@@ -1,15 +1,14 @@
 use crate::fiber::path::{NodeHeap, NodeHeapElement};
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use secp256k1::{PublicKey, SecretKey, SECP256K1};
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 fn test_node_heap() {
-    let secp = Secp256k1::new();
     let secret_key1 = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
-    let public_key1 = PublicKey::from_secret_key(&secp, &secret_key1);
+    let public_key1 = PublicKey::from_secret_key(SECP256K1, &secret_key1);
 
     let secret_key2 = SecretKey::from_slice(&[0xab; 32]).expect("32 bytes, within curve order");
-    let public_key2 = PublicKey::from_secret_key(&secp, &secret_key2);
+    let public_key2 = PublicKey::from_secret_key(SECP256K1, &secret_key2);
 
     let mut heap = NodeHeap::new(10);
     let node1 = NodeHeapElement {
@@ -49,12 +48,11 @@ fn test_node_heap() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 fn test_node_heap_probability() {
-    let secp = Secp256k1::new();
     let secret_key1 = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
-    let public_key1 = PublicKey::from_secret_key(&secp, &secret_key1);
+    let public_key1 = PublicKey::from_secret_key(SECP256K1, &secret_key1);
 
     let secret_key2 = SecretKey::from_slice(&[0xab; 32]).expect("32 bytes, within curve order");
-    let public_key2 = PublicKey::from_secret_key(&secp, &secret_key2);
+    let public_key2 = PublicKey::from_secret_key(SECP256K1, &secret_key2);
 
     let mut heap = NodeHeap::new(10);
     let node1 = NodeHeapElement {
@@ -91,12 +89,11 @@ fn test_node_heap_probability() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 fn test_node_heap_distance() {
-    let secp = Secp256k1::new();
     let secret_key1 = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
-    let public_key1 = PublicKey::from_secret_key(&secp, &secret_key1);
+    let public_key1 = PublicKey::from_secret_key(SECP256K1, &secret_key1);
 
     let secret_key2 = SecretKey::from_slice(&[0xab; 32]).expect("32 bytes, within curve order");
-    let public_key2 = PublicKey::from_secret_key(&secp, &secret_key2);
+    let public_key2 = PublicKey::from_secret_key(SECP256K1, &secret_key2);
 
     let mut heap = NodeHeap::new(10);
     let node1 = NodeHeapElement {
@@ -133,12 +130,11 @@ fn test_node_heap_distance() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 fn test_node_heap_push_or_fix() {
-    let secp = Secp256k1::new();
     let secret_key1 = SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
-    let public_key1 = PublicKey::from_secret_key(&secp, &secret_key1);
+    let public_key1 = PublicKey::from_secret_key(SECP256K1, &secret_key1);
 
     let secret_key2 = SecretKey::from_slice(&[0xab; 32]).expect("32 bytes, within curve order");
-    let public_key2 = PublicKey::from_secret_key(&secp, &secret_key2);
+    let public_key2 = PublicKey::from_secret_key(SECP256K1, &secret_key2);
 
     let mut heap = NodeHeap::new(10);
     let node1 = NodeHeapElement {

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -28,7 +28,7 @@ use crate::NetworkServiceEvent;
 use ckb_types::packed::Script;
 use ckb_types::{core::tx_pool::TxStatus, packed::OutPoint};
 use ractor::call;
-use secp256k1::Secp256k1;
+use secp256k1::SECP256K1;
 use std::collections::{HashMap, HashSet};
 use std::panic;
 use std::time::{Duration, SystemTime};
@@ -4745,7 +4745,6 @@ async fn test_payment_onion_invoice_udt_type_script_mismatch_fails() {
     let hash_algorithm = HashAlgorithm::CkbHash;
 
     // Build an onion packet for the receiver (last hop) carrying the payment hash.
-    let secp = Secp256k1::new();
     let hops_infos = vec![
         PaymentHopData {
             amount,
@@ -4772,7 +4771,7 @@ async fn test_payment_onion_invoice_udt_type_script_mismatch_fails() {
         source_node.get_private_key().clone(),
         hops_infos,
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -6174,7 +6173,6 @@ async fn test_payment_with_payment_data_record() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 10000000000);
     record.write(&mut custom_records);
@@ -6200,7 +6198,7 @@ async fn test_payment_with_payment_data_record() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -6273,7 +6271,6 @@ async fn test_payment_with_insufficient_total_amount() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     // set total amount to 20000000000, but pay only 10000000000
     let record = BasicMppPaymentData::new(payment_secret, 20000000000);
@@ -6300,7 +6297,7 @@ async fn test_payment_with_insufficient_total_amount() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -6398,7 +6395,6 @@ async fn test_payment_with_wrong_payment_secret() {
     let hash_algorithm = HashAlgorithm::CkbHash;
 
     let wrong_payment_secret = gen_rand_sha256_hash();
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(wrong_payment_secret, 10000000000);
     record.write(&mut custom_records);
@@ -6424,7 +6420,7 @@ async fn test_payment_with_wrong_payment_secret() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -6509,7 +6505,6 @@ async fn test_payment_with_insufficient_amount_with_payment_data() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 9000000000);
     record.write(&mut custom_records);
@@ -6535,7 +6530,7 @@ async fn test_payment_with_insufficient_amount_with_payment_data() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 
@@ -6620,7 +6615,6 @@ async fn test_payment_with_insufficient_amount_without_payment_data() {
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
 
-    let secp = Secp256k1::new();
     let hops_infos = vec![
         PaymentHopData {
             amount: 9000000000,
@@ -6641,7 +6635,7 @@ async fn test_payment_with_insufficient_amount_without_payment_data() {
         source_node.get_private_key().clone(),
         hops_infos.clone(),
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create peeled packet");
 

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use ractor::RpcReplyPort;
 use rand::Rng;
-use secp256k1::Secp256k1;
+use secp256k1::SECP256K1;
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tracing::{debug, error};
@@ -1891,12 +1891,11 @@ async fn test_trampoline_forwarding_fee_insufficient_manual_packet() {
     let node_b = &nodes[1];
     let channel_ab = channels[0];
 
-    let secp = Secp256k1::new();
     let payment_hash = gen_rand_sha256_hash();
 
     // 1. Construct Trampoline Onion for B
     // B should forward 1000 to some final target.
-    let (_sk, pk) = secp.generate_keypair(&mut rand::thread_rng());
+    let (_sk, pk) = SECP256K1.generate_keypair(&mut rand::thread_rng());
     let final_target: Pubkey = pk.into();
 
     let forward_payload = TrampolineHopPayload::Forward {
@@ -1927,7 +1926,7 @@ async fn test_trampoline_forwarding_fee_insufficient_manual_packet() {
         path,
         payloads,
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create onion")
     .into_bytes();
@@ -1988,11 +1987,10 @@ async fn test_trampoline_forwarding_fee_insufficient_equal_amount() {
     let node_b = &nodes[1];
     let channel_ab = channels[0];
 
-    let secp = Secp256k1::new();
     let payment_hash = gen_rand_sha256_hash();
 
     // Construct Trampoline Onion for B
-    let (_sk, pk) = secp.generate_keypair(&mut rand::thread_rng());
+    let (_sk, pk) = SECP256K1.generate_keypair(&mut rand::thread_rng());
     let final_target: Pubkey = pk.into();
 
     let forward_payload = TrampolineHopPayload::Forward {
@@ -2023,7 +2021,7 @@ async fn test_trampoline_forwarding_fee_insufficient_equal_amount() {
         path,
         payloads,
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("create onion")
     .into_bytes();
@@ -3056,13 +3054,12 @@ async fn test_trampoline_forward_invalid_onion_payload_missing_context() {
     };
 
     let session_key = gen_rand_session_key();
-    let secp = Secp256k1::new();
     let trampoline_packet = TrampolineOnionPacket::create(
         session_key,
         vec![node.pubkey],
         vec![hop_data],
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("build trampoline");
 
@@ -3147,13 +3144,12 @@ async fn test_trampoline_forward_invalid_amount_in_onion_packet() {
     };
 
     let session_key = gen_rand_session_key();
-    let secp = Secp256k1::new();
     let trampoline_packet = TrampolineOnionPacket::create(
         session_key,
         vec![node.pubkey],
         vec![hop_data],
         Some(payment_hash.as_ref().to_vec()),
-        &secp,
+        SECP256K1,
     )
     .expect("build trampoline");
 

--- a/crates/fiber-lib/src/invoice/invoice_impl.rs
+++ b/crates/fiber-lib/src/invoice/invoice_impl.rs
@@ -17,7 +17,7 @@ use molecule::prelude::{Builder, Entity};
 use secp256k1::{
     self,
     ecdsa::{RecoverableSignature, RecoveryId},
-    Message, PublicKey, Secp256k1,
+    Message, PublicKey, SECP256K1,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -241,9 +241,8 @@ impl CkbInvoice {
         let hash = Message::from_digest_slice(&self.hash()[..])
             .expect("Hash is 32 bytes long, same as MESSAGE_SIZE");
 
-        let secp_context = Secp256k1::new();
         let verification_result =
-            secp_context.verify_ecdsa(&hash, &signature.0.to_standard(), pub_key);
+            SECP256K1.verify_ecdsa(&hash, &signature.0.to_standard(), pub_key);
         match verification_result {
             Ok(()) => true,
             Err(_) => false,
@@ -267,7 +266,7 @@ impl CkbInvoice {
         let hash = Message::from_digest_slice(&self.hash()[..])
             .expect("Hash is 32 bytes long, same as MESSAGE_SIZE");
 
-        secp256k1::Secp256k1::new().recover_ecdsa(
+        SECP256K1.recover_ecdsa(
             &hash,
             &self
                 .signature

--- a/crates/fiber-lib/src/rpc/invoice.rs
+++ b/crates/fiber-lib/src/rpc/invoice.rs
@@ -21,7 +21,7 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::{error::CALL_EXECUTION_FAILED_CODE, ErrorObjectOwned};
 use ractor::{call, ActorRef};
 use rand::Rng;
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use secp256k1::{PublicKey, SecretKey, SECP256K1};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::time::Duration;
@@ -454,7 +454,7 @@ where
         let invoice = if let Some((public_key, secret_key)) = &self.keypair {
             invoice_builder = invoice_builder.payee_pub_key(*public_key);
             invoice_builder
-                .build_with_sign(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, secret_key))
+                .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, secret_key))
         } else {
             invoice_builder.build()
         };

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -39,14 +39,13 @@ use musig2::secp::MaybeScalar;
 #[cfg(not(target_arch = "wasm32"))]
 use musig2::CompactSignature;
 use musig2::SecNonce;
-use secp256k1::{Keypair, Secp256k1};
+use secp256k1::{Keypair, SECP256K1};
 use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use tentacle::secio::PeerId;
 
 fn gen_rand_local_signer() -> LocalSigner {
-    let secp = Secp256k1::new();
-    let keypair = Keypair::new(&secp, &mut rand::thread_rng());
+    let keypair = Keypair::new(SECP256K1, &mut rand::thread_rng());
     LocalSigner::new(keypair.secret_key())
 }
 

--- a/crates/fiber-lib/src/tests/gen_utils.rs
+++ b/crates/fiber-lib/src/tests/gen_utils.rs
@@ -3,7 +3,7 @@ use ckb_types::core::TransactionView;
 use ckb_types::packed::CellOutput;
 use ckb_types::prelude::{Builder, Entity, Unpack};
 use ckb_types::{packed::OutPoint, prelude::Pack};
-use secp256k1::{Keypair, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
+use secp256k1::{Keypair, PublicKey, SecretKey, XOnlyPublicKey, SECP256K1};
 
 use crate::ckb::contracts::{get_cell_deps_by_contracts, get_script_by_contract, Contract};
 use crate::fiber::features::FeatureVector;
@@ -43,8 +43,7 @@ pub fn gen_rand_secp256k1_public_key() -> PublicKey {
 }
 
 pub fn gen_rand_secp256k1_keypair() -> Keypair {
-    let secp = Secp256k1::new();
-    Keypair::new(&secp, &mut rand::thread_rng())
+    Keypair::new(SECP256K1, &mut rand::thread_rng())
 }
 
 pub fn gen_rand_secp256k1_keypair_tuple() -> (SecretKey, PublicKey) {
@@ -56,8 +55,7 @@ pub fn gen_rand_secp256k1_keypair_tuple() -> (SecretKey, PublicKey) {
 }
 
 pub fn gen_deterministic_secp256k1_keypair() -> Keypair {
-    let secp = Secp256k1::new();
-    Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[42u8; 32]).unwrap())
+    Keypair::from_secret_key(SECP256K1, &SecretKey::from_slice(&[42u8; 32]).unwrap())
 }
 
 pub fn gen_deterministic_secp256k1_keypair_tuple() -> (SecretKey, PublicKey) {

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -49,7 +49,7 @@ use ractor::{call, Actor, ActorRef};
 use rand::distributions::Alphanumeric;
 use rand::rngs::OsRng;
 use rand::Rng;
-use secp256k1::{Message, Secp256k1};
+use secp256k1::{Message, SECP256K1};
 #[cfg(not(target_arch = "wasm32"))]
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
@@ -219,11 +219,10 @@ pub fn get_fiber_config<P: AsRef<Path>>(base_dir: P, node_name: Option<&str>) ->
 
 // Mock function to create a dummy EcdsaSignature
 pub fn mock_ecdsa_signature() -> EcdsaSignature {
-    let secp = Secp256k1::new();
     let mut rng = OsRng;
-    let (secret_key, _public_key) = secp.generate_keypair(&mut rng);
+    let (secret_key, _public_key) = SECP256K1.generate_keypair(&mut rng);
     let message = Message::from_digest_slice(&[0u8; 32]).expect("32 bytes");
-    let signature = secp.sign_ecdsa(&message, &secret_key);
+    let signature = SECP256K1.sign_ecdsa(&message, &secret_key);
     EcdsaSignature(signature)
 }
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -21,7 +21,7 @@ use ckb_types::{
 };
 use molecule::prelude::Entity;
 use ractor::{Actor, ActorProcessingErr, ActorRef};
-use secp256k1::{Message, Secp256k1, SecretKey};
+use secp256k1::{Message, SecretKey, SECP256K1};
 use strum::AsRefStr;
 use tracing::{debug, error, info, warn};
 
@@ -1506,8 +1506,7 @@ fn sign_tx_with_settlement(
 
     let message = compute_tx_message(&tx);
     let secp256k1_message = Message::from_digest_slice(&message)?;
-    let secp256k1 = Secp256k1::new();
-    let signature = secp256k1.sign_ecdsa_recoverable(&secp256k1_message, &settlement_secret_key);
+    let signature = SECP256K1.sign_ecdsa_recoverable(&secp256k1_message, &settlement_secret_key);
     let (recov_id, data) = signature.serialize_compact();
     let mut signature_bytes = [0u8; 65];
     signature_bytes[0..64].copy_from_slice(&data[0..64]);

--- a/crates/fiber-wasm/Cargo.toml
+++ b/crates/fiber-wasm/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1.45.1", features = ["macros", "rt", "sync", "time"] }
 jsonrpsee = { version = "0.25.1", features = ["wasm-client"] }
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.50"
-secp256k1 = { version = "0.30.0", features = ["serde", "recovery", "rand"] }
+secp256k1 = { version = "0.30.0", features = ["serde", "recovery", "rand", "global-context"] }
 serde-wasm-bindgen = "0.6.5"
 serde = "1.0.219"
 

--- a/crates/fiber-wasm/src/lib.rs
+++ b/crates/fiber-wasm/src/lib.rs
@@ -35,7 +35,7 @@ use fnn::{
 };
 use jsonrpsee::wasm_client::WasmClientBuilder;
 use ractor::{Actor, ActorRef};
-use secp256k1::{Secp256k1, SecretKey};
+use secp256k1::{SECP256K1, SecretKey};
 use std::fmt::Debug;
 use tokio::{
     select,
@@ -124,7 +124,7 @@ pub async fn fiber(
             None => {
                 tracing::warn!("Ckb SecretKey not provided, generating a random one..");
                 let mut rng = secp256k1::rand::thread_rng();
-                Secp256k1::new().generate_keypair(&mut rng).0
+                SECP256K1.generate_keypair(&mut rng).0
             }
         };
     if let Some(ref mut value) = config.ckb {


### PR DESCRIPTION
Enable the global-context feature of secp256k1 crate and replace all Secp256k1::new() calls with the static SECP256K1 constant. This avoids the overhead of creating new secp256k1 contexts (which involves ~1MB of precomputation tables) on hot paths like:

- Onion packet peeling (every payment)
- Signature operations in LocalSigner
- Invoice verification and signing
- Trampoline onion creation

Also removes the now-redundant secp256k1_instance() wrapper function.