### PR TITLE
fix: replace magic number with constant for secp sighash placeholder

### DIFF
--- a/crates/fiber-lib/src/ckb/funding/funding_tx.rs
+++ b/crates/fiber-lib/src/ckb/funding/funding_tx.rs
@@ -35,6 +35,26 @@ use tracing::debug;
 // Number of blocks to keep the committed funding tx in the exclusion map.
 // It is the same with the value used in the CKB SDK.
 const KEEP_BLOCK_PERIOD: u64 = 13;
+// SecpSighash uses a 65-byte recoverable signature in `WitnessArgs.lock`:
+// 64-byte compact signature + 1-byte recovery id. The full serialized witness
+// is larger because it also includes Molecule table/bytes headers.
+const SECP_SIGHASH_PLACEHOLDER_SIGNATURE_BYTES: usize = 65;
+
+pub(crate) fn secp_sighash_placeholder_witness() -> packed::WitnessArgs {
+    packed::WitnessArgs::new_builder()
+        .lock(
+            Some(molecule::bytes::Bytes::from(vec![
+                0u8;
+                SECP_SIGHASH_PLACEHOLDER_SIGNATURE_BYTES
+            ]))
+            .pack(),
+        )
+        .build()
+}
+
+pub(crate) fn is_secp_sighash_placeholder_witness(witness: &[u8]) -> bool {
+    witness == secp_sighash_placeholder_witness().as_slice()
+}
 
 /// Funding transaction wrapper.
 ///
@@ -383,16 +403,12 @@ impl FundingTxBuilder {
             None => packed::Transaction::default().as_advanced_builder(),
         };
 
-        let placeholder_witness = packed::WitnessArgs::new_builder()
-            .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 170])).pack())
-            .build();
-
         let tx_builder = builder
             .set_inputs(inputs)
             .set_outputs(outputs)
             .set_outputs_data(outputs_data)
             .set_cell_deps(cell_deps.into_iter().collect())
-            .set_witnesses(vec![placeholder_witness.as_bytes().pack()]);
+            .set_witnesses(vec![secp_sighash_placeholder_witness().as_bytes().pack()]);
         Ok(tx_builder.build())
     }
 
@@ -410,13 +426,9 @@ impl FundingTxBuilder {
         );
 
         let sender = self.context.funding_source_lock_script.clone();
-        let placeholder_witness = packed::WitnessArgs::new_builder()
-            .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 170])).pack())
-            .build();
-
         let balancer = CapacityBalancer::new_simple(
             sender.clone(),
-            placeholder_witness,
+            secp_sighash_placeholder_witness(),
             self.request.funding_fee_rate,
         );
 
@@ -499,7 +511,6 @@ impl FundingTxBuilder {
 
         tx.as_advanced_builder().set_cell_deps(cell_deps).build()
     }
-
     fn finalize_funding_tx_update(
         self,
         tx: TransactionView,
@@ -1064,5 +1075,14 @@ mod tests {
             Err(FundingError::OverflowError) => {}
             other => panic!("expected OverflowError, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_secp_sighash_placeholder_witness_matches_sdk_layout() {
+        let placeholder = secp_sighash_placeholder_witness();
+        let lock = placeholder.lock().to_opt().expect("has lock placeholder");
+
+        assert_eq!(lock.len(), SECP_SIGHASH_PLACEHOLDER_SIGNATURE_BYTES);
+        assert!(is_secp_sighash_placeholder_witness(placeholder.as_slice()));
     }
 }

--- a/crates/fiber-lib/src/ckb/funding/mod.rs
+++ b/crates/fiber-lib/src/ckb/funding/mod.rs
@@ -1,4 +1,6 @@
 mod funding_tx;
 
-pub(crate) use funding_tx::{FundingContext, LiveCellsExclusionMap};
+pub(crate) use funding_tx::{
+    is_secp_sighash_placeholder_witness, FundingContext, LiveCellsExclusionMap,
+};
 pub use funding_tx::{FundingRequest, FundingTx};

--- a/crates/fiber-lib/src/ckb/mod.rs
+++ b/crates/fiber-lib/src/ckb/mod.rs
@@ -11,6 +11,7 @@ pub use client::{GetCellsResponse, GetShutdownTxResponse, GetTxResponse};
 pub use config::{CkbConfig, UdtCfgInfosExt, DEFAULT_CKB_BASE_DIR_NAME};
 pub use error::{CkbChainError, FundingError};
 pub use fiber_types::{UdtArgInfo, UdtCellDep, UdtCfgInfos, UdtDep, UdtScript};
+pub(crate) use funding::is_secp_sighash_placeholder_witness;
 pub use funding::{FundingRequest, FundingTx};
 pub use signer::LocalSigner;
 pub use tx_tracing_actor::{CkbTxTracer, CkbTxTracingMask, CkbTxTracingResult};

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -18,7 +18,7 @@ use crate::utils::payment::is_invoice_fulfilled;
 use crate::{
     ckb::{
         contracts::{get_cell_deps, get_script_by_contract, Contract},
-        FundingRequest,
+        is_secp_sighash_placeholder_witness, FundingRequest,
     },
     fiber::{
         config::{DEFAULT_MIN_SHUTDOWN_FEE, MAX_PAYMENT_TLC_EXPIRY_LIMIT, MIN_TLC_EXPIRY_DELTA},
@@ -6754,12 +6754,10 @@ impl ChannelActorState {
                 if !flags.is_empty() {
                     // In the old code, signatures are not saved. Reset the state and resign the
                     // funding tx if signatures does not match the flags.
-                    let placeholder_witness = packed::WitnessArgs::new_builder()
-                        .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 170])).pack())
-                        .build()
-                        .as_bytes()
-                        .to_vec();
-                    if witnesses.iter().any(|w| w == &placeholder_witness) {
+                    if witnesses
+                        .iter()
+                        .any(|w| is_secp_sighash_placeholder_witness(w))
+                    {
                         flags = AwaitingTxSignaturesFlags::empty();
                         self.update_state(ChannelState::AwaitingTxSignatures(flags));
                     }

--- a/tests/funding-tx-builder/src/main.rs
+++ b/tests/funding-tx-builder/src/main.rs
@@ -22,6 +22,20 @@ use ckb_types::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs, serde_as};
 
+const SECP_SIGHASH_PLACEHOLDER_SIGNATURE_BYTES: usize = 65;
+
+fn secp_sighash_placeholder_witness() -> packed::WitnessArgs {
+    packed::WitnessArgs::new_builder()
+        .lock(
+            Some(molecule::bytes::Bytes::from(vec![
+                0u8;
+                SECP_SIGHASH_PLACEHOLDER_SIGNATURE_BYTES
+            ]))
+            .pack(),
+        )
+        .build()
+}
+
 pub struct EntityHex;
 
 impl<T> SerializeAs<T> for EntityHex
@@ -120,14 +134,10 @@ impl TxBuilder for FundingTxBuilder {
         let builder = tx.as_advanced_builder();
 
         // set a placeholder_witness for calculating transaction fee according to transaction size
-        let placeholder_witness = packed::WitnessArgs::new_builder()
-            .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 170])).pack())
-            .build();
-
         let tx_builder = builder
             .set_outputs(outputs)
             .set_outputs_data(outputs_data)
-            .set_witnesses(vec![placeholder_witness.as_bytes().pack()]);
+            .set_witnesses(vec![secp_sighash_placeholder_witness().as_bytes().pack()]);
         let tx = tx_builder.build();
         Ok(tx)
     }
@@ -171,13 +181,9 @@ impl FundingTxBuilder {
         let sender = self.funding_source_lock_script.clone();
 
         // Build CapacityBalancer
-        let placeholder_witness = packed::WitnessArgs::new_builder()
-            .lock(Some(molecule::bytes::Bytes::from(vec![0u8; 170])).pack())
-            .build();
-
         let balancer = CapacityBalancer::new_simple(
             sender.clone(),
-            placeholder_witness,
+            secp_sighash_placeholder_witness(),
             self.request.funding_fee_rate,
         );
 


### PR DESCRIPTION
we should use 65 as the secp sighash placeholder, keep same with CKB sdk.

170 was much like the hexadecimal string length of 85-byte witness, not the number of bytes that the signature itself should occupy.

but still, we have a left issue that two peers may pay more fee, and the distribution may not fair enough.

