### PR TITLE
fix: fail pending TLCs when a hold invoice is cancelled (#1135)

### DIFF
--- a/crates/fiber-lib/src/rpc/invoice.rs
+++ b/crates/fiber-lib/src/rpc/invoice.rs
@@ -558,6 +558,11 @@ where
                             Some(payment_hash),
                         )
                     })?;
+                if let Some(network_actor) = &self.network_actor {
+                    let _ = network_actor.send_message(NetworkActorMessage::new_command(
+                        NetworkActorCommand::SettleHoldTlcSet(payment_hash),
+                    ));
+                }
                 Ok(GetInvoiceResult {
                     invoice_address: invoice.to_string(),
                     invoice: invoice.into(),

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -764,6 +764,11 @@ impl NetworkNode {
         self.store
             .update_invoice_status(payment_hash, CkbInvoiceStatus::Cancelled)
             .expect("cancel success");
+        self.network_actor
+            .send_message(NetworkActorMessage::new_command(
+                NetworkActorCommand::SettleHoldTlcSet(*payment_hash),
+            ))
+            .expect("network actor alive");
     }
 
     pub fn get_payment_preimage(&self, payment_hash: &Hash256) -> Option<Hash256> {


### PR DESCRIPTION
Fixes #1135

`cancel_invoice` only updated the invoice status in the store without notifying the network actor, leaving received TLCs unresolved and blocking cooperative channel shutdown. This change sends `SettleHoldTlcSet` to the network actor on cancellation so that pending TLCs are failed with `InvoiceCancelled`.

- **rpc/invoice.rs**: After cancelling an invoice, send `SettleHoldTlcSet(payment_hash)` to the network actor.
- **tests/test_utils.rs**: Test helper `cancel_invoice` also sends the command so integration tests behave like production.
- **invoice_settlement.rs**: New test `test_cancel_hold_invoice_fails_pending_tlcs` verifies that cancelling a hold invoice causes the sender's payment to fail.

Made with [Cursor](https://cursor.com)