### PR TITLE
fix: forward missing pending remote settlements to watchtower

### DIFF
--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -12,7 +12,8 @@ use fnn::fiber::{graph::NetworkGraph, network::init_chain_hash, network::Network
 use fnn::rpc::server::start_rpc;
 use fnn::rpc::watchtower::{
     CreatePreimageParams, CreateWatchChannelParams, RemovePreimageParams, RemoveWatchChannelParams,
-    UpdateLocalSettlementParams, UpdateRevocationParams, WatchtowerRpcClient,
+    UpdateLocalSettlementParams, UpdatePendingRemoteSettlementParams, UpdateRevocationParams,
+    WatchtowerRpcClient,
 };
 use fnn::store::Store;
 use fnn::tasks::{
@@ -553,6 +554,15 @@ async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
         ) => {
             watchtower_client
                 .update_local_settlement(UpdateLocalSettlementParams {
+                    channel_id,
+                    settlement_data,
+                })
+                .await
+                .expect(ASSUME_WATCHTOWER_CLIENT_CALL_OK);
+        }
+        NetworkServiceEvent::LocalCommitmentSigned(channel_id, settlement_data) => {
+            watchtower_client
+                .update_pending_remote_settlement(UpdatePendingRemoteSettlementParams {
                     channel_id,
                     settlement_data,
                 })

--- a/docs/biscuit-auth.md
+++ b/docs/biscuit-auth.md
@@ -102,6 +102,13 @@ rule(
     allow if right({channel_id}, "watchtower"); 
     "#, 
 ); 
+rule(
+    "update_pending_remote_settlement",
+    r#"
+    allow if write("watchtower");
+    allow if right({channel_id}, "watchtower");
+    "#,
+);
 rule( 
     "update_local_settlement", 
     r#" 


### PR DESCRIPTION
Watchtower has exposed the interface to push the events but it is not yet implemented.

Related to https://github.com/nervosnetwork/fiber/commit/6ae2929adde1a4b52699771b960542e5196c830a