### PR TITLE
fix(cch): check HTLC expiry delta before sending outgoing payment

### DIFF
--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use futures::StreamExt as _;
+use lightning_invoice::Bolt11Invoice;
 use lnd_grpc_tonic_client::routerrpc;
 use ractor::{forward, ActorRef};
+use std::str::FromStr;
 
 use crate::{
     cch::{
@@ -10,10 +12,13 @@ use crate::{
             ActionExecutor, CchOrderAction,
         },
         actor::CchState,
+        order::CchInvoice,
         trackers::{map_lnd_payment_changed_event, CchTrackingEvent, LndConnectionInfo},
         CchMessage, CchOrderStore,
     },
     fiber::{payment::SendPaymentCommand, NetworkActorCommand, NetworkActorMessage},
+    invoice::CkbInvoice,
+    time::{SystemTime, UNIX_EPOCH},
 };
 use fiber_types::{payment::PaymentStatus, CchOrder};
 use fiber_types::{CchOrderStatus, Hash256};
@@ -28,6 +33,10 @@ pub struct SendFiberOutgoingPaymentExecutor {
     network_actor_ref: ActorRef<NetworkActorMessage>,
     outgoing_pay_req: String,
     retry_count: u32,
+    /// Maximum TLC expiry for the entire payment route (in milliseconds).
+    /// This caps the route to prevent the outgoing payment from exceeding
+    /// the incoming payment's remaining expiry time.
+    tlc_expiry_limit: u64,
 }
 
 #[async_trait::async_trait]
@@ -39,12 +48,14 @@ impl ActionExecutor for SendFiberOutgoingPaymentExecutor {
             network_actor_ref,
             outgoing_pay_req,
             retry_count,
+            tlc_expiry_limit,
         } = *self;
 
         let message = move |rpc_reply| -> NetworkActorMessage {
             NetworkActorMessage::Command(NetworkActorCommand::SendPayment(
                 SendPaymentCommand {
                     invoice: Some(outgoing_pay_req),
+                    tlc_expiry_limit: Some(tlc_expiry_limit),
                     ..Default::default()
                 },
                 rpc_reply,
@@ -116,6 +127,10 @@ pub struct SendLightningOutgoingPaymentExecutor {
     cch_actor_ref: ActorRef<CchMessage>,
     outgoing_pay_req: String,
     lnd_connection: LndConnectionInfo,
+    /// Maximum total CLTV delta for the payment route (in blocks).
+    /// This caps the route to prevent the outgoing payment from exceeding
+    /// the incoming payment's remaining expiry time.
+    cltv_limit: i32,
 }
 
 #[async_trait::async_trait]
@@ -124,6 +139,7 @@ impl ActionExecutor for SendLightningOutgoingPaymentExecutor {
         let req = routerrpc::SendPaymentRequest {
             payment_request: self.outgoing_pay_req,
             timeout_seconds: BTC_PAYMENT_TIMEOUT_SECONDS,
+            cltv_limit: self.cltv_limit,
             ..Default::default()
         };
         tracing::debug!("SendLightningOutgoingPaymentExecutor req: {:?}", req);
@@ -207,6 +223,107 @@ impl SendOutgoingPaymentDispatcher {
         order.status == CchOrderStatus::IncomingAccepted
     }
 
+    /// Compute the maximum allowed outgoing payment route expiry (in seconds).
+    ///
+    /// The incoming TLC/HTLC has a guaranteed minimum remaining time of:
+    ///   `incoming_final_expiry_delta - elapsed_since_order_creation`
+    ///
+    /// We allow at most half of this remaining time for the outgoing payment route.
+    /// The other half is reserved for the CCH to settle the incoming payment
+    /// after receiving the preimage.
+    ///
+    /// Returns `None` if there is insufficient time remaining.
+    fn compute_max_outgoing_expiry_seconds<S: CchOrderStore>(
+        state: &CchState<S>,
+        order: &CchOrder,
+    ) -> Option<u64> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System time should always be after UNIX_EPOCH")
+            .as_secs();
+        let elapsed = now.saturating_sub(order.created_at);
+
+        // The incoming TLC/HTLC was accepted with at least this many seconds of expiry.
+        // Using `created_at` is conservative (the TLC was accepted after order creation).
+        let incoming_expiry_seconds = match &order.incoming_invoice {
+            CchInvoice::Fiber(_) => state.config.ckb_final_tlc_expiry_delta_seconds,
+            CchInvoice::Lightning(_) => state.config.btc_final_tlc_expiry_delta_blocks * 600,
+        };
+        let remaining = incoming_expiry_seconds.checked_sub(elapsed)?;
+
+        // Use half the remaining time for outgoing, half reserved for settling incoming
+        Some(remaining / 2)
+    }
+
+    /// Check whether there is sufficient time remaining on the incoming payment
+    /// to safely send the outgoing payment. If not, fail the order.
+    ///
+    /// Returns `Some(max_outgoing_seconds)` if safe, `None` if the order was failed.
+    fn check_expiry_or_fail(
+        cch_actor_ref: &ActorRef<CchMessage>,
+        order: &CchOrder,
+        max_outgoing_seconds: Option<u64>,
+    ) -> Option<u64> {
+        let max_outgoing_seconds = match max_outgoing_seconds {
+            Some(s) if s > 0 => s,
+            _ => {
+                let _ = cch_actor_ref.send_message(CchMessage::TrackingEvent(
+                    CchTrackingEvent::PaymentChanged {
+                        payment_hash: order.payment_hash,
+                        payment_preimage: None,
+                        status: PaymentStatus::Failed,
+                        failure_reason: Some(
+                            "Insufficient HTLC expiry delta: incoming payment has expired or \
+                             has no remaining time for outgoing payment"
+                                .into(),
+                        ),
+                    },
+                ));
+                return None;
+            }
+        };
+
+        // Verify the max outgoing expiry can accommodate the outgoing invoice's
+        // minimum final expiry delta (otherwise routing is impossible).
+        let outgoing_min_seconds = match &order.incoming_invoice {
+            CchInvoice::Fiber(_) => {
+                // Outgoing is BTC Lightning: parse the BTC invoice's min_final_cltv_expiry_delta
+                Bolt11Invoice::from_str(&order.outgoing_pay_req)
+                    .ok()
+                    .map(|inv| inv.min_final_cltv_expiry_delta() * 600)
+                    .unwrap_or(0)
+            }
+            CchInvoice::Lightning(_) => {
+                // Outgoing is CKB Fiber: parse the CKB invoice's final_tlc_minimum_expiry_delta
+                CkbInvoice::from_str(&order.outgoing_pay_req)
+                    .ok()
+                    .and_then(|inv| inv.final_tlc_minimum_expiry_delta().copied())
+                    .map(|millis| millis / 1000)
+                    .unwrap_or(0)
+            }
+        };
+
+        if max_outgoing_seconds < outgoing_min_seconds {
+            let _ = cch_actor_ref.send_message(CchMessage::TrackingEvent(
+                CchTrackingEvent::PaymentChanged {
+                    payment_hash: order.payment_hash,
+                    payment_preimage: None,
+                    status: PaymentStatus::Failed,
+                    failure_reason: Some(format!(
+                        "Insufficient HTLC expiry delta: max outgoing route expiry ({} seconds) \
+                         is less than the outgoing invoice's minimum final expiry ({} seconds). \
+                         Not enough time remaining on the incoming payment to safely \
+                         handle outgoing payment settlement.",
+                        max_outgoing_seconds, outgoing_min_seconds
+                    )),
+                },
+            ));
+            return None;
+        }
+
+        Some(max_outgoing_seconds)
+    }
+
     pub fn dispatch<S: CchOrderStore>(
         state: &CchState<S>,
         cch_actor_ref: &ActorRef<CchMessage>,
@@ -217,20 +334,35 @@ impl SendOutgoingPaymentDispatcher {
             return None;
         }
 
+        // Check the remaining incoming time and compute the max outgoing route expiry.
+        // This ensures the CCH has enough time to settle the incoming payment
+        // even in the worst case where the outgoing payment settles at the last moment.
+        let max_outgoing_seconds = Self::compute_max_outgoing_expiry_seconds(state, order);
+        let max_outgoing_seconds =
+            Self::check_expiry_or_fail(cch_actor_ref, order, max_outgoing_seconds)?;
+
         match dispatch_payment_handler(order) {
-            PaymentHandlerType::Fiber => Some(Box::new(SendFiberOutgoingPaymentExecutor {
-                payment_hash: order.payment_hash,
-                cch_actor_ref: cch_actor_ref.clone(),
-                network_actor_ref: state.network_actor.clone(),
-                outgoing_pay_req: order.outgoing_pay_req.clone(),
-                retry_count,
-            })),
-            PaymentHandlerType::Lightning => Some(Box::new(SendLightningOutgoingPaymentExecutor {
-                payment_hash: order.payment_hash,
-                cch_actor_ref: cch_actor_ref.clone(),
-                outgoing_pay_req: order.outgoing_pay_req.clone(),
-                lnd_connection: state.lnd_connection.clone(),
-            })),
+            PaymentHandlerType::Fiber => {
+                let tlc_expiry_limit = max_outgoing_seconds * 1000; // convert to milliseconds
+                Some(Box::new(SendFiberOutgoingPaymentExecutor {
+                    payment_hash: order.payment_hash,
+                    cch_actor_ref: cch_actor_ref.clone(),
+                    network_actor_ref: state.network_actor.clone(),
+                    outgoing_pay_req: order.outgoing_pay_req.clone(),
+                    retry_count,
+                    tlc_expiry_limit,
+                }))
+            }
+            PaymentHandlerType::Lightning => {
+                let cltv_limit = (max_outgoing_seconds / 600) as i32;
+                Some(Box::new(SendLightningOutgoingPaymentExecutor {
+                    payment_hash: order.payment_hash,
+                    cch_actor_ref: cch_actor_ref.clone(),
+                    outgoing_pay_req: order.outgoing_pay_req.clone(),
+                    lnd_connection: state.lnd_connection.clone(),
+                    cltv_limit,
+                }))
+            }
         }
     }
 }

--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -12,16 +12,17 @@ use crate::{
             ActionExecutor, CchOrderAction,
         },
         actor::CchState,
-        order::CchInvoice,
         trackers::{map_lnd_payment_changed_event, CchTrackingEvent, LndConnectionInfo},
         CchMessage, CchOrderStore,
     },
-    fiber::{payment::SendPaymentCommand, NetworkActorCommand, NetworkActorMessage},
+    fiber::{
+        config::MAX_PAYMENT_TLC_EXPIRY_LIMIT, payment::SendPaymentCommand, NetworkActorCommand,
+        NetworkActorMessage,
+    },
     invoice::CkbInvoice,
     time::{SystemTime, UNIX_EPOCH},
 };
-use fiber_types::{payment::PaymentStatus, CchOrder};
-use fiber_types::{CchOrderStatus, Hash256};
+use fiber_types::{payment::PaymentStatus, CchInvoice, CchOrder, CchOrderStatus, Hash256};
 
 const BTC_PAYMENT_TIMEOUT_SECONDS: i32 = 60;
 
@@ -343,7 +344,9 @@ impl SendOutgoingPaymentDispatcher {
 
         match dispatch_payment_handler(order) {
             PaymentHandlerType::Fiber => {
-                let tlc_expiry_limit = max_outgoing_seconds * 1000; // convert to milliseconds
+                let tlc_expiry_limit = max_outgoing_seconds
+                    .saturating_mul(1000)
+                    .min(MAX_PAYMENT_TLC_EXPIRY_LIMIT);
                 Some(Box::new(SendFiberOutgoingPaymentExecutor {
                     payment_hash: order.payment_hash,
                     cch_actor_ref: cch_actor_ref.clone(),

--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -233,6 +233,11 @@ impl SendOutgoingPaymentDispatcher {
     /// The other half is reserved for the CCH to settle the incoming payment
     /// after receiving the preimage.
     ///
+    /// The final expiry delta is extracted from the stored incoming invoice when
+    /// available, so that persisted orders use the actual inbound HTLC/TLC terms
+    /// even if the config has changed since order creation. Falls back to the
+    /// current config values when the invoice does not carry the setting.
+    ///
     /// Returns `None` if there is insufficient time remaining.
     fn compute_max_outgoing_expiry_seconds<S: CchOrderStore>(
         state: &CchState<S>,
@@ -246,9 +251,21 @@ impl SendOutgoingPaymentDispatcher {
 
         // The incoming TLC/HTLC was accepted with at least this many seconds of expiry.
         // Using `created_at` is conservative (the TLC was accepted after order creation).
+        //
+        // Prefer the final expiry delta encoded in the stored incoming invoice so
+        // that persisted orders are checked against their actual terms, not values
+        // that may have drifted if the config was updated between restart.
         let incoming_expiry_seconds = match &order.incoming_invoice {
-            CchInvoice::Fiber(_) => state.config.ckb_final_tlc_expiry_delta_seconds,
-            CchInvoice::Lightning(_) => state.config.btc_final_tlc_expiry_delta_blocks * 600,
+            CchInvoice::Fiber(inv) => {
+                // CkbInvoice stores the delta in milliseconds; convert to seconds.
+                inv.final_tlc_minimum_expiry_delta()
+                    .map(|ms| ms / 1000)
+                    .unwrap_or(state.config.ckb_final_tlc_expiry_delta_seconds)
+            }
+            CchInvoice::Lightning(inv) => {
+                // Bolt11Invoice stores the delta in blocks; convert to seconds.
+                inv.min_final_cltv_expiry_delta().saturating_mul(600)
+            }
         };
         let remaining = incoming_expiry_seconds.checked_sub(elapsed)?;
 

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -557,6 +557,20 @@ impl<S: CchOrderStore> CchState<S> {
         let payment_hash = *invoice.payment_hash();
         let amount_sats = invoice.amount().ok_or(CchError::CKBInvoiceMissingAmount)?;
 
+        // Validate amount and fee early so we reject overflow/too-large before other checks.
+        let fee_sats = amount_sats
+            .checked_mul(self.config.fee_rate_per_million_sats as u128)
+            .and_then(|v| v.checked_div(1_000_000u128))
+            .and_then(|v| v.checked_add(self.config.base_fee_sats as u128))
+            .ok_or(CchError::ReceiveBTCOrderAmountTooLarge)?;
+        let total_msat = i64::try_from(
+            amount_sats
+                .checked_add(fee_sats)
+                .and_then(|s| s.checked_mul(1_000u128))
+                .unwrap_or(u128::MAX),
+        )
+        .map_err(|_| CchError::ReceiveBTCOrderAmountTooLarge)?;
+
         // Validate that outgoing CKB invoice's final TLC is less than half of incoming BTC invoice's final CLTV expiry.
         // This ensures the CCH operator has sufficient time to settle the incoming side before the outgoing side expires.
         // CKB uses milliseconds, BTC uses blocks (~10 min each).
@@ -599,19 +613,6 @@ impl<S: CchOrderStore> CchState<S> {
         {
             return Err(CchError::OutgoingInvoiceExpiryTooShort);
         }
-
-        let fee_sats = amount_sats
-            .checked_mul(self.config.fee_rate_per_million_sats as u128)
-            .and_then(|v| v.checked_div(1_000_000u128))
-            .and_then(|v| v.checked_add(self.config.base_fee_sats as u128))
-            .ok_or(CchError::ReceiveBTCOrderAmountTooLarge)?;
-        let total_msat = i64::try_from(
-            amount_sats
-                .checked_add(fee_sats)
-                .and_then(|s| s.checked_mul(1_000u128))
-                .unwrap_or(u128::MAX),
-        )
-        .map_err(|_| CchError::ReceiveBTCOrderAmountTooLarge)?;
 
         // Verify wrapped_btc_type_script matches invoice UDT type script
         let wrapped_btc_type_script: ckb_jsonrpc_types::Script = get_script_by_contract(

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -457,6 +457,9 @@ fn create_test_fiber_invoice_with_amount(payment_hash: Hash256, amount: u128) ->
     let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
     let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
 
+    // Use DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS (108,000 s) converted to
+    // milliseconds, matching production invoice construction in actor.rs.
+    let default_expiry_delta_ms = 108_000 * 1000;
     let mut invoice = CkbInvoice {
         currency: Currency::Fibb,
         amount: Some(amount),
@@ -468,7 +471,7 @@ fn create_test_fiber_invoice_with_amount(payment_hash: Hash256, amount: u128) ->
                 .unwrap()
                 .as_millis(),
             attrs: vec![
-                Attribute::FinalHtlcMinimumExpiryDelta(12),
+                Attribute::FinalHtlcMinimumExpiryDelta(default_expiry_delta_ms),
                 Attribute::Description("test".to_string()),
                 Attribute::ExpiryTime(Duration::from_secs(3600)),
                 Attribute::PayeePublicKey(public_key),
@@ -556,8 +559,10 @@ async fn test_receive_btc_happy_path() {
     let harness = setup_test_harness().await;
 
     // Step 1: Create order directly in the database (bypassing LND hold invoice creation)
-    // In production, ReceiveBTC creates a hold invoice via LND, but we skip that for testing
-    let fiber_invoice = create_test_fiber_invoice(payment_hash);
+    // In production, ReceiveBTC creates a hold invoice via LND, but we skip that for testing.
+    // Use a small final TLC expiry delta (10,000 ms = 10 seconds) so it fits
+    // within the default incoming budget (180 blocks * 600 / 2 = 54,000 seconds).
+    let fiber_invoice = create_test_fiber_invoice_with_expiry(payment_hash, 10_000);
     let lightning_invoice = create_test_lightning_invoice_with_payment_hash(payment_hash);
     let order = CchOrder {
         created_at: SystemTime::now()
@@ -1216,22 +1221,25 @@ async fn test_send_btc_fails_insufficient_expiry_delta() {
     // Create a BTC invoice with min_final_cltv_expiry_delta = 36 blocks (= 21,600 seconds)
     let lightning_invoice = create_test_lightning_invoice_with_cltv(payment_hash, 36);
 
-    // Use a config with ckb_final_tlc_expiry_delta_seconds = 50,000 seconds (~14 hours).
+    // The incoming Fiber invoice has ckb_final_tlc_expiry_delta = 50,000 seconds.
     // Initial static check: 36 * 600 = 21,600 < 50,000 / 2 = 25,000 → passes.
     // But if the order was created 20,000 seconds ago:
     //   remaining = 50,000 - 20,000 = 30,000 seconds
     //   max_outgoing = 30,000 / 2 = 15,000 seconds
     //   needed = 21,600 seconds
     //   15,000 < 21,600 → fails!
+    let ckb_final_tlc_seconds: u64 = 50_000;
     let config = CchConfig {
         lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
         wrapped_btc_type_script_args: "0x".to_string(),
         min_outgoing_invoice_expiry_delta_seconds: 60,
-        ckb_final_tlc_expiry_delta_seconds: 50_000,
+        ckb_final_tlc_expiry_delta_seconds: ckb_final_tlc_seconds,
         ..Default::default()
     };
 
-    // Create an order with created_at 20,000 seconds in the past
+    // Create an order with created_at 20,000 seconds in the past.
+    // The incoming invoice's final expiry delta must match the config value
+    // because compute_max_outgoing_expiry_seconds reads from the stored invoice.
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -1241,7 +1249,10 @@ async fn test_send_btc_fails_insufficient_expiry_delta() {
         expiry_delta_seconds: 100_000, // large enough not to expire
         wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
         outgoing_pay_req: lightning_invoice.to_string(),
-        incoming_invoice: CchInvoice::Fiber(create_test_fiber_invoice(payment_hash)),
+        incoming_invoice: CchInvoice::Fiber(create_test_fiber_invoice_with_expiry(
+            payment_hash,
+            ckb_final_tlc_seconds * 1000,
+        )),
         payment_hash,
         payment_preimage: None,
         amount_sats: 100_000,
@@ -1282,6 +1293,8 @@ async fn test_receive_btc_fails_insufficient_expiry_delta() {
     let fiber_invoice = create_test_fiber_invoice_with_expiry(payment_hash, 100_000_000);
 
     // Use a config with btc_final_tlc_expiry_delta_blocks = 180 blocks (= 108,000 seconds).
+    // The incoming Lightning invoice must carry the same CLTV value because
+    // compute_max_outgoing_expiry_seconds now reads from the stored invoice.
     // If order was just created:
     //   remaining = 108,000 seconds
     //   max_outgoing = 54,000 seconds
@@ -1294,7 +1307,9 @@ async fn test_receive_btc_fails_insufficient_expiry_delta() {
         ..Default::default()
     };
 
-    let lightning_invoice = create_test_lightning_invoice_with_payment_hash(payment_hash);
+    // Create a Lightning invoice whose min_final_cltv_expiry_delta matches the
+    // default btc_final_tlc_expiry_delta_blocks (180 blocks).
+    let lightning_invoice = create_test_lightning_invoice_with_cltv(payment_hash, 180);
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -1342,17 +1357,18 @@ async fn test_send_btc_passes_sufficient_expiry_delta() {
     // Create a BTC invoice with small min_final_cltv_expiry_delta = 3 blocks (= 1,800 seconds)
     let lightning_invoice = create_test_lightning_invoice_with_cltv(payment_hash, 3);
 
-    // Use a config with ckb_final_tlc_expiry_delta_seconds = 100,000 seconds.
+    // The incoming Fiber invoice has ckb_final_tlc_expiry_delta = 100,000 seconds.
     // Even with 10,000 seconds elapsed:
     //   remaining = 100,000 - 10,000 = 90,000 seconds
     //   max_outgoing = 45,000 seconds
     //   needed = 3 * 600 = 1,800 seconds
     //   45,000 > 1,800 → passes ✓
+    let ckb_final_tlc_seconds: u64 = 100_000;
     let config = CchConfig {
         lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
         wrapped_btc_type_script_args: "0x".to_string(),
         min_outgoing_invoice_expiry_delta_seconds: 60,
-        ckb_final_tlc_expiry_delta_seconds: 100_000,
+        ckb_final_tlc_expiry_delta_seconds: ckb_final_tlc_seconds,
         ..Default::default()
     };
 
@@ -1365,7 +1381,10 @@ async fn test_send_btc_passes_sufficient_expiry_delta() {
         expiry_delta_seconds: 200_000,
         wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
         outgoing_pay_req: lightning_invoice.to_string(),
-        incoming_invoice: CchInvoice::Fiber(create_test_fiber_invoice(payment_hash)),
+        incoming_invoice: CchInvoice::Fiber(create_test_fiber_invoice_with_expiry(
+            payment_hash,
+            ckb_final_tlc_seconds * 1000,
+        )),
         payment_hash,
         payment_preimage: None,
         amount_sats: 100_000,

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -1135,3 +1135,260 @@ async fn test_receive_btc_fee_calculation() {
         ),
     }
 }
+
+// =============================================================================
+// Insufficient Expiry Delta Tests (#1000)
+// =============================================================================
+
+/// Create a test Lightning invoice with a custom min_final_cltv_expiry_delta.
+fn create_test_lightning_invoice_with_cltv(
+    payment_hash: Hash256,
+    min_final_cltv: u64,
+) -> lightning_invoice::Bolt11Invoice {
+    use bitcoin::hashes::Hash as _;
+    use lightning_invoice::{Currency as LnCurrency, InvoiceBuilder as LnInvoiceBuilder};
+
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let private_key = bitcoin::secp256k1::SecretKey::from_slice(&[43u8; 32]).unwrap();
+    let payment_hash_btc = bitcoin::hashes::sha256::Hash::from_slice(payment_hash.as_ref())
+        .expect("valid 32-byte hash");
+    let payment_secret = lightning_invoice::PaymentSecret([0u8; 32]);
+    let duration_since_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time");
+
+    LnInvoiceBuilder::new(LnCurrency::Bitcoin)
+        .description("test invoice".to_string())
+        .payment_hash(payment_hash_btc)
+        .payment_secret(payment_secret)
+        .duration_since_epoch(duration_since_epoch)
+        .min_final_cltv_expiry_delta(min_final_cltv)
+        .amount_milli_satoshis(100_000_000)
+        .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &private_key))
+        .expect("build lightning invoice")
+}
+
+/// Create a test Fiber invoice with a custom final_tlc_minimum_expiry_delta (in milliseconds).
+fn create_test_fiber_invoice_with_expiry(
+    payment_hash: Hash256,
+    final_tlc_expiry_delta_ms: u64,
+) -> CkbInvoice {
+    let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
+    let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
+
+    let mut invoice = CkbInvoice {
+        currency: Currency::Fibb,
+        amount: Some(100000),
+        signature: None,
+        data: InvoiceData {
+            payment_hash,
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+            attrs: vec![
+                Attribute::FinalHtlcMinimumExpiryDelta(final_tlc_expiry_delta_ms),
+                Attribute::Description("test".to_string()),
+                Attribute::ExpiryTime(Duration::from_secs(3600)),
+                Attribute::PayeePublicKey(public_key),
+            ],
+        },
+    };
+    invoice
+        .update_signature(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
+        .unwrap();
+    invoice
+}
+
+/// Tests that a SendBTC order fails when the incoming CKB TLC does not have enough
+/// remaining time to safely settle after the outgoing BTC payment completes.
+///
+/// Scenario: The order was created a long time ago, so the remaining incoming time
+/// is too short to cover the outgoing BTC payment's min_final_cltv_expiry_delta.
+///
+/// This addresses issue #1000: the check accounts for elapsed time since order creation,
+/// not just comparing final expiry deltas statically.
+#[tokio::test]
+async fn test_send_btc_fails_insufficient_expiry_delta() {
+    let (_, payment_hash) = create_valid_preimage_pair(250);
+    let store = MockCchOrderStore::new();
+
+    // Create a BTC invoice with min_final_cltv_expiry_delta = 36 blocks (= 21,600 seconds)
+    let lightning_invoice = create_test_lightning_invoice_with_cltv(payment_hash, 36);
+
+    // Use a config with ckb_final_tlc_expiry_delta_seconds = 50,000 seconds (~14 hours).
+    // Initial static check: 36 * 600 = 21,600 < 50,000 / 2 = 25,000 → passes.
+    // But if the order was created 20,000 seconds ago:
+    //   remaining = 50,000 - 20,000 = 30,000 seconds
+    //   max_outgoing = 30,000 / 2 = 15,000 seconds
+    //   needed = 21,600 seconds
+    //   15,000 < 21,600 → fails!
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ckb_final_tlc_expiry_delta_seconds: 50_000,
+        ..Default::default()
+    };
+
+    // Create an order with created_at 20,000 seconds in the past
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let order = CchOrder {
+        created_at: now - 20_000,
+        expiry_delta_seconds: 100_000, // large enough not to expire
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: lightning_invoice.to_string(),
+        incoming_invoice: CchInvoice::Fiber(create_test_fiber_invoice(payment_hash)),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::IncomingAccepted,
+        failure_reason: None,
+    };
+
+    store.insert_cch_order(order).unwrap();
+    let harness = setup_test_harness_with_config_and_store(config, store).await;
+
+    // The CchActor should detect the IncomingAccepted order on startup, dispatch
+    // SendOutgoingPayment, and the expiry check should fail the order.
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::Failed, 2000)
+        .await;
+    assert_eq!(order.status, CchOrderStatus::Failed);
+    assert!(order.failure_reason.is_some());
+    let reason = order.failure_reason.unwrap();
+    assert!(
+        reason.contains("Insufficient HTLC expiry delta"),
+        "Expected expiry delta failure message, got: {}",
+        reason,
+    );
+}
+
+/// Tests that a ReceiveBTC order fails when the incoming BTC HTLC does not have enough
+/// remaining time for the outgoing CKB payment's final TLC expiry delta.
+///
+/// Scenario: The outgoing CKB invoice has a very large final_tlc_minimum_expiry_delta
+/// that exceeds half the remaining incoming time.
+#[tokio::test]
+async fn test_receive_btc_fails_insufficient_expiry_delta() {
+    let (_, payment_hash) = create_valid_preimage_pair(251);
+    let store = MockCchOrderStore::new();
+
+    // Create a CKB invoice with a very large final TLC expiry delta (100,000 seconds = 100M ms)
+    let fiber_invoice = create_test_fiber_invoice_with_expiry(payment_hash, 100_000_000);
+
+    // Use a config with btc_final_tlc_expiry_delta_blocks = 180 blocks (= 108,000 seconds).
+    // If order was just created:
+    //   remaining = 108,000 seconds
+    //   max_outgoing = 54,000 seconds
+    //   outgoing needs 100,000 seconds
+    //   54,000 < 100,000 → fails!
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ..Default::default()
+    };
+
+    let lightning_invoice = create_test_lightning_invoice_with_payment_hash(payment_hash);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let order = CchOrder {
+        created_at: now,
+        expiry_delta_seconds: 200_000,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: fiber_invoice.to_string(),
+        incoming_invoice: CchInvoice::Lightning(lightning_invoice),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::IncomingAccepted,
+        failure_reason: None,
+    };
+
+    store.insert_cch_order(order).unwrap();
+    let harness = setup_test_harness_with_config_and_store(config, store).await;
+
+    // The CchActor should detect the IncomingAccepted order on startup, dispatch
+    // SendOutgoingPayment, and the expiry check should fail the order.
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::Failed, 2000)
+        .await;
+    assert_eq!(order.status, CchOrderStatus::Failed);
+    assert!(order.failure_reason.is_some());
+    let reason = order.failure_reason.unwrap();
+    assert!(
+        reason.contains("Insufficient HTLC expiry delta"),
+        "Expected expiry delta failure message, got: {}",
+        reason,
+    );
+}
+
+/// Tests that a SendBTC order succeeds when there is sufficient remaining incoming time
+/// to cover the outgoing payment's CLTV plus settle the incoming payment.
+/// This verifies that the expiry check doesn't incorrectly reject valid orders.
+#[tokio::test]
+async fn test_send_btc_passes_sufficient_expiry_delta() {
+    let (_preimage, payment_hash) = create_valid_preimage_pair(252);
+    let store = MockCchOrderStore::new();
+
+    // Create a BTC invoice with small min_final_cltv_expiry_delta = 3 blocks (= 1,800 seconds)
+    let lightning_invoice = create_test_lightning_invoice_with_cltv(payment_hash, 3);
+
+    // Use a config with ckb_final_tlc_expiry_delta_seconds = 100,000 seconds.
+    // Even with 10,000 seconds elapsed:
+    //   remaining = 100,000 - 10,000 = 90,000 seconds
+    //   max_outgoing = 45,000 seconds
+    //   needed = 3 * 600 = 1,800 seconds
+    //   45,000 > 1,800 → passes ✓
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ckb_final_tlc_expiry_delta_seconds: 100_000,
+        ..Default::default()
+    };
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let order = CchOrder {
+        created_at: now - 10_000,
+        expiry_delta_seconds: 200_000,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: lightning_invoice.to_string(),
+        incoming_invoice: CchInvoice::Fiber(create_test_fiber_invoice(payment_hash)),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::IncomingAccepted,
+        failure_reason: None,
+    };
+
+    store.insert_cch_order(order).unwrap();
+    let harness = setup_test_harness_with_config_and_store(config, store).await;
+
+    // The order should NOT fail from the expiry check. Since outgoing is Lightning (BTC),
+    // the SendLightningOutgoingPaymentExecutor will try to call LND (which isn't running).
+    // That will cause a transient error and retry, but the order should NOT be Failed.
+    // Wait briefly and confirm the order is NOT in Failed state.
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let order = harness.get_order(payment_hash).await.unwrap();
+    assert_ne!(
+        order.status,
+        CchOrderStatus::Failed,
+        "Order should not have failed - expiry check should have passed. \
+         Failure reason: {:?}",
+        order.failure_reason,
+    );
+}

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -563,7 +563,10 @@ async fn test_receive_btc_happy_path() {
     // Use a small final TLC expiry delta (10,000 ms = 10 seconds) so it fits
     // within the default incoming budget (180 blocks * 600 / 2 = 54,000 seconds).
     let fiber_invoice = create_test_fiber_invoice_with_expiry(payment_hash, 10_000);
-    let lightning_invoice = create_test_lightning_invoice_with_payment_hash(payment_hash);
+    // The incoming Lightning invoice must carry min_final_cltv_expiry_delta matching
+    // the default btc_final_tlc_expiry_delta_blocks (180) so the stored invoice
+    // reflects a realistic inbound HTLC budget.
+    let lightning_invoice = create_test_lightning_invoice_with_cltv(payment_hash, 180);
     let order = CchOrder {
         created_at: SystemTime::now()
             .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
## Summary

Add a dynamic expiry check when dispatching outgoing payments to prevent fund loss when the outgoing route's total expiry (including all routing hops) exceeds the incoming payment's remaining time.

## Problem

Previously, CCH only compared `final_tlc_expiry_delta` values statically at order creation time. This missed the scenario described in #1000: if there are many routing nodes for the outbound payment, the accumulated `tlc_expiry_delta` of the entire route can exceed the `inbound.final_tlc_expiry_delta`, causing the inbound payment to expire before CCH can settle it.

## Solution

When dispatching the outgoing payment (after incoming is accepted):

1. **Compute remaining incoming time**: `incoming_final_expiry_delta - elapsed_since_order_creation`
2. **Allocate half for outgoing**: `max_outgoing = remaining / 2` (other half reserved for settling incoming)
3. **Validate sufficiency**: If `max_outgoing` is less than the outgoing invoice's minimum final expiry delta, fail the order immediately
4. **Cap the outgoing route**:
   - **BTC (LND)**: Set `cltv_limit` on `SendPaymentRequest`
   - **CKB (Fiber)**: Set `tlc_expiry_limit` on `SendPaymentCommand`

## Tests

- `test_send_btc_fails_insufficient_expiry_delta` — SendBTC order with insufficient remaining incoming time
- `test_receive_btc_fails_insufficient_expiry_delta` — ReceiveBTC order with outgoing CKB TLC expiry exceeding available time
- `test_send_btc_passes_sufficient_expiry_delta` — Verifies valid orders pass the check

Fixes #1000