### PR TITLE
RPC method not found should not return unauthorized when auth is disabled

### DIFF
--- a/crates/fiber-lib/src/rpc/middleware.rs
+++ b/crates/fiber-lib/src/rpc/middleware.rs
@@ -105,8 +105,9 @@ impl<S> BiscuitAuthMiddleware<S> {
                     return true;
                 }
                 Err(err) => {
-                    tracing::debug!("Failed check_permission #{err:?}");
-                    return false;
+                    tracing::debug!("Failed get_rule #{err:?}");
+                    // no auth rule, but allow local rpc to proceed.
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
When biscuit auth is disabled, the rpc method not found should not return unauthorized error.