### PR TITLE
fix: handle overflow in BTC final TLC expiry delta calculation

### DIFF
--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -32,6 +32,9 @@ use crate::time::{Duration, SystemTime, UNIX_EPOCH};
 pub const ACTION_RETRY_BASE_MILLIS: u64 = 1000; // 1 second initial delay
 pub const ACTION_RETRY_MAX_MILLIS: u64 = 600_000; // 10 minute max delay
 
+/// Average time per Bitcoin block in milliseconds (10 minutes = 600 seconds = 600,000 ms).
+pub const BTC_BLOCK_TIME_MILLIS: u64 = 600_000;
+
 fn calculate_retry_delay(retry_count: u32) -> Duration {
     // Exponential backoff starting from ACTION_RETRY_BASE_MILLIS, capped at ACTION_RETRY_MAX_MILLIS
     let max_shift = (ACTION_RETRY_MAX_MILLIS / ACTION_RETRY_BASE_MILLIS).ilog2();
@@ -515,7 +518,7 @@ impl<S: CchOrderStore> CchState<S> {
         let btc_final_cltv_millis = self
             .config
             .btc_final_tlc_expiry_delta_blocks
-            .checked_mul(600 * 1000)
+            .checked_mul(BTC_BLOCK_TIME_MILLIS)
             .ok_or_else(|| {
                 CchError::ConfigError(format!(
                     "btc_final_tlc_expiry_delta_blocks ({}) is too large and causes overflow when converting to milliseconds",

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -14,6 +14,8 @@ pub enum CchStoreError {
 
 #[derive(Error, Debug)]
 pub enum CchError {
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
     #[error("Store error: {0}")]
     StoreError(#[from] CchStoreError),
     #[error("Outgoing invoice expiry time is too short")]


### PR DESCRIPTION
## Problem

When `btc_final_tlc_expiry_delta_blocks` is set to a very large value, multiplying it by `600 * 1000` to convert to milliseconds can overflow, causing unexpected behavior.

Related issue: #977

## Solution

- Use `checked_mul` instead of plain multiplication to detect overflow.
- Return a new `CchError::ConfigError` when overflow is detected, with a descriptive message indicating the problematic configuration value.
- Add the `ConfigError` variant to `CchError` enum.

## Changes

- **`crates/fiber-lib/src/cch/actor.rs`**: Replace `*` with `checked_mul` and propagate an error on overflow.
- **`crates/fiber-lib/src/cch/error.rs`**: Add `ConfigError(String)` variant to `CchError`.