### PR TITLE
docs: improve RPC docs for node identifiers and channel rebalancing

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -260,10 +260,11 @@ pub struct NodeInfoResponse {
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PeerInfo {
-    /// The identity public key of the peer.
+    /// The identity public key of the peer (also known as `node_id`).
     pub pubkey: Pubkey,
 
-    /// The peer ID of the peer
+    /// The peer ID of the peer (base58 string, derived by hashing the `pubkey` above).
+    /// This is used for P2P transport connections, e.g. when calling `open_channel` or `disconnect_peer`.
     #[serde_as(as = "DisplayFromStr")]
     pub peer_id: PeerId,
 

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -323,8 +323,13 @@ impl Privkey {
     }
 }
 
-/// The public key for a Node
-/// It stores the serialized form ([u8; 33]) directly for fast comparison and hashing
+/// A compressed secp256k1 public key (33 bytes), used as the primary identity of a node.
+/// In the RPC interface this value is also referred to as `node_id`.
+/// It is serialized as a 66-character hex string (e.g. `"02aaaa..."`) in JSON.
+///
+/// Note: `Pubkey` is different from `PeerId`. A `PeerId` is derived by hashing the
+/// public key and is used only for P2P transport connections. You can obtain both
+/// values from the `list_peers` or `node_info` RPC.
 #[serde_as]
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Pubkey(#[serde_as(as = "IfIsHumanReadable<SliceHexNoPrefix, [_; 33]>")] pub [u8; 33]);

--- a/crates/fiber-lib/src/rpc/channel.rs
+++ b/crates/fiber-lib/src/rpc/channel.rs
@@ -34,7 +34,9 @@ use tentacle::secio::PeerId;
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OpenChannelParams {
-    /// The peer ID to open a channel with, the peer must be connected through the [connect_peer](#peer-connect_peer) rpc first.
+    /// The peer ID to open a channel with (base58 string, derived from the peer's `Pubkey`).
+    /// The peer must be connected through the [connect_peer](#peer-connect_peer) rpc first.
+    /// You can obtain a peer's `peer_id` from the `list_peers` RPC.
     #[serde_as(as = "DisplayFromStr")]
     pub peer_id: PeerId,
 
@@ -162,7 +164,8 @@ pub struct AcceptChannelResult {
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct ListChannelsParams {
-    /// The peer ID to list channels for, an optional parameter, if not provided, all channels will be listed
+    /// The peer ID to list channels for (base58 string, derived from the peer's `Pubkey`).
+    /// An optional parameter, if not provided, all channels will be listed.
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub peer_id: Option<PeerId>,
     /// Whether to include closed channels in the list, an optional parameter, default value is false
@@ -269,7 +272,7 @@ pub struct Channel {
     #[serde_as(as = "Option<EntityHex>")]
     /// The outpoint of the channel
     pub channel_outpoint: Option<OutPoint>,
-    /// The peer ID of the channel
+    /// The peer ID of the channel counterparty (base58 string, derived from the peer's `Pubkey`).
     #[serde_as(as = "DisplayFromStr")]
     pub peer_id: PeerId,
     /// The UDT type script of the channel

--- a/crates/fiber-lib/src/rpc/graph.rs
+++ b/crates/fiber-lib/src/rpc/graph.rs
@@ -145,7 +145,7 @@ pub struct NodeInfo {
     pub addresses: Vec<MultiAddr>,
     /// The node features supported by the node.
     pub features: Vec<String>,
-    /// The identity public key of the node.
+    /// The identity public key of the node (secp256k1 compressed, hex string), same as `pubkey` in `list_peers`.
     pub node_id: Pubkey,
     #[serde_as(as = "U64Hex")]
     /// The latest timestamp set by the owner for the node announcement.
@@ -201,9 +201,9 @@ pub struct ChannelInfo {
     /// The outpoint of the channel.
     #[serde_as(as = "EntityHex")]
     pub channel_outpoint: OutPoint,
-    /// The identity public key of the first node.
+    /// The identity public key of the first node (secp256k1 compressed, hex string).
     pub node1: Pubkey,
-    /// The identity public key of the second node.
+    /// The identity public key of the second node (secp256k1 compressed, hex string).
     pub node2: Pubkey,
     /// The created timestamp of the channel, which is the block header timestamp of the block
     /// that contains the channel funding transaction.

--- a/crates/fiber-lib/src/rpc/info.rs
+++ b/crates/fiber-lib/src/rpc/info.rs
@@ -27,7 +27,9 @@ pub struct NodeInfoResult {
     /// The commit hash of the node software.
     pub commit_hash: String,
 
-    /// The identity public key of the node.
+    /// The identity public key of this node (secp256k1 compressed, hex string).
+    /// This is the same value referred to as `pubkey` in `list_peers` responses.
+    /// Note: this is different from `peer_id`, which is a base58 hash derived from this key.
     pub node_id: Pubkey,
 
     /// The features supported by the node.

--- a/crates/fiber-lib/src/rpc/peer.rs
+++ b/crates/fiber-lib/src/rpc/peer.rs
@@ -23,7 +23,7 @@ pub struct ConnectPeerParams {
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DisconnectPeerParams {
-    /// The peer ID of the peer to disconnect.
+    /// The peer ID of the peer to disconnect (base58 string, derived from the peer's `Pubkey`).
     #[serde_as(as = "DisplayFromStr")]
     pub peer_id: PeerId,
 }

--- a/docs/channel-rebalancing.md
+++ b/docs/channel-rebalancing.md
@@ -1,0 +1,110 @@
+# Channel Rebalancing
+
+Channel rebalancing lets you shift liquidity between your channels without
+opening or closing any channel. It works by sending a **circular payment** —
+funds flow out through one channel and back in through another. Your total
+balance stays the same; only routing fees paid to intermediate nodes are
+deducted.
+
+## When to Rebalance
+
+Suppose you have two channels:
+
+```
+You --[Channel A]--> Peer A    (local: 90, remote: 10)
+You --[Channel B]--> Peer B    (local: 10, remote: 90)
+```
+
+Channel A is mostly on your side (outbound-heavy), while Channel B is mostly on
+the remote side (inbound-heavy). You cannot send payments through Channel B
+because you have almost no local balance there. A rebalance can even them out.
+
+## Two Methods
+
+Fiber supports two ways to rebalance:
+
+### Method 1: Automatic Routing (`send_payment`)
+
+Set `target_pubkey` to your own node pubkey with `allow_self_payment: true`.
+The routing algorithm automatically finds a circular path.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "send_payment",
+  "params": [
+    {
+      "target_pubkey": "<your_own_pubkey>",
+      "amount": "0x5F5E100",
+      "keysend": true,
+      "allow_self_payment": true
+    }
+  ],
+  "id": 1
+}
+```
+
+**Pros**: Simple, no need to manually plan the route.
+
+**Cons**: You cannot control which channels the payment flows through. Not
+compatible with trampoline routing.
+
+### Method 2: Manual Routing (`build_router` + `send_payment_with_router`)
+
+This gives you full control over the exact path. Use it when you want to target
+specific channels for rebalancing.
+
+**Step 1** — Build a circular route with `build_router`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "build_router",
+  "params": [
+    {
+      "amount": "0x5F5E100",
+      "hops_info": [
+        { "pubkey": "<peer_A_pubkey>" },
+        { "pubkey": "<peer_B_pubkey>" },
+        { "pubkey": "<your_own_pubkey>" }
+      ]
+    }
+  ],
+  "id": 1
+}
+```
+
+This returns a `router_hops` array describing the full route with fees and
+expiry deltas.
+
+**Step 2** — Send the payment with the constructed route:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "send_payment_with_router",
+  "params": [
+    {
+      "router": "<router_hops from step 1>",
+      "keysend": true
+    }
+  ],
+  "id": 2
+}
+```
+
+**Pros**: Full control over which channels are used. You can also pin specific
+channels by providing `channel_outpoint` in `hops_info`.
+
+**Cons**: Requires you to know the network topology and plan the route.
+
+## Tips
+
+- Use `dry_run: true` first to verify the route is valid and check the fee
+  before actually sending.
+- The rebalance amount plus routing fees must not exceed your local balance in
+  the outbound channel.
+- Routing fees depend on the intermediate nodes' fee policies. You can set
+  `max_fee_amount` to cap the total fee.
+- After a successful rebalance, use `list_channels` to verify the updated
+  balances.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -43,3 +43,34 @@ The "Asset Handling Fee." Intermediate nodes lock up their own liquidity to forw
 
 ## Watchtower
 Your "Asset Bodyguard." Since channel asset states are stored off-chain, a dishonest partner might try to broadcast an "old agreement" to steal funds while you are offline. A Watchtower monitors the CKB chain 24/7 and automatically intercepts any cheating attempts, punishing the attacker.
+
+## Node Identifiers: Pubkey, Node ID, and Peer ID
+
+A Fiber node has two forms of identity. They look different, serve different purposes, and are **not interchangeable** in RPC calls.
+
+### Pubkey (aka Node ID)
+
+A 33-byte compressed secp256k1 public key, displayed as a 66-character hex string (e.g. `"02ab1234..."`). This is the cryptographic identity of a node. In the RPC interface it appears under several field names depending on context:
+
+| RPC Field | Used In |
+|-----------|---------|
+| `node_id` | `node_info`, `graph_nodes` |
+| `pubkey` | `list_peers`, `graph_nodes`, `hop_hints` |
+| `target_pubkey` | `send_payment` |
+| `node1` / `node2` | `graph_channels` |
+
+All of the above are the same type (`Pubkey`) and can be used wherever a `Pubkey` is expected.
+
+### Peer ID
+
+A base58-encoded string (e.g. `"QmYJnK7..."`), derived by **hashing** the node's `Pubkey`. This is used by the P2P transport layer to identify network connections. The derivation is one-way: you cannot recover a `Pubkey` from a `Peer ID`.
+
+| RPC Field | Used In |
+|-----------|---------|
+| `peer_id` | `open_channel`, `list_channels`, `disconnect_peer`, `list_peers` |
+
+### Which One to Use?
+
+- **Payment-related RPCs** (`send_payment`, `build_router`, etc.) expect a **`Pubkey`** (hex).
+- **Connection/channel management RPCs** (`open_channel`, `disconnect_peer`, etc.) expect a **`Peer ID`** (base58).
+- The `list_peers` RPC returns **both** `pubkey` and `peer_id` for each connected peer, making it easy to look up either value.


### PR DESCRIPTION
Clarify the distinction between Pubkey (secp256k1 hex) and PeerId (base58 hash) across all RPC doc comments and regenerate README.md. Add detailed documentation for channel rebalancing via send_payment and send_payment_with_router. Add a glossary section explaining node identifier types and a standalone channel-rebalancing guide.