### PR TITLE
fix: include fee in BTC receive invoice

### DIFF
--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -602,9 +602,11 @@ impl<S: CchOrderStore> CchState<S> {
             return Err(CchError::OutgoingInvoiceExpiryTooShort);
         }
 
-        let fee_sats = amount_sats * (self.config.fee_rate_per_million_sats as u128)
-            / 1_000_000u128
-            + (self.config.base_fee_sats as u128);
+        let fee_sats = amount_sats
+            .checked_mul(self.config.fee_rate_per_million_sats as u128)
+            .and_then(|v| v.checked_div(1_000_000u128))
+            .and_then(|v| v.checked_add(self.config.base_fee_sats as u128))
+            .ok_or(CchError::ReceiveBTCOrderAmountTooLarge)?;
         let total_msat = i64::try_from(
             amount_sats
                 .checked_add(fee_sats)

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -500,7 +500,10 @@ impl<S: CchOrderStore> CchState<S> {
             .as_ref(),
         )
         .into();
-        let invoice_amount_sats = amount_msat.div_ceil(1_000u128) + fee_sats;
+        let invoice_amount_sats = amount_msat
+            .div_ceil(1_000u128)
+            .checked_add(fee_sats)
+            .ok_or(CchError::SendBTCOrderAmountTooLarge)?;
 
         let invoice = InvoiceBuilder::new(send_btc.currency)
             .amount(Some(invoice_amount_sats))
@@ -602,12 +605,13 @@ impl<S: CchOrderStore> CchState<S> {
         let fee_sats = amount_sats * (self.config.fee_rate_per_million_sats as u128)
             / 1_000_000u128
             + (self.config.base_fee_sats as u128);
-        if amount_sats <= fee_sats {
-            return Err(CchError::ReceiveBTCOrderAmountTooSmall);
-        }
-        if amount_sats > (i64::MAX / 1_000i64) as u128 {
-            return Err(CchError::ReceiveBTCOrderAmountTooLarge);
-        }
+        let total_msat = i64::try_from(
+            amount_sats
+                .checked_add(fee_sats)
+                .and_then(|s| s.checked_mul(1_000u128))
+                .unwrap_or(u128::MAX),
+        )
+        .map_err(|_| CchError::ReceiveBTCOrderAmountTooLarge)?;
 
         // Verify wrapped_btc_type_script matches invoice UDT type script
         let wrapped_btc_type_script: ckb_jsonrpc_types::Script = get_script_by_contract(
@@ -646,7 +650,7 @@ impl<S: CchOrderStore> CchState<S> {
         let mut client = self.lnd_connection.create_invoices_client().await?;
         let req = invoicesrpc::AddHoldInvoiceRequest {
             hash: payment_hash.as_ref().to_vec(),
-            value_msat: ((amount_sats + fee_sats) * 1_000u128) as i64,
+            value_msat: total_msat,
             expiry: outgoing_invoice_expiry_delta_seconds as i64,
             cltv_expiry: self.config.btc_final_tlc_expiry_delta_blocks,
             ..Default::default()

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -656,9 +656,9 @@ impl<S: CchOrderStore> CchState<S> {
             ..Default::default()
         };
         let add_invoice_resp = client
-            .add_hold_invoice(req)
+            .add_hold_invoice(req.clone())
             .await
-            .map_err(|err| CchError::LndRpcError(err.to_string()))?
+            .map_err(|err| CchError::LndRpcError(format!("{}, request: {:?}", err, req)))?
             .into_inner();
         let incoming_invoice = Bolt11Invoice::from_str(&add_invoice_resp.payment_request)?;
 

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -646,7 +646,7 @@ impl<S: CchOrderStore> CchState<S> {
         let mut client = self.lnd_connection.create_invoices_client().await?;
         let req = invoicesrpc::AddHoldInvoiceRequest {
             hash: payment_hash.as_ref().to_vec(),
-            value_msat: (amount_sats * 1_000u128) as i64,
+            value_msat: ((amount_sats + fee_sats) * 1_000u128) as i64,
             expiry: outgoing_invoice_expiry_delta_seconds as i64,
             cltv_expiry: self.config.btc_final_tlc_expiry_delta_blocks,
             ..Default::default()

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -45,8 +45,8 @@ pub enum CchError {
         expected: Currency,
         actual: Currency,
     },
-    #[error("ReceiveBTC order payment amount is too small")]
-    ReceiveBTCOrderAmountTooSmall,
+    #[error("SendBTC order payment amount is too large")]
+    SendBTCOrderAmountTooLarge,
     #[error("ReceiveBTC order payment amount is too large")]
     ReceiveBTCOrderAmountTooLarge,
     #[error("Wrapped BTC type script mismatch")]

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -358,7 +358,24 @@ async fn setup_test_harness() -> TestHarness {
     setup_test_harness_with_store(MockCchOrderStore::new()).await
 }
 
+async fn setup_test_harness_with_config(config: CchConfig) -> TestHarness {
+    setup_test_harness_with_config_and_store(config, MockCchOrderStore::new()).await
+}
+
 async fn setup_test_harness_with_store(store: MockCchOrderStore) -> TestHarness {
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ..Default::default()
+    };
+    setup_test_harness_with_config_and_store(config, store).await
+}
+
+async fn setup_test_harness_with_config_and_store(
+    config: CchConfig,
+    store: MockCchOrderStore,
+) -> TestHarness {
     let event_port = Arc::new(OutputPort::<CchTrackingEvent>::default());
 
     let mock_state = MockNetworkState {
@@ -370,13 +387,6 @@ async fn setup_test_harness_with_store(store: MockCchOrderStore) -> TestHarness 
     let (network_actor, _) = Actor::spawn(None, MockNetworkActor, mock_state.clone())
         .await
         .expect("spawn mock network actor");
-
-    let config = CchConfig {
-        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
-        wrapped_btc_type_script_args: "0x".to_string(),
-        min_outgoing_invoice_expiry_delta_seconds: 60,
-        ..Default::default()
-    };
 
     let args = CchArgs {
         config,
@@ -439,13 +449,18 @@ fn create_test_lightning_invoice_with_payment_hash(
 
 /// Create a test Fiber invoice for testing
 fn create_test_fiber_invoice(payment_hash: Hash256) -> CkbInvoice {
+    create_test_fiber_invoice_with_amount(payment_hash, 100000)
+}
+
+/// Create a test Fiber invoice with a specific amount
+fn create_test_fiber_invoice_with_amount(payment_hash: Hash256, amount: u128) -> CkbInvoice {
     // Create a deterministic keypair for tests
     let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
     let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
 
     let mut invoice = CkbInvoice {
         currency: Currency::Fibb,
-        amount: Some(100000),
+        amount: Some(amount),
         signature: None,
         data: InvoiceData {
             payment_hash,
@@ -920,5 +935,205 @@ async fn test_receive_btc_rejects_ckb_invoice_without_udt() {
     match result {
         Err(CchError::WrappedBTCTypescriptMismatch) => {} // Expected
         other => panic!("Expected WrappedBTCTypescriptMismatch, got {:?}", other),
+    }
+}
+
+/// Tests that receive_btc rejects an invoice where amount + fee overflows i64 in msat.
+/// The total_msat = (amount_sats + fee_sats) * 1000 must fit in i64.
+#[tokio::test]
+async fn test_receive_btc_amount_too_large() {
+    let harness = setup_test_harness().await;
+
+    let (_preimage, payment_hash) = create_valid_preimage_pair(170);
+    // i64::MAX / 1000 + 1 = 9_223_372_036_854_776 sats, which makes total_msat overflow i64
+    let large_amount: u128 = (i64::MAX / 1_000) as u128 + 1;
+    let invoice = create_test_fiber_invoice_with_amount(payment_hash, large_amount);
+
+    let result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: invoice.to_string(),
+        }
+    )
+    .expect("actor call failed");
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, CchError::ReceiveBTCOrderAmountTooLarge),
+        "expected ReceiveBTCOrderAmountTooLarge, got: {:?}",
+        err
+    );
+}
+
+/// Tests that receive_btc rejects an invoice where amount_sats + fee_sats overflows u128.
+#[tokio::test]
+async fn test_receive_btc_amount_overflow_u128() {
+    let harness = setup_test_harness().await;
+
+    let (_preimage, payment_hash) = create_valid_preimage_pair(171);
+    // u128::MAX will cause amount_sats * fee_rate to wrap and checked_add/checked_mul to fail
+    let invoice = create_test_fiber_invoice_with_amount(payment_hash, u128::MAX);
+
+    let result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: invoice.to_string(),
+        }
+    )
+    .expect("actor call failed");
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, CchError::ReceiveBTCOrderAmountTooLarge),
+        "expected ReceiveBTCOrderAmountTooLarge, got: {:?}",
+        err
+    );
+}
+
+/// Tests that the send_btc proxy Fiber invoice includes the fee in its amount.
+///
+/// In the SendBTC flow, the hub creates a Fiber invoice (the proxy invoice) for the
+/// user to pay. Its amount must be `ceil(btc_amount_msat / 1000) + fee_sats` so
+/// the hub collects enough to cover the outgoing Lightning payment plus its fee.
+#[tokio::test]
+async fn test_send_btc_proxy_invoice_includes_fee() {
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        base_fee_sats: 1_000, // 1000 sat base fee to make the fee clearly visible
+        fee_rate_per_million_sats: 10_000, // 1% proportional fee
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config(config).await;
+
+    // The lightning invoice has 100_000_000 msat = 100_000 sats
+    let (order, _preimage) = harness.create_send_btc_order_with_preimage().await.unwrap();
+    let btc_amount_sats: u128 = 100_000; // 100_000_000 msat / 1000
+
+    // fee_sats = amount_msat * fee_rate / 1_000_000_000 + base_fee
+    //          = 100_000_000 * 10_000 / 1_000_000_000 + 1_000
+    //          = 1_000 + 1_000
+    //          = 2_000
+    let expected_fee: u128 = 2_000;
+    assert_eq!(
+        order.fee_sats, expected_fee,
+        "fee_sats should be calculated from rate + base"
+    );
+
+    // The proxy invoice amount must include the fee
+    let expected_total = btc_amount_sats + expected_fee;
+    assert_eq!(
+        order.amount_sats, expected_total,
+        "proxy invoice amount should be btc_amount + fee"
+    );
+
+    // Verify the Fiber invoice stored in the order also has the correct amount
+    let fiber_invoice = match &order.incoming_invoice {
+        CchInvoice::Fiber(inv) => inv.clone(),
+        other => panic!("expected Fiber invoice, got: {:?}", other),
+    };
+    assert_eq!(
+        fiber_invoice.amount(),
+        Some(expected_total),
+        "Fiber proxy invoice amount should include the fee"
+    );
+}
+
+/// Tests that the receive_btc order correctly calculates fee_sats and total_msat
+/// that would be used for the LND hold invoice.
+///
+/// Note: We cannot directly test the LND hold invoice creation since it requires
+/// an LND server. Instead we verify that the fee calculation and amount validation
+/// pass correctly (the call fails only at LND), confirming the hold invoice would
+/// be created with `value_msat = (amount_sats + fee_sats) * 1000`.
+#[tokio::test]
+async fn test_receive_btc_fee_calculation() {
+    use crate::ckb::contracts::{get_script_by_contract, Contract};
+    use crate::fiber::hash_algorithm::HashAlgorithm;
+    use crate::invoice::CkbScript;
+
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        base_fee_sats: 500,
+        fee_rate_per_million_sats: 5_000, // 0.5% proportional fee
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config(config).await;
+
+    let (_preimage, payment_hash) = create_valid_preimage_pair(180);
+    let amount_sats: u128 = 200_000;
+
+    // Build a Fiber invoice with the correct UDT type script and SHA256 hash algorithm
+    // to pass all validations before the LND call.
+    let wrapped_btc_type_script = get_script_by_contract(Contract::SimpleUDT, &[]);
+    let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
+    let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
+    let mut invoice = CkbInvoice {
+        currency: Currency::Fibb,
+        amount: Some(amount_sats),
+        signature: None,
+        data: InvoiceData {
+            payment_hash,
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+            attrs: vec![
+                Attribute::FinalHtlcMinimumExpiryDelta(12),
+                Attribute::Description("test".to_string()),
+                Attribute::ExpiryTime(Duration::from_secs(3600)),
+                Attribute::PayeePublicKey(public_key),
+                Attribute::UdtScript(CkbScript(wrapped_btc_type_script)),
+                Attribute::HashAlgorithm(HashAlgorithm::Sha256),
+            ],
+        },
+    };
+    invoice
+        .update_signature(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
+        .unwrap();
+
+    // receive_btc will fail at the LND call, but all prior validations
+    // (amount, fee, UDT script, hash algorithm) should pass.
+    let result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: invoice.to_string(),
+        }
+    )
+    .expect("actor call failed");
+
+    // The call should fail due to LND being unavailable, not due to amount validation.
+    // This confirms the fee calculation and overflow checks passed successfully,
+    // meaning the hold invoice would have been created with the correct total_msat.
+    let err = result.unwrap_err();
+
+    // fee_sats = 200_000 * 5_000 / 1_000_000 + 500 = 1_000 + 500 = 1_500
+    // total_msat = (200_000 + 1_500) * 1_000 = 201_500_000
+    let expected_fee: u128 = 1_500;
+    let expected_total_msat: i64 = ((amount_sats + expected_fee) * 1_000) as i64;
+    assert_eq!(expected_total_msat, 201_500_000);
+
+    match err {
+        CchError::LndRpcError(msg) => {
+            assert!(
+                msg.contains(&format!("value_msat: {}", expected_total_msat)),
+                "hold invoice request should contain value_msat={}, got: {}",
+                expected_total_msat,
+                msg
+            );
+        }
+        other => panic!(
+            "expected LND connection error (no LND server), got: {:?}. \
+             If this is an amount error, the fee calculation may be wrong.",
+            other
+        ),
     }
 }


### PR DESCRIPTION
## Summary

When creating a hold invoice for receiving BTC via cross-chain (CCH), the invoice value was calculated using only the payment amount, excluding the fee. This caused the LND hold invoice to be created with an incorrect (lower) value, leading to payment failures.

**Fix**: Include `fee_sats` in the `value_msat` calculation when creating the hold invoice.