### PR TITLE
feat: use tentacle spawn feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2464,9 +2464,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2479,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2489,15 +2489,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2506,15 +2506,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2523,15 +2523,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -2545,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2557,7 +2557,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3086,7 +3085,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3360,7 +3359,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5253,7 +5252,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5266,7 +5265,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5324,7 +5323,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6065,14 +6064,14 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tentacle"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400b2285e0add6c24ed2b3fdba72464176e420aa957cb5d347809d5db419c505"
+checksum = "f236fb0e0985299c3667a1f1d3daefa159d09ffbb01fcb8a7fda4bd3a74f8a7c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6088,7 +6087,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "rand 0.8.5",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tentacle-multiaddr",
  "tentacle-secio",
  "thiserror 1.0.69",
@@ -6392,9 +6391,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-yamux"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c31635b5c26807b3b15619bf22a76e2761c36bff915f3e3d54e79655410b74"
+checksum = "6489207fc5dedea9723f5dc1c3ab96103c001449fa6056ca6cdba74ffbd84512"
 dependencies = [
  "bytes",
  "futures",
@@ -7091,7 +7090,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7215,15 +7214,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3085,7 +3085,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3359,7 +3359,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5265,7 +5265,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6064,7 +6064,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7090,7 +7090,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -66,6 +66,7 @@ tonic = "0.11.0"
 tentacle = { version = "0.7", default-features = false, features = [
   "upnp",
   "parking_lot",
+  "unstable",
   "openssl-vendored",
   "tokio-runtime",
   "tokio-timer",
@@ -101,6 +102,7 @@ jsonrpsee = { version = "0.25.1", features = [
   "wasm-client",
 ] }
 tentacle = { version = "0.7", default-features = false, features = [
+  "unstable",
   "wasm-timer",
 ] }
 tokio = { version = "1", features = ["io-util", "macros", "rt", "sync"] }

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -4,7 +4,7 @@ use std::{
     cmp::max,
     collections::{HashMap, HashSet},
     marker::PhantomData,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::Duration,
 };
 
@@ -14,20 +14,19 @@ use ckb_types::{
     packed::OutPoint,
     prelude::Unpack,
 };
+use futures::StreamExt as _;
 use ractor::{
     call, call_t, concurrency::JoinHandle, Actor, ActorCell, ActorProcessingErr, ActorRef,
     ActorRuntime, MessagingErr, OutputPort, RpcReplyPort, SupervisionEvent,
 };
 use strum::AsRefStr;
 use tentacle::{
-    async_trait as tasync_trait,
     builder::MetaBuilder,
-    bytes::Bytes,
-    context::{ProtocolContext, ProtocolContextMutRef, SessionContext},
-    service::{ProtocolHandle, ProtocolMeta, ServiceAsyncControl, SessionType},
-    traits::ServiceProtocol,
+    context::SessionContext,
+    service::{ProtocolMeta, ServiceAsyncControl, SessionType},
+    traits::ProtocolSpawn,
     utils::{is_reachable, multiaddr_to_socketaddr},
-    SessionId,
+    SessionId, SubstreamReadPart,
 };
 use tokio::sync::oneshot;
 use tokio_util::codec::length_delimited;
@@ -38,7 +37,7 @@ use crate::fiber::network::DEFAULT_CHAIN_ACTOR_TIMEOUT;
 use crate::{
     ckb::{client::CkbChainClient, CkbChainMessage, GetTxResponse},
     fiber::network::MAX_SERVICE_PROTOCOAL_DATA_SIZE,
-    now_timestamp_as_millis_u64, unwrap_or_return,
+    now_timestamp_as_millis_u64,
     utils::actor::ActorHandleLogGuard,
     Error,
 };
@@ -332,9 +331,6 @@ pub trait SubscribableGossipMessageStore {
 
 #[derive(AsRefStr)]
 pub enum GossipActorMessage {
-    // The control for the service async control is received.
-    ReceivedControl(ServiceAsyncControl),
-
     // Network events to be processed by this actor.
     PeerConnected(Pubkey, SessionContext),
     PeerDisconnected(Pubkey, SessionContext),
@@ -456,7 +452,7 @@ where
             num_targeted_outbound_passive_syncing_peers,
         } = gossip_config;
 
-        let (network_control_sender, network_control_receiver) = oneshot::channel();
+        let network_control = SharedControl::new();
 
         let (store_sender, store_receiver) = oneshot::channel();
 
@@ -465,7 +461,7 @@ where
             actor_name,
             GossipActor::new(),
             (
-                network_control_receiver,
+                network_control.clone(),
                 store_sender,
                 gossip_network_maintenance_interval,
                 gossip_store_maintenance_interval,
@@ -486,7 +482,7 @@ where
                 extended_store: store,
                 _marker: std::marker::PhantomData,
             },
-            GossipProtocolHandle::new(actor, network_control_sender),
+            GossipProtocolHandle::new(actor, network_control),
         )
     }
 
@@ -1771,7 +1767,7 @@ pub enum ExtendedGossipMessageStoreMessage {
 
 pub(crate) struct GossipActorState<S, C> {
     store: ExtendedGossipMessageStore<S>,
-    control: Option<ServiceAsyncControl>,
+    control: SharedControl<ServiceAsyncControl>,
     // The number of active syncing peers that we have finished syncing with.
     // Together with the number of current active syncing peers, this is
     // used to determine if we should start a new active syncing peer.
@@ -2004,7 +2000,7 @@ where
     }
 
     fn get_control(&self) -> &ServiceAsyncControl {
-        self.control.as_ref().expect("control exists")
+        self.control.get().expect("control exists")
     }
 
     async fn send_message_to_session(
@@ -2047,7 +2043,24 @@ async fn send_message_to_session(
 
 pub(crate) struct GossipProtocolHandle {
     actor: ActorRef<GossipActorMessage>,
-    sender: Option<oneshot::Sender<ServiceAsyncControl>>,
+    control: SharedControl<ServiceAsyncControl>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct SharedControl<T>(Arc<OnceLock<T>>);
+
+impl<T> SharedControl<T> {
+    fn new() -> Self {
+        Self(Arc::new(OnceLock::new()))
+    }
+
+    fn get(&self) -> Option<&T> {
+        self.0.get()
+    }
+
+    fn set(&self, value: T) -> Result<(), T> {
+        self.0.set(value)
+    }
 }
 
 async fn get_message_cursor<S: GossipMessageStore>(
@@ -2450,12 +2463,9 @@ fn verify_node_announcement<S: GossipMessageStore>(
 impl GossipProtocolHandle {
     pub(crate) fn new(
         actor: ActorRef<GossipActorMessage>,
-        sender: oneshot::Sender<ServiceAsyncControl>,
+        control: SharedControl<ServiceAsyncControl>,
     ) -> Self {
-        Self {
-            actor,
-            sender: Some(sender),
-        }
+        Self { actor, control }
     }
 
     pub(crate) fn actor(&self) -> &ActorRef<GossipActorMessage> {
@@ -2472,10 +2482,7 @@ impl GossipProtocolHandle {
                         .new_codec(),
                 )
             })
-            .service_handle(move || {
-                let handle = Box::new(self);
-                ProtocolHandle::Callback(handle)
-            })
+            .protocol_spawn(self)
             .build()
     }
 }
@@ -2489,7 +2496,7 @@ where
     type Msg = GossipActorMessage;
     type State = GossipActorState<S, C>;
     type Arguments = (
-        oneshot::Receiver<ServiceAsyncControl>,
+        SharedControl<ServiceAsyncControl>,
         oneshot::Sender<ExtendedGossipMessageStore<S>>,
         Duration,
         Duration,
@@ -2506,7 +2513,7 @@ where
         &self,
         myself: ActorRef<Self::Msg>,
         (
-            rx,
+            control,
             tx,
             network_maintenance_interval,
             store_maintenance_interval,
@@ -2533,25 +2540,6 @@ where
             panic!("failed to send store to the caller");
         }
 
-        let cloned_myself = myself.clone();
-        ractor::concurrency::spawn(async move {
-            match rx.await {
-                Ok(control) => {
-                    if let Err(error) =
-                        cloned_myself.send_message(GossipActorMessage::ReceivedControl(control))
-                    {
-                        error!(
-                            "Failed to send ReceivedControl message to gossip actor: {:?}",
-                            error
-                        );
-                    }
-                }
-                Err(_) => {
-                    error!("Failed to receive control");
-                }
-            }
-        });
-
         myself.send_interval(network_maintenance_interval, || {
             GossipActorMessage::TickNetworkMaintenance
         });
@@ -2564,7 +2552,7 @@ where
         });
         let state = Self::State {
             store,
-            control: Default::default(),
+            control,
             num_targeted_active_syncing_peers,
             num_targeted_outbound_passive_syncing_peers,
             myself,
@@ -2609,10 +2597,6 @@ where
             ACTOR_HANDLE_WARN_THRESHOLD_MS,
         );
         match message {
-            GossipActorMessage::ReceivedControl(control) => {
-                state.control = Some(control);
-            }
-
             GossipActorMessage::PeerConnected(pubkey, session) => {
                 if state.is_peer_connected(&pubkey) {
                     return Ok(());
@@ -2851,80 +2835,108 @@ where
     }
 }
 
-#[tasync_trait]
-impl ServiceProtocol for GossipProtocolHandle {
-    async fn init(&mut self, context: &mut ProtocolContext) {
-        let sender = self
-            .sender
-            .take()
-            .expect("service control sender set and init called once");
-        if sender.send(context.control().clone()).is_err() {
-            panic!("Failed to send service control");
-        }
-    }
-
-    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
+impl ProtocolSpawn for GossipProtocolHandle {
+    fn spawn(
+        &self,
+        context: Arc<SessionContext>,
+        control: &ServiceAsyncControl,
+        mut read_part: SubstreamReadPart,
+    ) {
+        let _ = self.control.set(control.clone());
         trace!(
             "proto id [{}] open on session [{}], address: [{}], type: [{:?}], version: {}",
-            context.proto_id,
-            context.session.id,
-            context.session.address,
-            context.session.ty,
-            version
+            read_part.protocol_id(),
+            context.id,
+            context.address,
+            context.ty,
+            "spawn"
         );
 
-        if let Some(remote_pubkey) = context.session.remote_pubkey.clone() {
+        if let Some(remote_pubkey) = context.remote_pubkey.clone() {
             let _ = self.actor.send_message(GossipActorMessage::PeerConnected(
                 super::types::pubkey_from_tentacle(remote_pubkey),
-                context.session.clone(),
+                context.as_ref().clone(),
             ));
         } else {
-            warn!("Peer connected without remote pubkey {:?}", context.session);
+            warn!("Peer connected without remote pubkey {:?}", context);
         }
-    }
 
-    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-        trace!(
-            "proto id [{}] close on session [{}], address: [{}], type: [{:?}]",
-            context.proto_id,
-            context.session.id,
-            &context.session.address,
-            &context.session.ty
-        );
+        let actor = self.actor.clone();
+        tentacle::runtime::spawn(async move {
+            while let Some(frame) = read_part.next().await {
+                let data = match frame {
+                    Ok(data) => data,
+                    Err(err) => {
+                        warn!("Failed to read gossip protocol stream data: {:?}", err);
+                        break;
+                    }
+                };
+                let message = match GossipMessage::from_molecule_slice(&data) {
+                    Ok(message) => message,
+                    Err(err) => {
+                        warn!("Failed to parse gossip protocol message: {:?}", err);
+                        continue;
+                    }
+                };
+                match context.remote_pubkey.as_ref() {
+                    Some(pubkey) => {
+                        let _ = actor.send_message(GossipActorMessage::GossipMessageReceived(
+                            GossipMessageWithTarget {
+                                target: super::types::pubkey_from_tentacle(pubkey.clone()),
+                                message,
+                            },
+                        ));
+                    }
+                    None => {
+                        unreachable!("Received message without remote pubkey");
+                    }
+                }
+            }
 
-        match context.session.remote_pubkey.as_ref() {
-            Some(remote_pubkey) => {
-                let _ = self
-                    .actor
-                    .send_message(GossipActorMessage::PeerDisconnected(
+            trace!(
+                "proto id [{}] close on session [{}], address: [{}], type: [{:?}]",
+                read_part.protocol_id(),
+                context.id,
+                &context.address,
+                &context.ty
+            );
+
+            match context.remote_pubkey.as_ref() {
+                Some(remote_pubkey) => {
+                    let _ = actor.send_message(GossipActorMessage::PeerDisconnected(
                         super::types::pubkey_from_tentacle(remote_pubkey.clone()),
-                        context.session.clone(),
+                        context.as_ref().clone(),
                     ));
+                }
+                None => {
+                    unreachable!("Received message without remote pubkey");
+                }
             }
-            None => {
-                unreachable!("Received message without remote pubkey");
-            }
-        }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SharedControl;
+
+    #[tokio::test]
+    async fn test_shared_control_is_visible_across_clones() {
+        let control = SharedControl::new();
+        let cloned = control.clone();
+
+        assert!(control.get().is_none());
+
+        assert!(cloned.set(1_u8).is_ok());
+        assert_eq!(control.get(), Some(&1_u8));
     }
 
-    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: Bytes) {
-        let message = unwrap_or_return!(GossipMessage::from_molecule_slice(&data), "parse message");
-        match context.session.remote_pubkey.as_ref() {
-            Some(pubkey) => {
-                let _ = self
-                    .actor
-                    .send_message(GossipActorMessage::GossipMessageReceived(
-                        GossipMessageWithTarget {
-                            target: super::types::pubkey_from_tentacle(pubkey.clone()),
-                            message,
-                        },
-                    ));
-            }
-            None => {
-                unreachable!("Received message without remote pubkey");
-            }
-        }
-    }
+    #[tokio::test]
+    async fn test_shared_control_only_initializes_once() {
+        let control = SharedControl::new();
 
-    async fn notify(&mut self, _context: &mut ProtocolContext, _token: u64) {}
+        assert!(control.set(1_u8).is_ok());
+        assert_eq!(control.set(2_u8), Err(2_u8));
+        assert_eq!(control.get(), Some(&1_u8));
+    }
 }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -6,6 +6,7 @@ use ckb_types::packed::{Byte32, OutPoint, Script, Transaction};
 use ckb_types::prelude::{Builder, Entity, IntoTransactionView, Pack, Unpack};
 use ckb_types::H256;
 use either::Either;
+use futures::StreamExt as _;
 use once_cell::sync::OnceCell;
 use ractor::concurrency::Duration;
 use ractor::{
@@ -30,18 +31,14 @@ use tentacle::utils::{extract_peer_id, is_reachable, multiaddr_to_socketaddr};
 use tentacle::{
     async_trait,
     builder::{MetaBuilder, ServiceBuilder},
-    bytes::Bytes,
+    context::ServiceContext,
     context::SessionContext,
-    context::{ProtocolContext, ProtocolContextMutRef, ServiceContext},
     multiaddr::Multiaddr,
     secio::PeerId,
     secio::SecioKeyPair,
-    service::{
-        ProtocolHandle, ProtocolMeta, ServiceAsyncControl, ServiceError, ServiceEvent,
-        TargetProtocol,
-    },
-    traits::{ServiceHandle, ServiceProtocol},
-    ProtocolId, SessionId,
+    service::{ProtocolMeta, ServiceAsyncControl, ServiceError, ServiceEvent, TargetProtocol},
+    traits::{ProtocolSpawn, ServiceHandle},
+    ProtocolId, SessionId, SubstreamReadPart,
 };
 use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio_util::codec::length_delimited;
@@ -90,7 +87,7 @@ use crate::invoice::{
     CkbInvoice, CkbInvoiceStatus, InvoiceError, InvoiceStore, PreimageStore, SettleInvoiceError,
 };
 use crate::utils::{actor::ActorHandleLogGuard, payment::is_invoice_fulfilled};
-use crate::{now_timestamp_as_millis_u64, unwrap_or_return, Error};
+use crate::{now_timestamp_as_millis_u64, Error};
 use fiber_types::protocol::AnnouncedNodeName;
 #[cfg(any(debug_assertions, test, feature = "bench"))]
 use fiber_types::SessionRoute;
@@ -4843,69 +4840,80 @@ impl FiberProtocolHandle {
                         .new_codec(),
                 )
             })
-            .service_handle(move || {
-                let handle = Box::new(self);
-                ProtocolHandle::Callback(handle)
-            })
+            .protocol_spawn(self)
             .build()
     }
 }
 
-#[async_trait]
-impl ServiceProtocol for FiberProtocolHandle {
-    async fn init(&mut self, _context: &mut ProtocolContext) {}
-
-    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
-        let _session = context.session;
-        if let Some(remote_pubkey) = context.session.remote_pubkey.clone() {
+impl ProtocolSpawn for FiberProtocolHandle {
+    fn spawn(
+        &self,
+        context: Arc<SessionContext>,
+        _control: &ServiceAsyncControl,
+        mut read_part: SubstreamReadPart,
+    ) {
+        if let Some(remote_pubkey) = context.remote_pubkey.clone() {
             try_send_actor_message(
                 &self.actor,
                 NetworkActorMessage::new_event(NetworkActorEvent::PeerConnected(
                     super::types::pubkey_from_tentacle(remote_pubkey),
-                    context.session.clone(),
+                    context.as_ref().clone(),
                 )),
             );
         } else {
-            warn!("Peer connected without remote pubkey {:?}", context.session);
+            warn!("Peer connected without remote pubkey {:?}", context);
         }
-    }
+        let actor = self.actor.clone();
+        tentacle::runtime::spawn(async move {
+            while let Some(frame) = read_part.next().await {
+                let data = match frame {
+                    Ok(data) => data,
+                    Err(err) => {
+                        warn!("Failed to read fiber protocol stream data: {:?}", err);
+                        break;
+                    }
+                };
 
-    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-        match context.session.remote_pubkey.as_ref() {
-            Some(pubkey) => {
-                try_send_actor_message(
-                    &self.actor,
-                    NetworkActorMessage::new_event(NetworkActorEvent::PeerDisconnected(
-                        super::types::pubkey_from_tentacle(pubkey.clone()),
-                        context.session.clone(),
-                    )),
-                );
-            }
-            None => {
-                unreachable!("Received message without remote pubkey");
-            }
-        }
-    }
+                let msg = match FiberMessage::from_molecule_slice(&data) {
+                    Ok(msg) => msg,
+                    Err(err) => {
+                        warn!("Failed to parse fiber protocol message: {:?}", err);
+                        continue;
+                    }
+                };
 
-    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: Bytes) {
-        let msg = unwrap_or_return!(FiberMessage::from_molecule_slice(&data), "parse message");
-        match context.session.remote_pubkey.as_ref() {
-            Some(pubkey) => {
-                try_send_actor_message(
-                    &self.actor,
-                    NetworkActorMessage::new_event(NetworkActorEvent::FiberMessage(
-                        super::types::pubkey_from_tentacle(pubkey.clone()),
-                        msg,
-                    )),
-                );
+                match context.remote_pubkey.as_ref() {
+                    Some(pubkey) => {
+                        try_send_actor_message(
+                            &actor,
+                            NetworkActorMessage::new_event(NetworkActorEvent::FiberMessage(
+                                super::types::pubkey_from_tentacle(pubkey.clone()),
+                                msg,
+                            )),
+                        );
+                    }
+                    None => {
+                        unreachable!("Received message without remote pubkey");
+                    }
+                }
             }
-            None => {
-                unreachable!("Received message without remote pubkey");
-            }
-        }
-    }
 
-    async fn notify(&mut self, _context: &mut ProtocolContext, _token: u64) {}
+            match context.remote_pubkey.as_ref() {
+                Some(pubkey) => {
+                    try_send_actor_message(
+                        &actor,
+                        NetworkActorMessage::new_event(NetworkActorEvent::PeerDisconnected(
+                            super::types::pubkey_from_tentacle(pubkey.clone()),
+                            context.as_ref().clone(),
+                        )),
+                    );
+                }
+                None => {
+                    unreachable!("Received message without remote pubkey");
+                }
+            }
+        });
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Currently, fiber does not rely on ServiceHandle's aggregation functionality, and forcibly aggregating it is not cost-effective. Using the Spawn feature might be better. The dependent init behavior has been changed to a once-in-a-time behavior, and the initialization time has been delayed from network startup to the first connection establishment.