### PR TITLE
add watchtower querier trait

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,7 @@ jobs:
           - watchtower/force-close-after-open-channel
           - watchtower/force-close-preimage
           - watchtower/force-close-preimage-multiple
+          - watchtower/force-close-preimage-settled-by-recipient
           - watchtower/force-close-remote-with-pending-tlcs-and-stop-watchtower
           - watchtower/force-close-remote-without-pending-tlcs-and-stop-watchtower
           - watchtower/force-close-with-consecutive-settlement

--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -20,7 +20,7 @@ use fnn::watchtower::{
 };
 use fnn::ExitMessage;
 use fnn::{start_network, CchActor, Config, NetworkServiceEvent};
-use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::ws_client::{HeaderMap, HeaderValue};
 use ractor::{port::OutputPortSubscriberTrait as _, Actor, ActorRef, OutputPort};
 #[cfg(debug_assertions)]
@@ -36,6 +36,27 @@ use tracing::{debug, info, info_span, trace};
 use tracing_subscriber::{field::MakeExt, fmt, fmt::format, EnvFilter};
 
 const ASSUME_WATCHTOWER_ACTOR_ALIVE: &str = "watchtower actor must be alive";
+
+/// Build an HTTP client for the standalone watchtower RPC, optionally with a Bearer token.
+fn build_watchtower_rpc_client(
+    url: impl AsRef<str>,
+    token: Option<&str>,
+) -> Result<HttpClient, ExitMessage> {
+    let mut client_builder = HttpClientBuilder::default();
+    if let Some(token) = token {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {}", token)).map_err(|err| {
+                ExitMessage(format!("failed to create watchtower rpc client: {err:?}"))
+            })?,
+        );
+        client_builder = client_builder.set_headers(headers);
+    }
+    client_builder
+        .build(url)
+        .map_err(|err| ExitMessage(format!("failed to create watchtower rpc client: {}", err)))
+}
 
 #[tokio::main]
 pub async fn main() -> Result<(), ExitMessage> {
@@ -170,6 +191,36 @@ async fn run_node(
 
             info!("Starting fiber");
 
+            // Build the standalone watchtower RPC client once if configured.
+            let standalone_watchtower_client = fiber_config
+                .standalone_watchtower_rpc_url
+                .as_ref()
+                .map(|url| {
+                    if fiber_config.standalone_watchtower_token.is_none() {
+                        tracing::debug!(
+                            "create watchtower rpc client without standalone_watchtower_token"
+                        );
+                    }
+                    build_watchtower_rpc_client(
+                        url,
+                        fiber_config.standalone_watchtower_token.as_deref(),
+                    )
+                })
+                .transpose()?;
+
+            // Construct watchtower querier before starting network.
+            // Prefer local store (built-in watchtower) over standalone RPC for efficiency.
+            let watchtower_querier: Option<Arc<dyn fnn::fiber::WatchtowerQuerier>> =
+                if !fiber_config.disable_built_in_watchtower.unwrap_or_default() {
+                    Some(Arc::new(store.clone()))
+                } else if let Some(client) = standalone_watchtower_client.clone() {
+                    Some(Arc::new(fnn::rpc::watchtower::WatchtowerRpcQuerier::new(
+                        client,
+                    )))
+                } else {
+                    None
+                };
+
             let chain_client = CkbRpcClient::new(&ckb_config);
             let network_actor: ActorRef<NetworkActorMessage> = start_network(
                 fiber_config.clone(),
@@ -181,6 +232,7 @@ async fn run_node(
                 store.clone(),
                 network_graph.clone(),
                 default_shutdown_script,
+                watchtower_querier,
             )
             .await;
 
@@ -193,33 +245,7 @@ async fn run_node(
                 );
             }
 
-            let watchtower_client = if let Some(url) =
-                fiber_config.standalone_watchtower_rpc_url.clone()
-            {
-                let mut client_builder = HttpClientBuilder::default();
-
-                if let Some(token) = fiber_config.standalone_watchtower_token.as_ref() {
-                    let mut headers = HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        HeaderValue::from_str(&format!("Bearer {}", token)).map_err(|err| {
-                            ExitMessage(format!("failed to create watchtower rpc client: {err:?}"))
-                        })?,
-                    );
-                    client_builder = client_builder.set_headers(headers);
-                } else {
-                    tracing::debug!(
-                        "create watchtower rpc client without standalone_watchtower_token"
-                    );
-                }
-
-                let watchtower_client = client_builder.build(url).map_err(|err| {
-                    ExitMessage(format!("failed to create watchtower rpc client: {}", err))
-                })?;
-                Some(watchtower_client)
-            } else {
-                None
-            };
+            let watchtower_client = standalone_watchtower_client;
 
             let watchtower_actor = if fiber_config.disable_built_in_watchtower.unwrap_or_default() {
                 None

--- a/crates/fiber-json-types/src/watchtower.rs
+++ b/crates/fiber-json-types/src/watchtower.rs
@@ -168,7 +168,7 @@ pub struct RemovePreimageParams {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct QueryTlcStatusParams {
     /// Channel ID
     pub channel_id: Hash256,
@@ -177,7 +177,7 @@ pub struct QueryTlcStatusParams {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct QueryTlcStatusResult {
     /// Found preimage when the TLC has been settled on chain with the preimage path.
     pub preimage: Option<Hash256>,

--- a/crates/fiber-json-types/src/watchtower.rs
+++ b/crates/fiber-json-types/src/watchtower.rs
@@ -166,3 +166,18 @@ pub struct RemovePreimageParams {
     /// Payment hash
     pub payment_hash: Hash256,
 }
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct QueryTlcStatusParams {
+    pub channel_id: Hash256,
+    pub payment_hash: Hash256,
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct QueryTlcStatusResult {
+    pub preimage: Option<Hash256>,
+    /// Whether the TLC has been settled on chain
+    pub is_settled: bool,
+}

--- a/crates/fiber-json-types/src/watchtower.rs
+++ b/crates/fiber-json-types/src/watchtower.rs
@@ -170,13 +170,16 @@ pub struct RemovePreimageParams {
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct QueryTlcStatusParams {
+    /// Channel ID
     pub channel_id: Hash256,
+    /// Payment hash
     pub payment_hash: Hash256,
 }
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct QueryTlcStatusResult {
+    /// Found preimage when the TLC has been settled on chain with the preimage path.
     pub preimage: Option<Hash256>,
     /// Whether the TLC has been settled on chain
     pub is_settled: bool,

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -7411,8 +7411,6 @@ pub trait ChannelActorStateStore {
     fn remove_payment_hold_tlc(&self, payment_hash: &Hash256, channel_id: &Hash256, tlc_id: u64);
     fn get_payment_hold_tlcs(&self, payment_hash: Hash256) -> Vec<HoldTlc>;
     fn get_node_hold_tlcs(&self) -> HashMap<Hash256, Vec<HoldTlc>>;
-    /// Check if a tlc is settled on chain
-    fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool;
 
     /// Store a pending CommitDiff for channel reestablishment
     fn store_pending_commit_diff(&self, channel_id: &Hash256, diff: &CommitDiff);

--- a/crates/fiber-lib/src/fiber/mod.rs
+++ b/crates/fiber-lib/src/fiber/mod.rs
@@ -8,6 +8,7 @@ pub mod payment;
 #[cfg(all(feature = "pprof", not(target_arch = "wasm32")))]
 pub mod profiling;
 pub mod types;
+pub mod watchtower_query;
 
 mod fee;
 mod in_flight_ckb_tx_actor;
@@ -26,6 +27,7 @@ pub use network::{
     NetworkServiceEvent,
 };
 pub use settle_tlc_set_command::SettleTlcSetCommand;
+pub use watchtower_query::{TlcWatchtowerStatus, WatchtowerQuerier};
 
 pub(crate) const ASSUME_NETWORK_ACTOR_ALIVE: &str = "network actor must be alive";
 

--- a/crates/fiber-lib/src/fiber/mod.rs
+++ b/crates/fiber-lib/src/fiber/mod.rs
@@ -15,6 +15,7 @@ mod in_flight_ckb_tx_actor;
 mod key;
 mod path;
 mod settle_tlc_set_command;
+mod watchtower_query_actor;
 
 pub use config::FiberConfig;
 pub use fiber_types::*;

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -1400,7 +1400,7 @@ where
                                             WatchtowerQueryActorMessage::QueryPreimage {
                                                 channel_id,
                                                 tlc_id: tlc_id.into(),
-                                                payment_hash: payment_hash,
+                                                payment_hash,
                                             },
                                         );
                                     }
@@ -1573,10 +1573,10 @@ where
                                     let _ = wt_actor.send_message(
                                         WatchtowerQueryActorMessage::QuerySettled {
                                             channel_id,
-                                            payment_hash: payment_hash,
+                                            payment_hash,
                                             forwarding_channel_id,
                                             forwarding_tlc_id,
-                                            shared_secret: shared_secret,
+                                            shared_secret,
                                         },
                                     );
                                 }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -660,6 +660,7 @@ pub struct NetworkActor<S, C> {
     store: S,
     network_graph: Arc<RwLock<NetworkGraph<S>>>,
     chain_client: C,
+    watchtower_querier: Option<Arc<dyn super::WatchtowerQuerier>>,
 }
 
 impl<S, C> NetworkActor<S, C>
@@ -683,6 +684,7 @@ where
         store: S,
         network_graph: Arc<RwLock<NetworkGraph<S>>>,
         chain_client: C,
+        watchtower_querier: Option<Arc<dyn super::WatchtowerQuerier>>,
     ) -> Self {
         Self {
             event_sender,
@@ -690,6 +692,7 @@ where
             store: store.clone(),
             network_graph,
             chain_client,
+            watchtower_querier,
         }
     }
 
@@ -1362,8 +1365,19 @@ where
                                     }
                                 }
 
-                                let Some(payment_preimage) = self.store.get_preimage(&payment_hash)
-                                else {
+                                let mut payment_preimage = self.store.get_preimage(&payment_hash);
+                                if payment_preimage.is_none() {
+                                    if let Some(querier) = self.watchtower_querier.as_ref() {
+                                        payment_preimage = querier
+                                            .query_tlc_status(&channel_id, &payment_hash)
+                                            .await
+                                            .and_then(|s| s.preimage);
+                                        if let Some(preimage) = payment_preimage {
+                                            self.store.insert_preimage(payment_hash, preimage);
+                                        }
+                                    }
+                                }
+                                let Some(payment_preimage) = payment_preimage else {
                                     continue;
                                 };
                                 debug!(
@@ -1537,7 +1551,16 @@ where
                                 shared_secret,
                             ) in expired_tlcs
                             {
-                                if self.store.is_tlc_settled(&channel_id, &payment_hash) {
+                                let is_settled =
+                                    if let Some(querier) = self.watchtower_querier.as_ref() {
+                                        querier
+                                            .query_tlc_status(&channel_id, &payment_hash)
+                                            .await
+                                            .is_some_and(|s| s.is_settled)
+                                    } else {
+                                        false
+                                    };
+                                if is_settled {
                                     let (send, _recv) = oneshot::channel();
                                     let rpc_reply = RpcReplyPort::from(send);
                                     if let Err(err) = state
@@ -5029,6 +5052,7 @@ pub async fn start_network<
     store: S,
     network_graph: Arc<RwLock<NetworkGraph<S>>>,
     default_shutdown_script: Script,
+    watchtower_querier: Option<Arc<dyn super::WatchtowerQuerier>>,
 ) -> ActorRef<NetworkActorMessage> {
     let my_pubkey = config.public_key();
 
@@ -5040,6 +5064,7 @@ pub async fn start_network<
             store,
             network_graph,
             chain_client,
+            watchtower_querier,
         ),
         NetworkActorStartArguments {
             config,

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -63,6 +63,7 @@ use super::graph::{NetworkGraph, NetworkGraphStateStore, OwnedChannelUpdateEvent
 use super::types::{
     BroadcastMessageWithTimestamp, FiberMessage, ForwardTlcResult, GossipMessage, Init, OpenChannel,
 };
+use super::watchtower_query_actor::{WatchtowerQueryActor, WatchtowerQueryActorMessage};
 use super::{
     FiberConfig, InFlightCkbTxActor, InFlightCkbTxActorArguments, InFlightCkbTxKind,
     ASSUME_NETWORK_ACTOR_ALIVE,
@@ -384,6 +385,21 @@ pub enum NetworkActorCommand {
     ListPeers((), RpcReplyPort<Result<Vec<PeerInfo>, String>>),
     // Get all inbound channel requests that are waiting for `accept_channel`
     GetPendingAcceptChannels(RpcReplyPort<Result<Vec<PendingAcceptChannel>, String>>),
+
+    // Watchtower query result: preimage found for a TLC, settle it immediately.
+    WatchtowerPreimageResult {
+        channel_id: Hash256,
+        tlc_id: u64,
+        payment_hash: Hash256,
+        preimage: Hash256,
+    },
+    // Watchtower query result: TLC is settled on-chain.
+    // The forwarding TLC should be failed with ExpiryTooSoon.
+    WatchtowerSettledResult {
+        forwarding_channel_id: Hash256,
+        forwarding_tlc_id: u64,
+        shared_secret: [u8; 32],
+    },
 
     #[cfg(any(debug_assertions, feature = "bench"))]
     UpdateFeatures(FeatureVector),
@@ -1364,26 +1380,6 @@ where
                                         continue;
                                     }
                                 }
-
-                                let mut payment_preimage = self.store.get_preimage(&payment_hash);
-                                if payment_preimage.is_none() {
-                                    if let Some(querier) = self.watchtower_querier.as_ref() {
-                                        payment_preimage = querier
-                                            .query_tlc_status(&channel_id, &payment_hash)
-                                            .await
-                                            .and_then(|s| s.preimage);
-                                        if let Some(preimage) = payment_preimage {
-                                            self.store.insert_preimage(payment_hash, preimage);
-                                        }
-                                    }
-                                }
-                                let Some(payment_preimage) = payment_preimage else {
-                                    continue;
-                                };
-                                debug!(
-                                    "Found payment preimage for channel {:?} tlc {:?}",
-                                    channel_id, id
-                                );
                                 if self
                                     .store
                                     .get_invoice_status(&payment_hash)
@@ -1396,6 +1392,28 @@ where
                                 {
                                     continue;
                                 }
+
+                                let payment_preimage = self.store.get_preimage(&payment_hash);
+                                if payment_preimage.is_none() {
+                                    if let Some(wt_actor) = state.watchtower_query_actor.as_ref() {
+                                        let _ = wt_actor.send_message(
+                                            WatchtowerQueryActorMessage::QueryPreimage {
+                                                channel_id,
+                                                tlc_id: tlc_id.into(),
+                                                payment_hash: payment_hash,
+                                            },
+                                        );
+                                    }
+                                    continue;
+                                }
+                                let Some(payment_preimage) = payment_preimage else {
+                                    continue;
+                                };
+
+                                debug!(
+                                    "Found payment preimage for channel {:?} tlc {:?}",
+                                    channel_id, tlc_id
+                                );
 
                                 let (send, _recv) = oneshot::channel();
                                 let rpc_reply = RpcReplyPort::from(send);
@@ -1551,43 +1569,16 @@ where
                                 shared_secret,
                             ) in expired_tlcs
                             {
-                                let is_settled =
-                                    if let Some(querier) = self.watchtower_querier.as_ref() {
-                                        querier
-                                            .query_tlc_status(&channel_id, &payment_hash)
-                                            .await
-                                            .is_some_and(|s| s.is_settled)
-                                    } else {
-                                        false
-                                    };
-                                if is_settled {
-                                    let (send, _recv) = oneshot::channel();
-                                    let rpc_reply = RpcReplyPort::from(send);
-                                    if let Err(err) = state
-                                        .send_command_to_channel(
+                                if let Some(wt_actor) = state.watchtower_query_actor.as_ref() {
+                                    let _ = wt_actor.send_message(
+                                        WatchtowerQueryActorMessage::QuerySettled {
+                                            channel_id,
+                                            payment_hash: payment_hash,
                                             forwarding_channel_id,
-                                            ChannelCommand::RemoveTlc(
-                                                RemoveTlcCommand {
-                                                    id: forwarding_tlc_id,
-                                                    reason: RemoveTlcReason::RemoveTlcFail(
-                                                        TlcErrPacket::new(
-                                                            TlcErr::new(
-                                                                TlcErrorCode::ExpiryTooSoon,
-                                                            ),
-                                                            &shared_secret,
-                                                        ),
-                                                    ),
-                                                },
-                                                rpc_reply,
-                                            ),
-                                        )
-                                        .await
-                                    {
-                                        error!(
-                                            "Failed to remove settled tlc {:?} for channel {:?}: {}",
-                                            forwarding_tlc_id, forwarding_channel_id, err
-                                        );
-                                    }
+                                            forwarding_tlc_id,
+                                            shared_secret: shared_secret,
+                                        },
+                                    );
                                 }
                             }
                         }
@@ -1649,6 +1640,90 @@ where
                                 .expect(ASSUME_NETWORK_MYSELF_ALIVE);
                         }
                     }
+                }
+            }
+            NetworkActorCommand::WatchtowerPreimageResult {
+                channel_id,
+                tlc_id,
+                payment_hash,
+                preimage,
+            } => {
+                self.store.insert_preimage(payment_hash, preimage);
+                debug!(
+                    "Found watchtower preimage for channel {:?} tlc {:?}",
+                    channel_id, tlc_id
+                );
+                if self
+                    .store
+                    .get_invoice_status(&payment_hash)
+                    .is_some_and(|s| {
+                        !matches!(s, CkbInvoiceStatus::Open | CkbInvoiceStatus::Received)
+                    })
+                {
+                    return Ok(());
+                }
+                // Only send RemoveTlc if the channel still has this received TLC (it may have
+                // been removed already, e.g. by a concurrent payment winning the race).
+                let tlc_still_exists =
+                    self.store
+                        .get_channel_actor_state(&channel_id)
+                        .is_some_and(|actor_state| {
+                            actor_state
+                                .get_received_tlc(TLCId::Received(tlc_id))
+                                .is_some()
+                        });
+                if tlc_still_exists {
+                    let (send, _recv) = oneshot::channel();
+                    let rpc_reply = RpcReplyPort::from(send);
+                    if let Err(err) = state
+                        .send_command_to_channel(
+                            channel_id,
+                            ChannelCommand::RemoveTlc(
+                                RemoveTlcCommand {
+                                    id: tlc_id,
+                                    reason: RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
+                                        payment_preimage: preimage,
+                                    }),
+                                },
+                                rpc_reply,
+                            ),
+                        )
+                        .await
+                    {
+                        error!(
+                            "Failed to remove tlc {:?} with preimage for channel {:?}: {}",
+                            tlc_id, channel_id, err
+                        );
+                    }
+                }
+            }
+            NetworkActorCommand::WatchtowerSettledResult {
+                forwarding_channel_id,
+                forwarding_tlc_id,
+                shared_secret,
+            } => {
+                let (send, _recv) = oneshot::channel();
+                let rpc_reply = RpcReplyPort::from(send);
+                if let Err(err) = state
+                    .send_command_to_channel(
+                        forwarding_channel_id,
+                        ChannelCommand::RemoveTlc(
+                            RemoveTlcCommand {
+                                id: forwarding_tlc_id,
+                                reason: RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
+                                    TlcErr::new(TlcErrorCode::ExpiryTooSoon),
+                                    &shared_secret,
+                                )),
+                            },
+                            rpc_reply,
+                        ),
+                    )
+                    .await
+                {
+                    error!(
+                        "Failed to remove settled tlc {:?} for channel {:?}: {}",
+                        forwarding_tlc_id, forwarding_channel_id, err
+                    );
                 }
             }
             NetworkActorCommand::SettleHoldTlcSet(payment_hash) => {
@@ -2957,6 +3032,8 @@ pub struct NetworkActorState<S, C> {
 
     // Inflight payment actors
     inflight_payments: HashMap<Hash256, ActorRef<PaymentActorMessage>>,
+    // Actor for querying watchtower TLC status without blocking the network actor.
+    watchtower_query_actor: Option<ActorRef<WatchtowerQueryActorMessage>>,
 }
 
 #[derive(Debug, Clone)]
@@ -4707,6 +4784,20 @@ where
         let chain_actor = self.chain_actor.clone();
         let features = config.gen_node_features();
 
+        let watchtower_query_actor = if let Some(querier) = self.watchtower_querier.clone() {
+            let actor = WatchtowerQueryActor::new(querier, myself.clone());
+            let (actor_ref, _) = Actor::spawn_linked(
+                Some("watchtower_query".to_string()),
+                actor,
+                (),
+                myself.get_cell(),
+            )
+            .await?;
+            Some(actor_ref)
+        } else {
+            None
+        };
+
         let mut state = NetworkActorState {
             store: self.store.clone(),
             state_to_be_persisted,
@@ -4743,6 +4834,7 @@ where
                 funding_timeout_seconds: config.funding_timeout_seconds,
             },
             inflight_payments: Default::default(),
+            watchtower_query_actor,
         };
 
         let node_announcement = state.get_or_create_new_node_announcement_message();

--- a/crates/fiber-lib/src/fiber/tests/mod.rs
+++ b/crates/fiber-lib/src/fiber/tests/mod.rs
@@ -21,3 +21,5 @@ mod tlc_op;
 mod trampoline;
 mod types;
 mod utils;
+#[cfg(not(target_arch = "wasm32"))]
+mod watchtower_query;

--- a/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
@@ -187,10 +187,6 @@ impl ChannelActorStateStore for MockStore {
         HashMap::new()
     }
 
-    fn is_tlc_settled(&self, _channel_id: &Hash256, _payment_hash: &Hash256) -> bool {
-        false
-    }
-
     fn store_pending_commit_diff(&self, _channel_id: &Hash256, _diff: &CommitDiff) {
         // No-op for tests
     }

--- a/crates/fiber-lib/src/fiber/tests/watchtower_query.rs
+++ b/crates/fiber-lib/src/fiber/tests/watchtower_query.rs
@@ -1,0 +1,244 @@
+use crate::fiber::payment::SendPaymentCommand;
+use crate::fiber::types::Hash256;
+use crate::fiber::watchtower_query::{TlcWatchtowerStatus, WatchtowerQuerier};
+use crate::gen_rand_sha256_hash;
+use crate::invoice::{Currency, InvoiceBuilder};
+use crate::test_utils::init_tracing;
+use crate::tests::test_utils::*;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// A mock watchtower querier that returns predefined TLC statuses.
+pub struct MockWatchtowerQuerier {
+    statuses: Mutex<HashMap<(Hash256, Hash256), TlcWatchtowerStatus>>,
+}
+
+impl MockWatchtowerQuerier {
+    pub fn new() -> Self {
+        Self {
+            statuses: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Set the status that will be returned for a given (channel_id, payment_hash) query.
+    pub fn set_status(
+        &self,
+        channel_id: Hash256,
+        payment_hash: Hash256,
+        status: TlcWatchtowerStatus,
+    ) {
+        self.statuses
+            .lock()
+            .unwrap()
+            .insert((channel_id, payment_hash), status);
+    }
+}
+
+impl std::fmt::Debug for MockWatchtowerQuerier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MockWatchtowerQuerier").finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl WatchtowerQuerier for MockWatchtowerQuerier {
+    async fn query_tlc_status(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<TlcWatchtowerStatus> {
+        self.statuses
+            .lock()
+            .unwrap()
+            .get(&(*channel_id, *payment_hash))
+            .cloned()
+    }
+}
+
+/// Test: a->b payment where the preimage is only available via watchtower querier.
+///
+/// Scenario:
+///   1. node_b has a mock watchtower querier.
+///   2. node_b creates an invoice WITHOUT storing the preimage in its normal store.
+///   3. node_a sends payment to node_b using the invoice.
+///   4. node_b's CheckChannels picks up the preimage from the watchtower querier
+///      and settles the TLC with RemoveTlcFulfill.
+///   5. node_a's payment should succeed.
+#[tokio::test]
+async fn test_payment_success_via_watchtower_preimage_direct() {
+    init_tracing();
+
+    let watchtower_querier = Arc::new(MockWatchtowerQuerier::new());
+
+    // Create node_b with the mock watchtower querier
+    let config_b = NetworkNodeConfigBuilder::new()
+        .node_name(Some("node-b".to_string()))
+        .base_dir_prefix("test-wt-direct-b-")
+        .watchtower_querier(Some(watchtower_querier.clone()))
+        .build();
+    let mut node_b = NetworkNode::new_with_config(config_b).await;
+
+    // Create node_a normally
+    let config_a = NetworkNodeConfigBuilder::new()
+        .node_name(Some("node-a".to_string()))
+        .base_dir_prefix("test-wt-direct-a-")
+        .build();
+    let mut node_a = NetworkNode::new_with_config(config_a).await;
+
+    // Connect and establish channel
+    node_a.connect_to(&mut node_b).await;
+    let (channel_id, _funding_tx_hash) = establish_channel_between_nodes(
+        &mut node_a,
+        &mut node_b,
+        ChannelParameters::new(HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT),
+    )
+    .await;
+
+    // Generate a preimage and build an invoice on node_b
+    let preimage = gen_rand_sha256_hash();
+    let invoice = InvoiceBuilder::new(Currency::Fibd)
+        .amount(Some(1000000000))
+        .payment_preimage(preimage)
+        .payee_pub_key(node_b.pubkey.into())
+        .build()
+        .expect("build invoice");
+    let payment_hash = *invoice.payment_hash();
+
+    // Insert the invoice WITHOUT storing the preimage in the normal preimage store.
+    // This simulates the scenario where the preimage is only known to the watchtower
+    // (e.g., the node crashed and lost the preimage, but the watchtower observed it onchain).
+    node_b.insert_invoice(invoice.clone(), None);
+
+    // Configure the watchtower to return the preimage when queried for this channel + payment_hash.
+    watchtower_querier.set_status(
+        channel_id,
+        payment_hash,
+        TlcWatchtowerStatus {
+            preimage: Some(preimage),
+            is_settled: true,
+        },
+    );
+
+    // Send payment from a to b using the invoice
+    let res = node_a
+        .send_payment(SendPaymentCommand {
+            invoice: Some(invoice.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("send payment should succeed");
+
+    // The CheckChannels timer on node_b (every 3s in debug mode) should pick up the
+    // preimage from the watchtower, settle the received TLC, and propagate back to node_a.
+    node_a.wait_until_success(res.payment_hash).await;
+}
+
+/// Test: a->b->c payment where c settles via watchtower (preimage available through
+/// the watchtower on node_b), the TLC offered by a to b should be settled offchain,
+/// and the payment should succeed.
+///
+/// Scenario:
+///   1. node_b has a mock watchtower querier.
+///   2. node_c creates an invoice WITHOUT storing the preimage.
+///   3. node_a sends payment to node_c via node_b.
+///   4. The TLC reaches node_c, but node_c cannot settle (no preimage in store).
+///   5. node_b's watchtower querier returns the preimage (simulating watchtower
+///      observing c's onchain settlement on the b-c channel).
+///   6. node_b's CheckChannels picks up the preimage for the received TLC on the
+///      a-b channel and sends RemoveTlcFulfill to node_a.
+///   7. node_a's payment should succeed.
+#[tokio::test]
+async fn test_multi_hop_payment_success_via_watchtower_preimage() {
+    init_tracing();
+
+    let watchtower_querier = Arc::new(MockWatchtowerQuerier::new());
+
+    // Create 3 nodes: a (normal), b (with watchtower querier), c (normal)
+    let nodes = NetworkNode::new_n_interconnected_nodes_with_config(3, |i| {
+        let mut builder = NetworkNodeConfigBuilder::new()
+            .node_name(Some(format!("node-{}", i)))
+            .base_dir_prefix(&format!("test-wt-multihop-{}-", i));
+        if i == 1 {
+            // node_b gets the watchtower querier
+            builder = builder.watchtower_querier(Some(watchtower_querier.clone()));
+        }
+        builder.build()
+    })
+    .await;
+
+    let [mut node_a, mut node_b, mut node_c]: [NetworkNode; 3] = nodes.try_into().expect("3 nodes");
+
+    // Establish channels: a-b and b-c
+    let (ab_channel_id, ab_funding_tx_hash) = establish_channel_between_nodes(
+        &mut node_a,
+        &mut node_b,
+        ChannelParameters::new(HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT),
+    )
+    .await;
+
+    // Submit funding tx to all nodes for graph discovery
+    let ab_funding_tx = node_a
+        .get_transaction_view_from_hash(ab_funding_tx_hash)
+        .await
+        .expect("get funding tx");
+    node_c.submit_tx(ab_funding_tx.clone()).await;
+    node_c.add_channel_tx(ab_channel_id, ab_funding_tx_hash);
+
+    let (bc_channel_id, bc_funding_tx_hash) = establish_channel_between_nodes(
+        &mut node_b,
+        &mut node_c,
+        ChannelParameters::new(HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT),
+    )
+    .await;
+
+    // Submit funding tx to all nodes for graph discovery
+    let bc_funding_tx = node_b
+        .get_transaction_view_from_hash(bc_funding_tx_hash)
+        .await
+        .expect("get funding tx");
+    node_a.submit_tx(bc_funding_tx.clone()).await;
+    node_a.add_channel_tx(bc_channel_id, bc_funding_tx_hash);
+
+    // Wait for graph to see both channels
+    wait_for_network_graph_update(&node_a, 2).await;
+
+    // Generate a preimage and build an invoice on node_c
+    let preimage = gen_rand_sha256_hash();
+    let invoice = InvoiceBuilder::new(Currency::Fibd)
+        .amount(Some(1000000000))
+        .payment_preimage(preimage)
+        .payee_pub_key(node_c.pubkey.into())
+        .build()
+        .expect("build invoice");
+    let payment_hash = *invoice.payment_hash();
+
+    // Insert the invoice WITHOUT storing the preimage.
+    // node_c has the invoice but cannot settle because the preimage is not in its store.
+    node_c.insert_invoice(invoice.clone(), None);
+
+    // Configure node_b's watchtower querier to return the preimage for the a-b channel.
+    // This simulates: c settled the TLC onchain on the b-c channel with the preimage,
+    // and b's watchtower observed it and can now provide the preimage.
+    watchtower_querier.set_status(
+        ab_channel_id,
+        payment_hash,
+        TlcWatchtowerStatus {
+            preimage: Some(preimage),
+            is_settled: true,
+        },
+    );
+
+    // Send payment from a to c
+    let res = node_a
+        .send_payment(SendPaymentCommand {
+            invoice: Some(invoice.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("send payment should succeed");
+
+    // node_b's CheckChannels should find the preimage via watchtower for the received TLC
+    // on the a-b channel and settle it offchain with RemoveTlcFulfill.
+    // This propagates back to node_a, marking the payment as successful.
+    node_a.wait_until_success(res.payment_hash).await;
+}

--- a/crates/fiber-lib/src/fiber/watchtower_query.rs
+++ b/crates/fiber-lib/src/fiber/watchtower_query.rs
@@ -1,0 +1,23 @@
+use crate::fiber::types::Hash256;
+
+/// Status of a TLC as reported by the watchtower
+pub struct TlcWatchtowerStatus {
+    /// The preimage for the payment hash, if known by the watchtower
+    pub preimage: Option<Hash256>,
+    /// Whether the TLC has been settled on chain
+    pub is_settled: bool,
+}
+
+/// Trait for querying watchtower status of TLCs.
+/// Implemented by direct store access (built-in watchtower) and RPC client (standalone watchtower).
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait WatchtowerQuerier: Send + Sync {
+    /// Query the watchtower for the status of a TLC identified by channel_id and payment_hash.
+    /// Returns `None` if the watchtower is unreachable or encounters an error.
+    async fn query_tlc_status(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<TlcWatchtowerStatus>;
+}

--- a/crates/fiber-lib/src/fiber/watchtower_query.rs
+++ b/crates/fiber-lib/src/fiber/watchtower_query.rs
@@ -1,6 +1,7 @@
 use crate::fiber::types::Hash256;
 
 /// Status of a TLC as reported by the watchtower
+#[derive(Clone)]
 pub struct TlcWatchtowerStatus {
     /// The preimage for the payment hash, if known by the watchtower
     pub preimage: Option<Hash256>,

--- a/crates/fiber-lib/src/fiber/watchtower_query.rs
+++ b/crates/fiber-lib/src/fiber/watchtower_query.rs
@@ -1,4 +1,4 @@
-use crate::fiber::types::Hash256;
+use fiber_types::Hash256;
 
 /// Status of a TLC as reported by the watchtower
 #[derive(Clone)]

--- a/crates/fiber-lib/src/fiber/watchtower_query_actor.rs
+++ b/crates/fiber-lib/src/fiber/watchtower_query_actor.rs
@@ -1,0 +1,135 @@
+use std::sync::Arc;
+
+use ractor::{Actor, ActorProcessingErr, ActorRef};
+use strum::AsRefStr;
+use tracing::debug;
+
+use super::types::Hash256;
+use super::watchtower_query::WatchtowerQuerier;
+use super::{NetworkActorCommand, NetworkActorMessage, ASSUME_NETWORK_ACTOR_ALIVE};
+use crate::utils::actor::ActorHandleLogGuard;
+
+const ACTOR_HANDLE_WARN_THRESHOLD_MS: u64 = 15_000;
+
+#[derive(Debug, Clone, AsRefStr)]
+pub enum WatchtowerQueryActorMessage {
+    /// Query the watchtower for a preimage for a received TLC.
+    /// If found, the preimage is forwarded to the network actor to settle the TLC.
+    QueryPreimage {
+        channel_id: Hash256,
+        tlc_id: u64,
+        payment_hash: Hash256,
+    },
+    /// Query the watchtower for settlement status of an offered TLC.
+    /// If settled on-chain, a command is sent to fail the forwarding TLC.
+    QuerySettled {
+        channel_id: Hash256,
+        payment_hash: Hash256,
+        forwarding_channel_id: Hash256,
+        forwarding_tlc_id: u64,
+        shared_secret: [u8; 32],
+    },
+}
+
+pub struct WatchtowerQueryActor {
+    querier: Arc<dyn WatchtowerQuerier>,
+    network: ActorRef<NetworkActorMessage>,
+}
+
+impl WatchtowerQueryActor {
+    pub fn new(
+        querier: Arc<dyn WatchtowerQuerier>,
+        network: ActorRef<NetworkActorMessage>,
+    ) -> Self {
+        Self { querier, network }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl Actor for WatchtowerQueryActor {
+    type Msg = WatchtowerQueryActorMessage;
+    type State = ();
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let _handle_log_guard = ActorHandleLogGuard::new(
+            "WatchtowerQueryActor",
+            message.as_ref().to_string(),
+            "fiber.watchtower_query_actor",
+            ACTOR_HANDLE_WARN_THRESHOLD_MS,
+        );
+        match message {
+            WatchtowerQueryActorMessage::QueryPreimage {
+                channel_id,
+                tlc_id,
+                payment_hash,
+            } => {
+                if let Some(preimage) = self
+                    .querier
+                    .query_tlc_status(&channel_id, &payment_hash)
+                    .await
+                    .and_then(|s| s.preimage)
+                {
+                    debug!(
+                        "Watchtower returned preimage for channel {:?} tlc {:?}",
+                        channel_id, tlc_id
+                    );
+                    self.network
+                        .send_message(NetworkActorMessage::new_command(
+                            NetworkActorCommand::WatchtowerPreimageResult {
+                                channel_id,
+                                tlc_id,
+                                payment_hash,
+                                preimage,
+                            },
+                        ))
+                        .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+                }
+            }
+            WatchtowerQueryActorMessage::QuerySettled {
+                channel_id,
+                payment_hash,
+                forwarding_channel_id,
+                forwarding_tlc_id,
+                shared_secret,
+            } => {
+                let is_settled = self
+                    .querier
+                    .query_tlc_status(&channel_id, &payment_hash)
+                    .await
+                    .is_some_and(|s| s.is_settled);
+
+                if is_settled {
+                    debug!(
+                        "Watchtower confirmed TLC settled for channel {:?} payment_hash {:?}",
+                        channel_id, payment_hash
+                    );
+                    self.network
+                        .send_message(NetworkActorMessage::new_command(
+                            NetworkActorCommand::WatchtowerSettledResult {
+                                forwarding_channel_id,
+                                forwarding_tlc_id,
+                                shared_secret,
+                            },
+                        ))
+                        .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -1103,7 +1103,7 @@ Query the status of a TLC
 
 ##### Returns
 
-* `preimage` - <em>Option<[Hash256](#type-hash256)></em>, The preimage for the payment hash, if known
+* `preimage` - <em>Option<[Hash256](#type-hash256)></em>, Found preimage when the TLC has been settled on chain with the preimage path.
 * `is_settled` - <em>`bool`</em>, Whether the TLC has been settled on chain
 
 ---

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -62,6 +62,7 @@ You may refer to the e2e test cases in the `tests/bruno/e2e` directory for examp
         * [Method `update_local_settlement`](#watchtower-update_local_settlement)
         * [Method `create_preimage`](#watchtower-create_preimage)
         * [Method `remove_preimage`](#watchtower-remove_preimage)
+        * [Method `query_tlc_status`](#watchtower-query_tlc_status)
 * [RPC Types](#rpc-types)
 
     * [Type `Attribute`](#type-attribute)
@@ -1085,6 +1086,25 @@ Remove preimage
 ##### Returns
 
 * None
+
+---
+
+
+
+<a id="watchtower-query_tlc_status"></a>
+#### Method `query_tlc_status`
+
+Query the status of a TLC
+
+##### Params
+
+* `channel_id` - <em>[Hash256](#type-hash256)</em>, Channel ID
+* `payment_hash` - <em>[Hash256](#type-hash256)</em>, Payment hash
+
+##### Returns
+
+* `preimage` - <em>Option<[Hash256](#type-hash256)></em>, The preimage for the payment hash, if known
+* `is_settled` - <em>`bool`</em>, Whether the TLC has been settled on chain
 
 ---
 

--- a/crates/fiber-lib/src/rpc/biscuit.rs
+++ b/crates/fiber-lib/src/rpc/biscuit.rs
@@ -151,6 +151,10 @@ fn build_rules() -> HashMap<&'static str, AuthRule> {
         "remove_preimage",
         AuthRule::new(r#"allow if write("watchtower");"#).with_require_rpc_context(true),
     );
+    b.with_rule(
+        "query_tlc_status",
+        AuthRule::new(r#"allow if read("watchtower");"#).with_require_rpc_context(true),
+    );
 
     b.0
 }

--- a/crates/fiber-lib/src/rpc/watchtower.rs
+++ b/crates/fiber-lib/src/rpc/watchtower.rs
@@ -295,11 +295,11 @@ where
         _ctx: RpcContext,
         params: QueryTlcStatusParams,
     ) -> Result<QueryTlcStatusResult, ErrorObjectOwned> {
-        let status = self
-            .store
-            .query_tlc_status(&params.channel_id, &params.payment_hash);
+        let channel_id = params.channel_id.into();
+        let payment_hash = params.payment_hash.into();
+        let status = self.store.query_tlc_status(&channel_id, &payment_hash);
         Ok(QueryTlcStatusResult {
-            preimage: status.preimage,
+            preimage: status.preimage.map(Into::into),
             is_settled: status.is_settled,
         })
     }
@@ -323,19 +323,19 @@ impl<C: WatchtowerRpcClient + Send + Sync> crate::fiber::WatchtowerQuerier
 {
     async fn query_tlc_status(
         &self,
-        channel_id: &crate::fiber::types::Hash256,
-        payment_hash: &crate::fiber::types::Hash256,
+        channel_id: &fiber_types::Hash256,
+        payment_hash: &fiber_types::Hash256,
     ) -> Option<crate::fiber::TlcWatchtowerStatus> {
         match self
             .client
             .query_tlc_status(QueryTlcStatusParams {
-                channel_id: *channel_id,
-                payment_hash: *payment_hash,
+                channel_id: (*channel_id).into(),
+                payment_hash: (*payment_hash).into(),
             })
             .await
         {
             Ok(result) => Some(crate::fiber::TlcWatchtowerStatus {
-                preimage: result.preimage,
+                preimage: result.preimage.map(Into::into),
                 is_settled: result.is_settled,
             }),
             Err(e) => {

--- a/crates/fiber-lib/src/rpc/watchtower.rs
+++ b/crates/fiber-lib/src/rpc/watchtower.rs
@@ -13,8 +13,9 @@ pub use fiber_json_types::RpcContext;
 use fiber_types::{NodeId, Pubkey};
 
 pub use fiber_json_types::{
-    CreatePreimageParams, CreateWatchChannelParams, RemovePreimageParams, RemoveWatchChannelParams,
-    UpdateLocalSettlementParams, UpdatePendingRemoteSettlementParams, UpdateRevocationParams,
+    CreatePreimageParams, CreateWatchChannelParams, QueryTlcStatusParams, QueryTlcStatusResult,
+    RemovePreimageParams, RemoveWatchChannelParams, UpdateLocalSettlementParams,
+    UpdatePendingRemoteSettlementParams, UpdateRevocationParams,
 };
 
 /// RPC module for watchtower related operations
@@ -76,6 +77,14 @@ trait WatchtowerRpc {
         ctx: RpcContext,
         params: RemovePreimageParams,
     ) -> Result<(), ErrorObjectOwned>;
+
+    /// Query the status of a TLC
+    #[method(name = "query_tlc_status")]
+    async fn query_tlc_status(
+        &self,
+        ctx: RpcContext,
+        params: QueryTlcStatusParams,
+    ) -> Result<QueryTlcStatusResult, ErrorObjectOwned>;
 }
 
 /// ignore rpc-doc-gen
@@ -124,6 +133,13 @@ trait WatchtowerRpc {
     /// Remove preimage
     #[method(name = "remove_preimage")]
     async fn remove_preimage(&self, params: RemovePreimageParams) -> Result<(), ErrorObjectOwned>;
+
+    /// Query the status of a TLC
+    #[method(name = "query_tlc_status")]
+    async fn query_tlc_status(
+        &self,
+        params: QueryTlcStatusParams,
+    ) -> Result<QueryTlcStatusResult, ErrorObjectOwned>;
 }
 
 #[cfg(feature = "watchtower")]
@@ -273,5 +289,59 @@ where
         let payment_hash = params.payment_hash.into();
         self.store.remove_watch_preimage(node_id, payment_hash);
         Ok(())
+    }
+    async fn query_tlc_status(
+        &self,
+        _ctx: RpcContext,
+        params: QueryTlcStatusParams,
+    ) -> Result<QueryTlcStatusResult, ErrorObjectOwned> {
+        let status = self
+            .store
+            .query_tlc_status(&params.channel_id, &params.payment_hash);
+        Ok(QueryTlcStatusResult {
+            preimage: status.preimage,
+            is_settled: status.is_settled,
+        })
+    }
+}
+
+/// A wrapper around a watchtower RPC client that implements `WatchtowerQuerier`.
+pub struct WatchtowerRpcQuerier<C> {
+    client: C,
+}
+
+impl<C> WatchtowerRpcQuerier<C> {
+    pub fn new(client: C) -> Self {
+        Self { client }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<C: WatchtowerRpcClient + Send + Sync> crate::fiber::WatchtowerQuerier
+    for WatchtowerRpcQuerier<C>
+{
+    async fn query_tlc_status(
+        &self,
+        channel_id: &crate::fiber::types::Hash256,
+        payment_hash: &crate::fiber::types::Hash256,
+    ) -> Option<crate::fiber::TlcWatchtowerStatus> {
+        match self
+            .client
+            .query_tlc_status(QueryTlcStatusParams {
+                channel_id: *channel_id,
+                payment_hash: *payment_hash,
+            })
+            .await
+        {
+            Ok(result) => Some(crate::fiber::TlcWatchtowerStatus {
+                preimage: result.preimage,
+                is_settled: result.is_settled,
+            }),
+            Err(e) => {
+                tracing::warn!("Watchtower query failed: {}", e);
+                None
+            }
+        }
     }
 }

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -650,16 +650,6 @@ impl ChannelActorStateStore for Store {
             )
     }
 
-    fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool {
-        let key = [
-            &[WATCHTOWER_TLC_SETTLED_PREFIX],
-            channel_id.as_ref(),
-            &payment_hash.as_ref()[0..20],
-        ]
-        .concat();
-        self.get(key).is_some()
-    }
-
     fn store_pending_commit_diff(&self, channel_id: &Hash256, diff: &CommitDiff) {
         let key = [&[PENDING_COMMIT_DIFF_PREFIX], channel_id.as_ref()].concat();
         let value = serialize_to_vec(diff, "CommitDiff");
@@ -1286,6 +1276,33 @@ impl WatchtowerStore for Store {
         .concat();
         batch.put(key, []);
         batch.commit();
+    }
+
+    fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool {
+        let key = [
+            &[WATCHTOWER_TLC_SETTLED_PREFIX],
+            channel_id.as_ref(),
+            &payment_hash.as_ref()[0..20],
+        ]
+        .concat();
+        self.get(key).is_some()
+    }
+}
+
+#[cfg(feature = "watchtower")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl crate::fiber::WatchtowerQuerier for Store {
+    async fn query_tlc_status(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<crate::fiber::TlcWatchtowerStatus> {
+        Some(WatchtowerStore::query_tlc_status(
+            self,
+            channel_id,
+            payment_hash,
+        ))
     }
 }
 

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -1511,6 +1511,7 @@ impl NetworkNode {
                 store.clone(),
                 network_graph.clone(),
                 chain_client.clone(),
+                None,
             ),
             NetworkActorStartArguments {
                 config: fiber_config.clone(),

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -273,6 +273,7 @@ pub struct NetworkNodeConfig {
     rpc_config: Option<RpcConfig>,
     ckb_config: Option<CkbConfig>,
     mock_chain_actor_middleware: Option<Box<dyn MockChainActorMiddleware>>,
+    watchtower_querier: Option<std::sync::Arc<dyn crate::fiber::WatchtowerQuerier>>,
 }
 
 impl NetworkNodeConfig {
@@ -290,6 +291,7 @@ pub struct NetworkNodeConfigBuilder {
     #[allow(clippy::type_complexity)]
     fiber_config_updater: Option<Box<dyn FnOnce(&mut FiberConfig) + 'static>>,
     mock_chain_actor_middleware: Option<Box<dyn MockChainActorMiddleware>>,
+    watchtower_querier: Option<std::sync::Arc<dyn crate::fiber::WatchtowerQuerier>>,
 }
 
 impl Default for NetworkNodeConfigBuilder {
@@ -306,6 +308,7 @@ impl NetworkNodeConfigBuilder {
             rpc_config: None,
             fiber_config_updater: None,
             mock_chain_actor_middleware: None,
+            watchtower_querier: None,
         }
     }
 
@@ -341,6 +344,14 @@ impl NetworkNodeConfigBuilder {
         middleware: Box<dyn MockChainActorMiddleware>,
     ) -> Self {
         self.mock_chain_actor_middleware = Some(middleware);
+        self
+    }
+
+    pub fn watchtower_querier(
+        mut self,
+        querier: Option<std::sync::Arc<dyn crate::fiber::WatchtowerQuerier>>,
+    ) -> Self {
+        self.watchtower_querier = querier;
         self
     }
 
@@ -385,6 +396,7 @@ impl NetworkNodeConfigBuilder {
             fiber_config,
             rpc_config,
             mock_chain_actor_middleware: self.mock_chain_actor_middleware,
+            watchtower_querier: self.watchtower_querier,
         };
 
         if let Some(updater) = self.fiber_config_updater {
@@ -1471,6 +1483,7 @@ impl NetworkNode {
             rpc_config,
             ckb_config,
             mock_chain_actor_middleware,
+            watchtower_querier,
         } = config;
 
         let _span = tracing::info_span!("NetworkNode", node_name = &node_name).entered();
@@ -1511,7 +1524,7 @@ impl NetworkNode {
                 store.clone(),
                 network_graph.clone(),
                 chain_client.clone(),
-                None,
+                watchtower_querier,
             ),
             NetworkActorStartArguments {
                 config: fiber_config.clone(),
@@ -1642,6 +1655,7 @@ impl NetworkNode {
             fiber_config: self.fiber_config.clone(),
             rpc_config: self.rpc_config.clone(),
             mock_chain_actor_middleware: self.mock_chain_actor_middleware.clone(),
+            watchtower_querier: None,
         }
     }
 

--- a/crates/fiber-lib/src/watchtower/store.rs
+++ b/crates/fiber-lib/src/watchtower/store.rs
@@ -2,7 +2,10 @@ use ckb_sdk::util::blake160;
 use ckb_types::packed::Script;
 use musig2::{secp::Point, KeyAggContext};
 
-use crate::ckb::contracts::{get_script_by_contract, Contract};
+use crate::{
+    ckb::contracts::{get_script_by_contract, Contract},
+    fiber::watchtower_query::TlcWatchtowerStatus,
+};
 use fiber_types::{ChannelData, Hash256, NodeId, Privkey, Pubkey, RevocationData, SettlementData};
 
 pub trait WatchtowerStore {
@@ -63,6 +66,21 @@ pub trait WatchtowerStore {
 
     /// Mark a tlc as settled on chain
     fn update_tlc_settled(&self, channel_id: &Hash256, payment_hash: [u8; 20]);
+
+    /// Check if a tlc is settled on chain
+    fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool;
+
+    /// Query the status of a TLC, returning both preimage and settlement status
+    fn query_tlc_status(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> TlcWatchtowerStatus {
+        TlcWatchtowerStatus {
+            preimage: self.get_watch_preimage(payment_hash),
+            is_settled: self.is_tlc_settled(channel_id, payment_hash),
+        }
+    }
 }
 
 /// Compute the x-only aggregated public key for a channel.

--- a/crates/fiber-types/src/schema.rs
+++ b/crates/fiber-types/src/schema.rs
@@ -38,7 +38,7 @@ pub const ATTEMPT_PREFIX: u8 = 195;
 // Key: [PREFIX, channel_outpoint, payment_hash, attempt_id], Value: ()
 pub const ATTEMPT_CHANNEL_INDEX_PREFIX: u8 = 196;
 pub const HOLD_TLC_PREFIX: u8 = 197;
-// A shared prefix for watchtower and channel store
+#[cfg(feature = "watchtower")]
 pub const WATCHTOWER_TLC_SETTLED_PREFIX: u8 = 200;
 pub const CHANNEL_OPEN_RECORD_PREFIX: u8 = 201;
 #[cfg(feature = "watchtower")]

--- a/crates/fiber-wasm/src/lib.rs
+++ b/crates/fiber-wasm/src/lib.rs
@@ -203,6 +203,27 @@ pub async fn fiber(
                 .expect("get default funding lock script should be ok");
 
             info!("Starting fiber");
+
+            // Construct watchtower querier for WASM (standalone watchtower only)
+            let watchtower_querier: Option<std::sync::Arc<dyn fnn::fiber::WatchtowerQuerier>> =
+                if let Some(url) = fiber_config.standalone_watchtower_rpc_url.clone() {
+                    let querier_client =
+                        WasmClientBuilder::default()
+                            .build(url)
+                            .await
+                            .map_err(|err| {
+                                ExitMessage(format!(
+                                    "failed to create watchtower rpc client: {}",
+                                    err
+                                ))
+                            })?;
+                    Some(std::sync::Arc::new(
+                        fnn::rpc::watchtower::WatchtowerRpcQuerier::new(querier_client),
+                    ))
+                } else {
+                    None
+                };
+
             let network_actor = start_network(
                 fiber_config.clone(),
                 chain_client,
@@ -213,6 +234,7 @@ pub async fn fiber(
                 store.clone(),
                 network_graph.clone(),
                 default_shutdown_script,
+                watchtower_querier,
             )
             .await;
 

--- a/docs/biscuit-auth.md
+++ b/docs/biscuit-auth.md
@@ -118,6 +118,13 @@ rule(
 ); 
 rule("create_preimage", r#"allow if write("watchtower");"#); 
 rule("remove_preimage", r#"allow if write("watchtower");"#); 
+rule(
+    "query_tlc_status",
+    r#"
+    allow if read("watchtower");
+    allow if right({channel_id}, "watchtower");
+    "#,
+);
 ```
 
 ## 3. How to Configure Biscuit Auth in Fiber

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/01-node1-connect-node2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/01-node1-connect-node2.bru
@@ -1,0 +1,36 @@
+meta {
+  name: connect peer
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "connect_peer",
+    "params": [
+      {"address": "{{NODE1_ADDR}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/02-node2-connect-node3.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/02-node2-connect-node3.bru
@@ -1,0 +1,36 @@
+meta {
+  name: connect peer
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "connect_peer",
+    "params": [
+      {"address": "{{NODE2_ADDR}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isNull
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/03-node1-node2-open-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/03-node1-node2-open-channel.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Node1 open a channel to Node2
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "open_channel",
+    "params": [
+      {
+        "pubkey": "{{NODE2_PUBKEY}}",
+        "funding_amount": "0x377aab54d000"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.temporary_channel_id: isDefined
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 2000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/04-node2-get-auto-accepted-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/04-node2-get-auto-accepted-channel.bru
@@ -1,0 +1,39 @@
+meta {
+  name: get auto accepted channel id from Node2
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "pubkey": "{{NODE1_PUBKEY}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.channels[0].channel_id: isDefined
+}
+
+script:post-response {
+  console.log("N1-N2 channels: ", res.body.result);
+  bru.setVar("N1N2_CHANNEL_ID", res.body.result.channels[0].channel_id);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/05-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/05-ckb-generate-blocks.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for channel 1
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x2"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/06-node2-node3-open-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/06-node2-node3-open-channel.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Node2 open a channel to Node3
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "open_channel",
+    "params": [
+      {
+        "pubkey": "{{NODE3_PUBKEY}}",
+        "funding_amount": "0x377aab54d000"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.temporary_channel_id: isDefined
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 2000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/07-node3-get-auto-accepted-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/07-node3-get-auto-accepted-channel.bru
@@ -1,0 +1,39 @@
+meta {
+  name: get auto accepted channel id from Node3
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "pubkey": "{{NODE2_PUBKEY}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.channels[0].channel_id: isDefined
+}
+
+script:post-response {
+  console.log("N2-N3 channels: ", res.body.result);
+  bru.setVar("N2N3_CHANNEL_ID", res.body.result.channels[0].channel_id);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/08-ckb-generate-blocks.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/08-ckb-generate-blocks.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for channel 2
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x2"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/09-get-node1-funding-script.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/09-get-node1-funding-script.bru
@@ -1,0 +1,29 @@
+meta {
+  name: get node1 funding script
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "node_info",
+    "params": []
+  }
+}
+
+script:post-response {
+  bru.setVar("NODE1_FUNDING_SCRIPT", res.body.result.default_funding_lock_script);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/10-get-node3-funding-script.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/10-get-node3-funding-script.bru
@@ -1,0 +1,29 @@
+meta {
+  name: get node3 funding script
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "node_info",
+    "params": []
+  }
+}
+
+script:post-response {
+  bru.setVar("NODE3_FUNDING_SCRIPT", res.body.result.default_funding_lock_script);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/11-get-node1-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/11-get-node1-balance.bru
@@ -1,0 +1,40 @@
+meta {
+  name: get node1 balance
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "get_cells_capacity",
+    "params": [
+      {
+        "script_type": "lock"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  let script = bru.getVar("NODE1_FUNDING_SCRIPT");
+  let body = req.getBody();
+  body.params[0].script = script;
+  req.setBody(body);
+}
+
+script:post-response {
+  bru.setVar("NODE1_BALANCE", res.body.result.capacity);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/12-get-node3-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/12-get-node3-balance.bru
@@ -1,0 +1,40 @@
+meta {
+  name: get node3 balance
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "get_cells_capacity",
+    "params": [
+      {
+        "script_type": "lock"
+      }
+    ]
+  }
+}
+
+script:pre-request {
+  let script = bru.getVar("NODE3_FUNDING_SCRIPT");
+  let body = req.getBody();
+  body.params[0].script = script;
+  req.setBody(body);
+}
+
+script:post-response {
+  bru.setVar("NODE3_BALANCE", res.body.result.capacity);
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/13-node3-gen-invoice.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/13-node3-gen-invoice.bru
@@ -1,0 +1,70 @@
+meta {
+  name: Node3 generate hold invoice
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "new_invoice",
+    "params": [
+      {
+        "amount": "0x5f5e100",
+        "currency": "Fibd",
+        "description": "hold invoice for preimage settlement test",
+        "expiry": "0xe10",
+        "final_expiry_delta": "0xDFFA0",
+        "payment_hash": "{{payment_hash}}",
+        "hash_algorithm": "sha256"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isDefined
+}
+
+script:pre-request {
+  let payment_preimage;
+  let payment_hash;
+  try {
+    const crypto = require('crypto');
+    function generateRandomPreimage() {
+      let hex = '0x';
+      for (let i = 0; i < 64; i++) {
+        hex += Math.floor(Math.random() * 16).toString(16);
+      }
+      return hex;
+    }
+    payment_preimage = generateRandomPreimage();
+    const preimage_bytes = Buffer.from(payment_preimage.slice(2), 'hex');
+    payment_hash = "0x" + crypto.createHash('sha256').update(preimage_bytes).digest('hex');
+  } catch (e) {
+    // Fallback: hardcoded SHA256 pair if crypto module unavailable
+    payment_preimage = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    payment_hash = "0x8200cf0ce11447bf6353cbac964d07d1c390d61d07e6c5d0214450b3add6449b";
+  }
+  bru.setVar("payment_preimage", payment_preimage);
+  bru.setVar("payment_hash", payment_hash);
+}
+
+script:post-response {
+  console.log("generated result: ", res.body.result);
+  bru.setVar("encoded_invoice", res.body.result.invoice_address);
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/14-node1-send-payment-with-invoice.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/14-node1-send-payment-with-invoice.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Node1 send payment with invoice
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "send_payment",
+    "params": [
+      {
+        "invoice": "{{encoded_invoice}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+}
+
+script:pre-request {
+  await new Promise(r => setTimeout(r, 1000));
+}
+
+script:post-response {
+  bru.setVar("payment_hash", res.body.result.payment_hash);
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/15-node2-force-close-channel.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/15-node2-force-close-channel.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Node2 force close N2-N3 channel
+  type: http
+  seq: 15
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "shutdown_channel",
+    "params": [
+      {
+        "channel_id": "{{N2N3_CHANNEL_ID}}",
+        "force": true
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body);
+  await new Promise(r => setTimeout(r, 2000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/16-node2-disconnect-node3.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/16-node2-disconnect-node3.bru
@@ -1,0 +1,36 @@
+meta {
+  name: disconnect Node2 from Node3
+  type: http
+  seq: 16
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "disconnect_peer",
+    "params": [
+      {"pubkey": "{{NODE3_PUBKEY}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isDefined
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 1000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/17-ckb-generate-blocks-for-force-close-tx.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/17-ckb-generate-blocks-for-force-close-tx.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate one epoch for force close transaction
+  type: http
+  seq: 17
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x1"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/18-node3-remove-tlc.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/18-node3-remove-tlc.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Node3 settles payment by revealing preimage on-chain
+  type: http
+  seq: 18
+}
+
+post {
+  url: {{NODE3_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "remove_tlc",
+    "params": [
+      {
+        "channel_id": "{{N2N3_CHANNEL_ID}}",
+        "tlc_id": "0x0",
+        "reason": {
+          "payment_preimage": "{{payment_preimage}}"
+        }
+      }
+    ]
+  }
+}
+
+script:post-response {
+  console.log(res.body);
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/19-ckb-generate-blocks-for-settlement-tx-preimage.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/19-ckb-generate-blocks-for-settlement-tx-preimage.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for settlement transaction
+  type: http
+  seq: 19
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x2"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/20-ckb-generate-blocks-for-final-settlement-tx.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/20-ckb-generate-blocks-for-final-settlement-tx.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate a few epochs for final settlement transaction
+  type: http
+  seq: 20
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x7"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 5000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/21-ckb-generate-blocks-for-final-settlement-tx-commit.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/21-ckb-generate-blocks-for-final-settlement-tx-commit.bru
@@ -1,0 +1,33 @@
+meta {
+  name: generate one epoch for final settlement transaction commit
+  type: http
+  seq: 21
+}
+
+post {
+  url: {{CKB_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": 42,
+    "jsonrpc": "2.0",
+    "method": "generate_epochs",
+    "params": ["0x1"]
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 10000));
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/22-check-channel1-balance.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/22-check-channel1-balance.bru
@@ -1,0 +1,47 @@
+meta {
+  name: check N1-N2 channel balance, Node2 should have claimed TLC amount by finding Node3's preimage on-chain
+  type: http
+  seq: 22
+}
+
+post {
+  url: {{NODE2_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "list_channels",
+    "params": [
+      {
+        "pubkey": "{{NODE1_PUBKEY}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result.channels[0].offered_tlc_balance: eq "0x0"
+  res.body.result.channels[0].received_tlc_balance: eq "0x0"
+}
+
+script:post-response {
+  console.log("N1-N2 channel state: ", res.body.result.channels[0]);
+  // Node2 is the payee-side intermediary: it forwarded the payment from Node1 to Node3.
+  // After the TLC settles, Node2's local_balance on N1-N2 should have increased
+  // by at least the invoice amount (0x5f5e100 = 100_000_000 shannons).
+  const localBalance = BigInt(res.body.result.channels[0].local_balance);
+  const invoiceAmount = BigInt("0x5f5e100");
+  if (localBalance < invoiceAmount) {
+    throw new Error("Node2 local_balance " + localBalance + " is less than invoice amount " + invoiceAmount);
+  }
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/23-check-payment-status.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/23-check-payment-status.bru
@@ -1,0 +1,40 @@
+meta {
+  name: check payment status is Success
+  type: http
+  seq: 23
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "get_payment",
+    "params": [
+      {
+        "payment_hash": "{{payment_hash}}"
+      }
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+}
+
+script:post-response {
+  console.log("Payment status: ", res.body.result);
+  if (res.body.result.status != "Success") {
+    throw new Error("Assertion failed: payment status expected to be Success, got " + res.body.result.status);
+  }
+}

--- a/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/24-disconnect.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-settled-by-recipient/24-disconnect.bru
@@ -1,0 +1,36 @@
+meta {
+  name: disconnect peers
+  type: http
+  seq: 24
+}
+
+post {
+  url: {{NODE1_RPC_URL}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "id": "42",
+    "jsonrpc": "2.0",
+    "method": "disconnect_peer",
+    "params": [
+      {"pubkey": "{{NODE2_PUBKEY}}"}
+    ]
+  }
+}
+
+assert {
+  res.body.error: isUndefined
+  res.body.result: isDefined
+}
+
+script:post-response {
+  await new Promise(r => setTimeout(r, 1000));
+}


### PR DESCRIPTION
feat: implement watchtower querier trait and integrate with network actor

Allow network/channel actor to query tlc status from watchtower no matter it is in the same process or runs as a standalone service.

Refs <https://github.com/nervosnetwork/fiber/discussions/1077>
