### PR TITLE
fix: add limit to broadcast message queries and use loop-based pagination

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -2830,9 +2830,11 @@ where
                         error!("Failed to check chain hash: {:?}", e);
                         return Ok(());
                     }
-                    if get_broadcast_messages.count > MAX_NUM_OF_BROADCAST_MESSAGES {
+                    if get_broadcast_messages.count == 0
+                        || get_broadcast_messages.count > MAX_NUM_OF_BROADCAST_MESSAGES
+                    {
                         warn!(
-                            "Received GetBroadcastMessages with too many messages: {:?}",
+                            "Received GetBroadcastMessages with invalid count: {:?}",
                             get_broadcast_messages.count
                         );
                         return Ok(());

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -105,28 +105,19 @@ fn max_acceptable_gossip_message_timestamp() -> u64 {
 
 pub trait GossipMessageStore {
     /// The implementors should guarantee that the returned messages are sorted by timestamp in the ascending order.
-    fn get_broadcast_messages_iter(
-        &self,
-        after_cursor: &Cursor,
-    ) -> impl IntoIterator<Item = BroadcastMessageWithTimestamp>;
-
-    /// The implementors should guarantee that the returned messages are sorted by timestamp in the descending order.
-    fn get_broadcast_messages_iter_reverse(
-        &self,
-        before_cursor: Option<&Cursor>,
-        limit: usize,
-    ) -> impl IntoIterator<Item = BroadcastMessageWithTimestamp>;
-
+    /// `limit` controls the maximum number of messages to return; 0 means no limit (return all).
     fn get_broadcast_messages(
         &self,
         after_cursor: &Cursor,
-        count: Option<u16>,
-    ) -> Vec<BroadcastMessageWithTimestamp> {
-        self.get_broadcast_messages_iter(after_cursor)
-            .into_iter()
-            .take(count.unwrap_or(DEFAULT_NUM_OF_BROADCAST_MESSAGE) as usize)
-            .collect()
-    }
+        limit: usize,
+    ) -> Vec<BroadcastMessageWithTimestamp>;
+
+    /// The implementors should guarantee that the returned messages are sorted by timestamp in the descending order.
+    fn get_broadcast_messages_reverse(
+        &self,
+        before_cursor: Option<&Cursor>,
+        limit: usize,
+    ) -> Vec<BroadcastMessageWithTimestamp>;
 
     fn query_broadcast_messages<I: IntoIterator<Item = BroadcastMessageQuery>>(
         &self,
@@ -293,7 +284,7 @@ pub(crate) fn get_latest_startup_broadcast_message_cursor<S: GossipMessageStore>
         Some(local_pubkey) => {
             // TODO: Support lazy load of broadcast messages, know we just add a limit to the query to avoid loading too many messages into memory.
             store
-                .get_broadcast_messages_iter_reverse(None, 100)
+                .get_broadcast_messages_reverse(None, 100)
                 .into_iter()
                 .filter(|message| is_remote_cursor_candidate(store, local_pubkey, message))
                 .map(|message| message.cursor())
@@ -1723,9 +1714,8 @@ impl<S: GossipMessageStore + Send + Sync + 'static, C: CkbChainClient + Send + S
                 };
                 let messages = state
                     .store
-                    .get_broadcast_messages(&cursor, Some(DEFAULT_NUM_OF_BROADCAST_MESSAGE))
-                    .into_iter()
-                    .collect::<Vec<_>>();
+                    .get_broadcast_messages(&cursor, DEFAULT_NUM_OF_BROADCAST_MESSAGE as usize);
+
                 trace!(
                     "Loaded messages for subscription #{} with cursor {:?} (number of messages {:?})",
                     id,
@@ -2850,7 +2840,7 @@ where
                     let id = get_broadcast_messages.id;
                     let messages = state.get_store().get_broadcast_messages(
                         &get_broadcast_messages.after_cursor,
-                        Some(get_broadcast_messages.count),
+                        get_broadcast_messages.count as usize,
                     );
                     let result =
                         GossipMessage::GetBroadcastMessagesResult(GetBroadcastMessagesResult {

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -656,7 +656,7 @@ where
     // Process them and set nodes and channels accordingly.
     pub(crate) fn load_from_store(&mut self) {
         loop {
-            let messages = self.store.get_broadcast_messages(&self.latest_cursor, None);
+            let messages = self.store.get_broadcast_messages(&self.latest_cursor, 0);
             if messages.is_empty() {
                 break;
             }
@@ -887,18 +887,27 @@ where
     }
 
     pub fn get_nodes_with_params(&self, limit: usize, after: Option<Cursor>) -> Vec<NodeInfo> {
-        let cursor = after.unwrap_or_default();
-        self.store
-            .get_broadcast_messages_iter(&cursor)
-            .into_iter()
-            .filter_map(|message| match message {
-                BroadcastMessageWithTimestamp::NodeAnnouncement(node_announcement) => {
-                    Some(NodeInfo::from(node_announcement))
+        let mut cursor = after.unwrap_or_default();
+        let mut result = Vec::new();
+        loop {
+            let batch = self
+                .store
+                .get_broadcast_messages(&cursor, if limit > 0 { limit - result.len() } else { 0 });
+            if batch.is_empty() {
+                break;
+            }
+            for message in batch {
+                cursor = message.cursor();
+                if let BroadcastMessageWithTimestamp::NodeAnnouncement(node_announcement) = message
+                {
+                    result.push(NodeInfo::from(node_announcement));
+                    if limit > 0 && result.len() >= limit {
+                        return result;
+                    }
                 }
-                _ => None,
-            })
-            .take(limit)
-            .collect()
+            }
+        }
+        result
     }
 
     pub fn get_node(&self, node_id: &Pubkey) -> Option<&NodeInfo> {
@@ -949,31 +958,36 @@ where
         limit: usize,
         after: Option<Cursor>,
     ) -> Vec<ChannelInfo> {
-        let cursor = after.unwrap_or_default();
-        self.store
-            .get_broadcast_messages_iter(&cursor)
-            .into_iter()
-            .filter_map(|message| match message {
-                BroadcastMessageWithTimestamp::ChannelAnnouncement(
+        let mut cursor = after.unwrap_or_default();
+        let mut result = Vec::new();
+        loop {
+            let batch = self
+                .store
+                .get_broadcast_messages(&cursor, if limit > 0 { limit - result.len() } else { 0 });
+            if batch.is_empty() {
+                break;
+            }
+            for message in batch {
+                cursor = message.cursor();
+                if let BroadcastMessageWithTimestamp::ChannelAnnouncement(
                     timestamp,
                     channel_announcement,
-                ) => {
+                ) = message
+                {
                     let mut channel_info = ChannelInfo::from((timestamp, channel_announcement));
                     self.load_channel_updates_from_store(&mut channel_info);
-
-                    // assuming channel is closed if disabled from the both side
                     let is_closed = channel_info.update_of_node1.is_some_and(|u| !u.enabled)
                         && channel_info.update_of_node2.is_some_and(|u| !u.enabled);
                     if !is_closed {
-                        Some(channel_info)
-                    } else {
-                        None
+                        result.push(channel_info);
+                        if limit > 0 && result.len() >= limit {
+                            return result;
+                        }
                     }
                 }
-                _ => None,
-            })
-            .take(limit)
-            .collect()
+            }
+        }
+        result
     }
 
     pub fn get_channels_by_peer(&self, node_id: Pubkey) -> impl Iterator<Item = &ChannelInfo> {

--- a/crates/fiber-lib/src/fiber/tests/gossip.rs
+++ b/crates/fiber-lib/src/fiber/tests/gossip.rs
@@ -734,9 +734,8 @@ async fn test_gossip_store_prune_all_messages() {
     assert_eq!(
         context
             .get_store()
-            .get_broadcast_messages_iter(&Cursor::default())
-            .into_iter()
-            .count(),
+            .get_broadcast_messages(&Cursor::default(), 0)
+            .len(),
         num_messages
     );
 
@@ -751,9 +750,8 @@ async fn test_gossip_store_prune_all_messages() {
     assert_eq!(
         context
             .get_store()
-            .get_broadcast_messages_iter(&Cursor::default())
-            .into_iter()
-            .count(),
+            .get_broadcast_messages(&Cursor::default(), 0)
+            .len(),
         0
     );
 }
@@ -791,7 +789,7 @@ async fn test_gossip_store_prune_channel_announcement() {
     assert_eq!(
         context
             .get_store()
-            .get_broadcast_messages(&Cursor::default(), None)
+            .get_broadcast_messages(&Cursor::default(), 0)
             .len(),
         1
     );
@@ -813,7 +811,7 @@ async fn test_gossip_store_prune_channel_announcement() {
     assert_eq!(
         context
             .get_store()
-            .get_broadcast_messages(&Cursor::default(), None),
+            .get_broadcast_messages(&Cursor::default(), 0),
         vec![]
     );
 }
@@ -883,7 +881,7 @@ async fn test_gossip_store_prune_channel_update() {
     assert_eq!(
         context
             .get_store()
-            .get_broadcast_messages(&Cursor::default(), None)
+            .get_broadcast_messages(&Cursor::default(), 0)
             .len(),
         3
     );
@@ -922,7 +920,7 @@ async fn test_gossip_store_prune_channel_update() {
     assert_eq!(
         context
             .get_store()
-            .get_broadcast_messages(&Cursor::default(), None)
+            .get_broadcast_messages(&Cursor::default(), 0)
             .len(),
         3
     );
@@ -961,7 +959,7 @@ async fn test_gossip_store_prune_channel_update() {
     assert_eq!(
         context
             .get_store()
-            .get_broadcast_messages(&Cursor::default(), None)
+            .get_broadcast_messages(&Cursor::default(), 0)
             .len(),
         3
     );
@@ -1000,7 +998,7 @@ async fn test_gossip_store_prune_channel_update() {
     assert_eq!(
         context
             .get_store()
-            .get_broadcast_messages(&Cursor::default(), None),
+            .get_broadcast_messages(&Cursor::default(), 0),
         vec![]
     );
 }

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -750,7 +750,7 @@ async fn test_prune_channel_announcement_and_receive_channel_update() {
     assert_eq!(
         node2
             .get_store()
-            .get_broadcast_messages_iter(&Cursor::default())
+            .get_broadcast_messages(&Cursor::default(), 0)
             .into_iter()
             .filter(|message| !matches!(
                 message,
@@ -789,7 +789,7 @@ async fn test_prune_channel_announcement_and_receive_channel_update() {
     assert_eq!(
         node2
             .get_store()
-            .get_broadcast_messages_iter(&Cursor::default())
+            .get_broadcast_messages(&Cursor::default(), 0)
             .into_iter()
             .filter(|message| !matches!(
                 message,

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -855,15 +855,11 @@ impl NetworkGraphStateStore for Store {
             Some(after_hash) => {
                 let start_key = [&[PAYMENT_SESSION_PREFIX], after_hash.as_ref()].concat();
                 // Start from the `after` key and skip it (exclusive cursor)
-                let after_hash_owned = after_hash;
                 self.collect_by_prefix_with(
                     &prefix,
                     PrefixIterOptions::new()
                         .start_key(&start_key)
-                        .skip_while(Box::new(move |key| {
-                            // Skip the cursor key itself (keys are [prefix][hash])
-                            key.len() > 1 && key[1..] == *after_hash_owned.as_ref()
-                        })),
+                        .start_key_exclusive(),
                 )
                 .into_iter()
                 .filter_map(|kv| {
@@ -1298,10 +1294,9 @@ impl GossipMessageStore for Store {
         let cursor = after_cursor.to_bytes();
         let prefix = [BROADCAST_MESSAGE_PREFIX];
         let start = [&prefix, cursor.as_slice()].concat();
-        let start_cloned = start.clone();
         let mut options = PrefixIterOptions::new()
             .start_key(&start)
-            .skip_while(Box::new(move |key: &[u8]| key == start_cloned));
+            .start_key_exclusive();
         if limit > 0 {
             options = options.limit(limit);
         }
@@ -1333,10 +1328,7 @@ impl GossipMessageStore for Store {
         });
 
         if let Some(start) = start_cloned.as_ref() {
-            options = options.start_key(start).skip_while(Box::new({
-                let start = start.clone();
-                move |key: &[u8]| key == start
-            }));
+            options = options.start_key(start).start_key_exclusive();
         }
 
         self.collect_by_prefix_with(&prefix, options)

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -1290,38 +1290,40 @@ impl WatchtowerStore for Store {
 }
 
 impl GossipMessageStore for Store {
-    fn get_broadcast_messages_iter(
+    fn get_broadcast_messages(
         &self,
         after_cursor: &Cursor,
-    ) -> impl IntoIterator<Item = crate::fiber::types::BroadcastMessageWithTimestamp> {
+        limit: usize,
+    ) -> Vec<crate::fiber::types::BroadcastMessageWithTimestamp> {
         let cursor = after_cursor.to_bytes();
         let prefix = [BROADCAST_MESSAGE_PREFIX];
         let start = [&prefix, cursor.as_slice()].concat();
         let start_cloned = start.clone();
-        // We should skip the value with the same cursor (after_cursor is exclusive).
-        self.collect_by_prefix_with(
-            &prefix,
-            PrefixIterOptions::new()
-                .start_key(&start)
-                .skip_while(Box::new(move |key: &[u8]| key == start_cloned)),
-        )
-        .into_iter()
-        .map(|kv| {
-            debug_assert_eq!(kv.key.len(), 1 + CURSOR_SIZE);
-            let mut timestamp_bytes = [0u8; 8];
-            timestamp_bytes.copy_from_slice(&kv.key[1..9]);
-            let timestamp = u64::from_be_bytes(timestamp_bytes);
-            let message: BroadcastMessage = deserialize_from(kv.value.as_ref(), "BroadcastMessage");
-            (message, timestamp).into()
-        })
-        .collect::<Vec<_>>()
+        let mut options = PrefixIterOptions::new()
+            .start_key(&start)
+            .skip_while(Box::new(move |key: &[u8]| key == start_cloned));
+        if limit > 0 {
+            options = options.limit(limit);
+        }
+        self.collect_by_prefix_with(&prefix, options)
+            .into_iter()
+            .map(|kv| {
+                debug_assert_eq!(kv.key.len(), 1 + CURSOR_SIZE);
+                let mut timestamp_bytes = [0u8; 8];
+                timestamp_bytes.copy_from_slice(&kv.key[1..9]);
+                let timestamp = u64::from_be_bytes(timestamp_bytes);
+                let message: BroadcastMessage =
+                    deserialize_from(kv.value.as_ref(), "BroadcastMessage");
+                (message, timestamp).into()
+            })
+            .collect::<Vec<_>>()
     }
 
-    fn get_broadcast_messages_iter_reverse(
+    fn get_broadcast_messages_reverse(
         &self,
         before_cursor: Option<&Cursor>,
         limit: usize,
-    ) -> impl IntoIterator<Item = crate::fiber::types::BroadcastMessageWithTimestamp> {
+    ) -> Vec<crate::fiber::types::BroadcastMessageWithTimestamp> {
         let prefix = [BROADCAST_MESSAGE_PREFIX];
         let mut options = PrefixIterOptions::new().reverse().limit(limit);
 

--- a/crates/fiber-lib/src/store/store_trait.rs
+++ b/crates/fiber-lib/src/store/store_trait.rs
@@ -151,18 +151,11 @@ pub trait FiberStore: StorageBackend + Clone + std::fmt::Debug {
         );
 
         // Strip the cursor entry itself when exclusive.
+        // The cursor key is always the first element returned by collect_iterator
+        // because iteration starts from start_key in both forward and reverse.
         if let Some(ref cursor_key) = start_key_owned {
-            match direction {
-                IteratorDirection::Forward => {
-                    if results.first().is_some_and(|kv| kv.key == *cursor_key) {
-                        results.remove(0);
-                    }
-                }
-                IteratorDirection::Reverse => {
-                    if results.last().is_some_and(|kv| kv.key == *cursor_key) {
-                        results.pop();
-                    }
-                }
+            if results.first().is_some_and(|kv| kv.key == *cursor_key) {
+                results.remove(0);
             }
             // Truncate back to the original limit.
             if limit > 0 && results.len() > limit {

--- a/crates/fiber-lib/src/store/store_trait.rs
+++ b/crates/fiber-lib/src/store/store_trait.rs
@@ -1,9 +1,6 @@
 use fiber_store::backend::StorageBackend;
 use fiber_store::iterator::{IteratorDirection, KVPair};
 
-/// Type alias for the `skip_while` predicate used by [`PrefixIterOptions`].
-pub type SkipWhileFn = Box<dyn Fn(&[u8]) -> bool + Send + 'static>;
-
 /// Builder for prefix iteration options, modelled after `std::fs::OpenOptions`.
 ///
 /// # Examples
@@ -15,27 +12,25 @@ pub type SkipWhileFn = Box<dyn Fn(&[u8]) -> bool + Send + 'static>;
 /// // Reverse scan with limit:
 /// self.collect_by_prefix_with(&prefix, PrefixIterOptions::new().reverse().limit(1))
 ///
-/// // Paginated forward scan, skipping the cursor key:
-/// let start = cursor_key.clone();
+/// // Paginated forward scan with exclusive cursor:
 /// self.collect_by_prefix_with(&prefix, PrefixIterOptions::new()
 ///     .start_key(&cursor_key)
-///     .skip_while(Box::new(move |key| key == start)))
+///     .start_key_exclusive())
 /// ```
 pub struct PrefixIterOptions<'a> {
     pub(crate) direction: IteratorDirection,
     pub(crate) start_key: Option<&'a [u8]>,
-    pub(crate) skip_while: Option<SkipWhileFn>,
+    pub(crate) start_key_exclusive: bool,
     pub(crate) limit: usize,
 }
 
 impl<'a> PrefixIterOptions<'a> {
-    /// Create options with defaults: forward direction, no start key,
-    /// no skip_while, no limit.
+    /// Create options with defaults: forward direction, no start key, no limit.
     pub fn new() -> Self {
         Self {
             direction: IteratorDirection::Forward,
             start_key: None,
-            skip_while: None,
+            start_key_exclusive: false,
             limit: 0,
         }
     }
@@ -52,10 +47,10 @@ impl<'a> PrefixIterOptions<'a> {
         self
     }
 
-    /// Skip entries at the start while the predicate returns true.
-    /// Once a key fails the predicate, all subsequent entries are kept.
-    pub fn skip_while(mut self, f: SkipWhileFn) -> Self {
-        self.skip_while = Some(f);
+    /// Make the start key exclusive — the entry matching start_key itself
+    /// will be skipped. Only meaningful when `start_key` is set.
+    pub fn start_key_exclusive(mut self) -> Self {
+        self.start_key_exclusive = true;
         self
     }
 
@@ -102,7 +97,7 @@ pub trait FiberStore: StorageBackend + Clone + std::fmt::Debug {
         let PrefixIterOptions {
             direction,
             start_key,
-            skip_while,
+            start_key_exclusive,
             limit,
         } = options;
 
@@ -134,32 +129,48 @@ pub trait FiberStore: StorageBackend + Clone + std::fmt::Debug {
             }
         };
 
-        let results = self.collect_iterator(
+        // When start_key_exclusive is set, fetch one extra entry so the cursor
+        // entry doesn't consume a slot that should belong to real results.
+        let fetch_limit = if start_key_exclusive && start_key.is_some() && limit > 0 {
+            limit + 1
+        } else {
+            limit
+        };
+
+        let start_key_owned = if start_key_exclusive {
+            start_key.map(|k| k.to_vec())
+        } else {
+            None
+        };
+
+        let mut results = self.collect_iterator(
             start,
             direction,
             Box::new(move |key: &[u8]| key.starts_with(&prefix_owned)),
-            limit,
+            fetch_limit,
         );
 
-        // Apply skip_while post-collection, if provided.
-        match skip_while {
-            None => results,
-            Some(predicate) => {
-                let mut skipping = true;
-                results
-                    .into_iter()
-                    .filter(move |kv| {
-                        if skipping {
-                            if predicate(&kv.key) {
-                                return false;
-                            }
-                            skipping = false;
-                        }
-                        true
-                    })
-                    .collect()
+        // Strip the cursor entry itself when exclusive.
+        if let Some(ref cursor_key) = start_key_owned {
+            match direction {
+                IteratorDirection::Forward => {
+                    if results.first().is_some_and(|kv| kv.key == *cursor_key) {
+                        results.remove(0);
+                    }
+                }
+                IteratorDirection::Reverse => {
+                    if results.last().is_some_and(|kv| kv.key == *cursor_key) {
+                        results.pop();
+                    }
+                }
+            }
+            // Truncate back to the original limit.
+            if limit > 0 && results.len() > limit {
+                results.truncate(limit);
             }
         }
+
+        results
     }
 }
 

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -134,9 +134,7 @@ fn test_store_get_broadcast_messages_iter() {
     let outpoint = channel_announcement.out_point().clone();
     store.save_channel_announcement(timestamp, channel_announcement.clone());
     let default_cursor = Cursor::default();
-    let mut iter = store
-        .get_broadcast_messages_iter(&default_cursor)
-        .into_iter();
+    let mut iter = store.get_broadcast_messages(&default_cursor, 0).into_iter();
     assert_eq!(
         iter.next(),
         Some(BroadcastMessageWithTimestamp::ChannelAnnouncement(
@@ -146,7 +144,7 @@ fn test_store_get_broadcast_messages_iter() {
     );
     assert_eq!(iter.next(), None);
     let cursor = Cursor::new(timestamp, BroadcastMessageID::ChannelAnnouncement(outpoint));
-    let mut iter = store.get_broadcast_messages_iter(&cursor).into_iter();
+    let mut iter = store.get_broadcast_messages(&cursor, 0).into_iter();
     assert_eq!(iter.next(), None);
 }
 
@@ -159,7 +157,7 @@ fn test_store_get_broadcast_messages() {
     let outpoint = channel_announcement.out_point().clone();
     store.save_channel_announcement(timestamp, channel_announcement.clone());
     let default_cursor = Cursor::default();
-    let result = store.get_broadcast_messages(&default_cursor, None);
+    let result = store.get_broadcast_messages(&default_cursor, 0);
     assert_eq!(
         result,
         vec![BroadcastMessageWithTimestamp::ChannelAnnouncement(
@@ -168,7 +166,7 @@ fn test_store_get_broadcast_messages() {
         )],
     );
     let cursor = Cursor::new(timestamp, BroadcastMessageID::ChannelAnnouncement(outpoint));
-    let result = store.get_broadcast_messages(&cursor, None);
+    let result = store.get_broadcast_messages(&cursor, 0);
     assert_eq!(result, vec![]);
 }
 

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -1236,3 +1236,48 @@ fn test_store_channel_open_record() {
 fn deterministic_hash256(seed: u64, index: u32) -> fiber_types::Hash256 {
     crate::store::sample::deterministic_hash(seed, index).into()
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_store_get_broadcast_messages_reverse_excludes_cursor() {
+    let (store, _dir) = generate_store();
+    let first_timestamp = now_timestamp_as_millis_u64();
+    let first_channel_announcement = mock_channel();
+    let first_outpoint = first_channel_announcement.out_point().clone();
+    store.save_channel_announcement(first_timestamp, first_channel_announcement.clone());
+
+    let second_timestamp = first_timestamp + 1;
+    let second_channel_announcement = mock_channel();
+    let second_outpoint = second_channel_announcement.out_point().clone();
+    store.save_channel_announcement(second_timestamp, second_channel_announcement.clone());
+
+    let latest = store.get_broadcast_messages_reverse(None, 1);
+    assert_eq!(
+        latest,
+        vec![BroadcastMessageWithTimestamp::ChannelAnnouncement(
+            second_timestamp,
+            second_channel_announcement.clone(),
+        )],
+    );
+
+    let before_cursor = Cursor::new(
+        second_timestamp,
+        BroadcastMessageID::ChannelAnnouncement(second_outpoint),
+    );
+    let previous = store.get_broadcast_messages_reverse(Some(&before_cursor), 1);
+    assert_eq!(
+        previous,
+        vec![BroadcastMessageWithTimestamp::ChannelAnnouncement(
+            first_timestamp,
+            first_channel_announcement,
+        )],
+    );
+
+    let first_cursor = Cursor::new(
+        first_timestamp,
+        BroadcastMessageID::ChannelAnnouncement(first_outpoint),
+    );
+    assert!(store
+        .get_broadcast_messages_reverse(Some(&first_cursor), 1)
+        .is_empty());
+}


### PR DESCRIPTION
Replace unbounded get_broadcast_messages_iter with limit-aware get_broadcast_messages(cursor, limit) to avoid loading all broadcast messages into memory. Callers like get_nodes_with_params and get_channels_with_params now use loop-based pagination to correctly handle filtering (e.g. skipping closed channels) while respecting the requested limit.