### PR TITLE
fix: use wasm-bindgen spawn_local for wasm tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,7 @@ dependencies = [
  "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-time",
 ]

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -107,6 +107,7 @@ tentacle = { version = "0.7", default-features = false, features = [
 tokio = { version = "1", features = ["io-util", "macros", "rt", "sync"] }
 tracing = { version = "0.1", features = ["log"] }
 web-time = { version = "1.1.0", features = ["serde"] }
+wasm-bindgen-futures = "0.4"
 
 [features]
 bench = ["tempfile", "ckb-testtool"]

--- a/crates/fiber-lib/src/tasks.rs
+++ b/crates/fiber-lib/src/tasks.rs
@@ -2,6 +2,10 @@ use std::future::Future;
 
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
+/// Spawn a task on wasm32 using wasm_bindgen_futures
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::spawn_local as wasm_spawn_local;
+
 #[derive(Debug, Clone)]
 pub struct TaskTrackerWithCancellation {
     tracker: TaskTracker,
@@ -58,13 +62,13 @@ where
 }
 
 /// Spawn a task on wasm32
+/// Note: In WASM environment, we use wasm_bindgen_futures::spawn_local instead of
+/// tokio_util's spawn_local because the latter requires a LocalSet context which
+/// is not available in the browser's event loop.
 #[cfg(target_arch = "wasm32")]
 pub fn spawn<F>(fut: F)
 where
-    F: Future + 'static,
-    F::Output: 'static,
+    F: Future<Output = ()> + 'static,
 {
-    TOKIO_TASK_TRACKER_WITH_CANCELLATION
-        .tracker
-        .spawn_local(fut);
+    wasm_spawn_local(fut);
 }

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -2049,6 +2049,7 @@ dependencies = [
  "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 


### PR DESCRIPTION
This fixes a fiber-wasm crash.
The page crashes after being left idle for a period of time after the channel is created:

```
75f2baef-8e88-4895-b818-2d5b74f99f30:1 panicked at /home/joii/code/fiber-dev/fiber/crates/fiber-lib/src/tasks.rs:69:10:
`spawn_local` called from outside of a `task::LocalSet` or `runtime::LocalRuntime`

Stack:

Error
    at __wbg_new_227d7c05414eb861 (blob:http://localhost:5173/75f2baef-8e88-4895-b818-2d5b74f99f30:1:8400)
    at wasm://wasm/0273d6d6:wasm-function[2304]:0x53a34e
    at wasm://wasm/0273d6d6:wasm-function[4861]:0x645172
    at wasm://wasm/0273d6d6:wasm-function[4156]:0x61c5c2
    at wasm://wasm/0273d6d6:wasm-function[6306]:0x674a73
    at wasm://wasm/0273d6d6:wasm-function[517]:0x2acabf
    at wasm://wasm/0273d6d6:wasm-function[4000]:0x6060e5
    at wasm://wasm/0273d6d6:wasm-function[280]:0x16d8c1
    at wasm://wasm/0273d6d6:wasm-function[341]:0x1d5b5b
    at wasm://wasm/0273d6d6:wasm-function[1487]:0x45d017


__wbg_error_a6fa202b58aa1cd3 @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
$func2304 @ 0273d6d6:0x53a41b
$func4861 @ 0273d6d6:0x645172
$func4156 @ 0273d6d6:0x61c5c2
$func6306 @ 0273d6d6:0x674a73
$func517 @ 0273d6d6:0x2acabf
$func4000 @ 0273d6d6:0x6060e5
$func280 @ 0273d6d6:0x16d8c1
$func341 @ 0273d6d6:0x1d5b5b
$func1487 @ 0273d6d6:0x45d017
$func2558 @ 0273d6d6:0x563015
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
setInterval
__wbg_setInterval_c134f8826a82ba51 @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
$func4539 @ 0273d6d6:0x632261
$func1358 @ 0273d6d6:0x44283d
$func1410 @ 0273d6d6:0x44d095
$func2558 @ 0273d6d6:0x563015
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
75f2baef-8e88-4895-b818-2d5b74f99f30:2 Uncaught RuntimeError: unreachable
onerror @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
setInterval
__wbg_setInterval_c134f8826a82ba51 @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
$func4539 @ 0273d6d6:0x632261
$func1358 @ 0273d6d6:0x44283d
$func1410 @ 0273d6d6:0x44d095
$func2558 @ 0273d6d6:0x563015
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
75f2baef-8e88-4895-b818-2d5b74f99f30:1 panicked at /home/joii/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasm-bindgen-futures-0.4.64/src/task/singlethread.rs:132:37:
RefCell already borrowed

Stack:

Error
    at __wbg_new_227d7c05414eb861 (blob:http://localhost:5173/75f2baef-8e88-4895-b818-2d5b74f99f30:1:8400)
    at wasm://wasm/0273d6d6:wasm-function[2304]:0x53a34e
    at wasm://wasm/0273d6d6:wasm-function[4861]:0x645172
    at wasm://wasm/0273d6d6:wasm-function[4156]:0x61c5c2
    at wasm://wasm/0273d6d6:wasm-function[6306]:0x674a3b
    at wasm://wasm/0273d6d6:wasm-function[8255]:0x69b26d
    at wasm://wasm/0273d6d6:wasm-function[2558]:0x563083
    at wasm://wasm/0273d6d6:wasm-function[6863]:0x6841d5
    at wasm://wasm/0273d6d6:wasm-function[5608]:0x663954
    at wasm://wasm/0273d6d6:wasm-function[6785]:0x683311


__wbg_error_a6fa202b58aa1cd3 @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
$func2304 @ 0273d6d6:0x53a41b
$func4861 @ 0273d6d6:0x645172
$func4156 @ 0273d6d6:0x61c5c2
$func6306 @ 0273d6d6:0x674a3b
$func8255 @ 0273d6d6:0x69b26d
$func2558 @ 0273d6d6:0x563083
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
setInterval
__wbg_setInterval_c134f8826a82ba51 @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
$func4539 @ 0273d6d6:0x632261
$func1358 @ 0273d6d6:0x44283d
$func1410 @ 0273d6d6:0x44d095
$func2558 @ 0273d6d6:0x563015
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
75f2baef-8e88-4895-b818-2d5b74f99f30:2 Uncaught RuntimeError: unreachable
onerror @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
setInterval
__wbg_setInterval_c134f8826a82ba51 @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
$func4539 @ 0273d6d6:0x632261
$func1358 @ 0273d6d6:0x44283d
$func1410 @ 0273d6d6:0x44d095
$func2558 @ 0273d6d6:0x563015
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
0273d6d6:0x61c5e8 Uncaught RuntimeError: unreachable
    at 0273d6d6:0x61c5e8
    at 0273d6d6:0x674a73
    at 0273d6d6:0x2acabf
    at 0273d6d6:0x6060e5
    at 0273d6d6:0x16d8c1
    at 0273d6d6:0x1d5b5b
    at 0273d6d6:0x45d017
    at 0273d6d6:0x563015
    at 0273d6d6:0x6841d5
    at 0273d6d6:0x663954
$func4156 @ 0273d6d6:0x61c5e8
$func6306 @ 0273d6d6:0x674a73
$func517 @ 0273d6d6:0x2acabf
$func4000 @ 0273d6d6:0x6060e5
$func280 @ 0273d6d6:0x16d8c1
$func341 @ 0273d6d6:0x1d5b5b
$func1487 @ 0273d6d6:0x45d017
$func2558 @ 0273d6d6:0x563015
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
setInterval
__wbg_setInterval_c134f8826a82ba51 @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
$func4539 @ 0273d6d6:0x632261
$func1358 @ 0273d6d6:0x44283d
$func1410 @ 0273d6d6:0x44d095
$func2558 @ 0273d6d6:0x563015
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
0273d6d6:0x61c5e8 Uncaught RuntimeError: unreachable
    at 0273d6d6:0x61c5e8
    at 0273d6d6:0x674a3b
    at 0273d6d6:0x69b26d
    at 0273d6d6:0x563083
    at 0273d6d6:0x6841d5
    at 0273d6d6:0x663954
    at 0273d6d6:0x683311
    at Hg (75f2baef-8e88-4895-b818-2d5b74f99f30:1:16826)
    at F (75f2baef-8e88-4895-b818-2d5b74f99f30:2:687)
$func4156 @ 0273d6d6:0x61c5e8
$func6306 @ 0273d6d6:0x674a3b
$func8255 @ 0273d6d6:0x69b26d
$func2558 @ 0273d6d6:0x563083
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
setInterval
__wbg_setInterval_c134f8826a82ba51 @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
$func4539 @ 0273d6d6:0x632261
$func1358 @ 0273d6d6:0x44283d
$func1410 @ 0273d6d6:0x44d095
$func2558 @ 0273d6d6:0x563015
$func6863 @ 0273d6d6:0x6841d5
$func5608 @ 0273d6d6:0x663954
$wasm_bindgen__convert__closures_____invoke__h476c54af626292ed @ 0273d6d6:0x683311
Hg @ 75f2baef-8e88-4895-b818-2d5b74f99f30:1
F @ 75f2baef-8e88-4895-b818-2d5b74f99f30:2
```