### PR TITLE
fix(cch): validate invoice network/currency in send_btc and receive_btc

### DIFF
--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -1,4 +1,4 @@
-use crate::{cch::CchOrderStatus, fiber::types::Hash256, time::SystemTimeError};
+use crate::{cch::CchOrderStatus, fiber::types::Hash256, invoice::Currency, time::SystemTimeError};
 
 use jsonrpsee::types::{error::CALL_EXECUTION_FAILED_CODE, ErrorObjectOwned};
 use thiserror::Error;
@@ -36,6 +36,13 @@ pub enum CchError {
     CKBInvoiceFinalTlcExpiryDeltaTooLarge,
     #[error("CKB invoice hash algorithm is not SHA256, which is required for LND compatibility")]
     CKBInvoiceIncompatibleHashAlgorithm,
+    #[error("BTC invoice network mismatch: expected {expected}, got {actual}")]
+    BTCInvoiceNetworkMismatch { expected: String, actual: String },
+    #[error("CKB invoice network mismatch: expected {expected}, got {actual}")]
+    CKBInvoiceNetworkMismatch {
+        expected: Currency,
+        actual: Currency,
+    },
     #[error("ReceiveBTC order payment amount is too small")]
     ReceiveBTCOrderAmountTooSmall,
     #[error("ReceiveBTC order payment amount is too large")]

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -837,7 +837,7 @@ async fn test_send_btc_rejects_currency_mismatch() {
 }
 
 /// Tests that send_btc rejects when the BTC invoice network doesn't match the expected network.
-/// Issue #978: send_btc should fail when BTC invoice is for mainnet but node expects regtest
+/// Issue #978: send_btc should fail when BTC invoice is for regtest but node expects mainnet
 #[tokio::test]
 async fn test_send_btc_rejects_btc_invoice_network_mismatch() {
     let harness = setup_test_harness().await;

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -1,6 +1,6 @@
 #[cfg(target_arch = "wasm32")]
 use crate::fiber::KeyPair;
-use crate::{ckb::contracts::Contract, Result};
+use crate::{ckb::contracts::Contract, invoice::Currency, Result};
 use ckb_jsonrpc_types::{CellDep, Script};
 use clap_serde_derive::{
     clap::{self},
@@ -466,6 +466,15 @@ impl<'de> serde::Deserialize<'de> for AnnouncedNodeName {
 static FIBER_SECRET_KEY: OnceCell<super::KeyPair> = OnceCell::new();
 
 impl FiberConfig {
+    /// Returns the CKB invoice currency corresponding to the configured chain.
+    pub fn currency(&self) -> Currency {
+        match self.chain.as_str() {
+            "mainnet" => Currency::Fibb,
+            "testnet" => Currency::Fibt,
+            _ => Currency::Fibd,
+        }
+    }
+
     pub fn base_dir(&self) -> &PathBuf {
         self.base_dir.as_ref().expect("have set base dir")
     }

--- a/crates/fiber-lib/src/rpc/invoice.rs
+++ b/crates/fiber-lib/src/rpc/invoice.rs
@@ -282,11 +282,7 @@ impl<S> InvoiceRpcServerImpl<S> {
             );
 
             // restrict currency to be the same as network
-            let currency = match config.chain.as_str() {
-                "mainnet" => Currency::Fibb,
-                "testnet" => Currency::Fibt,
-                _ => Currency::Fibd,
-            };
+            let currency = config.currency();
 
             (
                 Some(keypair),

--- a/tests/bruno/e2e/cross-chain-hub/02-create-send-btc-order.bru
+++ b/tests/bruno/e2e/cross-chain-hub/02-create-send-btc-order.bru
@@ -23,7 +23,7 @@ body:json {
     "params": [
       {
         "btc_pay_req": "{{BTC_PAY_REQ}}",
-        "currency": "Fibt"
+        "currency": "Fibd"
       }
     ]
   }


### PR DESCRIPTION
## Summary

Add validation checks to ensure invoices match the node's configured network before processing cross-chain hub orders.

## Changes

- **send_btc**: Reject when the `currency` parameter doesn't match the node's configured network
- **send_btc**: Reject when the BTC invoice network doesn't match the expected Lightning network
- **receive_btc**: Reject when the CKB invoice currency doesn't match the node's configured network
- **receive_btc**: Confirm existing rejection of CKB invoices without wrapped BTC UDT type script (added test)
- Extract `FiberConfig::currency()` to deduplicate chain-to-currency mapping used in `rpc/invoice.rs` and `main.rs`

## New Error Variants

- `BTCInvoiceNetworkMismatch`: BTC invoice targets a different Bitcoin network than expected
- `CKBInvoiceNetworkMismatch`: CKB invoice currency doesn't match configured CKB network

## Tests

Added 4 new tests in `actor_tests.rs`:
- `test_send_btc_rejects_currency_mismatch` (#981)
- `test_send_btc_rejects_btc_invoice_network_mismatch` (#978)
- `test_receive_btc_rejects_currency_mismatch` (#982)
- `test_receive_btc_rejects_ckb_invoice_without_udt` (#983)

Fixes #978, #981, #982, #983