### PR TITLE
Fix v0.7.0 migration issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This document provides essential guidelines for AI coding agents working on the 
 - **Build System**: Cargo workspace with 5 member crates
 - **Test Runner**: cargo-nextest (preferred over `cargo test`)
 
+please wait several minutes for cargo commands to complete.
+
 ### Essential Commands
 
 #### Building

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -58,7 +58,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "version_check",
 ]
@@ -70,7 +70,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -101,12 +101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,9 +117,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -138,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -153,29 +147,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "arcode"
@@ -224,18 +218,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -246,11 +240,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
-version = "0.24.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "http 0.2.12",
+ "base64 0.22.1",
+ "http 1.4.0",
  "log",
  "url",
 ]
@@ -263,9 +258,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.1"
+version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -273,16 +268,14 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
- "bindgen 0.72.1",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libloading",
 ]
 
 [[package]]
@@ -377,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -387,7 +380,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -426,9 +419,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
@@ -496,28 +489,8 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.104",
+ "syn 2.0.114",
  "which",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -532,7 +505,7 @@ dependencies = [
  "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hex",
  "nom",
  "p256",
@@ -591,9 +564,9 @@ checksum = "341ee439c53e593fa7de26dead9515601539b6cf9a53e3368c1405471e3ea322"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.7"
+version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
+checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
  "bech32 0.11.1",
@@ -618,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 
 [[package]]
 name = "bitcoin-units"
@@ -634,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -665,7 +638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6cbbb8f56245b5a479b30a62cdc86d26e2f35c2b9f594bc4671654b03851380"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -722,7 +695,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -736,15 +709,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -796,10 +769,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -822,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
@@ -852,15 +826,14 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1025,7 +998,7 @@ dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1039,7 +1012,7 @@ dependencies = [
  "ckb-fixed-hash",
  "ckb-hash",
  "ckb-occupied-capacity",
- "molecule",
+ "molecule 0.8.0",
  "numext-fixed-uint",
 ]
 
@@ -1072,7 +1045,7 @@ version = "8.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e68e0993f54ba0d21152419a0668caa92adc928b5a9b01e45871ec055a31ce2"
 dependencies = [
- "bindgen 0.68.1",
+ "bindgen",
  "cc",
  "glob",
  "libc",
@@ -1100,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-mock-tx-types"
-version = "0.202.0"
+version = "0.202.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21143dcf9fd2a02656bcf4b2fb99500916e298207e3448dda3988db775f8972"
+checksum = "723e0733d87808cbd50faf27a29e428a4d52e975fc9387ab6c09a81a52299e06"
 dependencies = [
  "ckb-jsonrpc-types",
  "ckb-traits",
@@ -1137,7 +1110,7 @@ checksum = "ca553126a0269427c31b3dbca8d720a4c79267a80c9a0e6c589a86d460a6201b"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1238,7 +1211,7 @@ dependencies = [
  "dyn-clone",
  "enum-repr-derive",
  "futures",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hex",
  "jsonrpc-core",
  "log",
@@ -1343,7 +1316,7 @@ dependencies = [
  "derive_more 1.0.0",
  "golomb-coded-set",
  "merkle-cbt",
- "molecule",
+ "molecule 0.8.0",
  "numext-fixed-uint",
  "paste",
 ]
@@ -1443,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1475,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1494,20 +1467,20 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -1537,7 +1510,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1572,7 +1545,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1596,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
 dependencies = [
  "cookie",
  "document-features",
@@ -1640,9 +1613,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -1755,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -1803,7 +1776,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1837,7 +1810,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1851,7 +1824,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1862,7 +1835,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1873,7 +1846,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1905,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "debugid"
@@ -1940,12 +1913,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1969,7 +1942,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1989,7 +1962,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -2022,7 +1995,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2036,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -2051,9 +2024,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "eaglesong"
@@ -2088,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -2163,7 +2136,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2174,12 +2147,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2305,6 +2278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,9 +2303,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2364,8 +2343,8 @@ dependencies = [
  "fiber-sphinx",
  "fiber-wasm-db-common",
  "futures",
- "getrandom 0.2.16",
- "getrandom 0.3.3",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "git-version",
  "hex",
  "home",
@@ -2376,7 +2355,7 @@ dependencies = [
  "lnd-grpc-tonic-client",
  "metrics",
  "metrics-exporter-prometheus",
- "molecule",
+ "molecule 0.8.0",
  "musig2",
  "nom",
  "num_enum",
@@ -2402,7 +2381,7 @@ dependencies = [
  "tokio-metrics",
  "tokio-util",
  "tonic 0.11.0",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
@@ -2419,9 +2398,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -2440,9 +2419,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -2509,7 +2488,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2576,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2589,15 +2568,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
@@ -2613,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git-version"
@@ -2634,14 +2613,14 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-net"
@@ -2653,7 +2632,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.3.1",
+ "http 1.4.0",
  "js-sys",
  "pin-project",
  "serde",
@@ -2743,7 +2722,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2752,17 +2731,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.10.0",
+ "http 1.4.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2771,12 +2750,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2802,9 +2782,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash",
 ]
@@ -2844,9 +2824,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
@@ -2868,11 +2848,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2888,12 +2868,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -2915,7 +2894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2926,7 +2905,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2983,8 +2962,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.11",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -3020,7 +2999,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
  "log",
@@ -3062,23 +3041,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3086,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3110,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -3123,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3136,11 +3114,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -3151,42 +3128,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -3200,10 +3173,10 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6554f394e990a1af530a528a7fdcad6e01b29cb1b990f89df3ffd62cf15f7828"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "js-sys",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "wasm-bindgen",
  "web-sys",
@@ -3217,9 +3190,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -3238,13 +3211,13 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
 dependencies = [
  "attohttpc",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "url",
  "xmltree",
 ]
@@ -3283,13 +3256,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3300,7 +3274,7 @@ checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -3312,7 +3286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash 0.8.12",
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "is-terminal",
  "itoa",
  "log",
@@ -3340,9 +3314,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -3350,20 +3324,20 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -3385,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jni"
@@ -3413,19 +3387,19 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3474,14 +3448,14 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 1.3.1",
+ "http 1.4.0",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -3499,7 +3473,7 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
@@ -3509,10 +3483,10 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -3534,9 +3508,9 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -3550,7 +3524,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3560,7 +3534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38b0bcf407ac68d241f90e2d46041e6a06988f97fe1721fb80b91c42584fae6"
 dependencies = [
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -3572,11 +3546,11 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -3586,10 +3560,10 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66df7256371c45621b3b7d2fb23aea923d577616b9c0e9c0b950a6ea5c2be0ca"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3601,7 +3575,7 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower 0.5.2",
+ "tower 0.5.3",
 ]
 
 [[package]]
@@ -3610,11 +3584,11 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da2694c9ff271a9d3ebfe520f6b36820e85133a51be77a3cb549fd615095261"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower 0.5.2",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -3641,19 +3615,25 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "lightning-invoice"
@@ -3683,9 +3663,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linked_hash_set"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae85b5be22d9843c80e5fc80e9b64c8a3b1f98f867c709956eca3efff4e92e2"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
 dependencies = [
  "linked-hash-map",
 ]
@@ -3698,21 +3678,21 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lnd-grpc-tonic-client"
@@ -3734,11 +3714,10 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -3780,9 +3759,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
@@ -3795,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
 ]
@@ -3832,25 +3811,25 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.1",
  "metrics",
  "quanta",
  "rand 0.9.2",
@@ -3878,7 +3857,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3889,9 +3868,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -3910,17 +3889,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3928,6 +3908,17 @@ name = "molecule"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6efe1c7efcd0bdf4ca590e104bcb13087d9968956ae4ae98e92fb8c1da0f3730"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "faster-hex",
+]
+
+[[package]]
+name = "molecule"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "314eebe1fb025f681c1d6a62fdacbe831027177c1046503a8d73d8027fe19e16"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3966,7 +3957,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
  "security-framework 2.11.1",
@@ -4012,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-format"
@@ -4033,6 +4024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4054,7 +4046,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4105,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -4120,9 +4112,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -4138,9 +4130,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -4159,7 +4151,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4169,19 +4161,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.1+3.5.1"
+name = "openssl-probe"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -4221,7 +4219,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4238,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -4248,15 +4246,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -4303,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -4314,7 +4312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -4372,7 +4370,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4472,15 +4470,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -4511,7 +4509,7 @@ dependencies = [
  "spin",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4525,12 +4523,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4544,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -4594,14 +4592,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -4614,7 +4612,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
  "version_check",
  "yansi",
 ]
@@ -4656,7 +4654,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -4683,7 +4681,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4738,7 +4736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "log",
  "protobuf",
  "protobuf-support",
@@ -4798,9 +4796,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -4837,7 +4835,7 @@ source = "git+https://github.com/officeyutong/ractor?branch=use-non-send-future-
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4872,7 +4870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4902,7 +4900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4920,16 +4918,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4956,7 +4954,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4970,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -4980,9 +4978,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -4990,50 +4988,50 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c81d000a2c524133cc00d2f92f019d399e57906c3b7119271a2495354fe895"
+checksum = "23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92"
 dependencies = [
  "cfg-if",
  "libc",
- "rustix 1.0.8",
+ "rustix 1.1.3",
  "windows",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5043,9 +5041,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5054,22 +5052,22 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "cookie",
  "cookie_store",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -5087,8 +5085,8 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
- "tower-http 0.6.6",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5123,7 +5121,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -5147,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -5187,22 +5185,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5216,21 +5214,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
@@ -5250,7 +5248,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.2.0",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -5264,9 +5262,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5276,15 +5274,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -5306,11 +5304,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5327,9 +5325,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -5452,9 +5450,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
@@ -5465,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5475,9 +5473,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "send_wrapper"
@@ -5523,7 +5521,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5572,9 +5570,9 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.0.4",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -5590,7 +5588,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5599,7 +5597,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -5699,10 +5697,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -5715,6 +5714,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"
@@ -5730,9 +5735,9 @@ checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -5752,12 +5757,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5769,7 +5774,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -5823,9 +5828,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -5864,7 +5869,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5875,21 +5880,21 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.16.3"
+version = "12.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03f433c9befeea460a01d750e698aa86caf86dcfbd77d552885cd6c89d52f50"
+checksum = "751a2823d606b5d0a7616499e4130a516ebd01a44f39811be2b9600936509c23"
 dependencies = [
  "debugid",
- "memmap2 0.9.8",
+ "memmap2 0.9.9",
  "stable_deref_trait",
  "uuid",
 ]
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.16.3"
+version = "12.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d359ef6192db1760a34321ec4f089245ede4342c27e59be99642f12a859de8"
+checksum = "79b237cfbe320601dd24b4ac817a5b68bb28f5508e33f08d42be0682cadc8ac9"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -5909,9 +5914,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5941,27 +5946,27 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tentacle"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc03a774edf73d8b3480383d694a5a0c86b3fe22dddd75e9119a8e41dd11677"
+checksum = "400b2285e0add6c24ed2b3fdba72464176e420aa957cb5d347809d5db419c505"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5973,7 +5978,7 @@ dependencies = [
  "js-sys",
  "libc",
  "log",
- "molecule",
+ "molecule 0.9.2",
  "nohash-hasher",
  "parking_lot",
  "rand 0.8.5",
@@ -6009,18 +6014,18 @@ dependencies = [
 
 [[package]]
 name = "tentacle-secio"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60516aaca2ce3d00ef741d1bb01216921a062371bb63dd2ef53775b42afb9865"
+checksum = "0c0bfdc28264bd49c81ea0d027a9fa3f39b50960cd2b9c7e1748cfdb72d2265e"
 dependencies = [
  "bs58",
  "bytes",
  "chacha20poly1305",
  "futures",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hmac",
  "log",
- "molecule",
+ "molecule 0.9.2",
  "openssl",
  "openssl-sys",
  "rand 0.8.5",
@@ -6045,11 +6050,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -6060,18 +6065,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6085,30 +6090,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6125,9 +6130,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6145,9 +6150,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6169,7 +6174,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6193,7 +6198,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6232,9 +6237,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -6242,9 +6247,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6254,9 +6259,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -6298,9 +6303,9 @@ dependencies = [
 
 [[package]]
 name = "tokio_with_wasm"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfba9b946459940fb564dcf576631074cdfb0bfe4c962acd4c31f0dca7897e6"
+checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
 dependencies = [
  "js-sys",
  "tokio",
@@ -6312,12 +6317,12 @@ dependencies = [
 
 [[package]]
 name = "tokio_with_wasm_proc"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e04c1865c281139e5ccf633cb9f76ffdaabeebfe53b703984cf82878e2aabb"
+checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6331,18 +6336,31 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
  "winnow",
 ]
 
@@ -6415,7 +6433,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6454,9 +6472,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6488,18 +6506,18 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -6536,7 +6554,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6572,9 +6590,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -6596,32 +6614,32 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-width"
@@ -6631,9 +6649,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -6643,9 +6661,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
@@ -6683,13 +6701,14 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -6712,9 +6731,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6776,19 +6795,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6799,11 +6818,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -6812,9 +6832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6822,49 +6842,64 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.55"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.55"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
 
 [[package]]
 name = "wasm-logger"
@@ -6879,9 +6914,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6904,14 +6939,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.2",
+ "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6946,11 +6981,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6961,77 +6996,70 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -7041,30 +7069,30 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -7100,7 +7128,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -7109,7 +7137,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7145,27 +7173,28 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -7182,9 +7211,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7200,9 +7229,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7218,9 +7247,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -7230,9 +7259,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7248,9 +7277,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7266,9 +7295,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7284,9 +7313,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7302,33 +7331,30 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.10.0",
-]
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x25519-dalek"
@@ -7344,9 +7370,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xmltree"
@@ -7371,11 +7397,10 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -7383,34 +7408,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7430,35 +7455,35 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7467,9 +7492,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7478,17 +7503,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.1"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5858cd3a46fff31e77adea2935e357e3a2538d870741617bfb7c943e218fee6"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -123,6 +123,7 @@ web-time = { version = "1.1.0", features = ["serde"] }
 bench = ["tempfile", "ckb-testtool"]
 default = ["watchtower"]
 portable = ["rocksdb/portable"]
+sample = []
 watchtower = []
 metrics = ["dep:metrics", "ractor/metrics", "tentacle/metrics", "tokio-metrics", "metrics-exporter-prometheus"]
 pprof = ["dep:pprof"]

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -30,7 +30,9 @@ use crate::{
         key::blake2b_hash_with_salt,
         network::SendOnionPacketCommand,
         network::{get_chain_hash, sign_network_message, FiberMessageWithPeerId},
-        serde_utils::{CompactSignatureAsBytes, EntityHex, PubNonceAsBytes},
+        serde_utils::{
+            CompactSignatureAsBytes, EntityHex, PartialSignatureAsBytes, PubNonceAsBytes,
+        },
         types::{
             AcceptChannel, AddTlc, AnnouncementSignatures, BasicMppPaymentData,
             BroadcastMessageWithTimestamp, ChannelAnnouncement, ChannelReady, ChannelUpdate,
@@ -3905,6 +3907,7 @@ pub struct ShutdownInfo {
     #[serde_as(as = "EntityHex")]
     pub close_script: Script,
     pub fee_rate: u64,
+    #[serde_as(as = "Option<PartialSignatureAsBytes>")]
     pub signature: Option<PartialSignature>,
 }
 
@@ -3959,7 +3962,9 @@ impl ChannelTlcInfo {
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct PublicChannelInfo {
     // Channel announcement signatures, may be empty for private channel.
+    #[serde_as(as = "Option<(_, PartialSignatureAsBytes)>")]
     pub local_channel_announcement_signature: Option<(EcdsaSignature, PartialSignature)>,
+    #[serde_as(as = "Option<(_, PartialSignatureAsBytes)>")]
     pub remote_channel_announcement_signature: Option<(EcdsaSignature, PartialSignature)>,
 
     #[serde_as(as = "Option<PubNonceAsBytes>")]

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1074,7 +1074,7 @@ where
         let payment_hash = add_tlc.payment_hash;
         let forward_amount = peeled_onion_packet.current.amount;
         let invoice = self.store.get_invoice(&payment_hash);
-        let is_trampoline = peeled_onion_packet.current.trampoline_onion.is_some();
+        let is_trampoline = peeled_onion_packet.current.trampoline_onion().is_some();
         let is_last = peeled_onion_packet.is_last();
 
         let tlc = state
@@ -1095,11 +1095,10 @@ where
             // to obtain the final recipient payload.
             let trampoline_bytes = peeled_onion_packet
                 .current
-                .trampoline_onion
-                .as_deref()
+                .trampoline_onion()
                 .expect("trampoline_onion present");
 
-            let peeled_trampoline = TrampolineOnionPacket::new(trampoline_bytes.to_vec())
+            let peeled_trampoline = TrampolineOnionPacket::new(trampoline_bytes)
                 .peel(state.private_key(), Some(payment_hash.as_ref()), SECP256K1)
                 .map_err(|err| {
                     ProcessingChannelError::PeelingOnionPacketError(format!(

--- a/crates/fiber-lib/src/fiber/gen/fiber.rs
+++ b/crates/fiber-lib/src/fiber/gen/fiber.rs
@@ -14290,7 +14290,6 @@ impl ::core::fmt::Display for PaymentHopData {
         write!(f, ", {}: {}", "funding_tx_hash", self.funding_tx_hash())?;
         write!(f, ", {}: {}", "next_hop", self.next_hop())?;
         write!(f, ", {}: {}", "custom_records", self.custom_records())?;
-        write!(f, ", {}: {}", "trampoline_onion", self.trampoline_onion())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -14305,13 +14304,13 @@ impl ::core::default::Default for PaymentHopData {
     }
 }
 impl PaymentHopData {
-    const DEFAULT_VALUE: [u8; 93] = [
-        93, 0, 0, 0, 36, 0, 0, 0, 52, 0, 0, 0, 60, 0, 0, 0, 60, 0, 0, 0, 61, 0, 0, 0, 93, 0, 0, 0,
-        93, 0, 0, 0, 93, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    const DEFAULT_VALUE: [u8; 89] = [
+        89, 0, 0, 0, 32, 0, 0, 0, 48, 0, 0, 0, 56, 0, 0, 0, 56, 0, 0, 0, 57, 0, 0, 0, 89, 0, 0, 0,
+        89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
+        0,
     ];
-    pub const FIELD_COUNT: usize = 8;
+    pub const FIELD_COUNT: usize = 7;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -14367,17 +14366,11 @@ impl PaymentHopData {
     pub fn custom_records(&self) -> CustomRecordsOpt {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[28..]) as usize;
-        let end = molecule::unpack_number(&slice[32..]) as usize;
-        CustomRecordsOpt::new_unchecked(self.0.slice(start..end))
-    }
-    pub fn trampoline_onion(&self) -> BytesOpt {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[32..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[36..]) as usize;
-            BytesOpt::new_unchecked(self.0.slice(start..end))
+            let end = molecule::unpack_number(&slice[32..]) as usize;
+            CustomRecordsOpt::new_unchecked(self.0.slice(start..end))
         } else {
-            BytesOpt::new_unchecked(self.0.slice(start..))
+            CustomRecordsOpt::new_unchecked(self.0.slice(start..))
         }
     }
     pub fn as_reader<'r>(&'r self) -> PaymentHopDataReader<'r> {
@@ -14414,7 +14407,6 @@ impl molecule::prelude::Entity for PaymentHopData {
             .funding_tx_hash(self.funding_tx_hash())
             .next_hop(self.next_hop())
             .custom_records(self.custom_records())
-            .trampoline_onion(self.trampoline_onion())
     }
 }
 #[derive(Clone, Copy)]
@@ -14443,7 +14435,6 @@ impl<'r> ::core::fmt::Display for PaymentHopDataReader<'r> {
         write!(f, ", {}: {}", "funding_tx_hash", self.funding_tx_hash())?;
         write!(f, ", {}: {}", "next_hop", self.next_hop())?;
         write!(f, ", {}: {}", "custom_records", self.custom_records())?;
-        write!(f, ", {}: {}", "trampoline_onion", self.trampoline_onion())?;
         let extra_count = self.count_extra_fields();
         if extra_count != 0 {
             write!(f, ", .. ({} fields)", extra_count)?;
@@ -14452,7 +14443,7 @@ impl<'r> ::core::fmt::Display for PaymentHopDataReader<'r> {
     }
 }
 impl<'r> PaymentHopDataReader<'r> {
-    pub const FIELD_COUNT: usize = 8;
+    pub const FIELD_COUNT: usize = 7;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
     }
@@ -14508,17 +14499,11 @@ impl<'r> PaymentHopDataReader<'r> {
     pub fn custom_records(&self) -> CustomRecordsOptReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[28..]) as usize;
-        let end = molecule::unpack_number(&slice[32..]) as usize;
-        CustomRecordsOptReader::new_unchecked(&self.as_slice()[start..end])
-    }
-    pub fn trampoline_onion(&self) -> BytesOptReader<'r> {
-        let slice = self.as_slice();
-        let start = molecule::unpack_number(&slice[32..]) as usize;
         if self.has_extra_fields() {
-            let end = molecule::unpack_number(&slice[36..]) as usize;
-            BytesOptReader::new_unchecked(&self.as_slice()[start..end])
+            let end = molecule::unpack_number(&slice[32..]) as usize;
+            CustomRecordsOptReader::new_unchecked(&self.as_slice()[start..end])
         } else {
-            BytesOptReader::new_unchecked(&self.as_slice()[start..])
+            CustomRecordsOptReader::new_unchecked(&self.as_slice()[start..])
         }
     }
 }
@@ -14575,7 +14560,6 @@ impl<'r> molecule::prelude::Reader<'r> for PaymentHopDataReader<'r> {
         Byte32Reader::verify(&slice[offsets[4]..offsets[5]], compatible)?;
         PubkeyOptReader::verify(&slice[offsets[5]..offsets[6]], compatible)?;
         CustomRecordsOptReader::verify(&slice[offsets[6]..offsets[7]], compatible)?;
-        BytesOptReader::verify(&slice[offsets[7]..offsets[8]], compatible)?;
         Ok(())
     }
 }
@@ -14588,10 +14572,9 @@ pub struct PaymentHopDataBuilder {
     pub(crate) funding_tx_hash: Byte32,
     pub(crate) next_hop: PubkeyOpt,
     pub(crate) custom_records: CustomRecordsOpt,
-    pub(crate) trampoline_onion: BytesOpt,
 }
 impl PaymentHopDataBuilder {
-    pub const FIELD_COUNT: usize = 8;
+    pub const FIELD_COUNT: usize = 7;
     pub fn amount(mut self, v: Uint128) -> Self {
         self.amount = v;
         self
@@ -14620,10 +14603,6 @@ impl PaymentHopDataBuilder {
         self.custom_records = v;
         self
     }
-    pub fn trampoline_onion(mut self, v: BytesOpt) -> Self {
-        self.trampoline_onion = v;
-        self
-    }
 }
 impl molecule::prelude::Builder for PaymentHopDataBuilder {
     type Entity = PaymentHopData;
@@ -14637,7 +14616,6 @@ impl molecule::prelude::Builder for PaymentHopDataBuilder {
             + self.funding_tx_hash.as_slice().len()
             + self.next_hop.as_slice().len()
             + self.custom_records.as_slice().len()
-            + self.trampoline_onion.as_slice().len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
         let mut total_size = molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1);
@@ -14656,8 +14634,6 @@ impl molecule::prelude::Builder for PaymentHopDataBuilder {
         total_size += self.next_hop.as_slice().len();
         offsets.push(total_size);
         total_size += self.custom_records.as_slice().len();
-        offsets.push(total_size);
-        total_size += self.trampoline_onion.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
         for offset in offsets.into_iter() {
             writer.write_all(&molecule::pack_number(offset as molecule::Number))?;
@@ -14669,7 +14645,6 @@ impl molecule::prelude::Builder for PaymentHopDataBuilder {
         writer.write_all(self.funding_tx_hash.as_slice())?;
         writer.write_all(self.next_hop.as_slice())?;
         writer.write_all(self.custom_records.as_slice())?;
-        writer.write_all(self.trampoline_onion.as_slice())?;
         Ok(())
     }
     fn build(&self) -> Self::Entity {

--- a/crates/fiber-lib/src/fiber/gen/mod.rs
+++ b/crates/fiber-lib/src/fiber/gen/mod.rs
@@ -8,7 +8,7 @@ pub mod invoice;
 // We need to re-export these types.
 mod blockchain {
     pub use ckb_gen_types::packed::{
-        Byte32, Byte32Reader, Bytes, BytesOpt, BytesOptReader, BytesReader, BytesVec,
+        Byte32, Byte32Reader, Bytes, BytesReader, BytesVec,
         BytesVecReader, OutPoint, OutPointReader, Script, ScriptOpt, ScriptOptReader, ScriptReader,
         Transaction, TransactionReader, Uint128, Uint128Reader, Uint32, Uint32Reader, Uint64,
         Uint64Reader,

--- a/crates/fiber-lib/src/fiber/gen/mod.rs
+++ b/crates/fiber-lib/src/fiber/gen/mod.rs
@@ -8,9 +8,8 @@ pub mod invoice;
 // We need to re-export these types.
 mod blockchain {
     pub use ckb_gen_types::packed::{
-        Byte32, Byte32Reader, Bytes, BytesReader, BytesVec,
-        BytesVecReader, OutPoint, OutPointReader, Script, ScriptOpt, ScriptOptReader, ScriptReader,
-        Transaction, TransactionReader, Uint128, Uint128Reader, Uint32, Uint32Reader, Uint64,
-        Uint64Reader,
+        Byte32, Byte32Reader, Bytes, BytesReader, BytesVec, BytesVecReader, OutPoint,
+        OutPointReader, Script, ScriptOpt, ScriptOptReader, ScriptReader, Transaction,
+        TransactionReader, Uint128, Uint128Reader, Uint32, Uint32Reader, Uint64, Uint64Reader,
     };
 }

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1796,15 +1796,18 @@ where
         let last_expiry_delta =
             final_hop_expiry_delta_override.unwrap_or(payment_data.final_tlc_expiry_delta);
 
-        hops_data.push(PaymentHopData {
+        let mut last_hop = PaymentHopData {
             amount: last_amount,
             hash_algorithm,
             expiry: now + last_expiry_delta + rand_tlc_expiry_delta,
             payment_preimage,
             custom_records,
-            trampoline_onion,
             ..Default::default()
-        });
+        };
+        if let Some(onion) = trampoline_onion {
+            last_hop.set_trampoline_onion(onion);
+        }
+        hops_data.push(last_hop);
         // assert there is no duplicate node in the route
         assert_eq!(
             hops_data
@@ -1821,7 +1824,7 @@ where
                 assert!(hops_data.len() >= 2);
                 let len = hops_data.len();
                 assert_eq!(hops_data[len - 2].amount, hops_data[len - 1].amount);
-                assert!(hops_data.last().unwrap().trampoline_onion.is_some());
+                assert!(hops_data.last().unwrap().trampoline_onion().is_some());
             }
         }
         hops_data

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -2359,11 +2359,11 @@ where
 
         // Trampoline forwarding: the onion for this node is the last hop, but contains an
         // encrypted payload telling us the real final recipient and parameters.
-        if let Some(trampoline_bytes) = peeled_onion_packet.current.trampoline_onion.as_deref() {
+        if let Some(trampoline_bytes) = peeled_onion_packet.current.trampoline_onion() {
             return self
                 .forward_trampoline_packet(
                     state,
-                    trampoline_bytes,
+                    &trampoline_bytes,
                     previous_tlc,
                     payment_hash,
                     peeled_onion_packet.current.amount,

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -1795,8 +1795,9 @@ where
                     // This is needed both for actual payments and dry_run to get correct fee calculations
                     if let Some(trampoline) = &session.request.trampoline_context {
                         if let Some(last_hop) = hops.last_mut() {
-                            last_hop.trampoline_onion =
-                                Some(trampoline.remaining_trampoline_onion.clone());
+                            last_hop.set_trampoline_onion(
+                                trampoline.remaining_trampoline_onion.clone(),
+                            );
                         }
                         self.apply_trampoline_forwarding_fee(session, source, &hops, &mut max_fee)
                             .await?;

--- a/crates/fiber-lib/src/fiber/schema/fiber.mol
+++ b/crates/fiber-lib/src/fiber/schema/fiber.mol
@@ -232,7 +232,6 @@ table PaymentHopData {
     funding_tx_hash: Byte32,
     next_hop: PubkeyOpt,
     custom_records: CustomRecordsOpt,
-    trampoline_onion: BytesOpt,
 }
 
 // Trampoline hop payload for forwarding nodes

--- a/crates/fiber-lib/src/fiber/serde_utils.rs
+++ b/crates/fiber-lib/src/fiber/serde_utils.rs
@@ -1,5 +1,7 @@
 use molecule::prelude::Entity;
-use musig2::{BinaryEncoding, CompactSignature, PubNonce, SCHNORR_SIGNATURE_SIZE};
+use musig2::{
+    BinaryEncoding, CompactSignature, PartialSignature, PubNonce, SCHNORR_SIGNATURE_SIZE,
+};
 use serde::{de::Error, Deserialize, Deserializer, Serializer};
 use serde_with::{serde_conv, DeserializeAs, SerializeAs};
 
@@ -201,6 +203,28 @@ impl<'de> DeserializeAs<'de, PubNonce> for PubNonceAsBytes {
             return Err(serde::de::Error::custom("expected 66 bytes"));
         }
         PubNonce::from_bytes(&bytes).map_err(serde::de::Error::custom)
+    }
+}
+
+pub struct PartialSignatureAsBytes;
+
+impl SerializeAs<PartialSignature> for PartialSignatureAsBytes {
+    fn serialize_as<S>(signature: &PartialSignature, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes: [u8; 32] = signature.serialize();
+        serde::Serialize::serialize(&bytes, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, PartialSignature> for PartialSignatureAsBytes {
+    fn deserialize_as<D>(deserializer: D) -> Result<PartialSignature, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <[u8; 32]>::deserialize(deserializer)?;
+        PartialSignature::from_slice(&bytes).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -675,12 +675,11 @@ fn test_graph_trampoline_routing_no_sender_precheck_to_final() {
     let last = route.last().expect("last hop");
     assert!(last.next_hop.is_none());
     let trampoline_bytes = last
-        .trampoline_onion
-        .as_deref()
+        .trampoline_onion()
         .expect("trampoline payload should be present");
     // The payload is now an inner trampoline onion packet.
     assert!(
-        TrampolineOnionPacket::new(trampoline_bytes.to_vec())
+        TrampolineOnionPacket::new(trampoline_bytes)
             .into_sphinx_onion_packet()
             .is_ok(),
         "trampoline_onion should be a valid sphinx onion packet"
@@ -788,10 +787,8 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
 
     let last = route.last().expect("last hop");
     let trampoline_bytes = last
-        .trampoline_onion
-        .as_deref()
-        .expect("trampoline payload should be present")
-        .to_vec();
+        .trampoline_onion()
+        .expect("trampoline payload should be present");
 
     let assoc = Some(payment_hash.as_ref());
 
@@ -863,10 +860,8 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
     let trampoline_short = route_short
         .last()
         .unwrap()
-        .trampoline_onion
-        .as_deref()
-        .unwrap()
-        .to_vec();
+        .trampoline_onion()
+        .unwrap();
     let peeled_short_1 = TrampolineOnionPacket::new(trampoline_short)
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[2]),
@@ -1075,10 +1070,8 @@ fn test_graph_trampoline_routing_fee_fields_match_precompute() {
     let trampoline_bytes = route
         .last()
         .unwrap()
-        .trampoline_onion
-        .as_deref()
-        .unwrap()
-        .to_vec();
+        .trampoline_onion()
+        .unwrap();
 
     let peeled1 = TrampolineOnionPacket::new(trampoline_bytes)
         .peel(

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -857,11 +857,7 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
         .graph
         .build_route(payment_data.amount, None, None, &payment_data)
         .expect("trampoline route should be built");
-    let trampoline_short = route_short
-        .last()
-        .unwrap()
-        .trampoline_onion()
-        .unwrap();
+    let trampoline_short = route_short.last().unwrap().trampoline_onion().unwrap();
     let peeled_short_1 = TrampolineOnionPacket::new(trampoline_short)
         .peel(
             &crate::fiber::types::Privkey(network.secret_keys[2]),
@@ -1067,11 +1063,7 @@ fn test_graph_trampoline_routing_fee_fields_match_precompute() {
     }
 
     let assoc = Some(payment_hash.as_ref());
-    let trampoline_bytes = route
-        .last()
-        .unwrap()
-        .trampoline_onion()
-        .unwrap();
+    let trampoline_bytes = route.last().unwrap().trampoline_onion().unwrap();
 
     let peeled1 = TrampolineOnionPacket::new(trampoline_bytes)
         .peel(

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -4754,7 +4754,6 @@ async fn test_payment_onion_invoice_udt_type_script_mismatch_fails() {
             hash_algorithm,
             payment_preimage: None,
             custom_records: None,
-            trampoline_onion: None,
         },
         PaymentHopData {
             amount,
@@ -4764,7 +4763,6 @@ async fn test_payment_onion_invoice_udt_type_script_mismatch_fails() {
             hash_algorithm,
             payment_preimage: None,
             custom_records: None,
-            trampoline_onion: None,
         },
     ];
     let packet = PeeledPaymentOnionPacket::create(

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -1933,16 +1933,17 @@ async fn test_trampoline_forwarding_fee_insufficient_manual_packet() {
 
     // 2. Mock incoming packet stats
     // Incoming amount 900 < 1000
+    let mut current_hop_data = CurrentPaymentHopData {
+        amount: 900,
+        expiry: 5000,
+        payment_preimage: None,
+        hash_algorithm: HashAlgorithm::Sha256,
+        funding_tx_hash: Default::default(),
+        custom_records: None,
+    };
+    current_hop_data.set_trampoline_onion(trampoline_onion_bytes);
     let peeled_packet = PeeledPaymentOnionPacket {
-        current: CurrentPaymentHopData {
-            amount: 900,
-            expiry: 5000,
-            payment_preimage: None,
-            hash_algorithm: HashAlgorithm::Sha256,
-            funding_tx_hash: Default::default(),
-            custom_records: None,
-            trampoline_onion: Some(trampoline_onion_bytes),
-        },
+        current: current_hop_data,
         shared_secret: [0u8; 32],
         next: None,
     };
@@ -2027,16 +2028,17 @@ async fn test_trampoline_forwarding_fee_insufficient_equal_amount() {
     .into_bytes();
 
     // Incoming amount equals amount_to_forward -> should be treated as insufficient fee
+    let mut current_hop_data = CurrentPaymentHopData {
+        amount: 1000,
+        expiry: 5000,
+        payment_preimage: None,
+        hash_algorithm: HashAlgorithm::Sha256,
+        funding_tx_hash: Default::default(),
+        custom_records: None,
+    };
+    current_hop_data.set_trampoline_onion(trampoline_onion_bytes);
     let peeled_packet = PeeledPaymentOnionPacket {
-        current: CurrentPaymentHopData {
-            amount: 1000,
-            expiry: 5000,
-            payment_preimage: None,
-            hash_algorithm: HashAlgorithm::Sha256,
-            funding_tx_hash: Default::default(),
-            custom_records: None,
-            trampoline_onion: Some(trampoline_onion_bytes),
-        },
+        current: current_hop_data,
         shared_secret: [0u8; 32],
         next: None,
     };
@@ -3064,15 +3066,15 @@ async fn test_trampoline_forward_invalid_onion_payload_missing_context() {
     .expect("build trampoline");
 
     // 2. Prepare the PeeledPaymentOnionPacket
-    let current_hop = CurrentPaymentHopData {
+    let mut current_hop = CurrentPaymentHopData {
         amount: 2000,
         expiry: 5000,
         payment_preimage: None,
         hash_algorithm: HashAlgorithm::Sha256,
         funding_tx_hash: Default::default(),
         custom_records: None,
-        trampoline_onion: Some(trampoline_packet.into_bytes()),
     };
+    current_hop.set_trampoline_onion(trampoline_packet.into_bytes());
 
     let peeled_onion = PeeledPaymentOnionPacket {
         current: current_hop,
@@ -3154,15 +3156,15 @@ async fn test_trampoline_forward_invalid_amount_in_onion_packet() {
     .expect("build trampoline");
 
     // 2. Prepare the PeeledPaymentOnionPacket
-    let current_hop = CurrentPaymentHopData {
+    let mut current_hop = CurrentPaymentHopData {
         amount: 1100, // Invalid amount to build max_fee_amount
         expiry: 5000,
         payment_preimage: None,
         hash_algorithm: HashAlgorithm::Sha256,
         funding_tx_hash: Default::default(),
         custom_records: None,
-        trampoline_onion: Some(trampoline_packet.into_bytes()),
     };
+    current_hop.set_trampoline_onion(trampoline_packet.into_bytes());
 
     let peeled_onion = PeeledPaymentOnionPacket {
         current: current_hop,

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -288,12 +288,12 @@ fn test_peeled_large_onion_packet() {
 
     // default PACKET_DATA_LEN is 6500
     // v1 format saves 8 bytes per hop vs v0, allowing more hops
-    // Note: with trampoline_onion field, each hop is slightly larger
-    build_onion_packet(41).expect("build onion packet with 41 hops");
-    let res = build_onion_packet(42);
+    // Note: with trampoline_onion in custom_records, each hop is slightly larger
+    build_onion_packet(42).expect("build onion packet with 42 hops");
+    let res = build_onion_packet(43);
     assert!(
         res.is_err(),
-        "should fail to build onion packet with 42 hops"
+        "should fail to build onion packet with 43 hops"
     );
 }
 
@@ -578,7 +578,6 @@ fn test_payment_onion_packet_peel_wrong_key() {
             hash_algorithm: HashAlgorithm::Sha256,
             payment_preimage: None,
             custom_records: None,
-            trampoline_onion: None,
         },
         PaymentHopData {
             amount: 100,
@@ -588,7 +587,6 @@ fn test_payment_onion_packet_peel_wrong_key() {
             hash_algorithm: HashAlgorithm::Sha256,
             payment_preimage: None,
             custom_records: None,
-            trampoline_onion: None,
         },
     ];
     let packet =
@@ -1017,7 +1015,7 @@ fn test_payment_hop_data_v0_checksum() {
     let hop_data = create_checksum_test_hop_data();
     let data_v0 = PaymentSphinxCodec::pack_hop_data(ONION_PACKET_VERSION_V0, &hop_data);
     let check_sum = hex::encode(blake2b_256(&data_v0));
-    let expected = "7abddd1a352a8191bea7b694973a83d1d21c91ce50b2c657521ac83233103ce4";
+    let expected = "1ea2a67b30c7d2cedab21c6e5f4a3b860fc8b1ccc525f42dd1bdd4a7d6dfe489";
     assert_eq!(
         check_sum, expected,
         "PaymentHopData v0 checksum mismatch - v0 format compatibility broken"
@@ -1043,7 +1041,7 @@ fn test_payment_hop_data_v1_checksum() {
     let hop_data = create_checksum_test_hop_data();
     let data_v1 = PaymentSphinxCodec::pack_hop_data(ONION_PACKET_VERSION_V1, &hop_data);
     let check_sum = hex::encode(blake2b_256(&data_v1));
-    let expected = "6640af3fa9342368dbe2f3a54fa6bc0e17f394a7de8094ec7d4d33571c8c2160";
+    let expected = "05e50a25b23489e96a8c25a4d3eab07bf9c71c651046224b3cbf3fe3d5c876d7";
     assert_eq!(check_sum, expected, "PaymentHopData v1 checksum mismatch");
 }
 

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -20,7 +20,6 @@ use serde_with::IfIsHumanReadable;
 use anyhow::anyhow;
 use bitcoin::hashes::Hash;
 use ckb_jsonrpc_types::CellOutput;
-use ckb_types::packed::BytesOpt;
 use ckb_types::H256;
 use ckb_types::{
     core::FeeRate,
@@ -3793,10 +3792,36 @@ impl BasicMppPaymentData {
     }
 }
 
+/// Helper to store the trampoline onion packet inside `custom_records`.
+///
+/// This embeds the trampoline onion bytes as a custom record entry so that the molecule
+/// `PaymentHopData` schema stays at 7 fields — matching v0.6.1 — and old onion packets
+/// created before trampoline support can still be deserialized.
+pub(crate) struct TrampolineOnionData;
+
+impl TrampolineOnionData {
+    /// Custom record key for embedded trampoline onion data.
+    /// `BasicMppPaymentData` uses `USER_CUSTOM_RECORDS_MAX_INDEX + 1` (65536).
+    pub const CUSTOM_RECORD_KEY: u32 = USER_CUSTOM_RECORDS_MAX_INDEX + 2;
+
+    pub fn write(data: Vec<u8>, custom_records: &mut PaymentCustomRecords) {
+        custom_records.data.insert(Self::CUSTOM_RECORD_KEY, data);
+    }
+
+    pub fn read(custom_records: &PaymentCustomRecords) -> Option<Vec<u8>> {
+        custom_records.data.get(&Self::CUSTOM_RECORD_KEY).cloned()
+    }
+
+    #[allow(dead_code)]
+    pub fn take(custom_records: &mut PaymentCustomRecords) -> Option<Vec<u8>> {
+        custom_records.data.remove(&Self::CUSTOM_RECORD_KEY)
+    }
+}
+
 /// Trampoline onion hop payload.
 ///
-/// This is carried inside the *inner* trampoline onion packet (which is itself embedded in the
-/// `trampoline_onion` field of the *outer* payment onion hop payload).
+/// This is carried inside the *inner* trampoline onion packet (which is itself embedded in
+/// the `custom_records` of the *outer* payment onion hop payload via `TrampolineOnionData`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TrampolineHopPayload {
     /// Payload for a trampoline node.
@@ -4164,7 +4189,6 @@ pub struct PaymentHopData {
     pub funding_tx_hash: Hash256,
     pub next_hop: Option<Pubkey>,
     pub custom_records: Option<PaymentCustomRecords>,
-    pub trampoline_onion: Option<Vec<u8>>,
 }
 
 const PACKET_DATA_LEN: usize = 6500;
@@ -4178,7 +4202,6 @@ pub struct CurrentPaymentHopData {
     pub hash_algorithm: HashAlgorithm,
     pub funding_tx_hash: Hash256,
     pub custom_records: Option<PaymentCustomRecords>,
-    pub trampoline_onion: Option<Vec<u8>>,
 }
 
 impl From<PaymentHopData> for CurrentPaymentHopData {
@@ -4190,7 +4213,6 @@ impl From<PaymentHopData> for CurrentPaymentHopData {
             hash_algorithm: hop.hash_algorithm,
             funding_tx_hash: hop.funding_tx_hash,
             custom_records: hop.custom_records,
-            trampoline_onion: hop.trampoline_onion,
         }
     }
 }
@@ -4205,7 +4227,6 @@ impl From<CurrentPaymentHopData> for PaymentHopData {
             funding_tx_hash: hop.funding_tx_hash,
             custom_records: hop.custom_records,
             next_hop: None,
-            trampoline_onion: hop.trampoline_onion,
         }
     }
 }
@@ -4213,6 +4234,19 @@ impl From<CurrentPaymentHopData> for PaymentHopData {
 impl PaymentHopData {
     pub fn next_hop(&self) -> Option<Pubkey> {
         self.next_hop
+    }
+
+    /// Returns the trampoline onion bytes embedded in `custom_records`, if present.
+    pub fn trampoline_onion(&self) -> Option<Vec<u8>> {
+        self.custom_records
+            .as_ref()
+            .and_then(TrampolineOnionData::read)
+    }
+
+    /// Embeds a trampoline onion packet into `custom_records`.
+    pub fn set_trampoline_onion(&mut self, data: Vec<u8>) {
+        let cr = self.custom_records.get_or_insert_with(Default::default);
+        TrampolineOnionData::write(data, cr);
     }
 
     pub fn serialize(&self) -> Vec<u8> {
@@ -4281,17 +4315,15 @@ impl From<PaymentHopData> for molecule_fiber::PaymentHopData {
                     .set(payment_hop_data.custom_records.map(|x| x.into()))
                     .build(),
             )
-            .trampoline_onion(
-                BytesOpt::new_builder()
-                    .set(payment_hop_data.trampoline_onion.map(|data| data.pack()))
-                    .build(),
-            )
             .build()
     }
 }
 
 impl From<molecule_fiber::PaymentHopData> for PaymentHopData {
     fn from(payment_hop_data: molecule_fiber::PaymentHopData) -> Self {
+        let custom_records: Option<PaymentCustomRecords> =
+            payment_hop_data.custom_records().to_opt().map(|x| x.into());
+
         PaymentHopData {
             amount: payment_hop_data.amount().unpack(),
             expiry: payment_hop_data.expiry().unpack(),
@@ -4309,11 +4341,7 @@ impl From<molecule_fiber::PaymentHopData> for PaymentHopData {
                 .to_opt()
                 .map(|x| x.try_into())
                 .and_then(Result::ok),
-            custom_records: payment_hop_data.custom_records().to_opt().map(|x| x.into()),
-            trampoline_onion: payment_hop_data
-                .trampoline_onion()
-                .to_opt()
-                .map(|x| x.raw_data().into()),
+            custom_records,
         }
     }
 }
@@ -4409,6 +4437,21 @@ impl SphinxOnionCodec for PaymentSphinxCodec {
             ONION_PACKET_VERSION_V1 => molecule_table_data_len(buf),
             _ => None,
         }
+    }
+}
+
+impl CurrentPaymentHopData {
+    /// Returns the trampoline onion bytes embedded in `custom_records`, if present.
+    pub fn trampoline_onion(&self) -> Option<Vec<u8>> {
+        self.custom_records
+            .as_ref()
+            .and_then(TrampolineOnionData::read)
+    }
+
+    /// Embeds a trampoline onion packet into `custom_records`.
+    pub fn set_trampoline_onion(&mut self, data: Vec<u8>) {
+        let cr = self.custom_records.get_or_insert_with(Default::default);
+        TrampolineOnionData::write(data, cr);
     }
 }
 

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -3811,11 +3811,6 @@ impl TrampolineOnionData {
     pub fn read(custom_records: &PaymentCustomRecords) -> Option<Vec<u8>> {
         custom_records.data.get(&Self::CUSTOM_RECORD_KEY).cloned()
     }
-
-    #[allow(dead_code)]
-    pub fn take(custom_records: &mut PaymentCustomRecords) -> Option<Vec<u8>> {
-        custom_records.data.remove(&Self::CUSTOM_RECORD_KEY)
-    }
 }
 
 /// Trampoline onion hop payload.

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -9,7 +9,9 @@ use super::gen::gossip::{self as molecule_gossip};
 use super::hash_algorithm::{HashAlgorithm, UnknownHashAlgorithmError};
 use super::network::get_chain_hash;
 use super::r#gen::fiber::PubNonceOpt;
-use super::serde_utils::{EntityHex, PubNonceAsBytes, SliceBase58, SliceHex, SliceHexNoPrefix};
+use super::serde_utils::{
+    EntityHex, PartialSignatureAsBytes, PubNonceAsBytes, SliceBase58, SliceHex, SliceHexNoPrefix,
+};
 use crate::ckb::config::{UdtArgInfo, UdtCellDep, UdtCfgInfos, UdtDep, UdtScript};
 use crate::ckb::contracts::get_udt_whitelist;
 use crate::fiber::payment::{PaymentCustomRecords, USER_CUSTOM_RECORDS_MAX_INDEX};
@@ -785,10 +787,13 @@ impl TryFrom<molecule_fiber::AcceptChannel> for AcceptChannel {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitmentSigned {
     pub channel_id: Hash256,
+    #[serde_as(as = "PartialSignatureAsBytes")]
     pub funding_tx_partial_signature: PartialSignature,
+    #[serde_as(as = "PubNonceAsBytes")]
     pub next_commitment_nonce: PubNonce,
 }
 
@@ -1203,6 +1208,7 @@ impl TryFrom<molecule_fiber::AddTlc> for AddTlc {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RevokeAndAck {
     pub channel_id: Hash256,
+    #[serde_as(as = "PartialSignatureAsBytes")]
     pub revocation_partial_signature: PartialSignature,
     pub next_per_commitment_point: Pubkey,
     #[serde_as(as = "PubNonceAsBytes")]

--- a/crates/fiber-lib/src/store/.schema.json
+++ b/crates/fiber-lib/src/store/.schema.json
@@ -36,7 +36,7 @@
   "NodeId": "ef2bc800b89157eab65f84241d236d7d942feec6a09ac81d1c44ee3ec42b2248",
   "OutboundTlcStatus": "e1bd26b1c042a0358cd6959127474bcd47b81a5d1808093fba133a3983725242",
   "PaymentCustomRecords": "ffd9808f13c17b84d00132cf82f46a8561bb74938e19f1613c04ba9d742da9bc",
-  "PaymentHopData": "0157a3676e58fdfeca91c481e1c7e0891e8c7fc013025efc6f1bd1dbf2462a06",
+  "PaymentHopData": "4b812c1eccb1e223a39a3835113d13a50784ad7c1f28d369a3f24359fe6a321c",
   "PaymentOnionPacket": "11a21e69fdd950ea7cc46106ec5ae9de73f0de732e0c07a5e57c94e6b1911695",
   "PaymentSession": "18ba49a08bde5f5bb8ce8e58b7b0123a0a3ab19251dcea21a79070770cb4cccb",
   "PaymentStatus": "e261dd3257be525ba4bea793efcceb7dffb717a8de82a57bfe8e8b1d2d8913d9",

--- a/crates/fiber-lib/src/store/mod.rs
+++ b/crates/fiber-lib/src/store/mod.rs
@@ -1,5 +1,7 @@
 pub mod db_migrate;
 pub mod migration;
+#[cfg(any(test, feature = "sample"))]
+pub mod sample;
 mod schema;
 pub mod store_impl;
 pub use store_impl::Store;

--- a/crates/fiber-lib/src/store/sample/mod.rs
+++ b/crates/fiber-lib/src/store/sample/mod.rs
@@ -1,0 +1,173 @@
+/// `StoreSample` trait for generating deterministic sample data to test
+/// store serialization compatibility and data migration correctness.
+///
+/// Each implementation generates a set of representative sample instances
+/// for a given store-persisted type. These samples can be serialized to
+/// fixture files and used to verify that migrations produce correctly
+/// deserializable data across versions.
+///
+/// # Usage
+///
+/// ```ignore
+/// // Generate fixtures for the current version
+/// let samples = ChannelActorState::samples(42);
+/// for (i, sample) in samples.iter().enumerate() {
+///     let bytes = bincode::serialize(sample).unwrap();
+///     std::fs::write(format!("fixtures/v0.7.0/channel_state_{}.bin", i), bytes).unwrap();
+/// }
+///
+/// // Verify fixtures from a previous version still deserialize
+/// let bytes = std::fs::read("fixtures/v0.6.1/channel_state_0.bin").unwrap();
+/// let _state: ChannelActorState = bincode::deserialize(&bytes).unwrap();
+/// ```
+use serde::{Deserialize, Serialize};
+
+mod sample_broadcast;
+mod sample_channel;
+mod sample_holdtlc;
+mod sample_invoice;
+mod sample_network;
+mod sample_payment;
+
+/// Trait for types that are persisted in the store and need migration testing.
+///
+/// Implementations must produce deterministic samples for a given seed,
+/// meaning the same seed always yields identical byte-level output.
+pub trait StoreSample: Serialize + for<'de> Deserialize<'de> + Sized {
+    /// The store key prefix byte for this type (from `schema.rs`).
+    const STORE_PREFIX: u8;
+
+    /// A human-readable name for logging and fixture file naming.
+    const TYPE_NAME: &'static str;
+
+    /// Generate a set of deterministic sample instances.
+    ///
+    /// The `seed` parameter controls the deterministic random state.
+    /// Multiple samples should cover different meaningful states:
+    /// - Minimal/default state
+    /// - Fully populated state
+    /// - Edge cases (e.g., channel with shutdown in progress)
+    ///
+    /// **IMPORTANT**: The output must be fully deterministic — same seed
+    /// must always produce byte-identical serialized output. Do NOT use
+    /// `SystemTime::now()`, `rand::thread_rng()`, or any non-deterministic source.
+    fn samples(seed: u64) -> Vec<Self>;
+
+    /// Verify that all samples round-trip through bincode serialization.
+    fn verify_samples_roundtrip(seed: u64) {
+        let samples = Self::samples(seed);
+        assert!(
+            !samples.is_empty(),
+            "{}: samples() must return at least one sample",
+            Self::TYPE_NAME
+        );
+        for (i, sample) in samples.iter().enumerate() {
+            let bytes = bincode::serialize(sample).unwrap_or_else(|e| {
+                panic!("{} sample {}: serialize failed: {}", Self::TYPE_NAME, i, e)
+            });
+            let _roundtrip: Self = bincode::deserialize(&bytes).unwrap_or_else(|e| {
+                panic!(
+                    "{} sample {}: deserialize failed: {}",
+                    Self::TYPE_NAME,
+                    i,
+                    e
+                )
+            });
+        }
+    }
+
+    /// Generate and return the serialized bytes for all samples.
+    /// Useful for writing fixture files.
+    fn sample_bytes(seed: u64) -> Vec<Vec<u8>> {
+        Self::samples(seed)
+            .iter()
+            .map(|s| bincode::serialize(s).expect("serialization should not fail"))
+            .collect()
+    }
+}
+
+/// Generate a deterministic 32-byte hash from a seed and an index.
+/// Uses blake2b to ensure good distribution.
+pub fn deterministic_hash(seed: u64, index: u32) -> [u8; 32] {
+    use ckb_hash::blake2b_256;
+    let mut input = Vec::with_capacity(12);
+    input.extend_from_slice(&seed.to_le_bytes());
+    input.extend_from_slice(&index.to_le_bytes());
+    blake2b_256(&input)
+}
+
+/// Generate a deterministic secp256k1 secret key from a seed and index.
+/// The result is guaranteed to be a valid secret key.
+pub fn deterministic_seckey(seed: u64, index: u32) -> secp256k1::SecretKey {
+    let mut hash = deterministic_hash(seed, index);
+    // Ensure the hash is a valid secp256k1 secret key (non-zero, less than curve order).
+    // Setting the first byte to a small nonzero value practically guarantees validity.
+    hash[0] = ((hash[0] % 254) + 1) as u8;
+    secp256k1::SecretKey::from_slice(&hash).expect("deterministic_seckey should always be valid")
+}
+
+/// Generate a deterministic Pubkey from a seed and index.
+pub fn deterministic_pubkey(seed: u64, index: u32) -> crate::fiber::types::Pubkey {
+    let sk = deterministic_seckey(seed, index);
+    let pk = secp256k1::PublicKey::from_secret_key(secp256k1::SECP256K1, &sk);
+    pk.into()
+}
+
+/// Generate a deterministic Privkey from a seed and index.
+pub fn deterministic_privkey(seed: u64, index: u32) -> crate::fiber::types::Privkey {
+    let sk = deterministic_seckey(seed, index);
+    sk.into()
+}
+
+/// Generate a deterministic Hash256 from a seed and index.
+pub fn deterministic_hash256(seed: u64, index: u32) -> crate::fiber::types::Hash256 {
+    deterministic_hash(seed, index).into()
+}
+
+/// Create a deterministic EcdsaSignature from a seed and index.
+pub fn deterministic_ecdsa_signature(seed: u64, index: u32) -> crate::fiber::types::EcdsaSignature {
+    use secp256k1::{Message, SECP256K1};
+    let sk = deterministic_seckey(seed, index);
+    let message = Message::from_digest_slice(&deterministic_hash(seed, index.wrapping_add(1000)))
+        .expect("32 bytes");
+    let signature = SECP256K1.sign_ecdsa(&message, &sk);
+    crate::fiber::types::EcdsaSignature(signature)
+}
+
+/// Create a deterministic SchnorrSignature from a seed and index.
+/// Uses `sign_schnorr_no_aux_rand` to avoid non-deterministic auxiliary randomness.
+pub fn deterministic_schnorr_signature(seed: u64, index: u32) -> secp256k1::schnorr::Signature {
+    use secp256k1::{Keypair, SECP256K1};
+    let sk = deterministic_seckey(seed, index);
+    let keypair = Keypair::from_secret_key(SECP256K1, &sk);
+    let msg_bytes = deterministic_hash(seed, index.wrapping_add(2000));
+    SECP256K1.sign_schnorr_no_aux_rand(&msg_bytes, &keypair)
+}
+
+/// Create a deterministic XOnlyPublicKey from a seed and index.
+pub fn deterministic_xonly_pubkey(seed: u64, index: u32) -> secp256k1::XOnlyPublicKey {
+    use secp256k1::{Keypair, SECP256K1};
+    let sk = deterministic_seckey(seed, index);
+    let keypair = Keypair::from_secret_key(SECP256K1, &sk);
+    secp256k1::XOnlyPublicKey::from_keypair(&keypair).0
+}
+
+/// Create a deterministic OutPoint from a seed and index.
+pub fn deterministic_outpoint(seed: u64, index: u32) -> ckb_types::packed::OutPoint {
+    use ckb_types::prelude::Pack;
+    let hash = deterministic_hash(seed, index);
+    let tx_hash: ckb_types::packed::Byte32 = hash.pack();
+    ckb_types::packed::OutPoint::new(tx_hash, 0)
+}
+
+/// Create a deterministic RecoverableSignature from a seed and index.
+pub fn deterministic_recoverable_signature(
+    seed: u64,
+    index: u32,
+) -> secp256k1::ecdsa::RecoverableSignature {
+    use secp256k1::{Message, SECP256K1};
+    let sk = deterministic_seckey(seed, index);
+    let message = Message::from_digest_slice(&deterministic_hash(seed, index.wrapping_add(3000)))
+        .expect("32 bytes");
+    SECP256K1.sign_ecdsa_recoverable(&message, &sk)
+}

--- a/crates/fiber-lib/src/store/sample/sample_broadcast.rs
+++ b/crates/fiber-lib/src/store/sample/sample_broadcast.rs
@@ -1,0 +1,134 @@
+/// StoreSample implementation for `BroadcastMessage`.
+use crate::ckb::config::UdtCfgInfos;
+use crate::fiber::config::AnnouncedNodeName;
+use crate::fiber::features::FeatureVector;
+use crate::fiber::types::{
+    BroadcastMessage, ChannelAnnouncement, ChannelUpdate, ChannelUpdateChannelFlags,
+    ChannelUpdateMessageFlags, NodeAnnouncement,
+};
+use crate::store::schema::BROADCAST_MESSAGE_PREFIX;
+
+use super::{
+    deterministic_ecdsa_signature, deterministic_hash256, deterministic_outpoint,
+    deterministic_pubkey, deterministic_schnorr_signature, deterministic_xonly_pubkey, StoreSample,
+};
+
+impl StoreSample for BroadcastMessage {
+    const STORE_PREFIX: u8 = BROADCAST_MESSAGE_PREFIX;
+    const TYPE_NAME: &'static str = "BroadcastMessage";
+
+    fn samples(seed: u64) -> Vec<Self> {
+        vec![
+            sample_node_announcement(seed),
+            sample_channel_announcement(seed),
+            sample_channel_update(seed),
+        ]
+    }
+}
+
+/// BroadcastMessage::NodeAnnouncement variant with all Options Some.
+fn sample_node_announcement(seed: u64) -> BroadcastMessage {
+    BroadcastMessage::NodeAnnouncement(NodeAnnouncement {
+        signature: Some(deterministic_ecdsa_signature(seed, 0)),
+        features: FeatureVector::default(),
+        timestamp: 1_704_067_200,
+        node_id: deterministic_pubkey(seed, 1),
+        version: "0.7.0".to_string(),
+        node_name: AnnouncedNodeName::from_string("test-node").expect("valid node name"),
+        addresses: vec!["/ip4/127.0.0.1/tcp/8000".parse().expect("valid multiaddr")],
+        chain_hash: deterministic_hash256(seed, 2),
+        auto_accept_min_ckb_funding_amount: 100_000_000_000,
+        udt_cfg_infos: UdtCfgInfos::default(),
+    })
+}
+
+/// BroadcastMessage::ChannelAnnouncement variant with all Options Some.
+fn sample_channel_announcement(seed: u64) -> BroadcastMessage {
+    BroadcastMessage::ChannelAnnouncement(ChannelAnnouncement {
+        node1_signature: Some(deterministic_ecdsa_signature(seed, 10)),
+        node2_signature: Some(deterministic_ecdsa_signature(seed, 11)),
+        ckb_signature: Some(deterministic_schnorr_signature(seed, 12)),
+        features: 0,
+        chain_hash: deterministic_hash256(seed, 13),
+        channel_outpoint: deterministic_outpoint(seed, 14),
+        node1_id: deterministic_pubkey(seed, 15),
+        node2_id: deterministic_pubkey(seed, 16),
+        ckb_key: deterministic_xonly_pubkey(seed, 17),
+        capacity: 800_000_000_000,
+        udt_type_script: Some(ckb_types::packed::Script::default()),
+    })
+}
+
+/// BroadcastMessage::ChannelUpdate variant with signature Some.
+fn sample_channel_update(seed: u64) -> BroadcastMessage {
+    BroadcastMessage::ChannelUpdate(ChannelUpdate {
+        signature: Some(deterministic_ecdsa_signature(seed, 20)),
+        chain_hash: deterministic_hash256(seed, 21),
+        channel_outpoint: deterministic_outpoint(seed, 22),
+        timestamp: 1_704_070_800,
+        message_flags: ChannelUpdateMessageFlags::UPDATE_OF_NODE1,
+        channel_flags: ChannelUpdateChannelFlags::empty(),
+        tlc_expiry_delta: 40,
+        tlc_minimum_value: 1000,
+        tlc_fee_proportional_millionths: 500,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_broadcast_message_samples_roundtrip() {
+        BroadcastMessage::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_broadcast_message_samples_deterministic() {
+        let bytes_a = BroadcastMessage::sample_bytes(42);
+        let bytes_b = BroadcastMessage::sample_bytes(42);
+        assert_eq!(bytes_a, bytes_b, "Same seed must produce identical bytes");
+    }
+
+    #[test]
+    fn test_broadcast_message_different_seeds() {
+        let bytes_42 = BroadcastMessage::sample_bytes(42);
+        let bytes_99 = BroadcastMessage::sample_bytes(99);
+        assert_ne!(
+            bytes_42, bytes_99,
+            "Different seeds should produce different bytes"
+        );
+    }
+
+    #[test]
+    fn test_broadcast_message_sample_count() {
+        let samples = BroadcastMessage::samples(42);
+        assert_eq!(samples.len(), 3, "Should produce all 3 enum variants");
+    }
+
+    #[test]
+    fn test_broadcast_message_options_populated() {
+        let samples = BroadcastMessage::samples(42);
+        // NodeAnnouncement
+        if let BroadcastMessage::NodeAnnouncement(na) = &samples[0] {
+            assert!(na.signature.is_some());
+        } else {
+            panic!("Expected NodeAnnouncement");
+        }
+        // ChannelAnnouncement
+        if let BroadcastMessage::ChannelAnnouncement(ca) = &samples[1] {
+            assert!(ca.node1_signature.is_some());
+            assert!(ca.node2_signature.is_some());
+            assert!(ca.ckb_signature.is_some());
+            assert!(ca.udt_type_script.is_some());
+        } else {
+            panic!("Expected ChannelAnnouncement");
+        }
+        // ChannelUpdate
+        if let BroadcastMessage::ChannelUpdate(cu) = &samples[2] {
+            assert!(cu.signature.is_some());
+        } else {
+            panic!("Expected ChannelUpdate");
+        }
+    }
+}

--- a/crates/fiber-lib/src/store/sample/sample_channel.rs
+++ b/crates/fiber-lib/src/store/sample/sample_channel.rs
@@ -1,0 +1,481 @@
+/// StoreSample implementation for `ChannelActorState`.
+///
+/// Provides deterministic sample instances for migration testing.
+use std::collections::{HashMap, VecDeque};
+
+use crate::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use ckb_types::packed::{Script, Transaction};
+use musig2::secp::MaybeScalar;
+use musig2::SecNonceBuilder;
+
+use crate::fiber::channel::{
+    AddTlcCommand, AppliedFlags, ChannelActorState, ChannelBasePublicKeys, ChannelConstraints,
+    ChannelState, ChannelTlcInfo, CommitmentNumbers, InMemorySigner, PendingTlcs, PrevTlcInfo,
+    PublicChannelInfo, RetryableTlcOperation, ShutdownInfo, TLCId, TlcInfo, TlcState, TlcStatus,
+};
+use crate::fiber::hash_algorithm::HashAlgorithm;
+use crate::fiber::types::{
+    ChannelAnnouncement, ChannelUpdate, ChannelUpdateChannelFlags, ChannelUpdateMessageFlags,
+    PaymentOnionPacket, RemoveTlcFulfill, RemoveTlcReason, RevokeAndAck, TlcErrPacket,
+};
+use crate::store::schema::CHANNEL_ACTOR_STATE_PREFIX;
+
+use super::{
+    deterministic_ecdsa_signature, deterministic_hash, deterministic_hash256,
+    deterministic_outpoint, deterministic_pubkey, deterministic_schnorr_signature,
+    deterministic_xonly_pubkey, StoreSample,
+};
+
+/// Create a deterministic SystemTime anchored to a fixed epoch.
+fn deterministic_time(offset_secs: u64) -> SystemTime {
+    // Use a fixed reference point: 2024-01-01T00:00:00Z (Unix timestamp 1704067200)
+    UNIX_EPOCH + Duration::from_secs(1_704_067_200 + offset_secs)
+}
+
+/// Create a deterministic PubNonce from a seed and index.
+fn deterministic_pub_nonce(seed: u64, index: u32) -> musig2::PubNonce {
+    let hash = deterministic_hash(seed, index);
+    let sec_nonce = SecNonceBuilder::new(hash).build();
+    sec_nonce.public_nonce()
+}
+
+/// Create a deterministic InMemorySigner from a seed and index.
+fn deterministic_signer(seed: u64, index: u32) -> InMemorySigner {
+    let params = deterministic_hash(seed, index);
+    InMemorySigner::generate_from_seed(&params)
+}
+
+/// Create ChannelBasePublicKeys from an InMemorySigner's public keys.
+fn channel_pubkeys_from_signer(signer: &InMemorySigner) -> ChannelBasePublicKeys {
+    ChannelBasePublicKeys {
+        funding_pubkey: signer.funding_key.pubkey(),
+        tlc_base_key: signer.tlc_base_key.pubkey(),
+    }
+}
+
+/// Create a deterministic ChannelBasePublicKeys from a seed and index.
+fn deterministic_channel_pubkeys(seed: u64, base_index: u32) -> ChannelBasePublicKeys {
+    ChannelBasePublicKeys {
+        funding_pubkey: deterministic_pubkey(seed, base_index),
+        tlc_base_key: deterministic_pubkey(seed, base_index + 1),
+    }
+}
+
+impl StoreSample for ChannelActorState {
+    const STORE_PREFIX: u8 = CHANNEL_ACTOR_STATE_PREFIX;
+    const TYPE_NAME: &'static str = "ChannelActorState";
+
+    fn samples(seed: u64) -> Vec<Self> {
+        vec![Self::sample_minimal(seed), Self::sample_full(seed)]
+    }
+}
+
+impl ChannelActorState {
+    /// Sample 0: Minimal state — all Option fields are None, all collections empty, all defaults.
+    fn sample_minimal(seed: u64) -> Self {
+        let signer = deterministic_signer(seed, 0);
+        let local_channel_public_keys = channel_pubkeys_from_signer(&signer);
+
+        ChannelActorState {
+            state: ChannelState::ChannelReady,
+            public_channel_info: None,
+            local_tlc_info: ChannelTlcInfo::default(),
+            remote_tlc_info: None,
+            local_pubkey: deterministic_pubkey(seed, 10),
+            remote_pubkey: deterministic_pubkey(seed, 11),
+            id: deterministic_hash256(seed, 0),
+            funding_tx: None,
+            funding_tx_confirmed_at: None,
+            funding_udt_type_script: None,
+            is_acceptor: false,
+            is_one_way: false,
+            to_local_amount: 0,
+            to_remote_amount: 0,
+            local_reserved_ckb_amount: 0,
+            remote_reserved_ckb_amount: 0,
+            commitment_fee_rate: 0,
+            commitment_delay_epoch: 0,
+            funding_fee_rate: 0,
+            signer,
+            local_channel_public_keys,
+            commitment_numbers: CommitmentNumbers::default(),
+            local_constraints: ChannelConstraints::default(),
+            remote_constraints: ChannelConstraints::default(),
+            tlc_state: Default::default(),
+            retryable_tlc_operations: VecDeque::new(),
+            waiting_forward_tlc_tasks: HashMap::new(),
+            remote_shutdown_script: None,
+            local_shutdown_script: Script::default(),
+            last_committed_remote_nonce: None,
+            remote_revocation_nonce_for_verify: None,
+            remote_revocation_nonce_for_send: None,
+            remote_revocation_nonce_for_next: None,
+            latest_commitment_transaction: None,
+            remote_commitment_points: vec![],
+            remote_channel_public_keys: None,
+            local_shutdown_info: None,
+            remote_shutdown_info: None,
+            shutdown_transaction_hash: None,
+            reestablishing: false,
+            last_revoke_ack_msg: None,
+            created_at: deterministic_time(0),
+            // #[serde(skip)] fields — not serialized, use defaults
+            waiting_peer_response: None,
+            network: None,
+            scheduled_channel_update_handle: None,
+            pending_notify_settle_tlcs: vec![],
+            ephemeral_config: Default::default(),
+            private_key: None,
+        }
+    }
+
+    /// Sample 1: Fully populated state — every Option field is Some, every nested
+    /// Option is Some, every collection is non-empty. This is the most comprehensive
+    /// test for bincode serialization compatibility across versions.
+    fn sample_full(seed: u64) -> Self {
+        let signer = deterministic_signer(seed, 100);
+        let local_channel_public_keys = channel_pubkeys_from_signer(&signer);
+        let channel_id = deterministic_hash256(seed, 100);
+        let outpoint = deterministic_outpoint(seed, 150);
+
+        // --- PublicChannelInfo: all fields Some ---
+        let channel_announcement = ChannelAnnouncement {
+            node1_signature: Some(deterministic_ecdsa_signature(seed, 210)),
+            node2_signature: Some(deterministic_ecdsa_signature(seed, 211)),
+            ckb_signature: Some(deterministic_schnorr_signature(seed, 212)),
+            features: 0,
+            chain_hash: deterministic_hash256(seed, 213),
+            channel_outpoint: outpoint.clone(),
+            node1_id: deterministic_pubkey(seed, 214),
+            node2_id: deterministic_pubkey(seed, 215),
+            ckb_key: deterministic_xonly_pubkey(seed, 216),
+            capacity: 800_000_000_000,
+            udt_type_script: Some(Script::default()),
+        };
+
+        let channel_update = ChannelUpdate {
+            signature: Some(deterministic_ecdsa_signature(seed, 220)),
+            chain_hash: deterministic_hash256(seed, 213),
+            channel_outpoint: outpoint,
+            timestamp: 1_704_067_200,
+            message_flags: ChannelUpdateMessageFlags::UPDATE_OF_NODE1,
+            channel_flags: ChannelUpdateChannelFlags::empty(),
+            tlc_expiry_delta: 40,
+            tlc_minimum_value: 1000,
+            tlc_fee_proportional_millionths: 500,
+        };
+
+        let public_channel_info = PublicChannelInfo {
+            local_channel_announcement_signature: Some((
+                deterministic_ecdsa_signature(seed, 200),
+                MaybeScalar::two(),
+            )),
+            remote_channel_announcement_signature: Some((
+                deterministic_ecdsa_signature(seed, 201),
+                MaybeScalar::two(),
+            )),
+            remote_channel_announcement_nonce: Some(deterministic_pub_nonce(seed, 202)),
+            channel_announcement: Some(channel_announcement),
+            channel_update: Some(channel_update),
+        };
+
+        // --- TlcState: with offered and received TLCs, all nested Options populated ---
+        let offered_tlc = TlcInfo {
+            status: TlcStatus::Outbound(crate::fiber::channel::OutboundTlcStatus::LocalAnnounced),
+            tlc_id: TLCId::Offered(0),
+            amount: 50_000_000,
+            payment_hash: deterministic_hash256(seed, 300),
+            total_amount: Some(100_000_000),
+            payment_secret: Some(deterministic_hash256(seed, 301)),
+            attempt_id: Some(1),
+            expiry: 1_704_070_800,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            onion_packet: Some(PaymentOnionPacket::new(
+                deterministic_hash(seed, 302).to_vec(),
+            )),
+            shared_secret: deterministic_hash(seed, 303),
+            is_trampoline_hop: true,
+            created_at: CommitmentNumbers::default(),
+            removed_reason: Some(RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
+                payment_preimage: deterministic_hash256(seed, 304),
+            })),
+            forwarding_tlc: Some((deterministic_hash256(seed, 305), 42)),
+            removed_confirmed_at: Some(5),
+            applied_flags: AppliedFlags::ADD | AppliedFlags::REMOVE,
+        };
+
+        let received_tlc = TlcInfo {
+            status: TlcStatus::Inbound(crate::fiber::channel::InboundTlcStatus::Committed),
+            tlc_id: TLCId::Received(0),
+            amount: 30_000_000,
+            payment_hash: deterministic_hash256(seed, 310),
+            total_amount: Some(60_000_000),
+            payment_secret: Some(deterministic_hash256(seed, 311)),
+            attempt_id: Some(2),
+            expiry: 1_704_074_400,
+            hash_algorithm: HashAlgorithm::Sha256,
+            onion_packet: Some(PaymentOnionPacket::new(
+                deterministic_hash(seed, 312).to_vec(),
+            )),
+            shared_secret: deterministic_hash(seed, 313),
+            is_trampoline_hop: false,
+            created_at: CommitmentNumbers::default(),
+            removed_reason: Some(RemoveTlcReason::RemoveTlcFail(TlcErrPacket {
+                onion_packet: deterministic_hash(seed, 314).to_vec(),
+            })),
+            forwarding_tlc: Some((deterministic_hash256(seed, 315), 7)),
+            removed_confirmed_at: Some(10),
+            applied_flags: AppliedFlags::ADD,
+        };
+
+        let tlc_state = TlcState {
+            offered_tlcs: PendingTlcs {
+                tlcs: vec![offered_tlc],
+                next_tlc_id: 1,
+            },
+            received_tlcs: PendingTlcs {
+                tlcs: vec![received_tlc],
+                next_tlc_id: 1,
+            },
+            waiting_ack: true,
+        };
+
+        // --- RetryableTlcOperations: non-empty with both variants ---
+        let retryable_ops = VecDeque::from(vec![
+            RetryableTlcOperation::RemoveTlc(
+                TLCId::Received(0),
+                RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
+                    payment_preimage: deterministic_hash256(seed, 350),
+                }),
+            ),
+            RetryableTlcOperation::AddTlc(AddTlcCommand {
+                amount: 10_000_000,
+                payment_hash: deterministic_hash256(seed, 351),
+                attempt_id: Some(3),
+                expiry: 1_704_078_000,
+                hash_algorithm: HashAlgorithm::CkbHash,
+                onion_packet: Some(PaymentOnionPacket::new(
+                    deterministic_hash(seed, 352).to_vec(),
+                )),
+                shared_secret: deterministic_hash(seed, 353),
+                is_trampoline_hop: false,
+                previous_tlc: Some(PrevTlcInfo::new_with_shared_secret(
+                    deterministic_hash256(seed, 354),
+                    5,
+                    1000,
+                    deterministic_hash(seed, 355),
+                )),
+            }),
+        ]);
+
+        // --- waiting_forward_tlc_tasks: non-empty ---
+        let mut waiting_forward = HashMap::new();
+        waiting_forward.insert(TLCId::Received(0), deterministic_hash(seed, 360));
+
+        // --- RevokeAndAck: all fields populated ---
+        let revoke_and_ack = RevokeAndAck {
+            channel_id,
+            revocation_partial_signature: MaybeScalar::two(),
+            next_per_commitment_point: deterministic_pubkey(seed, 810),
+            next_revocation_nonce: deterministic_pub_nonce(seed, 811),
+        };
+
+        ChannelActorState {
+            state: ChannelState::ChannelReady,
+            public_channel_info: Some(public_channel_info),
+            local_tlc_info: ChannelTlcInfo {
+                enabled: true,
+                timestamp: 1_704_067_200_000,
+                tlc_fee_proportional_millionths: 500,
+                tlc_expiry_delta: 40,
+                tlc_minimum_value: 1000,
+            },
+            remote_tlc_info: Some(ChannelTlcInfo {
+                enabled: true,
+                timestamp: 1_704_067_200_000,
+                tlc_fee_proportional_millionths: 600,
+                tlc_expiry_delta: 40,
+                tlc_minimum_value: 2000,
+            }),
+            local_pubkey: deterministic_pubkey(seed, 110),
+            remote_pubkey: deterministic_pubkey(seed, 111),
+            id: channel_id,
+            funding_tx: Some(Transaction::default()),
+            funding_tx_confirmed_at: Some((
+                ckb_types::H256(deterministic_hash(seed, 151)),
+                100,
+                1_704_067_200,
+            )),
+            funding_udt_type_script: Some(Script::default()),
+            is_acceptor: true,
+            is_one_way: true,
+            to_local_amount: 500_000_000_000,
+            to_remote_amount: 300_000_000_000,
+            local_reserved_ckb_amount: 6_200_000_000,
+            remote_reserved_ckb_amount: 6_200_000_000,
+            commitment_fee_rate: 1000,
+            commitment_delay_epoch: 40,
+            funding_fee_rate: 1000,
+            signer,
+            local_channel_public_keys,
+            commitment_numbers: CommitmentNumbers::default(),
+            local_constraints: ChannelConstraints::new(100_000_000_000, 30),
+            remote_constraints: ChannelConstraints::new(100_000_000_000, 30),
+            tlc_state,
+            retryable_tlc_operations: retryable_ops,
+            waiting_forward_tlc_tasks: waiting_forward,
+            remote_shutdown_script: Some(Script::default()),
+            local_shutdown_script: Script::default(),
+            last_committed_remote_nonce: Some(deterministic_pub_nonce(seed, 400)),
+            remote_revocation_nonce_for_verify: Some(deterministic_pub_nonce(seed, 401)),
+            remote_revocation_nonce_for_send: Some(deterministic_pub_nonce(seed, 402)),
+            remote_revocation_nonce_for_next: Some(deterministic_pub_nonce(seed, 403)),
+            latest_commitment_transaction: Some(Transaction::default()),
+            remote_commitment_points: vec![
+                (0, deterministic_pubkey(seed, 500)),
+                (1, deterministic_pubkey(seed, 501)),
+            ],
+            remote_channel_public_keys: Some(deterministic_channel_pubkeys(seed, 600)),
+            local_shutdown_info: Some(ShutdownInfo {
+                close_script: Script::default(),
+                fee_rate: 2000,
+                signature: Some(MaybeScalar::two()),
+            }),
+            remote_shutdown_info: Some(ShutdownInfo {
+                close_script: Script::default(),
+                fee_rate: 2000,
+                signature: Some(MaybeScalar::two()),
+            }),
+            shutdown_transaction_hash: Some(ckb_types::H256(deterministic_hash(seed, 950))),
+            reestablishing: true,
+            last_revoke_ack_msg: Some(revoke_and_ack),
+            created_at: deterministic_time(3600),
+            // #[serde(skip)] fields — not serialized, use defaults
+            waiting_peer_response: None,
+            network: None,
+            scheduled_channel_update_handle: None,
+            pending_notify_settle_tlcs: vec![],
+            ephemeral_config: Default::default(),
+            private_key: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_channel_actor_state_samples_roundtrip() {
+        ChannelActorState::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_channel_actor_state_samples_deterministic() {
+        let bytes_a = ChannelActorState::sample_bytes(42);
+        let bytes_b = ChannelActorState::sample_bytes(42);
+        assert_eq!(bytes_a, bytes_b, "Same seed must produce identical bytes");
+    }
+
+    #[test]
+    fn test_channel_actor_state_different_seeds() {
+        let bytes_42 = ChannelActorState::sample_bytes(42);
+        let bytes_99 = ChannelActorState::sample_bytes(99);
+        assert_ne!(
+            bytes_42, bytes_99,
+            "Different seeds should produce different bytes"
+        );
+    }
+
+    #[test]
+    fn test_channel_actor_state_sample_count() {
+        let samples = ChannelActorState::samples(42);
+        assert_eq!(samples.len(), 2, "Should produce 2 sample variants");
+    }
+
+    #[test]
+    fn test_channel_actor_state_full_no_none() {
+        let full = ChannelActorState::sample_full(42);
+
+        // --- Top-level Option fields ---
+        assert!(full.public_channel_info.is_some());
+        assert!(full.remote_tlc_info.is_some());
+        assert!(full.funding_tx.is_some());
+        assert!(full.funding_tx_confirmed_at.is_some());
+        assert!(full.funding_udt_type_script.is_some());
+        assert!(full.remote_shutdown_script.is_some());
+        assert!(full.last_committed_remote_nonce.is_some());
+        assert!(full.remote_revocation_nonce_for_verify.is_some());
+        assert!(full.remote_revocation_nonce_for_send.is_some());
+        assert!(full.remote_revocation_nonce_for_next.is_some());
+        assert!(full.latest_commitment_transaction.is_some());
+        assert!(full.remote_channel_public_keys.is_some());
+        assert!(full.local_shutdown_info.is_some());
+        assert!(full.remote_shutdown_info.is_some());
+        assert!(full.shutdown_transaction_hash.is_some());
+        assert!(full.last_revoke_ack_msg.is_some());
+
+        // --- PublicChannelInfo nested Options ---
+        let pci = full.public_channel_info.as_ref().unwrap();
+        assert!(pci.local_channel_announcement_signature.is_some());
+        assert!(pci.remote_channel_announcement_signature.is_some());
+        assert!(pci.remote_channel_announcement_nonce.is_some());
+        assert!(pci.channel_announcement.is_some());
+        assert!(pci.channel_update.is_some());
+
+        // --- ChannelAnnouncement nested Options ---
+        let ca = pci.channel_announcement.as_ref().unwrap();
+        assert!(ca.node1_signature.is_some());
+        assert!(ca.node2_signature.is_some());
+        assert!(ca.ckb_signature.is_some());
+        assert!(ca.udt_type_script.is_some());
+
+        // --- ChannelUpdate nested Options ---
+        let cu = pci.channel_update.as_ref().unwrap();
+        assert!(cu.signature.is_some());
+
+        // --- ShutdownInfo nested Options ---
+        assert!(full
+            .local_shutdown_info
+            .as_ref()
+            .unwrap()
+            .signature
+            .is_some());
+        assert!(full
+            .remote_shutdown_info
+            .as_ref()
+            .unwrap()
+            .signature
+            .is_some());
+
+        // --- TlcState non-empty ---
+        assert!(!full.tlc_state.offered_tlcs.tlcs.is_empty());
+        assert!(!full.tlc_state.received_tlcs.tlcs.is_empty());
+
+        // --- TlcInfo nested Options (offered) ---
+        let offered = &full.tlc_state.offered_tlcs.tlcs[0];
+        assert!(offered.total_amount.is_some());
+        assert!(offered.payment_secret.is_some());
+        assert!(offered.attempt_id.is_some());
+        assert!(offered.onion_packet.is_some());
+        assert!(offered.removed_reason.is_some());
+        assert!(offered.forwarding_tlc.is_some());
+        assert!(offered.removed_confirmed_at.is_some());
+
+        // --- TlcInfo nested Options (received) ---
+        let received = &full.tlc_state.received_tlcs.tlcs[0];
+        assert!(received.total_amount.is_some());
+        assert!(received.payment_secret.is_some());
+        assert!(received.attempt_id.is_some());
+        assert!(received.onion_packet.is_some());
+        assert!(received.removed_reason.is_some());
+        assert!(received.forwarding_tlc.is_some());
+        assert!(received.removed_confirmed_at.is_some());
+
+        // --- Collections non-empty ---
+        assert!(!full.retryable_tlc_operations.is_empty());
+        assert!(!full.waiting_forward_tlc_tasks.is_empty());
+        assert!(!full.remote_commitment_points.is_empty());
+    }
+}

--- a/crates/fiber-lib/src/store/sample/sample_holdtlc.rs
+++ b/crates/fiber-lib/src/store/sample/sample_holdtlc.rs
@@ -1,0 +1,58 @@
+/// StoreSample implementation for `HoldTlc`.
+use crate::fiber::types::HoldTlc;
+use crate::store::schema::HOLD_TLC_PREFIX;
+
+use super::{deterministic_hash256, StoreSample};
+
+impl StoreSample for HoldTlc {
+    const STORE_PREFIX: u8 = HOLD_TLC_PREFIX;
+    const TYPE_NAME: &'static str = "HoldTlc";
+
+    fn samples(seed: u64) -> Vec<Self> {
+        vec![
+            HoldTlc {
+                channel_id: deterministic_hash256(seed, 0),
+                tlc_id: 0,
+                hold_expire_at: 1_704_067_200_000,
+            },
+            HoldTlc {
+                channel_id: deterministic_hash256(seed, 1),
+                tlc_id: 42,
+                hold_expire_at: 1_704_070_800_000,
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hold_tlc_samples_roundtrip() {
+        HoldTlc::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_hold_tlc_samples_deterministic() {
+        let bytes_a = HoldTlc::sample_bytes(42);
+        let bytes_b = HoldTlc::sample_bytes(42);
+        assert_eq!(bytes_a, bytes_b, "Same seed must produce identical bytes");
+    }
+
+    #[test]
+    fn test_hold_tlc_different_seeds() {
+        let bytes_42 = HoldTlc::sample_bytes(42);
+        let bytes_99 = HoldTlc::sample_bytes(99);
+        assert_ne!(
+            bytes_42, bytes_99,
+            "Different seeds should produce different bytes"
+        );
+    }
+
+    #[test]
+    fn test_hold_tlc_sample_count() {
+        let samples = HoldTlc::samples(42);
+        assert_eq!(samples.len(), 2, "Should produce 2 samples");
+    }
+}

--- a/crates/fiber-lib/src/store/sample/sample_invoice.rs
+++ b/crates/fiber-lib/src/store/sample/sample_invoice.rs
@@ -1,0 +1,119 @@
+/// StoreSample implementation for `CkbInvoice` and `CkbInvoiceStatus`.
+use crate::fiber::hash_algorithm::HashAlgorithm;
+use crate::invoice::{
+    Attribute, CkbInvoice, CkbInvoiceStatus, Currency, InvoiceData, InvoiceSignature,
+};
+use crate::store::schema::{CKB_INVOICE_PREFIX, CKB_INVOICE_STATUS_PREFIX};
+use core::time::Duration;
+
+use super::{deterministic_hash256, deterministic_recoverable_signature, StoreSample};
+
+impl StoreSample for CkbInvoice {
+    const STORE_PREFIX: u8 = CKB_INVOICE_PREFIX;
+    const TYPE_NAME: &'static str = "CkbInvoice";
+
+    fn samples(seed: u64) -> Vec<Self> {
+        vec![sample_minimal(seed), sample_full(seed)]
+    }
+}
+
+impl StoreSample for CkbInvoiceStatus {
+    const STORE_PREFIX: u8 = CKB_INVOICE_STATUS_PREFIX;
+    const TYPE_NAME: &'static str = "CkbInvoiceStatus";
+
+    fn samples(_seed: u64) -> Vec<Self> {
+        // All enum variants to ensure each one round-trips.
+        vec![
+            CkbInvoiceStatus::Open,
+            CkbInvoiceStatus::Cancelled,
+            CkbInvoiceStatus::Expired,
+            CkbInvoiceStatus::Received,
+            CkbInvoiceStatus::Paid,
+        ]
+    }
+}
+
+/// Minimal CkbInvoice: required fields only, Options are None, no attributes.
+fn sample_minimal(seed: u64) -> CkbInvoice {
+    CkbInvoice {
+        currency: Currency::Fibd,
+        amount: None,
+        signature: None,
+        data: InvoiceData {
+            timestamp: 1_704_067_200_000,
+            payment_hash: deterministic_hash256(seed, 0),
+            attrs: vec![],
+        },
+    }
+}
+
+/// Full CkbInvoice: all Options are Some, multiple attributes present.
+fn sample_full(seed: u64) -> CkbInvoice {
+    let recoverable_sig = deterministic_recoverable_signature(seed, 50);
+    CkbInvoice {
+        currency: Currency::Fibt,
+        amount: Some(100_000_000_000),
+        signature: Some(InvoiceSignature(recoverable_sig)),
+        data: InvoiceData {
+            timestamp: 1_704_070_800_000,
+            payment_hash: deterministic_hash256(seed, 10),
+            attrs: vec![
+                Attribute::FinalHtlcTimeout(9_600_000),
+                Attribute::FinalHtlcMinimumExpiryDelta(9_600_000),
+                Attribute::ExpiryTime(Duration::from_secs(3600)),
+                Attribute::Description("test invoice".to_string()),
+                Attribute::FallbackAddr(
+                    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq...".to_string(),
+                ),
+                Attribute::HashAlgorithm(HashAlgorithm::CkbHash),
+                Attribute::PaymentSecret(deterministic_hash256(seed, 11)),
+            ],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ckb_invoice_samples_roundtrip() {
+        CkbInvoice::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_ckb_invoice_samples_deterministic() {
+        let bytes_a = CkbInvoice::sample_bytes(42);
+        let bytes_b = CkbInvoice::sample_bytes(42);
+        assert_eq!(bytes_a, bytes_b, "Same seed must produce identical bytes");
+    }
+
+    #[test]
+    fn test_ckb_invoice_different_seeds() {
+        let bytes_42 = CkbInvoice::sample_bytes(42);
+        let bytes_99 = CkbInvoice::sample_bytes(99);
+        assert_ne!(
+            bytes_42, bytes_99,
+            "Different seeds should produce different bytes"
+        );
+    }
+
+    #[test]
+    fn test_ckb_invoice_status_samples_roundtrip() {
+        CkbInvoiceStatus::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_ckb_invoice_status_sample_count() {
+        let samples = CkbInvoiceStatus::samples(42);
+        assert_eq!(samples.len(), 5, "Should produce all 5 enum variants");
+    }
+
+    #[test]
+    fn test_ckb_invoice_full_no_none() {
+        let full = sample_full(42);
+        assert!(full.amount.is_some());
+        assert!(full.signature.is_some());
+        assert!(!full.data.attrs.is_empty());
+    }
+}

--- a/crates/fiber-lib/src/store/sample/sample_network.rs
+++ b/crates/fiber-lib/src/store/sample/sample_network.rs
@@ -1,0 +1,85 @@
+/// StoreSample implementation for `PersistentNetworkActorState`.
+///
+/// Since `PersistentNetworkActorState` has private fields, we construct
+/// populated instances via `serde_json` deserialization.
+use crate::fiber::network::PersistentNetworkActorState;
+use crate::store::schema::PEER_ID_NETWORK_ACTOR_STATE_PREFIX;
+
+use super::{deterministic_pubkey, StoreSample};
+
+impl StoreSample for PersistentNetworkActorState {
+    const STORE_PREFIX: u8 = PEER_ID_NETWORK_ACTOR_STATE_PREFIX;
+    const TYPE_NAME: &'static str = "PersistentNetworkActorState";
+
+    fn samples(seed: u64) -> Vec<Self> {
+        vec![sample_minimal(), sample_full(seed)]
+    }
+}
+
+/// Minimal state: empty HashMaps (the Default).
+fn sample_minimal() -> PersistentNetworkActorState {
+    PersistentNetworkActorState::new()
+}
+
+/// Full state: populated peer_pubkey_map and saved_peer_addresses.
+///
+/// Because the struct fields are private, we construct it via JSON
+/// deserialization which has access to all fields through serde.
+///
+/// We use a single entry per HashMap to ensure deterministic serialization
+/// (HashMap with one entry has a stable iteration order).
+fn sample_full(seed: u64) -> PersistentNetworkActorState {
+    let pubkey1 = deterministic_pubkey(seed, 0);
+    // Derive PeerId from raw secp256k1 public key bytes via tentacle.
+    let pk1_bytes = pubkey1.serialize();
+    let tentacle_pk1 = tentacle::secio::PublicKey::from_raw_key(pk1_bytes.to_vec());
+    let peer_id1 = tentacle::secio::PeerId::from_public_key(&tentacle_pk1);
+
+    // Build JSON matching the serde_as format:
+    // peer_pubkey_map and saved_peer_addresses are serialized as Vec<(String, _)>
+    // because of #[serde_as(as = "Vec<(DisplayFromStr, _)>")].
+    // Use single entries to guarantee deterministic HashMap serialization.
+    let json = serde_json::json!({
+        "peer_pubkey_map": [
+            [peer_id1.to_base58(), pubkey1],
+        ],
+        "saved_peer_addresses": [
+            [peer_id1.to_base58(), ["/ip4/127.0.0.1/tcp/8000", "/ip4/10.0.0.1/tcp/7000"]],
+        ],
+    });
+
+    serde_json::from_value(json).expect("PersistentNetworkActorState JSON deserialization")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_persistent_network_actor_state_samples_roundtrip() {
+        PersistentNetworkActorState::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_persistent_network_actor_state_samples_deterministic() {
+        let bytes_a = PersistentNetworkActorState::sample_bytes(42);
+        let bytes_b = PersistentNetworkActorState::sample_bytes(42);
+        assert_eq!(bytes_a, bytes_b, "Same seed must produce identical bytes");
+    }
+
+    #[test]
+    fn test_persistent_network_actor_state_different_seeds() {
+        let bytes_42 = PersistentNetworkActorState::sample_bytes(42);
+        let bytes_99 = PersistentNetworkActorState::sample_bytes(99);
+        assert_ne!(
+            bytes_42, bytes_99,
+            "Different seeds should produce different bytes"
+        );
+    }
+
+    #[test]
+    fn test_persistent_network_actor_state_sample_count() {
+        let samples = PersistentNetworkActorState::samples(42);
+        assert_eq!(samples.len(), 2, "Should produce 2 sample variants");
+    }
+}

--- a/crates/fiber-lib/src/store/sample/sample_payment.rs
+++ b/crates/fiber-lib/src/store/sample/sample_payment.rs
@@ -1,0 +1,325 @@
+/// StoreSample implementations for payment types:
+/// - `PaymentSession` (prefix 192)
+/// - `PaymentCustomRecords` (prefix 194)
+/// - `Attempt` (prefix 195)
+use std::collections::HashMap;
+
+use crate::fiber::hash_algorithm::HashAlgorithm;
+use crate::fiber::payment::{
+    Attempt, AttemptStatus, PaymentCustomRecords, PaymentSession, PaymentStatus, SendPaymentData,
+    SessionRoute, SessionRouteNode, TrampolineContext,
+};
+use crate::fiber::types::PaymentHopData;
+use crate::store::schema::{ATTEMPT_PREFIX, PAYMENT_CUSTOM_RECORD_PREFIX, PAYMENT_SESSION_PREFIX};
+
+use super::{
+    deterministic_hash, deterministic_hash256, deterministic_outpoint, deterministic_pubkey,
+    StoreSample,
+};
+
+// ─── PaymentSession ─────────────────────────────────────────────────
+
+impl StoreSample for PaymentSession {
+    const STORE_PREFIX: u8 = PAYMENT_SESSION_PREFIX;
+    const TYPE_NAME: &'static str = "PaymentSession";
+
+    fn samples(seed: u64) -> Vec<Self> {
+        vec![sample_session_minimal(seed), sample_session_full(seed)]
+    }
+}
+
+/// Helper: build a minimal `SendPaymentData` with no Options set.
+fn minimal_send_payment_data(seed: u64) -> SendPaymentData {
+    SendPaymentData {
+        target_pubkey: deterministic_pubkey(seed, 0),
+        amount: 100_000_000,
+        payment_hash: deterministic_hash256(seed, 1),
+        invoice: None,
+        final_tlc_expiry_delta: 9_600_000,
+        tlc_expiry_limit: 576_000_000,
+        timeout: None,
+        max_fee_amount: None,
+        max_parts: None,
+        keysend: false,
+        udt_type_script: None,
+        preimage: None,
+        custom_records: None,
+        allow_self_payment: false,
+        hop_hints: vec![],
+        router: vec![],
+        allow_mpp: false,
+        dry_run: false,
+        trampoline_hops: None,
+        trampoline_context: None,
+        channel_stats: Default::default(),
+    }
+}
+
+/// Helper: build a fully-populated `SendPaymentData`.
+fn full_send_payment_data(seed: u64) -> SendPaymentData {
+    use crate::fiber::graph::RouterHop;
+    use crate::fiber::payment::HopHint;
+
+    // Use single entry to guarantee deterministic HashMap serialization.
+    let mut custom_records_data = HashMap::new();
+    custom_records_data.insert(1u32, vec![0xab, 0xcd]);
+
+    SendPaymentData {
+        target_pubkey: deterministic_pubkey(seed, 100),
+        amount: 500_000_000,
+        payment_hash: deterministic_hash256(seed, 101),
+        invoice: Some("fibd50000000001p...example".to_string()),
+        final_tlc_expiry_delta: 9_600_000,
+        tlc_expiry_limit: 576_000_000,
+        timeout: Some(60_000),
+        max_fee_amount: Some(5_000_000),
+        max_parts: Some(4),
+        keysend: false,
+        udt_type_script: Some(ckb_types::packed::Script::default()),
+        preimage: Some(deterministic_hash256(seed, 102)),
+        custom_records: Some(PaymentCustomRecords {
+            data: custom_records_data,
+        }),
+        allow_self_payment: true,
+        hop_hints: vec![HopHint {
+            pubkey: deterministic_pubkey(seed, 103),
+            channel_outpoint: deterministic_outpoint(seed, 104),
+            fee_rate: 500,
+            tlc_expiry_delta: 40,
+        }],
+        router: vec![RouterHop {
+            target: deterministic_pubkey(seed, 105),
+            channel_outpoint: deterministic_outpoint(seed, 106),
+            amount_received: 500_000_000,
+            incoming_tlc_expiry: 1_704_070_800,
+        }],
+        allow_mpp: true,
+        dry_run: false,
+        trampoline_hops: Some(vec![deterministic_pubkey(seed, 107)]),
+        trampoline_context: Some(TrampolineContext {
+            remaining_trampoline_onion: vec![0x01, 0x02, 0x03],
+            previous_tlcs: vec![],
+            hash_algorithm: HashAlgorithm::CkbHash,
+        }),
+        channel_stats: Default::default(),
+    }
+}
+
+fn sample_session_minimal(seed: u64) -> PaymentSession {
+    PaymentSession {
+        request: minimal_send_payment_data(seed),
+        last_error: None,
+        last_error_code: None,
+        try_limit: 10,
+        status: PaymentStatus::Created,
+        created_at: 1_704_067_200_000,
+        last_updated_at: 1_704_067_200_000,
+        cached_attempts: vec![], // #[serde(skip)]
+    }
+}
+
+fn sample_session_full(seed: u64) -> PaymentSession {
+    use crate::fiber::types::TlcErrorCode;
+
+    PaymentSession {
+        request: full_send_payment_data(seed),
+        last_error: Some("TemporaryChannelFailure".to_string()),
+        last_error_code: Some(TlcErrorCode::TemporaryChannelFailure),
+        try_limit: 30,
+        status: PaymentStatus::Inflight,
+        created_at: 1_704_067_200_000,
+        last_updated_at: 1_704_070_800_000,
+        cached_attempts: vec![], // #[serde(skip)]
+    }
+}
+
+// ─── PaymentCustomRecords ───────────────────────────────────────────
+
+impl StoreSample for PaymentCustomRecords {
+    const STORE_PREFIX: u8 = PAYMENT_CUSTOM_RECORD_PREFIX;
+    const TYPE_NAME: &'static str = "PaymentCustomRecords";
+
+    fn samples(_seed: u64) -> Vec<Self> {
+        vec![sample_records_minimal(), sample_records_full()]
+    }
+}
+
+fn sample_records_minimal() -> PaymentCustomRecords {
+    PaymentCustomRecords {
+        data: HashMap::new(),
+    }
+}
+
+fn sample_records_full() -> PaymentCustomRecords {
+    // Use single entry to guarantee deterministic HashMap serialization.
+    let mut data = HashMap::new();
+    data.insert(1u32, vec![0x01, 0x02, 0x03]);
+    PaymentCustomRecords { data }
+}
+
+// ─── Attempt ────────────────────────────────────────────────────────
+
+impl StoreSample for Attempt {
+    const STORE_PREFIX: u8 = ATTEMPT_PREFIX;
+    const TYPE_NAME: &'static str = "Attempt";
+
+    fn samples(seed: u64) -> Vec<Self> {
+        vec![sample_attempt_minimal(seed), sample_attempt_full(seed)]
+    }
+}
+
+fn sample_attempt_minimal(seed: u64) -> Attempt {
+    Attempt {
+        id: 0,
+        try_limit: 3,
+        tried_times: 1,
+        hash: deterministic_hash256(seed, 200),
+        status: AttemptStatus::Created,
+        payment_hash: deterministic_hash256(seed, 201),
+        route: SessionRoute::default(),
+        route_hops: vec![],
+        session_key: deterministic_hash(seed, 202),
+        preimage: None,
+        created_at: 1_704_067_200_000,
+        last_updated_at: 1_704_067_200_000,
+        last_error: None,
+    }
+}
+
+fn sample_attempt_full(seed: u64) -> Attempt {
+    let hop1 = PaymentHopData {
+        amount: 50_000_000,
+        expiry: 1_704_070_800,
+        payment_preimage: Some(deterministic_hash256(seed, 300)),
+        hash_algorithm: HashAlgorithm::CkbHash,
+        funding_tx_hash: deterministic_hash256(seed, 301),
+        next_hop: Some(deterministic_pubkey(seed, 302)),
+        custom_records: Some(PaymentCustomRecords {
+            data: {
+                let mut m = HashMap::new();
+                m.insert(1u32, vec![0xab]);
+                m
+            },
+        }),
+    };
+
+    let hop2 = PaymentHopData {
+        amount: 45_000_000,
+        expiry: 1_704_074_400,
+        payment_preimage: None,
+        hash_algorithm: HashAlgorithm::Sha256,
+        funding_tx_hash: deterministic_hash256(seed, 303),
+        next_hop: None, // last hop
+        custom_records: None,
+    };
+
+    let route = SessionRoute {
+        nodes: vec![
+            SessionRouteNode {
+                pubkey: deterministic_pubkey(seed, 310),
+                amount: 50_000_000,
+                channel_outpoint: deterministic_outpoint(seed, 311),
+            },
+            SessionRouteNode {
+                pubkey: deterministic_pubkey(seed, 312),
+                amount: 45_000_000,
+                channel_outpoint: deterministic_outpoint(seed, 313),
+            },
+        ],
+    };
+
+    Attempt {
+        id: 1,
+        try_limit: 10,
+        tried_times: 3,
+        hash: deterministic_hash256(seed, 210),
+        status: AttemptStatus::Inflight,
+        payment_hash: deterministic_hash256(seed, 211),
+        route,
+        route_hops: vec![hop1, hop2],
+        session_key: deterministic_hash(seed, 212),
+        preimage: Some(deterministic_hash256(seed, 213)),
+        created_at: 1_704_067_200_000,
+        last_updated_at: 1_704_070_800_000,
+        last_error: Some("temporary failure".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── PaymentSession ─────────────────────────────────────────────
+
+    #[test]
+    fn test_payment_session_samples_roundtrip() {
+        PaymentSession::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_payment_session_samples_deterministic() {
+        let bytes_a = PaymentSession::sample_bytes(42);
+        let bytes_b = PaymentSession::sample_bytes(42);
+        assert_eq!(bytes_a, bytes_b, "Same seed must produce identical bytes");
+    }
+
+    #[test]
+    fn test_payment_session_full_no_none() {
+        let full = sample_session_full(42);
+        assert!(full.last_error.is_some());
+        assert!(full.last_error_code.is_some());
+        assert!(full.request.invoice.is_some());
+        assert!(full.request.timeout.is_some());
+        assert!(full.request.max_fee_amount.is_some());
+        assert!(full.request.max_parts.is_some());
+        assert!(full.request.udt_type_script.is_some());
+        assert!(full.request.preimage.is_some());
+        assert!(full.request.custom_records.is_some());
+        assert!(full.request.trampoline_hops.is_some());
+        assert!(full.request.trampoline_context.is_some());
+        assert!(!full.request.hop_hints.is_empty());
+        assert!(!full.request.router.is_empty());
+    }
+
+    // ─── PaymentCustomRecords ───────────────────────────────────────
+
+    #[test]
+    fn test_payment_custom_records_samples_roundtrip() {
+        PaymentCustomRecords::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_payment_custom_records_samples_deterministic() {
+        let bytes_a = PaymentCustomRecords::sample_bytes(42);
+        let bytes_b = PaymentCustomRecords::sample_bytes(42);
+        assert_eq!(bytes_a, bytes_b, "Same seed must produce identical bytes");
+    }
+
+    // ─── Attempt ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_attempt_samples_roundtrip() {
+        Attempt::verify_samples_roundtrip(42);
+    }
+
+    #[test]
+    fn test_attempt_samples_deterministic() {
+        let bytes_a = Attempt::sample_bytes(42);
+        let bytes_b = Attempt::sample_bytes(42);
+        assert_eq!(bytes_a, bytes_b, "Same seed must produce identical bytes");
+    }
+
+    #[test]
+    fn test_attempt_full_no_none() {
+        let full = sample_attempt_full(42);
+        assert!(full.preimage.is_some());
+        assert!(full.last_error.is_some());
+        assert!(!full.route.nodes.is_empty());
+        assert!(!full.route_hops.is_empty());
+        // Check nested Options in PaymentHopData
+        let first_hop = &full.route_hops[0];
+        assert!(first_hop.payment_preimage.is_some());
+        assert!(first_hop.next_hop.is_some());
+        assert!(first_hop.custom_records.is_some());
+    }
+}

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "arcode"
@@ -315,6 +315,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes 0.14.1",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +359,12 @@ name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bincode"
@@ -486,6 +502,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin"
+version = "0.32.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+dependencies = [
+ "base58ck",
+ "bech32 0.11.1",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.1",
+ "hex-conservative 0.2.2",
+ "hex_lit",
+ "secp256k1 0.29.1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitcoin-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +539,16 @@ name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -515,6 +568,7 @@ checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
+ "serde",
 ]
 
 [[package]]
@@ -1342,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1374,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1882,7 +1936,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "serdect",
+ "serdect 0.2.0",
  "signature",
  "spki 0.7.3",
 ]
@@ -1934,7 +1988,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -2023,13 +2077,13 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiber-sphinx"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf0842bceebcf3b9f660ab011f65b5ab79d5500ffdd22d509319501c6efd3fc"
+checksum = "c2ef0454b7ac3e87de49cab71ef0f27f716d00974cedb1b00426ab7b822212d8"
 dependencies = [
  "chacha20",
  "hmac",
- "secp256k1 0.28.2",
+ "secp256k1 0.30.0",
  "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
@@ -2037,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#97d52f8f635d2c8dd25c11a401d195d4b006b010"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#3affbe09936059f0c5ca7744a9eef828bf25f2ce"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2048,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#40d2e876f5e877656a9d0a2c5cf1a7f16545dd57"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#38ff6ee85bf1df8287ac08be826641688928527e"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2059,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=quake%2Foneway-channel#8697183621d4ca4ff24b107201b222f93f8e9b58"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=quake%2Foneway-channel#1d754470664dde502bf6484dbdd5a0f32b7791d2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2081,9 +2135,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2092,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.6.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#97d52f8f635d2c8dd25c11a401d195d4b006b010"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#3affbe09936059f0c5ca7744a9eef828bf25f2ce"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2101,7 +2155,7 @@ dependencies = [
  "bech32 0.9.1",
  "bincode 1.3.3",
  "biscuit-auth",
- "bitcoin",
+ "bitcoin 0.30.2",
  "bitflags 2.10.0",
  "bitmask-enum",
  "bs58",
@@ -2127,7 +2181,7 @@ dependencies = [
  "hyper 1.8.1",
  "indicatif",
  "jsonrpsee",
- "lightning-invoice",
+ "lightning-invoice 0.29.0",
  "lnd-grpc-tonic-client",
  "molecule",
  "musig2",
@@ -2140,7 +2194,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "scrypt",
- "secp256k1 0.28.2",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -2161,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.6.1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#40d2e876f5e877656a9d0a2c5cf1a7f16545dd57"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#38ff6ee85bf1df8287ac08be826641688928527e"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2170,7 +2224,7 @@ dependencies = [
  "bech32 0.9.1",
  "bincode 1.3.3",
  "biscuit-auth",
- "bitcoin",
+ "bitcoin 0.30.2",
  "bitflags 2.10.0",
  "bitmask-enum",
  "bs58",
@@ -2196,7 +2250,7 @@ dependencies = [
  "hyper 1.8.1",
  "indicatif",
  "jsonrpsee",
- "lightning-invoice",
+ "lightning-invoice 0.29.0",
  "lnd-grpc-tonic-client",
  "molecule",
  "musig2",
@@ -2209,7 +2263,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "scrypt",
- "secp256k1 0.28.2",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -2229,8 +2283,8 @@ dependencies = [
 
 [[package]]
 name = "fnn"
-version = "0.6.1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=quake%2Foneway-channel#8697183621d4ca4ff24b107201b222f93f8e9b58"
+version = "0.7.0-rc1"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=quake%2Foneway-channel#1d754470664dde502bf6484dbdd5a0f32b7791d2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2239,7 +2293,7 @@ dependencies = [
  "bech32 0.9.1",
  "bincode 1.3.3",
  "biscuit-auth",
- "bitcoin",
+ "bitcoin 0.32.8",
  "bitflags 2.10.0",
  "bitmask-enum",
  "bs58",
@@ -2265,7 +2319,7 @@ dependencies = [
  "hyper 1.8.1",
  "indicatif",
  "jsonrpsee",
- "lightning-invoice",
+ "lightning-invoice 0.33.2",
  "lnd-grpc-tonic-client",
  "molecule",
  "musig2",
@@ -2278,7 +2332,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "scrypt",
- "secp256k1 0.28.2",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -2306,8 +2360,8 @@ dependencies = [
  "clap",
  "console",
  "fnn 0.6.0",
- "fnn 0.6.1 (git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1)",
- "fnn 0.6.1 (git+https://github.com/nervosnetwork/fiber.git?branch=quake%2Foneway-channel)",
+ "fnn 0.6.1",
+ "fnn 0.7.0-rc1",
  "hex",
  "indicatif",
  "ouroboros",
@@ -2936,14 +2990,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -3487,7 +3540,7 @@ version = "0.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0c1f811ae288f86c6767055c55b5f7a721ca1e61bf1897a9ae2ec663e8aba1"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.30.2",
  "hex-conservative 0.1.2",
 ]
 
@@ -3498,10 +3551,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b186aca4a605d4db3b85979922be287b9ebd5dedd8132963bb9dbeb8f7d2a04"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin",
+ "bitcoin 0.30.2",
  "lightning",
  "num-traits",
  "secp256k1 0.27.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+dependencies = [
+ "bech32 0.11.1",
+ "bitcoin 0.32.8",
+ "lightning-types",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+dependencies = [
+ "bitcoin 0.32.8",
 ]
 
 [[package]]
@@ -3608,9 +3681,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
@@ -3705,17 +3778,17 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "musig2"
-version = "0.0.11"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed08befaac75bfb31ca5e87678c4e8490bcd21d0c98ccb4f12f4065a7567e83"
+checksum = "d89eb08ce8778538f84198774795f418358360a29841cfea8dbbb28c04d777e2"
 dependencies = [
  "base16ct",
  "hmac",
  "once_cell",
  "secp",
- "secp256k1 0.28.2",
+ "secp256k1 0.30.0",
  "serde",
- "serdect",
+ "serdect 0.3.0",
  "sha2 0.10.9",
  "subtle",
 ]
@@ -4642,9 +4715,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4654,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4665,9 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -4979,22 +5052,22 @@ dependencies = [
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "secp"
-version = "0.2.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4754628ff9006f80c6abd1cd1e88c5ca6f5a60eab151ad2e16268aab3514d0"
+checksum = "d7ac68feda6cce08c5091b4e87cf93d4b7fa04b4afd9988d4b36121d949f79ec"
 dependencies = [
  "base16ct",
  "once_cell",
- "secp256k1 0.28.2",
+ "secp256k1 0.30.0",
  "serde",
- "serdect",
+ "serdect 0.3.0",
  "subtle",
 ]
 
@@ -5012,12 +5085,13 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
+ "bitcoin_hashes 0.14.1",
  "rand 0.8.5",
- "secp256k1-sys 0.9.2",
+ "secp256k1-sys 0.10.1",
  "serde",
 ]
 
@@ -5030,6 +5104,7 @@ dependencies = [
  "bitcoin_hashes 0.14.1",
  "rand 0.8.5",
  "secp256k1-sys 0.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -5037,15 +5112,6 @@ name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -5228,6 +5294,16 @@ name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct",
  "serde",
@@ -5682,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -5703,9 +5779,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6447,14 +6523,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.5",
+ "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6928,18 +7004,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#7478148736b73e4ef89548fa720f101a6e41fec2"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#399b059b0f1c7b5252e74addaafe066072e4ba5c"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.7.0-rc1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#7478148736b73e4ef89548fa720f101a6e41fec2"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#399b059b0f1c7b5252e74addaafe066072e4ba5c"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#dbd71d1488bf53315d9e9a081bb409b1094b3957"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#7478148736b73e4ef89548fa720f101a6e41fec2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.7.0-rc1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#dbd71d1488bf53315d9e9a081bb409b1094b3957"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#7478148736b73e4ef89548fa720f101a6e41fec2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#1124c92f8e3d4c3a9d4e7d3ed4521fddb005d86d"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#1318597f168574c4ed5d68dd1c830c026e392b29"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#399b059b0f1c7b5252e74addaafe066072e4ba5c"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#433de2da8bada5be84d4cd5785e693fe8326df68"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.6.1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#1124c92f8e3d4c3a9d4e7d3ed4521fddb005d86d"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#1318597f168574c4ed5d68dd1c830c026e392b29"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.7.0-rc1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#399b059b0f1c7b5252e74addaafe066072e4ba5c"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#433de2da8bada5be84d4cd5785e693fe8326df68"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -203,11 +203,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
-version = "0.24.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "http 0.2.12",
+ "base64 0.22.1",
+ "http 1.4.0",
  "log",
  "url",
 ]
@@ -964,7 +965,7 @@ dependencies = [
  "ckb-fixed-hash 0.202.0",
  "ckb-hash 0.202.0",
  "ckb-occupied-capacity 0.202.0",
- "molecule",
+ "molecule 0.8.0",
  "numext-fixed-uint",
 ]
 
@@ -979,7 +980,7 @@ dependencies = [
  "ckb-fixed-hash 1.0.2",
  "ckb-hash 1.0.1",
  "ckb-occupied-capacity 1.0.2",
- "molecule",
+ "molecule 0.8.0",
  "numext-fixed-uint",
  "seq-macro",
  "strum 0.27.2",
@@ -1303,7 +1304,7 @@ dependencies = [
  "derive_more 1.0.0",
  "golomb-coded-set",
  "merkle-cbt",
- "molecule",
+ "molecule 0.8.0",
  "numext-fixed-uint",
  "paste",
 ]
@@ -1327,7 +1328,7 @@ dependencies = [
  "derive_more 1.0.0",
  "golomb-coded-set",
  "merkle-cbt",
- "molecule",
+ "molecule 0.8.0",
  "numext-fixed-uint",
  "paste",
 ]
@@ -2091,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#3affbe09936059f0c5ca7744a9eef828bf25f2ce"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#1cce085111eaa28f8062d5ea394c316bb67de7e6"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2102,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#38ff6ee85bf1df8287ac08be826641688928527e"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#1124c92f8e3d4c3a9d4e7d3ed4521fddb005d86d"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2113,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#1d754470664dde502bf6484dbdd5a0f32b7791d2"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#dbd71d1488bf53315d9e9a081bb409b1094b3957"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2146,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.6.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#3affbe09936059f0c5ca7744a9eef828bf25f2ce"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#1cce085111eaa28f8062d5ea394c316bb67de7e6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2183,7 +2184,7 @@ dependencies = [
  "jsonrpsee",
  "lightning-invoice 0.29.0",
  "lnd-grpc-tonic-client",
- "molecule",
+ "molecule 0.8.0",
  "musig2",
  "nom",
  "num_enum",
@@ -2215,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.6.1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#38ff6ee85bf1df8287ac08be826641688928527e"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.1#1124c92f8e3d4c3a9d4e7d3ed4521fddb005d86d"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2252,7 +2253,7 @@ dependencies = [
  "jsonrpsee",
  "lightning-invoice 0.29.0",
  "lnd-grpc-tonic-client",
- "molecule",
+ "molecule 0.8.0",
  "musig2",
  "nom",
  "num_enum",
@@ -2284,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.7.0-rc1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#1d754470664dde502bf6484dbdd5a0f32b7791d2"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#dbd71d1488bf53315d9e9a081bb409b1094b3957"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2321,7 +2322,7 @@ dependencies = [
  "jsonrpsee",
  "lightning-invoice 0.33.2",
  "lnd-grpc-tonic-client",
- "molecule",
+ "molecule 0.8.0",
  "musig2",
  "nom",
  "num_enum",
@@ -3145,13 +3146,13 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
 dependencies = [
  "attohttpc",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "url",
  "xmltree",
 ]
@@ -3764,6 +3765,17 @@ name = "molecule"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6efe1c7efcd0bdf4ca590e104bcb13087d9968956ae4ae98e92fb8c1da0f3730"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "faster-hex",
+]
+
+[[package]]
+name = "molecule"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "314eebe1fb025f681c1d6a62fdacbe831027177c1046503a8d73d8027fe19e16"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -4949,9 +4961,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -5632,9 +5644,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc03a774edf73d8b3480383d694a5a0c86b3fe22dddd75e9119a8e41dd11677"
+checksum = "400b2285e0add6c24ed2b3fdba72464176e420aa957cb5d347809d5db419c505"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5646,7 +5658,7 @@ dependencies = [
  "js-sys",
  "libc",
  "log",
- "molecule",
+ "molecule 0.9.2",
  "nohash-hasher",
  "parking_lot",
  "rand 0.8.5",
@@ -5682,9 +5694,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle-secio"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60516aaca2ce3d00ef741d1bb01216921a062371bb63dd2ef53775b42afb9865"
+checksum = "0c0bfdc28264bd49c81ea0d027a9fa3f39b50960cd2b9c7e1748cfdb72d2265e"
 dependencies = [
  "bs58",
  "bytes",
@@ -5693,7 +5705,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hmac",
  "log",
- "molecule",
+ "molecule 0.9.2",
  "openssl",
  "openssl-sys",
  "rand 0.8.5",
@@ -5904,9 +5916,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -6258,9 +6270,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -6281,9 +6293,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-width"
@@ -7098,6 +7110,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -2113,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=quake%2Foneway-channel#1d754470664dde502bf6484dbdd5a0f32b7791d2"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#1d754470664dde502bf6484dbdd5a0f32b7791d2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2284,7 +2284,7 @@ dependencies = [
 [[package]]
 name = "fnn"
 version = "0.7.0-rc1"
-source = "git+https://github.com/nervosnetwork/fiber.git?branch=quake%2Foneway-channel#1d754470664dde502bf6484dbdd5a0f32b7791d2"
+source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0#1d754470664dde502bf6484dbdd5a0f32b7791d2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2309,7 +2309,7 @@ dependencies = [
  "console_error_panic_hook",
  "either",
  "fiber-sphinx",
- "fiber-wasm-db-common 0.1.0 (git+https://github.com/nervosnetwork/fiber.git?branch=quake%2Foneway-channel)",
+ "fiber-wasm-db-common 0.1.0 (git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.7.0)",
  "futures",
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/migrate/Cargo.toml
+++ b/migrate/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.0", features = ["derive"] }
 ckb-types = "1"
 fiber_v060 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.6.0" }
 fiber_v061 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.6.1" }
-fiber_v070 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "quake/oneway-channel"}
+fiber_v070 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.7.0"}
 serde_json = "1.0.135"
 ouroboros = "0.18.5"
 

--- a/migrate/Cargo.toml
+++ b/migrate/Cargo.toml
@@ -17,8 +17,8 @@ hex = "0.4.3"
 clap = { version = "4.0", features = ["derive"] }
 ckb-types = "1"
 fiber_v060 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.6.0" }
-fiber_v061 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.6.1" }
-fiber_v070 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.7.0"}
+fiber_v061 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.6.1", features = ["sample"] }
+fiber_v070 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.7.0", features = ["sample"]}
 serde_json = "1.0.135"
 ouroboros = "0.18.5"
 

--- a/migrate/src/lib.rs
+++ b/migrate/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod migrations;
 pub mod util;
+
+#[cfg(test)]
+mod tests;

--- a/migrate/src/migrations/mig_20260203_trampoline.rs
+++ b/migrate/src/migrations/mig_20260203_trampoline.rs
@@ -102,8 +102,7 @@ impl Migration for MigrationObj {
                 continue;
             }
 
-            let old: OldAttempt =
-                bincode::deserialize(&v).expect("deserialize to old attempt");
+            let old: OldAttempt = bincode::deserialize(&v).expect("deserialize to old attempt");
             let new = migrate_attempt(old);
 
             let new_bytes = bincode::serialize(&new).expect("serialize to new attempt");
@@ -290,9 +289,7 @@ fn migrate_retryable_tlc_operations(
         .collect()
 }
 
-fn migrate_retryable_tlc_operation(
-    old: OldRetryableTlcOperation,
-) -> NewRetryableTlcOperation {
+fn migrate_retryable_tlc_operation(old: OldRetryableTlcOperation) -> NewRetryableTlcOperation {
     match old {
         OldRetryableTlcOperation::RemoveTlc(tlc_id, reason) => {
             NewRetryableTlcOperation::RemoveTlc(convert(tlc_id), convert(reason))
@@ -323,8 +320,6 @@ fn migrate_attempt(old: OldAttempt) -> NewAttempt {
                 funding_tx_hash: convert(hop.funding_tx_hash),
                 next_hop: convert(hop.next_hop),
                 custom_records: convert(hop.custom_records),
-                // New field: default to None for existing attempts
-                trampoline_onion: None,
             })
             .collect(),
         session_key: old.session_key,

--- a/migrate/src/migrations/mig_20260203_trampoline.rs
+++ b/migrate/src/migrations/mig_20260203_trampoline.rs
@@ -90,11 +90,32 @@ impl Migration for MigrationObj {
 }
 
 fn migrate_channel_state(old: OldChannelActorState) -> NewChannelActorState {
+    let state = convert(old.state);
+    let local_pubkey = convert(old.local_pubkey);
+    let remote_pubkey = convert(old.remote_pubkey);
+    let id = convert(old.id);
+    let signer = convert(old.signer);
+    let local_channel_public_keys = convert(old.local_channel_public_keys);
+    let commitment_numbers = convert(old.commitment_numbers);
+    let local_constraints = convert(old.local_constraints);
+    let remote_constraints = convert(old.remote_constraints);
+    let tlc_state = migrate_tlc_state(old.tlc_state);
+    let retryable_tlc_operations = convert(old.retryable_tlc_operations);
+    let shutdown_transaction_hash = convert(old.shutdown_transaction_hash);
+    let waiting_forward_tlc_tasks = convert(old.waiting_forward_tlc_tasks);
+    let remote_commitment_points = convert(old.remote_commitment_points);
+    let remote_channel_public_keys = convert(old.remote_channel_public_keys);
+    let local_shutdown_info = convert(old.local_shutdown_info);
+    let remote_shutdown_info = convert(old.remote_shutdown_info);
+    let last_revoke_ack_msg = convert(old.last_revoke_ack_msg);
+    let public_channel_info = convert(old.public_channel_info);
+    let local_tlc_info = convert(old.local_tlc_info);
+    let remote_tlc_info = convert(old.remote_tlc_info);
     NewChannelActorState {
-        state: convert(old.state),
-        local_pubkey: convert(old.local_pubkey),
-        remote_pubkey: convert(old.remote_pubkey),
-        id: convert(old.id),
+        state,
+        local_pubkey,
+        remote_pubkey,
+        id,
         funding_tx: old.funding_tx,
         funding_tx_confirmed_at: old.funding_tx_confirmed_at,
         funding_udt_type_script: old.funding_udt_type_script,
@@ -108,32 +129,32 @@ fn migrate_channel_state(old: OldChannelActorState) -> NewChannelActorState {
         commitment_fee_rate: old.commitment_fee_rate,
         commitment_delay_epoch: old.commitment_delay_epoch,
         funding_fee_rate: old.funding_fee_rate,
-        signer: convert(old.signer),
-        local_channel_public_keys: convert(old.local_channel_public_keys),
-        commitment_numbers: convert(old.commitment_numbers),
-        local_constraints: convert(old.local_constraints),
-        remote_constraints: convert(old.remote_constraints),
-        tlc_state: migrate_tlc_state(old.tlc_state),
+        signer,
+        local_channel_public_keys,
+        commitment_numbers,
+        local_constraints,
+        remote_constraints,
+        tlc_state,
         remote_shutdown_script: old.remote_shutdown_script,
         local_shutdown_script: old.local_shutdown_script,
         last_committed_remote_nonce: old.last_committed_remote_nonce,
         remote_revocation_nonce_for_next: old.remote_revocation_nonce_for_next,
         remote_revocation_nonce_for_send: old.remote_revocation_nonce_for_send,
         remote_revocation_nonce_for_verify: old.remote_revocation_nonce_for_verify,
-        retryable_tlc_operations: convert(old.retryable_tlc_operations),
-        shutdown_transaction_hash: convert(old.shutdown_transaction_hash),
-        waiting_forward_tlc_tasks: convert(old.waiting_forward_tlc_tasks),
+        retryable_tlc_operations,
+        shutdown_transaction_hash,
+        waiting_forward_tlc_tasks,
         latest_commitment_transaction: old.latest_commitment_transaction,
-        remote_commitment_points: convert(old.remote_commitment_points),
-        remote_channel_public_keys: convert(old.remote_channel_public_keys),
-        local_shutdown_info: convert(old.local_shutdown_info),
-        remote_shutdown_info: convert(old.remote_shutdown_info),
+        remote_commitment_points,
+        remote_channel_public_keys,
+        local_shutdown_info,
+        remote_shutdown_info,
         reestablishing: old.reestablishing,
-        last_revoke_ack_msg: convert(old.last_revoke_ack_msg),
+        last_revoke_ack_msg,
         created_at: old.created_at,
-        public_channel_info: convert(old.public_channel_info),
-        local_tlc_info: convert(old.local_tlc_info),
-        remote_tlc_info: convert(old.remote_tlc_info),
+        public_channel_info,
+        local_tlc_info,
+        remote_tlc_info,
         waiting_peer_response: None,
         network: None,
         scheduled_channel_update_handle: None,

--- a/migrate/src/migrations/mig_20260203_trampoline.rs
+++ b/migrate/src/migrations/mig_20260203_trampoline.rs
@@ -117,7 +117,7 @@ impl Migration for MigrationObj {
     }
 }
 
-fn migrate_channel_state(old: OldChannelActorState) -> NewChannelActorState {
+pub(crate) fn migrate_channel_state(old: OldChannelActorState) -> NewChannelActorState {
     let state = convert(old.state);
     let local_pubkey = convert(old.local_pubkey);
     let remote_pubkey = convert(old.remote_pubkey);
@@ -241,7 +241,7 @@ fn migrate_tlc_info(old: OldTlcInfo) -> NewTlcInfo {
     }
 }
 
-fn migrate_payment_session(old: OldPaymentSession) -> NewPaymentSession {
+pub(crate) fn migrate_payment_session(old: OldPaymentSession) -> NewPaymentSession {
     NewPaymentSession {
         request: migrate_send_payment_data(old.request),
         last_error: old.last_error,
@@ -300,7 +300,7 @@ fn migrate_retryable_tlc_operation(old: OldRetryableTlcOperation) -> NewRetryabl
     }
 }
 
-fn migrate_attempt(old: OldAttempt) -> NewAttempt {
+pub(crate) fn migrate_attempt(old: OldAttempt) -> NewAttempt {
     NewAttempt {
         id: old.id,
         try_limit: old.try_limit,

--- a/migrate/src/tests/migration_tests.rs
+++ b/migrate/src/tests/migration_tests.rs
@@ -1,0 +1,308 @@
+/// Migration tests: generate v0.6.1 sample data, run migration functions,
+/// and verify the output deserializes correctly as v0.7.0 types.
+use crate::migrations::mig_20260203_trampoline::{
+    migrate_attempt, migrate_channel_state, migrate_payment_session,
+};
+use fiber_v061::fiber::channel::ChannelActorState as OldChannelActorState;
+use fiber_v061::fiber::payment::{Attempt as OldAttempt, PaymentSession as OldPaymentSession};
+use fiber_v061::store::sample::StoreSample;
+use fiber_v070::fiber::channel::ChannelActorState as NewChannelActorState;
+use fiber_v070::fiber::payment::{Attempt as NewAttempt, PaymentSession as NewPaymentSession};
+
+// ─── ChannelActorState migration tests ──────────────────────────────
+
+#[test]
+fn test_migrate_channel_state_from_v061_samples() {
+    let old_samples = OldChannelActorState::samples(42);
+    for (i, old) in old_samples.into_iter().enumerate() {
+        let new = migrate_channel_state(old);
+
+        // The migrated state should roundtrip through bincode
+        let bytes = bincode::serialize(&new).unwrap_or_else(|e| {
+            panic!("ChannelActorState sample {i}: serialize after migration failed: {e}")
+        });
+        let deserialized: NewChannelActorState = bincode::deserialize(&bytes).unwrap_or_else(|e| {
+            panic!("ChannelActorState sample {i}: deserialize after migration failed: {e}")
+        });
+
+        // Verify new fields have correct default values
+        assert!(
+            !deserialized.is_one_way,
+            "ChannelActorState sample {i}: is_one_way should default to false"
+        );
+    }
+}
+
+#[test]
+fn test_migrate_channel_state_bytes_roundtrip() {
+    // Simulate what the real migration does: serialize v0.6.1 data,
+    // then deserialize as v0.6.1, migrate, serialize as v0.7.0
+    let old_bytes_list = OldChannelActorState::sample_bytes(42);
+    for (i, old_bytes) in old_bytes_list.iter().enumerate() {
+        let old: OldChannelActorState = bincode::deserialize(old_bytes).unwrap_or_else(|e| {
+            panic!("ChannelActorState sample {i}: deserialize as v0.6.1 failed: {e}")
+        });
+
+        let new = migrate_channel_state(old);
+
+        let new_bytes = bincode::serialize(&new).unwrap_or_else(|e| {
+            panic!("ChannelActorState sample {i}: serialize as v0.7.0 failed: {e}")
+        });
+
+        let result: Result<NewChannelActorState, _> = bincode::deserialize(&new_bytes);
+        assert!(
+            result.is_ok(),
+            "ChannelActorState sample {i}: v0.7.0 deserialize failed: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_migrate_channel_state_preserves_fields() {
+    let old_samples = OldChannelActorState::samples(42);
+    for (i, old) in old_samples.into_iter().enumerate() {
+        let old_is_acceptor = old.is_acceptor;
+        let old_to_local_amount = old.to_local_amount;
+        let old_to_remote_amount = old.to_remote_amount;
+        let old_commitment_fee_rate = old.commitment_fee_rate;
+
+        let new = migrate_channel_state(old);
+
+        assert_eq!(
+            new.is_acceptor, old_is_acceptor,
+            "ChannelActorState sample {i}: is_acceptor should be preserved"
+        );
+        assert_eq!(
+            new.to_local_amount, old_to_local_amount,
+            "ChannelActorState sample {i}: to_local_amount should be preserved"
+        );
+        assert_eq!(
+            new.to_remote_amount, old_to_remote_amount,
+            "ChannelActorState sample {i}: to_remote_amount should be preserved"
+        );
+        assert_eq!(
+            new.commitment_fee_rate, old_commitment_fee_rate,
+            "ChannelActorState sample {i}: commitment_fee_rate should be preserved"
+        );
+    }
+}
+
+// ─── PaymentSession migration tests ─────────────────────────────────
+
+#[test]
+fn test_migrate_payment_session_from_v061_samples() {
+    let old_samples = OldPaymentSession::samples(42);
+    for (i, old) in old_samples.into_iter().enumerate() {
+        let new = migrate_payment_session(old);
+
+        let bytes = bincode::serialize(&new).unwrap_or_else(|e| {
+            panic!("PaymentSession sample {i}: serialize after migration failed: {e}")
+        });
+        let deserialized: NewPaymentSession = bincode::deserialize(&bytes).unwrap_or_else(|e| {
+            panic!("PaymentSession sample {i}: deserialize after migration failed: {e}")
+        });
+
+        // Verify new fields have correct default values
+        assert!(
+            deserialized.last_error_code.is_none(),
+            "PaymentSession sample {i}: last_error_code should default to None"
+        );
+        assert!(
+            deserialized.request.trampoline_hops.is_none(),
+            "PaymentSession sample {i}: trampoline_hops should default to None"
+        );
+        assert!(
+            deserialized.request.trampoline_context.is_none(),
+            "PaymentSession sample {i}: trampoline_context should default to None"
+        );
+    }
+}
+
+#[test]
+fn test_migrate_payment_session_bytes_roundtrip() {
+    let old_bytes_list = OldPaymentSession::sample_bytes(42);
+    for (i, old_bytes) in old_bytes_list.iter().enumerate() {
+        let old: OldPaymentSession = bincode::deserialize(old_bytes).unwrap_or_else(|e| {
+            panic!("PaymentSession sample {i}: deserialize as v0.6.1 failed: {e}")
+        });
+
+        let new = migrate_payment_session(old);
+
+        let new_bytes = bincode::serialize(&new).unwrap_or_else(|e| {
+            panic!("PaymentSession sample {i}: serialize as v0.7.0 failed: {e}")
+        });
+
+        let result: Result<NewPaymentSession, _> = bincode::deserialize(&new_bytes);
+        assert!(
+            result.is_ok(),
+            "PaymentSession sample {i}: v0.7.0 deserialize failed: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_migrate_payment_session_preserves_fields() {
+    let old_samples = OldPaymentSession::samples(42);
+    for (i, old) in old_samples.into_iter().enumerate() {
+        let old_try_limit = old.try_limit;
+        let old_created_at = old.created_at;
+        let old_amount = old.request.amount;
+        let old_keysend = old.request.keysend;
+
+        let new = migrate_payment_session(old);
+
+        assert_eq!(
+            new.try_limit, old_try_limit,
+            "PaymentSession sample {i}: try_limit should be preserved"
+        );
+        assert_eq!(
+            new.created_at, old_created_at,
+            "PaymentSession sample {i}: created_at should be preserved"
+        );
+        assert_eq!(
+            new.request.amount, old_amount,
+            "PaymentSession sample {i}: amount should be preserved"
+        );
+        assert_eq!(
+            new.request.keysend, old_keysend,
+            "PaymentSession sample {i}: keysend should be preserved"
+        );
+    }
+}
+
+// ─── Attempt migration tests ────────────────────────────────────────
+
+#[test]
+fn test_migrate_attempt_from_v061_samples() {
+    let old_samples = OldAttempt::samples(42);
+    for (i, old) in old_samples.into_iter().enumerate() {
+        let new = migrate_attempt(old);
+
+        let bytes = bincode::serialize(&new).unwrap_or_else(|e| {
+            panic!("Attempt sample {i}: serialize after migration failed: {e}")
+        });
+        let _deserialized: NewAttempt = bincode::deserialize(&bytes).unwrap_or_else(|e| {
+            panic!("Attempt sample {i}: deserialize after migration failed: {e}")
+        });
+    }
+}
+
+#[test]
+fn test_migrate_attempt_bytes_roundtrip() {
+    let old_bytes_list = OldAttempt::sample_bytes(42);
+    for (i, old_bytes) in old_bytes_list.iter().enumerate() {
+        let old: OldAttempt = bincode::deserialize(old_bytes)
+            .unwrap_or_else(|e| panic!("Attempt sample {i}: deserialize as v0.6.1 failed: {e}"));
+
+        let new = migrate_attempt(old);
+
+        let new_bytes = bincode::serialize(&new)
+            .unwrap_or_else(|e| panic!("Attempt sample {i}: serialize as v0.7.0 failed: {e}"));
+
+        let result: Result<NewAttempt, _> = bincode::deserialize(&new_bytes);
+        assert!(
+            result.is_ok(),
+            "Attempt sample {i}: v0.7.0 deserialize failed: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_migrate_attempt_preserves_fields() {
+    let old_samples = OldAttempt::samples(42);
+    for (i, old) in old_samples.into_iter().enumerate() {
+        let old_id = old.id;
+        let old_try_limit = old.try_limit;
+        let old_tried_times = old.tried_times;
+        let old_created_at = old.created_at;
+        let old_route_hops_len = old.route_hops.len();
+
+        let new = migrate_attempt(old);
+
+        assert_eq!(new.id, old_id, "Attempt sample {i}: id should be preserved");
+        assert_eq!(
+            new.try_limit, old_try_limit,
+            "Attempt sample {i}: try_limit should be preserved"
+        );
+        assert_eq!(
+            new.tried_times, old_tried_times,
+            "Attempt sample {i}: tried_times should be preserved"
+        );
+        assert_eq!(
+            new.created_at, old_created_at,
+            "Attempt sample {i}: created_at should be preserved"
+        );
+        assert_eq!(
+            new.route_hops.len(),
+            old_route_hops_len,
+            "Attempt sample {i}: route_hops length should be preserved"
+        );
+    }
+}
+
+// ─── v0.6.1 bytes → cannot deserialize as v0.7.0 (validates migration need) ─
+
+#[test]
+fn test_v061_channel_state_bytes_cannot_deserialize_as_v070() {
+    // This confirms that v0.6.1 serialized data CANNOT be directly
+    // deserialized as v0.7.0, validating the need for migration.
+    let old_bytes_list = OldChannelActorState::sample_bytes(42);
+    for old_bytes in &old_bytes_list {
+        let result: Result<NewChannelActorState, _> = bincode::deserialize(old_bytes);
+        // At least one sample should fail to deserialize as v0.7.0
+        // (due to the is_one_way field difference)
+        assert!(
+            result.is_err(),
+            "ChannelActorState sample unexpectedly deserialized as v0.7.0"
+        );
+    }
+    // If all samples happen to deserialize (unlikely but possible for
+    // minimal samples), that's still acceptable - the migration code
+    // handles this case with the `is_ok()` skip check.
+}
+
+// ─── Determinism test for migration output ──────────────────────────
+
+#[test]
+fn test_migration_output_is_deterministic() {
+    // Running migration on the same v0.6.1 sample data twice
+    // should produce identical v0.7.0 bytes.
+    let old_channel_samples_1 = OldChannelActorState::samples(42);
+    let old_channel_samples_2 = OldChannelActorState::samples(42);
+    for (s1, s2) in old_channel_samples_1
+        .into_iter()
+        .zip(old_channel_samples_2.into_iter())
+    {
+        let new1 = bincode::serialize(&migrate_channel_state(s1)).unwrap();
+        let new2 = bincode::serialize(&migrate_channel_state(s2)).unwrap();
+        assert_eq!(
+            new1, new2,
+            "ChannelActorState migration is not deterministic"
+        );
+    }
+
+    let old_payment_samples_1 = OldPaymentSession::samples(42);
+    let old_payment_samples_2 = OldPaymentSession::samples(42);
+    for (s1, s2) in old_payment_samples_1
+        .into_iter()
+        .zip(old_payment_samples_2.into_iter())
+    {
+        let new1 = bincode::serialize(&migrate_payment_session(s1)).unwrap();
+        let new2 = bincode::serialize(&migrate_payment_session(s2)).unwrap();
+        assert_eq!(new1, new2, "PaymentSession migration is not deterministic");
+    }
+
+    let old_attempt_samples_1 = OldAttempt::samples(42);
+    let old_attempt_samples_2 = OldAttempt::samples(42);
+    for (s1, s2) in old_attempt_samples_1
+        .into_iter()
+        .zip(old_attempt_samples_2.into_iter())
+    {
+        let new1 = bincode::serialize(&migrate_attempt(s1)).unwrap();
+        let new2 = bincode::serialize(&migrate_attempt(s2)).unwrap();
+        assert_eq!(new1, new2, "Attempt migration is not deterministic");
+    }
+}

--- a/migrate/src/tests/mod.rs
+++ b/migrate/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod migration_tests;
+mod sample_tests;

--- a/migrate/src/tests/sample_tests.rs
+++ b/migrate/src/tests/sample_tests.rs
@@ -1,0 +1,161 @@
+/// Tests using `StoreSample` to verify that v0.7.0 types round-trip
+/// correctly through bincode serialization, and that migration functions
+/// produce valid v0.7.0 data.
+use fiber_v070::fiber::channel::ChannelActorState;
+use fiber_v070::fiber::network::PersistentNetworkActorState;
+use fiber_v070::fiber::payment::{Attempt, PaymentCustomRecords, PaymentSession};
+use fiber_v070::fiber::types::{BroadcastMessage, HoldTlc};
+use fiber_v070::invoice::{CkbInvoice, CkbInvoiceStatus};
+use fiber_v070::store::sample::StoreSample;
+
+// ─── Round-trip tests ───────────────────────────────────────────────
+// These verify that fiber_v070 sample data serializes and deserializes
+// correctly within the migrate crate's build environment.
+
+#[test]
+fn test_channel_actor_state_roundtrip_in_migrate() {
+    ChannelActorState::verify_samples_roundtrip(42);
+}
+
+#[test]
+fn test_persistent_network_actor_state_roundtrip_in_migrate() {
+    PersistentNetworkActorState::verify_samples_roundtrip(42);
+}
+
+#[test]
+fn test_ckb_invoice_roundtrip_in_migrate() {
+    CkbInvoice::verify_samples_roundtrip(42);
+}
+
+#[test]
+fn test_ckb_invoice_status_roundtrip_in_migrate() {
+    CkbInvoiceStatus::verify_samples_roundtrip(42);
+}
+
+#[test]
+fn test_payment_session_roundtrip_in_migrate() {
+    PaymentSession::verify_samples_roundtrip(42);
+}
+
+#[test]
+fn test_payment_custom_records_roundtrip_in_migrate() {
+    PaymentCustomRecords::verify_samples_roundtrip(42);
+}
+
+#[test]
+fn test_attempt_roundtrip_in_migrate() {
+    Attempt::verify_samples_roundtrip(42);
+}
+
+#[test]
+fn test_broadcast_message_roundtrip_in_migrate() {
+    BroadcastMessage::verify_samples_roundtrip(42);
+}
+
+#[test]
+fn test_hold_tlc_roundtrip_in_migrate() {
+    HoldTlc::verify_samples_roundtrip(42);
+}
+
+// ─── Cross-version deserialization tests ────────────────────────────
+// These verify that v0.7.0 sample bytes can be deserialized by the
+// migrate crate's fiber_v070 dependency. This catches schema drift
+// between the local crate and the git dependency.
+
+#[test]
+fn test_channel_actor_state_sample_bytes_deserialize() {
+    for (i, bytes) in ChannelActorState::sample_bytes(42).iter().enumerate() {
+        let result: Result<ChannelActorState, _> = bincode::deserialize(bytes);
+        assert!(
+            result.is_ok(),
+            "ChannelActorState sample {i} failed to deserialize: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_payment_session_sample_bytes_deserialize() {
+    for (i, bytes) in PaymentSession::sample_bytes(42).iter().enumerate() {
+        let result: Result<PaymentSession, _> = bincode::deserialize(bytes);
+        assert!(
+            result.is_ok(),
+            "PaymentSession sample {i} failed to deserialize: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_attempt_sample_bytes_deserialize() {
+    for (i, bytes) in Attempt::sample_bytes(42).iter().enumerate() {
+        let result: Result<Attempt, _> = bincode::deserialize(bytes);
+        assert!(
+            result.is_ok(),
+            "Attempt sample {i} failed to deserialize: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_broadcast_message_sample_bytes_deserialize() {
+    for (i, bytes) in BroadcastMessage::sample_bytes(42).iter().enumerate() {
+        let result: Result<BroadcastMessage, _> = bincode::deserialize(bytes);
+        assert!(
+            result.is_ok(),
+            "BroadcastMessage sample {i} failed to deserialize: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_ckb_invoice_sample_bytes_deserialize() {
+    for (i, bytes) in CkbInvoice::sample_bytes(42).iter().enumerate() {
+        let result: Result<CkbInvoice, _> = bincode::deserialize(bytes);
+        assert!(
+            result.is_ok(),
+            "CkbInvoice sample {i} failed to deserialize: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[test]
+fn test_hold_tlc_sample_bytes_deserialize() {
+    for (i, bytes) in HoldTlc::sample_bytes(42).iter().enumerate() {
+        let result: Result<HoldTlc, _> = bincode::deserialize(bytes);
+        assert!(
+            result.is_ok(),
+            "HoldTlc sample {i} failed to deserialize: {:?}",
+            result.err()
+        );
+    }
+}
+
+// ─── Determinism tests ─────────────────────────────────────────────
+// Verify that the same seed produces identical serialized bytes across
+// multiple calls, which is essential for fixture-based migration testing.
+
+#[test]
+fn test_all_samples_deterministic() {
+    // Call sample_bytes twice with the same seed and verify identical output
+    macro_rules! check_deterministic {
+        ($ty:ty, $name:expr) => {
+            let a = <$ty>::sample_bytes(42);
+            let b = <$ty>::sample_bytes(42);
+            assert_eq!(a, b, "{} samples are not deterministic", $name);
+        };
+    }
+
+    check_deterministic!(ChannelActorState, "ChannelActorState");
+    check_deterministic!(PersistentNetworkActorState, "PersistentNetworkActorState");
+    check_deterministic!(CkbInvoice, "CkbInvoice");
+    check_deterministic!(CkbInvoiceStatus, "CkbInvoiceStatus");
+    check_deterministic!(PaymentSession, "PaymentSession");
+    check_deterministic!(PaymentCustomRecords, "PaymentCustomRecords");
+    check_deterministic!(Attempt, "Attempt");
+    check_deterministic!(BroadcastMessage, "BroadcastMessage");
+    check_deterministic!(HoldTlc, "HoldTlc");
+}


### PR DESCRIPTION
1. I have ported the patch to `migrate/v0.6.0` and `migrate/v0.6.1`, now we can should use latest crates.
2. Fix issues in trampoline routing related migrations
3. Add `sample` trait for types which involved storage, we may write more robust unit testing for migration in future versions.