### PR TITLE
Fix gossip startup sync cursor pollution

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -176,6 +176,10 @@ pub trait GossipMessageStore {
 
     fn get_latest_broadcast_message_cursor(&self) -> Option<Cursor>;
 
+    fn get_latest_remote_broadcast_message_cursor(&self) -> Option<Cursor>;
+
+    fn update_latest_remote_broadcast_message_cursor(&self, cursor: Cursor);
+
     fn get_latest_channel_announcement_timestamp(&self, outpoint: &OutPoint) -> Option<u64>;
 
     fn get_latest_channel_update_timestamp(
@@ -1275,7 +1279,11 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
             )
             .await
             {
-                Ok(message) => {
+                Ok((message, saved_to_store)) => {
+                    if saved_to_store {
+                        self.store
+                            .update_latest_remote_broadcast_message_cursor(message.cursor());
+                    }
                     verified_sorted_messages.push(message);
                 }
                 Err(error) => {
@@ -1965,9 +1973,9 @@ where
         self.peer_states.get(pubkey).map(|s| s.session_id)
     }
 
-    fn get_latest_cursor(&self) -> Cursor {
+    fn get_latest_remote_cursor(&self) -> Cursor {
         self.get_store()
-            .get_latest_broadcast_message_cursor()
+            .get_latest_remote_broadcast_message_cursor()
             .unwrap_or_default()
     }
 
@@ -1976,7 +1984,7 @@ where
     // before this cursor are not important for the node to sync with the network.
     // We will start syncing from this cursor to avoid syncing from the very beginning of the network.
     fn get_safe_cursor_to_start_syncing(&self) -> Cursor {
-        let latest_cursor_timestamp = self.get_latest_cursor().timestamp;
+        let latest_cursor_timestamp = self.get_latest_remote_cursor().timestamp;
         let safe_cursor_timestamp = latest_cursor_timestamp
             .saturating_sub(MAX_MISSING_BROADCAST_MESSAGE_TIMESTAMP_DRIFT.as_millis() as u64);
         let timestamp_after_considered_stale = now_timestamp_as_millis_u64()
@@ -2122,33 +2130,43 @@ async fn verify_and_save_broadcast_message<S: GossipMessageStore>(
     store: &S,
     chain: &ActorRef<CkbChainMessage>,
     client: &impl CkbChainClient,
-) -> Result<BroadcastMessageWithTimestamp, Error> {
-    let timestamp = match message {
+) -> Result<(BroadcastMessageWithTimestamp, bool), Error> {
+    let (timestamp, already_saved) = match message {
         BroadcastMessage::ChannelAnnouncement(channel_announcement) => {
             let on_chain_info =
                 get_channel_on_chain_info(channel_announcement.out_point(), chain, client).await?;
-            if !verify_channel_announcement(channel_announcement, &on_chain_info, store).await? {
+            let already_saved =
+                verify_channel_announcement(channel_announcement, &on_chain_info, store).await?;
+            if !already_saved {
                 store.save_channel_announcement(
                     on_chain_info.timestamp,
                     channel_announcement.clone(),
                 );
             }
-            on_chain_info.timestamp
+            (on_chain_info.timestamp, already_saved)
         }
         BroadcastMessage::ChannelUpdate(channel_update) => {
-            if !verify_channel_update(channel_update, store)? {
+            let already_saved = verify_channel_update(channel_update, store)?;
+            if !already_saved {
                 store.save_channel_update(channel_update.clone());
             }
-            channel_update.timestamp
+            (channel_update.timestamp, already_saved)
         }
         BroadcastMessage::NodeAnnouncement(node_announcement) => {
-            if !verify_node_announcement(node_announcement, store)? {
+            let already_saved = verify_node_announcement(node_announcement, store)?;
+            if !already_saved {
                 store.save_node_announcement(node_announcement.clone());
             }
-            node_announcement.timestamp
+            (node_announcement.timestamp, already_saved)
         }
     };
-    Ok((message.clone(), timestamp).into())
+    let message_with_timestamp: BroadcastMessageWithTimestamp = (message.clone(), timestamp).into();
+    let saved_to_store = !already_saved
+        && store
+            .get_broadcast_message_with_cursor(&message_with_timestamp.cursor())
+            .as_ref()
+            == Some(&message_with_timestamp);
+    Ok((message_with_timestamp, saved_to_store))
 }
 
 async fn get_channel_tx(

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -4,7 +4,10 @@ use std::{
     cmp::max,
     collections::{HashMap, HashSet},
     marker::PhantomData,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -107,6 +110,12 @@ pub trait GossipMessageStore {
         after_cursor: &Cursor,
     ) -> impl IntoIterator<Item = BroadcastMessageWithTimestamp>;
 
+    /// The implementors should guarantee that the returned messages are sorted by timestamp in the descending order.
+    fn get_broadcast_messages_iter_reverse(
+        &self,
+        before_cursor: Option<&Cursor>,
+    ) -> impl IntoIterator<Item = BroadcastMessageWithTimestamp>;
+
     fn get_broadcast_messages(
         &self,
         after_cursor: &Cursor,
@@ -175,10 +184,6 @@ pub trait GossipMessageStore {
     ) -> Option<BroadcastMessageWithTimestamp>;
 
     fn get_latest_broadcast_message_cursor(&self) -> Option<Cursor>;
-
-    fn get_latest_remote_broadcast_message_cursor(&self) -> Option<Cursor>;
-
-    fn update_latest_remote_broadcast_message_cursor(&self, cursor: Cursor);
 
     fn get_latest_channel_announcement_timestamp(&self, outpoint: &OutPoint) -> Option<u64>;
 
@@ -254,6 +259,47 @@ pub trait GossipMessageStore {
     fn get_channel_timestamps_iter(&self) -> impl IntoIterator<Item = (OutPoint, [u64; 3])>;
 
     fn delete_channel_timestamps(&self, outpoint: &OutPoint);
+}
+
+fn is_remote_cursor_candidate<S: GossipMessageStore>(
+    store: &S,
+    local_pubkey: &Pubkey,
+    message: &BroadcastMessageWithTimestamp,
+) -> bool {
+    match message {
+        BroadcastMessageWithTimestamp::NodeAnnouncement(node_announcement) => {
+            node_announcement.node_id != *local_pubkey
+        }
+        BroadcastMessageWithTimestamp::ChannelAnnouncement(_, channel_announcement) => {
+            channel_announcement.node1_id != *local_pubkey
+                && channel_announcement.node2_id != *local_pubkey
+        }
+        BroadcastMessageWithTimestamp::ChannelUpdate(channel_update) => store
+            .get_latest_channel_announcement(&channel_update.channel_outpoint)
+            .map(|(_, channel_announcement)| {
+                channel_announcement.node1_id != *local_pubkey
+                    && channel_announcement.node2_id != *local_pubkey
+            })
+            .unwrap_or(false),
+    }
+}
+
+pub(crate) fn get_latest_startup_broadcast_message_cursor<S: GossipMessageStore>(
+    store: &S,
+    local_pubkey: Option<&Pubkey>,
+) -> Cursor {
+    match local_pubkey {
+        Some(local_pubkey) => store
+            .get_broadcast_messages_iter_reverse(None)
+            .into_iter()
+            .filter(|message| is_remote_cursor_candidate(store, local_pubkey, message))
+            .map(|message| message.cursor())
+            .next()
+            .unwrap_or_default(),
+        None => store
+            .get_latest_broadcast_message_cursor()
+            .unwrap_or_default(),
+    }
 }
 
 // A batch of gossip messages has been added to the store since the last time
@@ -468,6 +514,7 @@ where
             actor_name,
             GossipActor::new(),
             (
+                pubkey,
                 network_control_receiver,
                 store_sender,
                 gossip_network_maintenance_interval,
@@ -1074,11 +1121,13 @@ impl<S> ExtendedGossipMessageStore<S>
 where
     S: GossipMessageStore + Send + Sync + Clone + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     async fn new<C: CkbChainClient + Clone + Send + Sync + 'static>(
         maintenance_interval: Duration,
         announce_private_addr: bool,
         store: S,
         gossip_actor: ActorRef<GossipActorMessage>,
+        latest_remote_broadcast_timestamp: Arc<AtomicU64>,
         chain_actor: ActorRef<CkbChainMessage>,
         chain_client: C,
         supervisor: ActorCell,
@@ -1094,6 +1143,7 @@ where
                 announce_private_addr,
                 store.clone(),
                 gossip_actor,
+                latest_remote_broadcast_timestamp.clone(),
                 chain_actor,
                 chain_client.clone(),
             ),
@@ -1212,6 +1262,7 @@ pub struct ExtendedGossipMessageStoreState<S, C> {
     announce_private_addr: bool,
     store: S,
     gossip_actor: ActorRef<GossipActorMessage>,
+    latest_remote_broadcast_timestamp: Arc<AtomicU64>,
     chain_actor: ActorRef<CkbChainMessage>,
     chain_client: C,
     next_id: u64,
@@ -1227,6 +1278,7 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
         announce_private_addr: bool,
         store: S,
         gossip_actor: ActorRef<GossipActorMessage>,
+        latest_remote_broadcast_timestamp: Arc<AtomicU64>,
         chain_actor: ActorRef<CkbChainMessage>,
         chain_client: C,
     ) -> Self {
@@ -1234,6 +1286,7 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
             announce_private_addr,
             store,
             gossip_actor,
+            latest_remote_broadcast_timestamp,
             chain_actor,
             chain_client,
             next_id: Default::default(),
@@ -1281,8 +1334,8 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
             {
                 Ok((message, saved_to_store)) => {
                     if saved_to_store {
-                        self.store
-                            .update_latest_remote_broadcast_message_cursor(message.cursor());
+                        self.latest_remote_broadcast_timestamp
+                            .fetch_max(message.cursor().timestamp, Ordering::AcqRel);
                     }
                     verified_sorted_messages.push(message);
                 }
@@ -1554,6 +1607,7 @@ impl<S: GossipMessageStore + Send + Sync + 'static, C: CkbChainClient + Send + S
         bool,
         S,
         ActorRef<GossipActorMessage>,
+        Arc<AtomicU64>,
         ActorRef<CkbChainMessage>,
         C,
     );
@@ -1566,6 +1620,7 @@ impl<S: GossipMessageStore + Send + Sync + 'static, C: CkbChainClient + Send + S
             announce_private_addr,
             store,
             gossip_actor,
+            latest_remote_broadcast_timestamp,
             chain_actor,
             chain_client,
         ): Self::Arguments,
@@ -1577,6 +1632,7 @@ impl<S: GossipMessageStore + Send + Sync + 'static, C: CkbChainClient + Send + S
             announce_private_addr,
             store,
             gossip_actor,
+            latest_remote_broadcast_timestamp,
             chain_actor,
             chain_client,
         ))
@@ -1794,6 +1850,7 @@ pub(crate) struct GossipActorState<S, C> {
     query_reply_ports:
         HashMap<(Pubkey, u64), RpcReplyPort<Result<QueryBroadcastMessagesResult, GossipError>>>,
     peer_states: HashMap<Pubkey, PeerState>,
+    latest_remote_broadcast_timestamp: Arc<AtomicU64>,
 }
 
 impl<S, C> GossipActorState<S, C>
@@ -1973,18 +2030,14 @@ where
         self.peer_states.get(pubkey).map(|s| s.session_id)
     }
 
-    fn get_latest_remote_cursor(&self) -> Cursor {
-        self.get_store()
-            .get_latest_remote_broadcast_message_cursor()
-            .unwrap_or_default()
-    }
-
     // A cursor that is "safe" to start syncing from. By "safe" we mean that
     // the node is mostly having the messages that are newer than this cursor or the messages
     // before this cursor are not important for the node to sync with the network.
     // We will start syncing from this cursor to avoid syncing from the very beginning of the network.
     fn get_safe_cursor_to_start_syncing(&self) -> Cursor {
-        let latest_cursor_timestamp = self.get_latest_remote_cursor().timestamp;
+        let latest_cursor_timestamp = self
+            .latest_remote_broadcast_timestamp
+            .load(Ordering::Acquire);
         let safe_cursor_timestamp = latest_cursor_timestamp
             .saturating_sub(MAX_MISSING_BROADCAST_MESSAGE_TIMESTAMP_DRIFT.as_millis() as u64);
         let timestamp_after_considered_stale = now_timestamp_as_millis_u64()
@@ -2497,6 +2550,7 @@ where
     type Msg = GossipActorMessage;
     type State = GossipActorState<S, C>;
     type Arguments = (
+        Option<Pubkey>,
         oneshot::Receiver<ServiceAsyncControl>,
         oneshot::Sender<ExtendedGossipMessageStore<S>>,
         Duration,
@@ -2514,6 +2568,7 @@ where
         &self,
         myself: ActorRef<Self::Msg>,
         (
+            local_pubkey,
             rx,
             tx,
             network_maintenance_interval,
@@ -2527,11 +2582,15 @@ where
             chain_client,
         ): Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
+        let latest_remote_broadcast_timestamp = Arc::new(AtomicU64::new(
+            get_latest_startup_broadcast_message_cursor(&store, local_pubkey.as_ref()).timestamp,
+        ));
         let store = ExtendedGossipMessageStore::new(
             store_maintenance_interval,
             announce_private_addr,
             store,
             myself.clone(),
+            latest_remote_broadcast_timestamp.clone(),
             chain_actor.clone(),
             chain_client.clone(),
             myself.get_cell(),
@@ -2582,6 +2641,7 @@ where
             query_reply_ports: Default::default(),
             num_finished_active_syncing_peers: Default::default(),
             peer_states: Default::default(),
+            latest_remote_broadcast_timestamp,
         };
         Ok(state)
     }

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -114,6 +114,7 @@ pub trait GossipMessageStore {
     fn get_broadcast_messages_iter_reverse(
         &self,
         before_cursor: Option<&Cursor>,
+        limit: usize,
     ) -> impl IntoIterator<Item = BroadcastMessageWithTimestamp>;
 
     fn get_broadcast_messages(
@@ -289,13 +290,16 @@ pub(crate) fn get_latest_startup_broadcast_message_cursor<S: GossipMessageStore>
     local_pubkey: Option<&Pubkey>,
 ) -> Cursor {
     match local_pubkey {
-        Some(local_pubkey) => store
-            .get_broadcast_messages_iter_reverse(None)
-            .into_iter()
-            .filter(|message| is_remote_cursor_candidate(store, local_pubkey, message))
-            .map(|message| message.cursor())
-            .next()
-            .unwrap_or_default(),
+        Some(local_pubkey) => {
+            // TODO: Support lazy load of broadcast messages, know we just add a limit to the query to avoid loading too many messages into memory.
+            store
+                .get_broadcast_messages_iter_reverse(None, 100)
+                .into_iter()
+                .filter(|message| is_remote_cursor_candidate(store, local_pubkey, message))
+                .map(|message| message.cursor())
+                .next()
+                .unwrap_or_default()
+        }
         None => store
             .get_latest_broadcast_message_cursor()
             .unwrap_or_default(),

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -2161,11 +2161,7 @@ async fn verify_and_save_broadcast_message<S: GossipMessageStore>(
         }
     };
     let message_with_timestamp: BroadcastMessageWithTimestamp = (message.clone(), timestamp).into();
-    let saved_to_store = !already_saved
-        && store
-            .get_broadcast_message_with_cursor(&message_with_timestamp.cursor())
-            .as_ref()
-            == Some(&message_with_timestamp);
+    let saved_to_store = !already_saved;
     Ok((message_with_timestamp, saved_to_store))
 }
 

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -55,7 +55,10 @@ use super::channel::{
     ProcessingChannelError, ProcessingChannelResult, RemoveTlcCommand, StopReason,
     DEFAULT_MAX_TLC_VALUE_IN_FLIGHT,
 };
-use super::gossip::{GossipActorMessage, GossipMessageStore, GossipMessageUpdates};
+use super::gossip::{
+    get_latest_startup_broadcast_message_cursor, GossipActorMessage, GossipMessageStore,
+    GossipMessageUpdates,
+};
 use super::graph::{NetworkGraph, NetworkGraphStateStore, OwnedChannelUpdateEvent};
 use super::types::{
     BroadcastMessageWithTimestamp, FiberMessage, ForwardTlcResult, GossipMessage, Init, OpenChannel,
@@ -4496,12 +4499,11 @@ where
             )
             .await;
 
-            let graph_subscribing_cursor = {
-                let graph = self.network_graph.write().await;
-                graph
-                    .get_latest_cursor()
-                    .go_back_for_some_time(MAX_GRAPH_MISSING_BROADCAST_MESSAGE_TIMESTAMP_DRIFT)
-            };
+            let graph_subscribing_cursor = get_latest_startup_broadcast_message_cursor(
+                &self.store,
+                Some(&private_key.pubkey()),
+            )
+            .go_back_for_some_time(MAX_GRAPH_MISSING_BROADCAST_MESSAGE_TIMESTAMP_DRIFT);
 
             gossip_service
                 .get_subscriber()

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -449,6 +449,80 @@ async fn test_sync_historical_channel_announcement_on_startup_with_auto_announce
 }
 
 #[tokio::test]
+async fn test_sync_historical_channel_announcement_after_restart_with_polluted_local_cursor() {
+    init_tracing();
+
+    let mut node1 = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some("node1".to_string()))
+            .fiber_config_updater(|config| {
+                config.auto_announce_node = Some(false);
+            })
+            .build(),
+    )
+    .await;
+    let mut node2 = NetworkNode::new_with_node_name("node2").await;
+
+    node2.connect_to(&mut node1).await;
+    wait_until_async_timeout(|| async {
+        node2.store.get_latest_broadcast_message_cursor().is_some()
+    })
+    .await;
+    node2.stop().await;
+
+    let historical_timestamp =
+        now_timestamp_as_millis_u64() - Duration::from_secs(3 * 60 * 60).as_millis() as u64;
+    let capacity = 42;
+    let priv_key: Privkey = get_test_priv_key();
+    let pubkey = priv_key.x_only_pub_key().serialize();
+    let pubkey_hash = &blake2b_256(pubkey.as_slice())[0..20];
+    let tx = TransactionView::new_advanced_builder()
+        .output(
+            CellOutput::new_builder()
+                .capacity(capacity)
+                .lock(ScriptBuilder::default().args(pubkey_hash.pack()).build())
+                .build(),
+        )
+        .output_data([0u8; 8].pack())
+        .build();
+    let outpoint = tx.output_pts()[0].clone();
+    let (node_announcement_1, node_announcement_2, channel_announcement) =
+        create_fake_channel_announcement_message(priv_key, capacity, outpoint.clone());
+
+    set_next_block_timestamp(historical_timestamp).await;
+    assert!(matches!(
+        node1.submit_tx(tx.clone()).await,
+        TxStatus::Committed(..)
+    ));
+
+    for message in [
+        BroadcastMessage::NodeAnnouncement(node_announcement_1.clone()),
+        BroadcastMessage::NodeAnnouncement(node_announcement_2.clone()),
+        BroadcastMessage::ChannelAnnouncement(channel_announcement.clone()),
+    ] {
+        node1.mock_received_gossip_message_from_peer(
+            get_test_pub_key(),
+            broadcast_message_to_gossip(&message),
+        );
+    }
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    node2.start().await;
+    assert!(matches!(
+        node2.submit_tx(tx.clone()).await,
+        TxStatus::Committed(..)
+    ));
+    node2.connect_to(&mut node1).await;
+
+    wait_until_async_timeout(|| async { !node2.get_network_graph_channels().await.is_empty() })
+        .await;
+
+    let channels = node2.get_network_graph_channels().await;
+    assert_eq!(channels.len(), 1);
+    assert_eq!(channels[0].channel_outpoint, outpoint);
+}
+
+#[tokio::test]
 async fn test_node1_node2_channel_update() {
     let channel_context = ChannelTestContext::gen().await;
     let funding_tx = channel_context.funding_tx.clone();

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -33,16 +33,12 @@ use ckb_types::{
 };
 use fiber_types::{ChannelFlags, ShutdownInfo};
 use musig2::{PartialSignature, SecNonce};
-use once_cell::sync::Lazy;
 use ractor::{call, ActorProcessingErr, ActorRef};
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tentacle::{
     multiaddr::{MultiAddr, Multiaddr, Protocol},
     secio::PeerId,
 };
-use tokio::sync::Mutex;
-
-static BLOCK_TIMESTAMP_TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 fn get_test_priv_key() -> Privkey {
     Privkey::from_slice(&[42u8; 32])
@@ -333,7 +329,6 @@ async fn test_sync_channel_announcement_on_startup() {
 #[tokio::test]
 async fn test_sync_historical_channel_announcement_on_startup_with_auto_announce_enabled() {
     init_tracing();
-    let _block_timestamp_guard = BLOCK_TIMESTAMP_TEST_LOCK.lock().await;
 
     let mut node1 = NetworkNode::new_with_node_name("node1").await;
     let mut node2 = NetworkNode::new_with_node_name("node2").await;
@@ -391,7 +386,6 @@ async fn test_sync_historical_channel_announcement_on_startup_with_auto_announce
 #[tokio::test]
 async fn test_sync_historical_channel_announcement_on_startup_with_auto_announce_disabled() {
     init_tracing();
-    let _block_timestamp_guard = BLOCK_TIMESTAMP_TEST_LOCK.lock().await;
 
     let mut node1 = NetworkNode::new_with_node_name("node1").await;
     let mut node2 = NetworkNode::new_with_config(
@@ -583,8 +577,6 @@ async fn test_channel_update_version() {
 
 #[tokio::test]
 async fn test_query_missing_broadcast_message() {
-    let _block_timestamp_guard = BLOCK_TIMESTAMP_TEST_LOCK.lock().await;
-
     let channel_context = ChannelTestContext::gen().await;
     let funding_tx = channel_context.funding_tx.clone();
     let out_point = channel_context.channel_outpoint().clone();

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -33,12 +33,16 @@ use ckb_types::{
 };
 use fiber_types::{ChannelFlags, ShutdownInfo};
 use musig2::{PartialSignature, SecNonce};
+use once_cell::sync::Lazy;
 use ractor::{call, ActorProcessingErr, ActorRef};
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tentacle::{
     multiaddr::{MultiAddr, Multiaddr, Protocol},
     secio::PeerId,
 };
+use tokio::sync::Mutex;
+
+static BLOCK_TIMESTAMP_TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 fn get_test_priv_key() -> Privkey {
     Privkey::from_slice(&[42u8; 32])
@@ -327,6 +331,130 @@ async fn test_sync_channel_announcement_on_startup() {
 }
 
 #[tokio::test]
+async fn test_sync_historical_channel_announcement_on_startup_with_auto_announce_enabled() {
+    init_tracing();
+    let _block_timestamp_guard = BLOCK_TIMESTAMP_TEST_LOCK.lock().await;
+
+    let mut node1 = NetworkNode::new_with_node_name("node1").await;
+    let mut node2 = NetworkNode::new_with_node_name("node2").await;
+
+    let historical_timestamp =
+        now_timestamp_as_millis_u64() - Duration::from_secs(3 * 60 * 60).as_millis() as u64;
+    let capacity = 42;
+    let priv_key: Privkey = get_test_priv_key();
+    let pubkey = priv_key.x_only_pub_key().serialize();
+    let pubkey_hash = &blake2b_256(pubkey.as_slice())[0..20];
+    let tx = TransactionView::new_advanced_builder()
+        .output(
+            CellOutput::new_builder()
+                .capacity(capacity)
+                .lock(ScriptBuilder::default().args(pubkey_hash.pack()).build())
+                .build(),
+        )
+        .output_data([0u8; 8].pack())
+        .build();
+    let outpoint = tx.output_pts()[0].clone();
+    let (node_announcement_1, node_announcement_2, channel_announcement) =
+        create_fake_channel_announcement_message(priv_key, capacity, outpoint.clone());
+
+    set_next_block_timestamp(historical_timestamp).await;
+    assert!(matches!(
+        node1.submit_tx(tx.clone()).await,
+        TxStatus::Committed(..)
+    ));
+
+    for message in [
+        BroadcastMessage::NodeAnnouncement(node_announcement_1.clone()),
+        BroadcastMessage::NodeAnnouncement(node_announcement_2.clone()),
+        BroadcastMessage::ChannelAnnouncement(channel_announcement.clone()),
+    ] {
+        node1.mock_received_gossip_message_from_peer(
+            get_test_pub_key(),
+            broadcast_message_to_gossip(&message),
+        );
+    }
+
+    node1.connect_to(&mut node2).await;
+    assert!(matches!(
+        node2.submit_tx(tx.clone()).await,
+        TxStatus::Committed(..)
+    ));
+
+    wait_until_async_timeout(|| async { !node2.get_network_graph_channels().await.is_empty() })
+        .await;
+
+    let channels = node2.get_network_graph_channels().await;
+    assert_eq!(channels.len(), 1);
+    assert_eq!(channels[0].channel_outpoint, outpoint);
+}
+
+#[tokio::test]
+async fn test_sync_historical_channel_announcement_on_startup_with_auto_announce_disabled() {
+    init_tracing();
+    let _block_timestamp_guard = BLOCK_TIMESTAMP_TEST_LOCK.lock().await;
+
+    let mut node1 = NetworkNode::new_with_node_name("node1").await;
+    let mut node2 = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some("node2".to_string()))
+            .fiber_config_updater(|config| {
+                config.auto_announce_node = Some(false);
+            })
+            .build(),
+    )
+    .await;
+
+    let historical_timestamp =
+        now_timestamp_as_millis_u64() - Duration::from_secs(3 * 60 * 60).as_millis() as u64;
+    let capacity = 42;
+    let priv_key: Privkey = get_test_priv_key();
+    let pubkey = priv_key.x_only_pub_key().serialize();
+    let pubkey_hash = &blake2b_256(pubkey.as_slice())[0..20];
+    let tx = TransactionView::new_advanced_builder()
+        .output(
+            CellOutput::new_builder()
+                .capacity(capacity)
+                .lock(ScriptBuilder::default().args(pubkey_hash.pack()).build())
+                .build(),
+        )
+        .output_data([0u8; 8].pack())
+        .build();
+    let outpoint = tx.output_pts()[0].clone();
+    let (node_announcement_1, node_announcement_2, channel_announcement) =
+        create_fake_channel_announcement_message(priv_key, capacity, outpoint.clone());
+
+    set_next_block_timestamp(historical_timestamp).await;
+    assert!(matches!(
+        node1.submit_tx(tx.clone()).await,
+        TxStatus::Committed(..)
+    ));
+
+    for message in [
+        BroadcastMessage::NodeAnnouncement(node_announcement_1.clone()),
+        BroadcastMessage::NodeAnnouncement(node_announcement_2.clone()),
+        BroadcastMessage::ChannelAnnouncement(channel_announcement.clone()),
+    ] {
+        node1.mock_received_gossip_message_from_peer(
+            get_test_pub_key(),
+            broadcast_message_to_gossip(&message),
+        );
+    }
+
+    node1.connect_to(&mut node2).await;
+    assert!(matches!(
+        node2.submit_tx(tx.clone()).await,
+        TxStatus::Committed(..)
+    ));
+
+    wait_until_async_timeout(|| async { !node2.get_network_graph_channels().await.is_empty() })
+        .await;
+
+    let channels = node2.get_network_graph_channels().await;
+    assert_eq!(channels.len(), 1);
+    assert_eq!(channels[0].channel_outpoint, outpoint);
+}
+
+#[tokio::test]
 async fn test_node1_node2_channel_update() {
     let channel_context = ChannelTestContext::gen().await;
     let funding_tx = channel_context.funding_tx.clone();
@@ -455,6 +583,8 @@ async fn test_channel_update_version() {
 
 #[tokio::test]
 async fn test_query_missing_broadcast_message() {
+    let _block_timestamp_guard = BLOCK_TIMESTAMP_TEST_LOCK.lock().await;
+
     let channel_context = ChannelTestContext::gen().await;
     let funding_tx = channel_context.funding_tx.clone();
     let out_point = channel_context.channel_outpoint().clone();

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -1320,9 +1320,10 @@ impl GossipMessageStore for Store {
     fn get_broadcast_messages_iter_reverse(
         &self,
         before_cursor: Option<&Cursor>,
+        limit: usize,
     ) -> impl IntoIterator<Item = crate::fiber::types::BroadcastMessageWithTimestamp> {
         let prefix = [BROADCAST_MESSAGE_PREFIX];
-        let mut options = PrefixIterOptions::new().reverse();
+        let mut options = PrefixIterOptions::new().reverse().limit(limit);
 
         let start_cloned = before_cursor.map(|cursor| {
             let cursor_bytes = cursor.to_bytes();

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -212,14 +212,6 @@ pub fn check_validate<P: AsRef<Path>>(path: P) -> Result<(), String> {
                 );
             }
             BROADCAST_MESSAGE_TIMESTAMP_PREFIX => {}
-            LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX => {
-                if Cursor::from_bytes(&value).is_err() {
-                    errors.insert(
-                        "Failed to deserialize LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX"
-                            .to_string(),
-                    );
-                }
-            }
             PAYMENT_SESSION_PREFIX => {
                 check_deserialization::<PaymentSession>(
                     &value,
@@ -300,7 +292,6 @@ pub enum KeyValue {
     OutPointChannelId(OutPoint, Hash256),
     BroadcastMessageTimestamp(BroadcastMessageID, u64),
     BroadcastMessage(Cursor, BroadcastMessage),
-    LatestRemoteBroadcastMessageCursor(Cursor),
     #[cfg(feature = "watchtower")]
     WatchtowerChannel(NodeId, Hash256, ChannelData),
     #[cfg(feature = "watchtower")]
@@ -427,9 +418,6 @@ impl StoreKeyValue for KeyValue {
             KeyValue::BroadcastMessage(cursor, _) => {
                 [&[BROADCAST_MESSAGE_PREFIX], cursor.to_bytes().as_slice()].concat()
             }
-            KeyValue::LatestRemoteBroadcastMessageCursor(_) => {
-                vec![LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX]
-            }
             KeyValue::PaymentCustomRecord(payment_hash, _data) => {
                 [&[PAYMENT_CUSTOM_RECORD_PREFIX], payment_hash.as_ref()].concat()
             }
@@ -479,7 +467,6 @@ impl StoreKeyValue for KeyValue {
             KeyValue::BroadcastMessage(_cursor, broadcast_message) => {
                 serialize_to_vec(broadcast_message, "BroadcastMessage")
             }
-            KeyValue::LatestRemoteBroadcastMessageCursor(cursor) => cursor.to_bytes().to_vec(),
             KeyValue::PaymentHistoryTimedResult(_, result) => {
                 serialize_to_vec(result, "TimedResult")
             }
@@ -1330,6 +1317,39 @@ impl GossipMessageStore for Store {
         .collect::<Vec<_>>()
     }
 
+    fn get_broadcast_messages_iter_reverse(
+        &self,
+        before_cursor: Option<&Cursor>,
+    ) -> impl IntoIterator<Item = crate::fiber::types::BroadcastMessageWithTimestamp> {
+        let prefix = [BROADCAST_MESSAGE_PREFIX];
+        let mut options = PrefixIterOptions::new().reverse();
+
+        let start_cloned = before_cursor.map(|cursor| {
+            let cursor_bytes = cursor.to_bytes();
+            [&prefix, cursor_bytes.as_slice()].concat()
+        });
+
+        if let Some(start) = start_cloned.as_ref() {
+            options = options.start_key(start).skip_while(Box::new({
+                let start = start.clone();
+                move |key: &[u8]| key == start
+            }));
+        }
+
+        self.collect_by_prefix_with(&prefix, options)
+            .into_iter()
+            .map(|kv| {
+                debug_assert_eq!(kv.key.len(), 1 + CURSOR_SIZE);
+                let mut timestamp_bytes = [0u8; 8];
+                timestamp_bytes.copy_from_slice(&kv.key[1..9]);
+                let timestamp = u64::from_be_bytes(timestamp_bytes);
+                let message: BroadcastMessage =
+                    deserialize_from(kv.value.as_ref(), "BroadcastMessage");
+                (message, timestamp).into()
+            })
+            .collect::<Vec<_>>()
+    }
+
     fn get_broadcast_message_with_cursor(
         &self,
         cursor: &Cursor,
@@ -1350,25 +1370,6 @@ impl GossipMessageStore for Store {
                 let last_key = kv.key.to_vec();
                 Cursor::from_bytes(&last_key[1..]).expect("deserialize Cursor should be OK")
             })
-    }
-
-    fn get_latest_remote_broadcast_message_cursor(&self) -> Option<Cursor> {
-        self.get([LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX])
-            .and_then(|value| Cursor::from_bytes(&value).ok())
-    }
-
-    fn update_latest_remote_broadcast_message_cursor(&self, cursor: Cursor) {
-        if self
-            .get_latest_remote_broadcast_message_cursor()
-            .is_some_and(|existing| existing >= cursor)
-        {
-            return;
-        }
-
-        let kv = KeyValue::LatestRemoteBroadcastMessageCursor(cursor);
-        let mut batch = self.batch();
-        batch.put(kv.key(), kv.value());
-        batch.commit();
     }
 
     fn get_latest_channel_announcement_timestamp(&self, outpoint: &OutPoint) -> Option<u64> {

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -212,6 +212,14 @@ pub fn check_validate<P: AsRef<Path>>(path: P) -> Result<(), String> {
                 );
             }
             BROADCAST_MESSAGE_TIMESTAMP_PREFIX => {}
+            LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX => {
+                if Cursor::from_bytes(&value).is_err() {
+                    errors.insert(
+                        "Failed to deserialize LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX"
+                            .to_string(),
+                    );
+                }
+            }
             PAYMENT_SESSION_PREFIX => {
                 check_deserialization::<PaymentSession>(
                     &value,
@@ -292,6 +300,7 @@ pub enum KeyValue {
     OutPointChannelId(OutPoint, Hash256),
     BroadcastMessageTimestamp(BroadcastMessageID, u64),
     BroadcastMessage(Cursor, BroadcastMessage),
+    LatestRemoteBroadcastMessageCursor(Cursor),
     #[cfg(feature = "watchtower")]
     WatchtowerChannel(NodeId, Hash256, ChannelData),
     #[cfg(feature = "watchtower")]
@@ -418,6 +427,9 @@ impl StoreKeyValue for KeyValue {
             KeyValue::BroadcastMessage(cursor, _) => {
                 [&[BROADCAST_MESSAGE_PREFIX], cursor.to_bytes().as_slice()].concat()
             }
+            KeyValue::LatestRemoteBroadcastMessageCursor(_) => {
+                vec![LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX]
+            }
             KeyValue::PaymentCustomRecord(payment_hash, _data) => {
                 [&[PAYMENT_CUSTOM_RECORD_PREFIX], payment_hash.as_ref()].concat()
             }
@@ -467,6 +479,7 @@ impl StoreKeyValue for KeyValue {
             KeyValue::BroadcastMessage(_cursor, broadcast_message) => {
                 serialize_to_vec(broadcast_message, "BroadcastMessage")
             }
+            KeyValue::LatestRemoteBroadcastMessageCursor(cursor) => cursor.to_bytes().to_vec(),
             KeyValue::PaymentHistoryTimedResult(_, result) => {
                 serialize_to_vec(result, "TimedResult")
             }
@@ -1337,6 +1350,25 @@ impl GossipMessageStore for Store {
                 let last_key = kv.key.to_vec();
                 Cursor::from_bytes(&last_key[1..]).expect("deserialize Cursor should be OK")
             })
+    }
+
+    fn get_latest_remote_broadcast_message_cursor(&self) -> Option<Cursor> {
+        self.get([LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX])
+            .and_then(|value| Cursor::from_bytes(&value).ok())
+    }
+
+    fn update_latest_remote_broadcast_message_cursor(&self, cursor: Cursor) {
+        if self
+            .get_latest_remote_broadcast_message_cursor()
+            .is_some_and(|existing| existing >= cursor)
+        {
+            return;
+        }
+
+        let kv = KeyValue::LatestRemoteBroadcastMessageCursor(cursor);
+        let mut batch = self.batch();
+        batch.put(kv.key(), kv.value());
+        batch.commit();
     }
 
     fn get_latest_channel_announcement_timestamp(&self, outpoint: &OutPoint) -> Option<u64> {

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -1,6 +1,6 @@
 use crate::ckb::signer::LocalSigner;
 use crate::fiber::channel::*;
-use crate::fiber::gossip::GossipMessageStore;
+use crate::fiber::gossip::{get_latest_startup_broadcast_message_cursor, GossipMessageStore};
 use crate::fiber::network::get_chain_hash;
 use crate::fiber::types::new_channel_update_unsigned;
 use crate::fiber::types::*;
@@ -15,6 +15,7 @@ use crate::fiber::{
     PaymentCustomRecords, PaymentSession, PaymentStatus, Privkey, Pubkey, PublicChannelInfo,
     RevocationData, SendPaymentData, SettlementData, SigningCommitmentFlags, TimedResult,
 };
+use crate::gen_rand_channel_outpoint;
 use crate::gen_rand_fiber_private_key;
 use crate::gen_rand_fiber_public_key;
 use crate::gen_rand_sha256_hash;
@@ -242,33 +243,114 @@ fn test_store_save_node_announcement() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-fn test_store_latest_remote_broadcast_message_cursor() {
+fn test_get_latest_startup_broadcast_message_cursor_skips_local_messages_conservatively() {
     let (store, _dir) = generate_store();
-    let (_sk, node_announcement) = mock_node();
-    let local_cursor = node_announcement.cursor();
-    let older_cursor = Cursor::new(
-        local_cursor.timestamp.saturating_sub(1),
-        BroadcastMessageID::NodeAnnouncement(node_announcement.node_id),
-    );
-    let newer_cursor = Cursor::new(
-        local_cursor.timestamp.saturating_add(1),
-        BroadcastMessageID::NodeAnnouncement(node_announcement.node_id),
-    );
+    let local_signer = gen_rand_local_signer();
+    let local_privkey: Privkey = (*local_signer.secret_key()).into();
+    let local_pubkey = local_privkey.pubkey();
+    let remote_signer = gen_rand_local_signer();
+    let remote_privkey: Privkey = (*remote_signer.secret_key()).into();
+    let remote_pubkey = remote_privkey.pubkey();
+    let remote_peer_signer = gen_rand_local_signer();
+    let remote_peer_pubkey: Pubkey = (*remote_peer_signer.pubkey()).into();
+    let announcement_signer = gen_rand_local_signer();
+    let x_only_pubkey = announcement_signer.x_only_pub_key();
 
-    store.save_node_announcement(node_announcement);
-    assert_eq!(store.get_latest_remote_broadcast_message_cursor(), None);
+    let local_node_announcement = NodeAnnouncement::new_signed(
+        AnnouncedNodeName::from_string("local").expect("invalid name"),
+        FeatureVector::default(),
+        vec![],
+        &local_privkey,
+        get_chain_hash(),
+        10,
+        0,
+        Default::default(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
+    store.save_node_announcement(local_node_announcement.clone());
 
-    store.update_latest_remote_broadcast_message_cursor(local_cursor.clone());
-    store.update_latest_remote_broadcast_message_cursor(older_cursor);
+    let local_channel_outpoint = gen_rand_channel_outpoint();
+    let local_channel_announcement = ChannelAnnouncement::new_unsigned(
+        &local_pubkey,
+        &remote_pubkey,
+        local_channel_outpoint.clone(),
+        get_chain_hash(),
+        &x_only_pubkey,
+        0,
+        None,
+    );
+    store.save_channel_announcement(20, local_channel_announcement);
+    store.save_channel_update(new_channel_update_unsigned(
+        local_channel_outpoint,
+        30,
+        ChannelUpdateMessageFlags::UPDATE_OF_NODE1,
+        ChannelUpdateChannelFlags::empty(),
+        1,
+        1,
+        1,
+    ));
+
+    let remote_node_announcement = NodeAnnouncement::new_signed(
+        AnnouncedNodeName::from_string("remote").expect("invalid name"),
+        FeatureVector::default(),
+        vec![],
+        &remote_privkey,
+        get_chain_hash(),
+        40,
+        0,
+        Default::default(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
+    store.save_node_announcement(remote_node_announcement);
+
+    let remote_channel_outpoint = gen_rand_channel_outpoint();
+    let remote_channel_announcement = ChannelAnnouncement::new_unsigned(
+        &remote_pubkey,
+        &remote_peer_pubkey,
+        remote_channel_outpoint.clone(),
+        get_chain_hash(),
+        &x_only_pubkey,
+        0,
+        None,
+    );
+    store.save_channel_announcement(50, remote_channel_announcement);
+    let remote_channel_update = new_channel_update_unsigned(
+        remote_channel_outpoint,
+        60,
+        ChannelUpdateMessageFlags::UPDATE_OF_NODE1,
+        ChannelUpdateChannelFlags::empty(),
+        1,
+        1,
+        1,
+    );
+    store.save_channel_update(remote_channel_update.clone());
+
+    store.save_channel_update(new_channel_update_unsigned(
+        gen_rand_channel_outpoint(),
+        70,
+        ChannelUpdateMessageFlags::UPDATE_OF_NODE1,
+        ChannelUpdateChannelFlags::empty(),
+        1,
+        1,
+        1,
+    ));
+
+    let newer_local_node_announcement = NodeAnnouncement::new_signed(
+        AnnouncedNodeName::from_string("local").expect("invalid name"),
+        FeatureVector::default(),
+        vec![],
+        &local_privkey,
+        get_chain_hash(),
+        80,
+        0,
+        Default::default(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
+    store.save_node_announcement(newer_local_node_announcement);
+
     assert_eq!(
-        store.get_latest_remote_broadcast_message_cursor(),
-        Some(local_cursor.clone())
-    );
-
-    store.update_latest_remote_broadcast_message_cursor(newer_cursor.clone());
-    assert_eq!(
-        store.get_latest_remote_broadcast_message_cursor(),
-        Some(newer_cursor)
+        get_latest_startup_broadcast_message_cursor(&store, Some(&local_pubkey)),
+        remote_channel_update.cursor()
     );
 }
 

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -240,6 +240,38 @@ fn test_store_save_node_announcement() {
     assert_eq!(new_node_announcement, Some(node_announcement));
 }
 
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_store_latest_remote_broadcast_message_cursor() {
+    let (store, _dir) = generate_store();
+    let (_sk, node_announcement) = mock_node();
+    let local_cursor = node_announcement.cursor();
+    let older_cursor = Cursor::new(
+        local_cursor.timestamp.saturating_sub(1),
+        BroadcastMessageID::NodeAnnouncement(node_announcement.node_id),
+    );
+    let newer_cursor = Cursor::new(
+        local_cursor.timestamp.saturating_add(1),
+        BroadcastMessageID::NodeAnnouncement(node_announcement.node_id),
+    );
+
+    store.save_node_announcement(node_announcement);
+    assert_eq!(store.get_latest_remote_broadcast_message_cursor(), None);
+
+    store.update_latest_remote_broadcast_message_cursor(local_cursor.clone());
+    store.update_latest_remote_broadcast_message_cursor(older_cursor);
+    assert_eq!(
+        store.get_latest_remote_broadcast_message_cursor(),
+        Some(local_cursor.clone())
+    );
+
+    store.update_latest_remote_broadcast_message_cursor(newer_cursor.clone());
+    assert_eq!(
+        store.get_latest_remote_broadcast_message_cursor(),
+        Some(newer_cursor)
+    );
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/fiber-types/src/schema.rs
+++ b/crates/fiber-types/src/schema.rs
@@ -12,6 +12,7 @@
 //! | 65           | OutPoint             | ChannelId                   |
 //! | 96           | Cursor               | BroadcastMessage            |
 //! | 97           | BroadcastMessageID   | u64                         |
+//! | 98           | ()                   | Cursor                      |
 //! | 192          | Hash256              | PaymentSession              |
 //! | 193          | OutPoint | Direction | TimedResult                 |
 //! | 194          | Hash256              | PaymentCustomRecords        |
@@ -30,6 +31,7 @@ pub const PUBKEY_CHANNEL_ID_PREFIX: u8 = 64;
 pub const CHANNEL_OUTPOINT_CHANNEL_ID_PREFIX: u8 = 65;
 pub const BROADCAST_MESSAGE_PREFIX: u8 = 96;
 pub const BROADCAST_MESSAGE_TIMESTAMP_PREFIX: u8 = 97;
+pub const LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX: u8 = 98;
 pub const PAYMENT_SESSION_PREFIX: u8 = 192;
 pub const PAYMENT_HISTORY_TIMED_RESULT_PREFIX: u8 = 193;
 pub const PAYMENT_CUSTOM_RECORD_PREFIX: u8 = 194;

--- a/crates/fiber-types/src/schema.rs
+++ b/crates/fiber-types/src/schema.rs
@@ -12,7 +12,6 @@
 //! | 65           | OutPoint             | ChannelId                   |
 //! | 96           | Cursor               | BroadcastMessage            |
 //! | 97           | BroadcastMessageID   | u64                         |
-//! | 98           | ()                   | Cursor                      |
 //! | 192          | Hash256              | PaymentSession              |
 //! | 193          | OutPoint | Direction | TimedResult                 |
 //! | 194          | Hash256              | PaymentCustomRecords        |
@@ -31,7 +30,6 @@ pub const PUBKEY_CHANNEL_ID_PREFIX: u8 = 64;
 pub const CHANNEL_OUTPOINT_CHANNEL_ID_PREFIX: u8 = 65;
 pub const BROADCAST_MESSAGE_PREFIX: u8 = 96;
 pub const BROADCAST_MESSAGE_TIMESTAMP_PREFIX: u8 = 97;
-pub const LATEST_REMOTE_BROADCAST_MESSAGE_CURSOR_PREFIX: u8 = 98;
 pub const PAYMENT_SESSION_PREFIX: u8 = 192;
 pub const PAYMENT_HISTORY_TIMED_RESULT_PREFIX: u8 = 193;
 pub const PAYMENT_CUSTOM_RECORD_PREFIX: u8 = 194;


### PR DESCRIPTION
Our node used the latest broadcast cursor in the local store to decide where to start syncing gossip, but that cursor mixed two different sources of state: gossip learned from remote peers and announcements generated by the local node itself.

When auto_announce was enabled, the node saved its own NodeAnnouncement as soon as a peer connected. That immediately pushed the “latest broadcast cursor” close to the current time.

## Fix
- store the last remote broadcast cursor and use it for startup gossip sync watermarks
- update the remote cursor only when newly verified gossip learned from peers is saved