### PR TITLE
Fix flaky e2e test

### DIFF
--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/09-node1-add-tlc1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/09-node1-add-tlc1.bru
@@ -45,5 +45,5 @@ script:pre-request {
 script:post-response {
   console.log("generated result: ", res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  await new Promise(r => setTimeout(r, 2000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/10-node1-add-tlc2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/10-node1-add-tlc2.bru
@@ -45,5 +45,5 @@ script:pre-request {
 script:post-response {
   console.log("generated result: ", res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  await new Promise(r => setTimeout(r, 2000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/11-node1-add-tlc3.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-consecutive-settlement/11-node1-add-tlc3.bru
@@ -45,5 +45,5 @@ script:pre-request {
 script:post-response {
   console.log("generated result: ", res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  await new Promise(r => setTimeout(r, 2000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-stop-watchtower/09-node1-add-tlc1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-stop-watchtower/09-node1-add-tlc1.bru
@@ -45,5 +45,5 @@ script:pre-request {
 script:post-response {
   console.log("generated result: ", res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  await new Promise(r => setTimeout(r, 2000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-stop-watchtower/10-node2-add-tlc2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-stop-watchtower/10-node2-add-tlc2.bru
@@ -45,5 +45,5 @@ script:pre-request {
 script:post-response {
   console.log("generated result: ", res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  await new Promise(r => setTimeout(r, 2000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/11-node1-add-tlc1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/11-node1-add-tlc1.bru
@@ -44,6 +44,7 @@ script:pre-request {
 
 script:post-response {
   console.log("generated result: ", res.body.result);
-  // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  // Sleep for sometime to make sure the commitment round-trip (AddTlc -> CommitmentSigned ->
+  // RevokeAndAck) finishes before next add_tlc request, avoiding WaitingTlcAck errors.
+  await new Promise(r => setTimeout(r, 2000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/13-node1-add-tlc2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs-and-udt/13-node1-add-tlc2.bru
@@ -45,5 +45,5 @@ script:pre-request {
 script:post-response {
   console.log("generated result: ", res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  await new Promise(r => setTimeout(r, 2000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/09-node1-add-tlc1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/09-node1-add-tlc1.bru
@@ -45,5 +45,6 @@ script:pre-request {
 script:post-response {
   console.log("generated result: ", res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  // The full AddTlc → CommitmentSigned → RevokeAndAck round-trip can take >1s on slow CI machines.
+  await new Promise(r => setTimeout(r, 2000));
 }

--- a/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/11-node1-add-tlc2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-with-pending-tlcs/11-node1-add-tlc2.bru
@@ -45,5 +45,5 @@ script:pre-request {
 script:post-response {
   console.log("generated result: ", res.body.result);
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  await new Promise(r => setTimeout(r, 2000));
 }


### PR DESCRIPTION
Fixes flaky e2e test: https://github.com/nervosnetwork/fiber/actions/runs/22891695488/job/66416141462


```console
{
  jsonrpc: '2.0',
  id: '42',
  error: {
    code: -32000,
    message: 'Unable to handle TLC command in waiting TLC ACK state',
    data: {
      channel_id: '0x6b65cc546c8d882be30a183b654b6adac9f35c5cc10a0f979e0baa2e491d5a78',
      tlc_id: '0x1',
      reason: [Object]
    }
  }
}
   ✕ assert: res.body.error: isUndefined
      expected { code: -32000, …(2) } to be undefined
   ✕ assert: res.body.result: isNull
      expected undefined to be null
```