### PR TITLE
ci: add missing e2e test suites to workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,8 @@ jobs:
           - 3-nodes-transfer
           - invoice-ops
           - open-use-close-a-channel
+          - period-check/force-close-expiry
+          - shutdown-force
           - udt
           - reestablish
           - cross-chain-hub


### PR DESCRIPTION
## Summary

- Add `shutdown-force` and `period-check/force-close-expiry` e2e test suites to the CI workflow matrix. Both test suites exist on disk but were never included in `.github/workflows/e2e.yml`.

---
*This PR description was generated by AI.*