### PR TITLE
Return proper error for rpc

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -170,7 +170,7 @@ pub struct TlcNotification {
 pub enum ChannelCommand {
     TxCollaborationCommand(TxCollaborationCommand),
     FundingTxSigned(Transaction),
-    CommitmentSigned(),
+    CommitmentSigned(Option<RpcReplyPort<Result<(), String>>>),
     AddTlc(AddTlcCommand, RpcReplyPort<Result<AddTlcResponse, TlcErr>>),
     RemoveTlc(RemoveTlcCommand, RpcReplyPort<ProcessingChannelResult>),
     Shutdown(ShutdownCommand, RpcReplyPort<Result<(), String>>),
@@ -186,7 +186,7 @@ impl Display for ChannelCommand {
         match self {
             ChannelCommand::TxCollaborationCommand(_) => write!(f, "TxCollaborationCommand"),
             ChannelCommand::FundingTxSigned(_) => write!(f, "FundingTxSigned"),
-            ChannelCommand::CommitmentSigned() => write!(f, "CommitmentSigned"),
+            ChannelCommand::CommitmentSigned(_) => write!(f, "CommitmentSigned"),
             ChannelCommand::AddTlc(_, _) => write!(f, "AddTlc"),
             ChannelCommand::RemoveTlc(_, _) => write!(f, "RemoveTlc"),
             ChannelCommand::Shutdown(_, _) => write!(f, "Shutdown"),
@@ -202,6 +202,7 @@ impl Display for ChannelCommand {
 impl ChannelCommand {
     pub fn rpc_reply_port(self) -> Option<RpcReplyPort<Result<(), String>>> {
         match self {
+            ChannelCommand::CommitmentSigned(Some(port)) => Some(port),
             ChannelCommand::Shutdown(_, port) => Some(port),
             ChannelCommand::Update(_, port) => Some(port),
             _ => None,
@@ -2258,8 +2259,12 @@ where
                 }
                 Ok(())
             }
-            ChannelCommand::CommitmentSigned() => {
-                self.handle_commitment_signed_command(myself, state).await
+            ChannelCommand::CommitmentSigned(rpc_reply) => {
+                let result = self.handle_commitment_signed_command(myself, state).await;
+                if let Some(reply) = rpc_reply {
+                    let _ = reply.send(result.clone().map_err(|e| e.to_string()));
+                }
+                result
             }
             ChannelCommand::AddTlc(command, reply) => {
                 let res = self.handle_add_tlc_command(myself, state, &command).await;
@@ -6448,7 +6453,7 @@ impl ChannelActorState {
                 .send_message(NetworkActorMessage::new_command(
                     NetworkActorCommand::ControlFiberChannel(ChannelCommandWithId {
                         channel_id: self.get_id(),
-                        command: ChannelCommand::CommitmentSigned(),
+                        command: ChannelCommand::CommitmentSigned(None),
                     }),
                 ))
                 .expect(ASSUME_NETWORK_ACTOR_ALIVE);

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -283,7 +283,7 @@ pub struct SendOnionPacketCommand {
 pub enum NetworkActorCommand {
     /// Network commands
     // Connect to a peer, and optionally also save the peer to the peer store.
-    ConnectPeer(Multiaddr, bool),
+    ConnectPeer(Multiaddr, bool, Option<RpcReplyPort<Result<(), String>>>),
     // Connect to a peer via pubkey, resolving address from local graph/saved state.
     ConnectPeerWithPubkey(Pubkey, RpcReplyPort<Result<(), String>>),
     DisconnectPeer(
@@ -339,7 +339,7 @@ pub enum NetworkActorCommand {
     SignFundingTx(Pubkey, Hash256, Transaction, Option<Vec<Vec<u8>>>),
     NotifyFundingTx(Transaction),
     CheckChannelsShutdown,
-    CheckChannelShutdown(Hash256),
+    CheckChannelShutdown(Hash256, RpcReplyPort<Result<(), String>>),
     RemoteForceShutdownChannel(Hash256, Option<GetShutdownTxResponse>),
     // Broadcast our BroadcastMessage to the network.
     BroadcastMessages(Vec<BroadcastMessageWithTimestamp>),
@@ -1083,13 +1083,25 @@ where
             NetworkActorCommand::SendFiberMessage(FiberMessageWithTarget { target, message }) => {
                 state.send_fiber_message_to_pubkey(&target, message).await?;
             }
-            NetworkActorCommand::ConnectPeer(addr, save) => {
+            NetworkActorCommand::ConnectPeer(addr, save, rpc_reply) => {
                 // TODO: It is more than just dialing a peer. We need to exchange capabilities of the peer,
                 // e.g. whether the peer support some specific feature.
                 if save {
                     state.enqueue_peer_address_to_save(addr.clone());
                 }
-                state.control.dial(addr, TargetProtocol::All).await?;
+                match state.control.dial(addr, TargetProtocol::All).await {
+                    Ok(()) => {
+                        if let Some(reply) = rpc_reply {
+                            let _ = reply.send(Ok(()));
+                        }
+                    }
+                    Err(err) => {
+                        if let Some(reply) = rpc_reply {
+                            let _ = reply.send(Err(err.to_string()));
+                        }
+                        return Err(err.into());
+                    }
+                }
 
                 // TODO: note that the dial function does not return error immediately even if dial fails.
                 // Tentacle sends an event by calling handle_error function instead, which
@@ -1150,7 +1162,7 @@ where
                     if let Some(addr) = addresses.iter().choose(&mut rand::thread_rng()) {
                         myself
                             .send_message(NetworkActorMessage::new_command(
-                                NetworkActorCommand::ConnectPeer(addr.to_owned(), false),
+                                NetworkActorCommand::ConnectPeer(addr.to_owned(), false, None),
                             ))
                             .expect(ASSUME_NETWORK_MYSELF_ALIVE);
                     }
@@ -1243,7 +1255,7 @@ where
                         state
                             .network
                             .send_message(NetworkActorMessage::new_command(
-                                NetworkActorCommand::ConnectPeer(addr.clone(), false),
+                                NetworkActorCommand::ConnectPeer(addr.clone(), false, None),
                             ))
                             .expect(ASSUME_NETWORK_MYSELF_ALIVE);
                     }
@@ -1264,7 +1276,7 @@ where
                         state
                             .network
                             .send_message(NetworkActorMessage::new_command(
-                                NetworkActorCommand::ConnectPeer(addr.clone(), false),
+                                NetworkActorCommand::ConnectPeer(addr.clone(), false, None),
                             ))
                             .expect(ASSUME_NETWORK_MYSELF_ALIVE);
                     }
@@ -1914,7 +1926,7 @@ where
                     ))
                     .expect("network actor alive");
             }
-            NetworkActorCommand::CheckChannelShutdown(channel_id) => {
+            NetworkActorCommand::CheckChannelShutdown(channel_id, rpc_reply) => {
                 if let Some(channel_state) = self.store.get_channel_actor_state(&channel_id) {
                     let funding_lock_script =
                         state.get_cached_channel_funding_lock_script(channel_id, &channel_state);
@@ -1930,10 +1942,12 @@ where
                         )
                         .await;
                     });
+                    let _ = rpc_reply.send(Ok(()));
                 } else {
                     tracing::debug!(
                         "stop check channel shutdown, can't find {channel_id:?} actor state"
                     );
+                    let _ = rpc_reply.send(Err(format!("Channel not found: {:?}", channel_id)));
                 }
             }
             NetworkActorCommand::RemoteForceShutdownChannel(channel_id, response) => {
@@ -4697,7 +4711,7 @@ where
                 Ok(addr) => {
                     myself
                         .send_message(NetworkActorMessage::new_command(
-                            NetworkActorCommand::ConnectPeer(addr, false),
+                            NetworkActorCommand::ConnectPeer(addr, false, None),
                         ))
                         .expect(ASSUME_NETWORK_MYSELF_ALIVE);
                 }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -286,7 +286,11 @@ pub enum NetworkActorCommand {
     ConnectPeer(Multiaddr, bool),
     // Connect to a peer via pubkey, resolving address from local graph/saved state.
     ConnectPeerWithPubkey(Pubkey, RpcReplyPort<Result<(), String>>),
-    DisconnectPeer(Pubkey, PeerDisconnectReason),
+    DisconnectPeer(
+        Pubkey,
+        PeerDisconnectReason,
+        Option<RpcReplyPort<Result<(), String>>>,
+    ),
     // Save the address of a peer to the peer store, the address here must be a valid
     // multiaddr with the peer id.
     SavePeerAddress(Multiaddr),
@@ -1109,13 +1113,18 @@ where
                     }
                 }
             }
-            NetworkActorCommand::DisconnectPeer(pubkey, reason) => {
+            NetworkActorCommand::DisconnectPeer(pubkey, reason, reply) => {
                 if let Some(session) = state.peer_session_map.get(&pubkey).map(|p| p.session_id) {
                     debug!(
                         "Disconnecting peer {:?} session w {:?}ith reason {:?}",
                         &pubkey, &session, &reason
                     );
                     state.control.disconnect(session).await?;
+                    if let Some(reply) = reply {
+                        let _ = reply.send(Ok(()));
+                    }
+                } else if let Some(reply) = reply {
+                    let _ = reply.send(Err(format!("peer {:?} is not connected", pubkey)));
                 }
             }
             NetworkActorCommand::SavePeerAddress(addr) => {
@@ -1273,6 +1282,7 @@ where
                                 NetworkActorCommand::DisconnectPeer(
                                     pubkey,
                                     PeerDisconnectReason::InitMessageTimeout,
+                                    None,
                                 ),
                             ))
                             .expect(ASSUME_NETWORK_MYSELF_ALIVE);
@@ -4123,6 +4133,7 @@ where
                     NetworkActorCommand::DisconnectPeer(
                         peer_pubkey,
                         PeerDisconnectReason::ChainHashMismatch,
+                        None,
                     ),
                 ))
                 .expect(ASSUME_NETWORK_MYSELF_ALIVE);

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -405,7 +405,11 @@ async fn do_test_owned_channel_removed_from_graph_on_disconnected(public: bool) 
     node1
         .network_actor
         .send_message(NetworkActorMessage::new_command(
-            NetworkActorCommand::DisconnectPeer(node2.pubkey, PeerDisconnectReason::Requested),
+            NetworkActorCommand::DisconnectPeer(
+                node2.pubkey,
+                PeerDisconnectReason::Requested,
+                None,
+            ),
         ))
         .expect("node_a alive");
 
@@ -466,7 +470,11 @@ async fn do_test_owned_channel_saved_to_graph_on_reconnected(public: bool) {
     node1
         .network_actor
         .send_message(NetworkActorMessage::new_command(
-            NetworkActorCommand::DisconnectPeer(node2.pubkey, PeerDisconnectReason::Requested),
+            NetworkActorCommand::DisconnectPeer(
+                node2.pubkey,
+                PeerDisconnectReason::Requested,
+                None,
+            ),
         ))
         .expect("node_a alive");
 
@@ -4156,7 +4164,11 @@ async fn test_reestablish_channel() {
     node_a
         .network_actor
         .send_message(NetworkActorMessage::new_command(
-            NetworkActorCommand::DisconnectPeer(node_b.pubkey, PeerDisconnectReason::Requested),
+            NetworkActorCommand::DisconnectPeer(
+                node_b.pubkey,
+                PeerDisconnectReason::Requested,
+                None,
+            ),
         ))
         .expect("node_a alive");
 

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -3878,7 +3878,7 @@ async fn test_revoke_old_commitment_transaction() {
         .send_message(NetworkActorMessage::Command(
             NetworkActorCommand::ControlFiberChannel(ChannelCommandWithId {
                 channel_id: new_channel_id,
-                command: ChannelCommand::CommitmentSigned(),
+                command: ChannelCommand::CommitmentSigned(None),
             }),
         ))
         .expect("node_a alive");

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -5048,7 +5048,11 @@ async fn test_send_payment_remove_tlc_with_preimage_will_retry() {
     node_0
         .network_actor
         .send_message(NetworkActorMessage::new_command(
-            NetworkActorCommand::DisconnectPeer(node1_pubkey, PeerDisconnectReason::Requested),
+            NetworkActorCommand::DisconnectPeer(
+                node1_pubkey,
+                PeerDisconnectReason::Requested,
+                None,
+            ),
         ))
         .expect("node_a alive");
 
@@ -5146,7 +5150,11 @@ async fn test_send_payment_send_each_other_reestablishing() {
     node_0
         .network_actor
         .send_message(NetworkActorMessage::new_command(
-            NetworkActorCommand::DisconnectPeer(node1_pubkey, PeerDisconnectReason::Requested),
+            NetworkActorCommand::DisconnectPeer(
+                node1_pubkey,
+                PeerDisconnectReason::Requested,
+                None,
+            ),
         ))
         .expect("node_a alive");
 
@@ -5781,7 +5789,11 @@ async fn test_send_payment_with_reconnect_two_times() {
         node0
             .network_actor
             .send_message(NetworkActorMessage::new_command(
-                NetworkActorCommand::DisconnectPeer(node1_pubkey, PeerDisconnectReason::Requested),
+                NetworkActorCommand::DisconnectPeer(
+                    node1_pubkey,
+                    PeerDisconnectReason::Requested,
+                    None,
+                ),
             ))
             .expect("node_a alive");
 

--- a/crates/fiber-lib/src/fiber/tests/rpc.rs
+++ b/crates/fiber-lib/src/fiber/tests/rpc.rs
@@ -17,7 +17,7 @@ use crate::{
         graph::{GraphNodesParams, GraphNodesResult},
         invoice::{InvoiceParams, InvoiceResult, NewInvoiceParams},
         payment::{GetPaymentCommandParams, GetPaymentCommandResult},
-        peer::{ConnectPeerParams, ListPeersResult},
+        peer::{ConnectPeerParams, DisconnectPeerParams, ListPeersResult},
     },
 };
 use biscuit_auth::macros::biscuit;
@@ -882,7 +882,11 @@ async fn test_rpc_shutdown_following_disconnect() {
     node_0
         .network_actor
         .send_message(NetworkActorMessage::new_command(
-            NetworkActorCommand::DisconnectPeer(node_1.pubkey, PeerDisconnectReason::Requested),
+            NetworkActorCommand::DisconnectPeer(
+                node_1.pubkey,
+                PeerDisconnectReason::Requested,
+                None,
+            ),
         ))
         .expect("node_a alive");
 
@@ -1253,4 +1257,101 @@ fn test_rpc_status_enum_naming_consistency() {
     } else {
         panic!("state_flags field not found in JSON: {}", json_str);
     }
+}
+
+#[tokio::test]
+async fn test_rpc_connect_peer_empty_address() {
+    let node = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some("node-0".to_string()))
+            .base_dir_prefix("test-fnn-connect-empty-addr-")
+            .rpc_config(Some(gen_rpc_config()))
+            .build(),
+    )
+    .await;
+
+    let res: Result<(), String> = node
+        .send_rpc_request(
+            "connect_peer",
+            ConnectPeerParams {
+                address: Some("".to_string()),
+                pubkey: None,
+                save: None,
+            },
+        )
+        .await;
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(
+        err.contains("address must not be empty"),
+        "expected 'address must not be empty' error, got: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_rpc_connect_peer_no_address_no_pubkey() {
+    let node = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some("node-0".to_string()))
+            .base_dir_prefix("test-fnn-connect-no-params-")
+            .rpc_config(Some(gen_rpc_config()))
+            .build(),
+    )
+    .await;
+
+    let res: Result<(), String> = node
+        .send_rpc_request(
+            "connect_peer",
+            ConnectPeerParams {
+                address: None,
+                pubkey: None,
+                save: None,
+            },
+        )
+        .await;
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(
+        err.contains("address") || err.contains("pubkey"),
+        "expected error about missing address/pubkey, got: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_rpc_disconnect_peer_not_connected() {
+    let node = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some("node-0".to_string()))
+            .base_dir_prefix("test-fnn-disconnect-not-connected-")
+            .rpc_config(Some(gen_rpc_config()))
+            .build(),
+    )
+    .await;
+
+    // Use a valid-format but non-connected pubkey (compressed secp256k1 point)
+    // This is a well-known generator point, so it's a valid curve point.
+    let fake_pubkey = fiber_json_types::Pubkey::from_slice(&[
+        0x02, 0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87,
+        0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b, 0x16,
+        0xf8, 0x17, 0x98,
+    ])
+    .unwrap();
+
+    let res: Result<(), String> = node
+        .send_rpc_request(
+            "disconnect_peer",
+            DisconnectPeerParams {
+                pubkey: fake_pubkey,
+            },
+        )
+        .await;
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(
+        err.contains("not connected"),
+        "expected 'not connected' error, got: {}",
+        err
+    );
 }

--- a/crates/fiber-lib/src/rpc/dev.rs
+++ b/crates/fiber-lib/src/rpc/dev.rs
@@ -1,13 +1,10 @@
 // #[cfg(not(target_arch = "wasm32"))]
 // use crate::watchtower::WatchtowerStore;
-use crate::rpc::utils::rpc_error;
-use crate::{
-    fiber::{
-        channel::{ChannelCommand, ChannelCommandWithId, RemoveTlcCommand},
-        NetworkActorCommand, NetworkActorMessage,
-    },
-    handle_actor_cast,
+use crate::fiber::{
+    channel::{ChannelCommand, ChannelCommandWithId, RemoveTlcCommand},
+    NetworkActorCommand, NetworkActorMessage,
 };
+use crate::rpc::utils::rpc_error;
 use ckb_types::core::TransactionView;
 use ckb_types::prelude::Entity;
 use fiber_json_types::serde_utils::Hash256 as JsonHash256;
@@ -134,13 +131,15 @@ impl DevRpcServerImpl {
         params: CommitmentSignedParams,
     ) -> Result<(), ErrorObjectOwned> {
         let channel_id = params.channel_id.into();
-        let message = NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
-            ChannelCommandWithId {
-                channel_id,
-                command: ChannelCommand::CommitmentSigned(),
-            },
-        ));
-        handle_actor_cast!(self.network_actor, message, params)
+        let message = |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
+                ChannelCommandWithId {
+                    channel_id,
+                    command: ChannelCommand::CommitmentSigned(Some(rpc_reply)),
+                },
+            ))
+        };
+        handle_actor_call!(self.network_actor, message, params)
     }
 
     pub async fn add_tlc(&self, params: AddTlcParams) -> Result<AddTlcResult, ErrorObjectOwned> {
@@ -263,9 +262,12 @@ impl DevRpcServerImpl {
         params: CheckChannelShutdownParams,
     ) -> Result<(), ErrorObjectOwned> {
         let channel_id = params.channel_id.into();
-        let message =
-            NetworkActorMessage::Command(NetworkActorCommand::CheckChannelShutdown(channel_id));
+        let message = |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::CheckChannelShutdown(
+                channel_id, rpc_reply,
+            ))
+        };
 
-        handle_actor_cast!(self.network_actor, message, params)
+        handle_actor_call!(self.network_actor, message, params)
     }
 }

--- a/crates/fiber-lib/src/rpc/peer.rs
+++ b/crates/fiber-lib/src/rpc/peer.rs
@@ -61,11 +61,23 @@ impl PeerRpcServer for PeerRpcServerImpl {
 impl PeerRpcServerImpl {
     pub async fn connect_peer(&self, params: ConnectPeerParams) -> Result<(), ErrorObjectOwned> {
         if let Some(address_str) = params.address.as_ref() {
+            // FIXME: it's better to fix this in Multiaddr
+            if address_str.is_empty() {
+                return Err(rpc_error(
+                    "address must not be empty, expected a multiaddr like /ip4/1.2.3.4/tcp/8080",
+                    &params,
+                ));
+            }
             let address = address_str.parse::<Multiaddr>().rpc_err(&params)?;
             let save = params.save.unwrap_or(true);
-            let message =
-                NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(address, save));
-            return crate::handle_actor_cast!(self.actor, message, params);
+            let message = |rpc_reply| {
+                NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
+                    address,
+                    save,
+                    Some(rpc_reply),
+                ))
+            };
+            return crate::handle_actor_call!(self.actor, message, params);
         }
 
         if let Some(pubkey_str) = params.pubkey {

--- a/crates/fiber-lib/src/rpc/peer.rs
+++ b/crates/fiber-lib/src/rpc/peer.rs
@@ -89,11 +89,14 @@ impl PeerRpcServerImpl {
         params: DisconnectPeerParams,
     ) -> Result<(), ErrorObjectOwned> {
         let pubkey = Pubkey::try_from(params.pubkey).rpc_err(&params)?;
-        let message = NetworkActorMessage::Command(NetworkActorCommand::DisconnectPeer(
-            pubkey,
-            PeerDisconnectReason::Requested,
-        ));
-        crate::handle_actor_cast!(self.actor, message, params)
+        let message = |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::DisconnectPeer(
+                pubkey,
+                PeerDisconnectReason::Requested,
+                Some(rpc_reply),
+            ))
+        };
+        crate::handle_actor_call!(self.actor, message, params)
     }
 
     pub async fn list_peers(&self) -> Result<ListPeersResult, ErrorObjectOwned> {

--- a/crates/fiber-lib/src/rpc/utils.rs
+++ b/crates/fiber-lib/src/rpc/utils.rs
@@ -82,13 +82,3 @@ macro_rules! handle_actor_call {
         }
     };
 }
-
-#[macro_export]
-macro_rules! handle_actor_cast {
-    ($actor:expr, $message:expr, $params:expr) => {
-        match $actor.cast($message) {
-            Ok(_) => Ok(()),
-            Err(err) => log_and_error!($params, format!("{}", err)),
-        }
-    };
-}

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -1795,7 +1795,7 @@ impl NetworkNode {
 
         self.network_actor
             .send_message(NetworkActorMessage::new_command(
-                NetworkActorCommand::ConnectPeer(peer_addr.clone(), false),
+                NetworkActorCommand::ConnectPeer(peer_addr.clone(), false, None),
             ))
             .expect("self alive");
     }

--- a/tests/bruno/e2e/watchtower/revocation/11-disconnect.bru
+++ b/tests/bruno/e2e/watchtower/revocation/11-disconnect.bru
@@ -1,5 +1,5 @@
 meta {
-  name: disconnect NODE2 from NODE1
+  name: disconnect NODE3 from NODE1
   type: http
   seq: 11
 }
@@ -21,7 +21,7 @@ body:json {
     "jsonrpc": "2.0",
     "method": "disconnect_peer",
     "params": [
-      {"pubkey": "{{NODE2_PUBKEY}}"}
+      {"pubkey": "{{NODE3_PUBKEY}}"}
     ]
   }
 }
@@ -33,5 +33,5 @@ assert {
 
 script:post-response {
   // Sleep for sometime to make sure current operation finishes before next request starts.
-  await new Promise(r => setTimeout(r, 1000));
+  await new Promise(r => setTimeout(r, 2000));
 }


### PR DESCRIPTION
Some rpc ignore actor error, we should return proper error message from rpc, especially for `disconnect_peer`, `tests/bruno/e2e/watchtower/revocation/11-disconnect.bru` used the wrong pubkey, but we missed it.
