### PR TITLE
Add CHANGELOG, migration guide, and data migrations for v0.8.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [v0.8.0-rc1] - 2026-03-28
+
+### Breaking Changes
+
+#### RPC: PeerId replaced with Pubkey
+
+All RPC methods and types that previously used `peer_id` (base58-encoded libp2p PeerId) now use `pubkey` (hex-encoded compressed secp256k1 public key). ([#1154])
+
+- `open_channel`: parameter `peer_id` renamed to `pubkey`, type changed from PeerId to Pubkey
+- `list_channels`: parameter `peer_id` renamed to `pubkey`
+- `disconnect_peer`: parameter `peer_id` renamed to `pubkey`
+- `connect_peer`: parameter `address` changed from required `MultiAddr` to optional `String`; new optional parameter `pubkey` added (at least one of `address` or `pubkey` must be provided)
+- `node_info` response: field `node_id` renamed to `pubkey`; `addresses` type changed from `Vec<MultiAddr>` to `Vec<String>`
+- `Channel` type: field `peer_id` renamed to `pubkey`
+- `PeerInfo` type: field `peer_id` removed; `address` type changed from `MultiAddr` to `String`
+- `NodeInfo` (graph) type: field `node_id` renamed to `pubkey`; `addresses` type changed to `Vec<String>`
+
+#### RPC: JSON type serialization overhaul
+
+A new `fiber-json-types` crate was introduced for RPC-facing types, changing several serialization formats. ([#1169])
+
+- `Attribute` (invoice) enum variants changed from PascalCase to snake_case (e.g., `FinalHtlcTimeout` → `final_htlc_timeout`)
+- `Attribute::UdtScript` inner type changed from structured `CkbScript` to hex string
+- `Attribute::PayeePublicKey` inner type changed from `PublicKey` to `Pubkey`
+- `HashAlgorithm` enum variants changed from PascalCase to snake_case (e.g., `CkbHash` → `ckb_hash`)
+- `CkbInvoice.signature` type changed from structured `InvoiceSignature` to hex string; `InvoiceSignature` type removed
+- `CchInvoice::Fiber` and `CchInvoice::Lightning` now carry encoded invoice strings instead of structured objects
+- `ChannelState` flags serialization changed to SCREAMING_SNAKE_CASE with pipe separator (e.g., `"OUR_INIT_SENT | THEIR_INIT_SENT"`)
+
+#### RPC: CCH order status renames
+
+- `CchOrderStatus::Succeeded` renamed to `Success` ([#1211])
+- `CchOrderStatus::OutgoingSucceeded` renamed to `OutgoingSuccess` ([#1211])
+
+#### RPC: Error behavior changes
+
+Several RPC methods now wait for operations to complete and return proper errors instead of silently returning success. ([#1202])
+
+- `connect_peer`, `disconnect_peer`: now return errors on failure
+- `commitment_signed`, `check_channel_shutdown` (dev RPCs): now return errors on failure
+
+#### Store: Data format changes requiring migration
+
+- Channel actor state (prefix 0) gains two new fields: `pending_replay_updates` and `last_was_revoke` ([#1111])
+- Channel-by-pubkey index (prefix 64) re-keyed from PeerId to Pubkey ([#1154])
+- Network actor state (prefix 16) restructured: `peer_pubkey_map` removed, `saved_peer_addresses` re-keyed from PeerId to Pubkey ([#1154])
+- Channel open records (prefix 201) changed `peer_id` field to `pubkey` ([#1154])
+
+Run `fnn-migrate` to apply all data migrations automatically. See the [migration guide](docs/notes/v0.8.0-migration-guide.md) for details.
+
+### Features
+
+- Support external wallet signing for channel funding, enabling hardware wallets, multisig setups, and browser-based signers via new `open_channel_with_external_funding` and `submit_signed_funding_tx` RPCs ([#1120])
+- CCH can now run as a standalone process, connecting to a Fiber node over HTTP RPC and subscribing to store changes via WebSocket `subscribe_store_changes` endpoint ([#1165])
+- Automatic funding retry with exponential backoff (up to 5 retries) for transient CKB RPC/network errors during channel funding ([#1213])
+- New `fiber-cli` crate providing a command-line client for all Fiber RPC methods with colorized output and auto-generated subcommands ([#1144])
+- Inbound and reconnect protections: per-peer budget for inbound connections, single-flight guard on pending channel opens, bounded deferred TLC replay, delayed channel-ready until reestablish completes ([#1200])
+- New `list_payments` RPC for querying payment sessions ([#1152])
+- Unified storage layer with `StorageBackend` trait abstracting over RocksDB, SQLite, and browser backends ([#1191])
+- RPC documentation improvements for node identifiers and channel rebalancing ([#1150])
+
+### Bug Fixes
+
+- Persist `CommitDiff` to disk so commitment replay after restart is deterministic, fixing potential wrong-order or missing replay during reestablish ([#1111])
+- Forward `LocalCommitmentSigned` event to watchtower so it has data needed to dispute stale remote-initiated closes ([#1151])
+- CCH: dynamically compute remaining incoming time and cap outgoing route expiry to prevent HTLC timeout issues in multi-hop routes ([#1148])
+- Fix gossip startup sync cursor pollution where locally-generated messages could incorrectly advance the cursor, skipping remote gossip updates ([#1227])
+- Treat no-route errors as permanent in CCH outgoing payments ([#979])
+- Handle overflow in BTC final TLC expiry delta calculation ([#977])
+- Fix receive_btc invoice currency code from 'Fibt' to 'Fibd' ([#1146])
+- Fix clearer error when key file has 0x prefix ([#1162])
+
+### Refactoring
+
+- Extract `fiber-types` crate for all serializable types ([#1152])
+- Extract `fiber-store` crate with `StorageBackend` trait ([#1168])
+- Add `fiber-json-types` crate for RPC-facing types ([#1169])
+- Rename various types and CCH fields for consistency ([#1211])
+- Use upstream ractor release ([#1214])
+- Cleanup unused fields ([#1231])
+
+[v0.8.0-rc1]: https://github.com/nervosnetwork/fiber/compare/v0.7.1...v0.8.0-rc1
+[#979]: https://github.com/nervosnetwork/fiber/pull/979
+[#977]: https://github.com/nervosnetwork/fiber/pull/977
+[#1111]: https://github.com/nervosnetwork/fiber/pull/1111
+[#1120]: https://github.com/nervosnetwork/fiber/pull/1120
+[#1144]: https://github.com/nervosnetwork/fiber/pull/1144
+[#1146]: https://github.com/nervosnetwork/fiber/pull/1146
+[#1148]: https://github.com/nervosnetwork/fiber/pull/1148
+[#1150]: https://github.com/nervosnetwork/fiber/pull/1150
+[#1151]: https://github.com/nervosnetwork/fiber/pull/1151
+[#1152]: https://github.com/nervosnetwork/fiber/pull/1152
+[#1154]: https://github.com/nervosnetwork/fiber/pull/1154
+[#1162]: https://github.com/nervosnetwork/fiber/pull/1162
+[#1165]: https://github.com/nervosnetwork/fiber/pull/1165
+[#1168]: https://github.com/nervosnetwork/fiber/pull/1168
+[#1169]: https://github.com/nervosnetwork/fiber/pull/1169
+[#1191]: https://github.com/nervosnetwork/fiber/pull/1191
+[#1200]: https://github.com/nervosnetwork/fiber/pull/1200
+[#1202]: https://github.com/nervosnetwork/fiber/pull/1202
+[#1211]: https://github.com/nervosnetwork/fiber/pull/1211
+[#1213]: https://github.com/nervosnetwork/fiber/pull/1213
+[#1214]: https://github.com/nervosnetwork/fiber/pull/1214
+[#1227]: https://github.com/nervosnetwork/fiber/pull/1227
+[#1231]: https://github.com/nervosnetwork/fiber/pull/1231

--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -72,6 +72,21 @@ pub async fn main() -> Result<(), ExitMessage> {
     let _span = info_span!("node", node = fnn::get_node_prefix()).entered();
 
     let config = Config::parse();
+
+    if config.check_validate {
+        let parsed_fiber_config = config
+            .parsed_fiber()
+            .ok_or(ExitMessage("fiber config must be set".to_string()))?;
+        let store_path = parsed_fiber_config.store_path();
+        if let Err(err) = fnn::store::check_validate(&store_path) {
+            eprintln!("db validate failed:\n{}", err);
+            std::process::exit(1);
+        } else {
+            println!("db validate success");
+            std::process::exit(0);
+        }
+    }
+
     let parsed_fiber_config = config
         .parsed_fiber()
         .ok_or(ExitMessage("fiber config must be set".to_string()))?;

--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -77,7 +77,13 @@ pub async fn main() -> Result<(), ExitMessage> {
         let parsed_fiber_config = config
             .parsed_fiber()
             .ok_or(ExitMessage("fiber config must be set".to_string()))?;
-        let store_path = parsed_fiber_config.store_path();
+        let store_path = parsed_fiber_config.base_dir().join("store");
+        if !store_path.exists() {
+            return Err(ExitMessage(format!(
+                "store path does not exist: {}",
+                store_path.display()
+            )));
+        }
         if let Err(err) = fnn::store::check_validate(&store_path) {
             eprintln!("db validate failed:\n{}", err);
             std::process::exit(1);

--- a/crates/fiber-lib/src/config.rs
+++ b/crates/fiber-lib/src/config.rs
@@ -23,6 +23,8 @@ pub struct Config {
     // ckb actor config, None represents that we should not run ckb actor
     pub ckb: Option<CkbConfig>,
     pub base_dir: PathBuf,
+    /// When true, validate the database and exit without starting services.
+    pub check_validate: bool,
 }
 
 impl Config {
@@ -109,6 +111,10 @@ pub mod native {
         #[arg(short, long, value_parser, num_args = 0.., value_delimiter = ',')]
         services: Vec<Service>,
 
+        /// Run database validation and exit
+        #[arg(long, default_value_t = false)]
+        check_validate: bool,
+
         /// config for fiber network
         #[command(flatten)]
         pub fiber: <FiberConfig as ClapSerde>::Opt,
@@ -156,6 +162,7 @@ pub mod native {
 
             // Base directory for all things to be stored to disk
             let base_dir = args.base_dir.clone().unwrap_or(get_default_base_dir());
+            let check_validate = args.check_validate;
 
             // Get config file by
             // 1. Using the explicitly set command line argument `config`
@@ -194,7 +201,7 @@ pub mod native {
                 args.services
             };
 
-            if services.is_empty() {
+            if services.is_empty() && !check_validate {
                 error!("Must run at least one service. Specifying services to run by command line or config file.");
                 print_help_and_exit(1);
             };
@@ -243,6 +250,7 @@ pub mod native {
                 rpc,
                 ckb,
                 base_dir,
+                check_validate,
             }
         }
     }
@@ -309,6 +317,7 @@ mod wasm {
                 rpc,
                 ckb,
                 base_dir: PathBuf::from_str(&database_prefix).unwrap(),
+                check_validate: false,
             }
         }
     }

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -162,7 +162,7 @@ pub fn check_validate<P: AsRef<Path>>(path: P) -> Result<(), String> {
         }
     }
 
-    for KVPair { key, value } in store.collect_by_prefix(&[]) {
+    for (key, value) in store.prefix_iterator(&[]) {
         if key.is_empty() {
             errors.insert("Encountered empty key".to_string());
             continue;

--- a/crates/fiber-store/src/backend.rs
+++ b/crates/fiber-store/src/backend.rs
@@ -52,6 +52,11 @@ pub trait StorageBackend: Send + Sync {
     /// Return a lazy iterator over all key-value pairs whose keys start with
     /// `prefix`.
     ///
+    /// This is primarily used by the migration tool (`fnn-migrate`) and
+    /// `check_validate` to scan store prefixes without loading every entry into
+    /// memory at once. Normal business logic should use higher-level query
+    /// methods instead.
+    ///
     /// The default implementation batches calls to [`Self::collect_iterator`]
     /// so that only a bounded number of entries are held in memory at any time.
     fn prefix_iterator(&self, prefix: &[u8]) -> PrefixIterator<'_, Self> {

--- a/crates/fiber-store/src/backend.rs
+++ b/crates/fiber-store/src/backend.rs
@@ -1,4 +1,4 @@
-use crate::iterator::{IteratorDirection, KVPair};
+use crate::iterator::{IteratorDirection, KVPair, PrefixIterator};
 
 /// A function that determines whether to keep taking items during iteration.
 /// Returns `true` to continue taking, `false` to stop.
@@ -48,4 +48,13 @@ pub trait StorageBackend: Send + Sync {
         take_while_fn: TakeWhileFn,
         limit: usize,
     ) -> Vec<KVPair>;
+
+    /// Return a lazy iterator over all key-value pairs whose keys start with
+    /// `prefix`.
+    ///
+    /// The default implementation batches calls to [`Self::collect_iterator`]
+    /// so that only a bounded number of entries are held in memory at any time.
+    fn prefix_iterator(&self, prefix: &[u8]) -> PrefixIterator<'_, Self> {
+        PrefixIterator::new(self, prefix.to_vec())
+    }
 }

--- a/crates/fiber-store/src/iterator.rs
+++ b/crates/fiber-store/src/iterator.rs
@@ -11,3 +11,94 @@ pub struct KVPair {
     pub key: Vec<u8>,
     pub value: Vec<u8>,
 }
+
+/// Default batch size for [`PrefixIterator`].
+const PREFIX_ITER_BATCH_SIZE: usize = 1000;
+
+/// A lazy, batched iterator over all key-value pairs whose keys share a common
+/// prefix.
+///
+/// Instead of loading every matching entry into memory at once, this iterator
+/// fetches [`PREFIX_ITER_BATCH_SIZE`] items at a time via
+/// [`StorageBackend::collect_iterator`](crate::backend::StorageBackend::collect_iterator)
+/// and yields them one by one. When the current batch is exhausted it
+/// automatically fetches the next batch, using the last-seen key (with a `0x00`
+/// byte appended) as the start position so that the backend's prefix-seek picks
+/// up where we left off.
+pub struct PrefixIterator<'a, S: ?Sized> {
+    store: &'a S,
+    prefix: Vec<u8>,
+    /// Current batch of items fetched from the backend.
+    buffer: std::vec::IntoIter<KVPair>,
+    /// The last key yielded, used to compute the start position for the next
+    /// batch fetch.
+    last_key: Option<Vec<u8>>,
+    /// Whether the previous `collect_iterator` call returned fewer items than
+    /// the batch size, which signals that there are no more items to fetch.
+    exhausted: bool,
+}
+
+impl<'a, S: crate::backend::StorageBackend + ?Sized> PrefixIterator<'a, S> {
+    /// Create a new `PrefixIterator` that lazily fetches entries from `store`
+    /// whose keys begin with `prefix`.
+    pub fn new(store: &'a S, prefix: Vec<u8>) -> Self {
+        let mut iter = Self {
+            store,
+            prefix,
+            buffer: Vec::new().into_iter(),
+            last_key: None,
+            exhausted: false,
+        };
+        iter.fetch_batch();
+        iter
+    }
+
+    /// Fetch the next batch of items from the backend.
+    fn fetch_batch(&mut self) {
+        let start = match self.last_key.take() {
+            Some(mut k) => {
+                // Start right after the last key we yielded.
+                k.push(0x00);
+                k
+            }
+            None => self.prefix.clone(),
+        };
+
+        let prefix_clone = self.prefix.clone();
+        let batch = self.store.collect_iterator(
+            start,
+            IteratorDirection::Forward,
+            Box::new(move |key: &[u8]| key.starts_with(&prefix_clone)),
+            PREFIX_ITER_BATCH_SIZE,
+        );
+
+        self.exhausted = batch.len() < PREFIX_ITER_BATCH_SIZE;
+        self.buffer = batch.into_iter();
+    }
+}
+
+impl<S: crate::backend::StorageBackend + ?Sized> Iterator for PrefixIterator<'_, S> {
+    type Item = (Vec<u8>, Vec<u8>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(kv) = self.buffer.next() {
+                self.last_key = Some(kv.key.clone());
+                return Some((kv.key, kv.value));
+            }
+
+            // Current batch is drained.
+            if self.exhausted {
+                return None;
+            }
+
+            // Fetch the next batch and try again.
+            self.fetch_batch();
+
+            // Guard against empty batches to avoid infinite loops.
+            if self.exhausted && self.buffer.len() == 0 {
+                return None;
+            }
+        }
+    }
+}

--- a/crates/fiber-store/src/iterator.rs
+++ b/crates/fiber-store/src/iterator.rs
@@ -13,7 +13,7 @@ pub struct KVPair {
 }
 
 /// Default batch size for [`PrefixIterator`].
-const PREFIX_ITER_BATCH_SIZE: usize = 1000;
+const PREFIX_ITER_BATCH_SIZE: usize = 100;
 
 /// A lazy, batched iterator over all key-value pairs whose keys share a common
 /// prefix.

--- a/crates/fiber-store/src/lib.rs
+++ b/crates/fiber-store/src/lib.rs
@@ -4,7 +4,7 @@ pub mod iterator;
 
 pub use backend::{BatchWriter, StorageBackend};
 pub use error::StoreError;
-pub use iterator::{IteratorDirection, KVPair};
+pub use iterator::{IteratorDirection, KVPair, PrefixIterator};
 
 // db_migrate and migration require a concrete Store backend
 #[cfg(any(feature = "rocksdb", feature = "sqlite", target_arch = "wasm32"))]

--- a/docs/notes/v0.8.0-migration-guide.md
+++ b/docs/notes/v0.8.0-migration-guide.md
@@ -1,0 +1,140 @@
+# v0.8.0 Migration Guide
+
+This guide covers upgrading a Fiber node from v0.7.x to v0.8.0.
+
+Unlike the v0.7.0 migration (which required closing all channels and starting
+fresh), **v0.8.0 supports in-place data migration**. The `fnn-migrate` tool
+will update your existing database without losing channel state or funds.
+
+## Prerequisites
+
+- Fiber node is running v0.7.0 or v0.7.1
+- Node is **stopped** (not running)
+- A recent backup of your data directory (see the [backup guide](backup-guide.md))
+
+## Step 1: Stop the node
+
+```bash
+# Find the running process
+ps aux | grep fnn
+
+# Terminate it (replace PID with your process ID)
+kill <PID>
+```
+
+## Step 2: Back up your data directory
+
+Always create a backup before migrating:
+
+```bash
+tar -zcvf backup-fiber-dir.tar.gz fiber-dir
+```
+
+## Step 3: Build or download v0.8.0
+
+Build from source:
+
+```bash
+git checkout v0.8.0-rc1
+cargo build --release -p fnn -p fnn-migrate
+```
+
+Or download the pre-built binaries from the
+[releases page](https://github.com/nervosnetwork/fiber/releases).
+
+## Step 4: Run the migration tool
+
+```bash
+./fnn-migrate -d /path/to/fiber-dir
+```
+
+The tool applies all pending migrations in order. You will see log output for
+each migration step:
+
+| Migration | What it does |
+|-----------|-------------|
+| Channel actor state (prefix 0) | Appends new `pending_replay_updates` and `last_was_revoke` fields with default values |
+| Channel-by-pubkey index (prefix 64) | Re-keys the channel index from PeerId to Pubkey |
+| Network actor state (prefix 16) | Clears legacy PeerId-keyed network state (rebuilt on next start) |
+| Channel open records (prefix 201) | Deletes ephemeral channel-opening status records (rebuilt if needed) |
+
+The migration is idempotent — running it again on an already-migrated database
+is safe and will be a no-op.
+
+## Step 5: Update your configuration
+
+No configuration file changes are required for v0.8.0.
+
+## Step 6: Start the node
+
+```bash
+./fnn -c /path/to/fiber-dir/config.yml -d /path/to/fiber-dir
+```
+
+On first start after migration the node will:
+
+- Rebuild the network peer address map from gossip
+- Re-establish connections with known peers
+- Resume any in-flight payments
+
+## RPC client changes
+
+v0.8.0 introduces several RPC breaking changes. If you have scripts or
+integrations that call the Fiber RPC, update them for the following:
+
+### PeerId → Pubkey
+
+All `peer_id` parameters and response fields have been replaced with `pubkey`.
+PeerIds were base58-encoded libp2p identifiers; Pubkeys are hex-encoded
+compressed secp256k1 public keys (66 hex characters).
+
+**Before (v0.7.x):**
+```json
+{"method": "open_channel", "params": [{"peer_id": "QmXxx..."}]}
+```
+
+**After (v0.8.0):**
+```json
+{"method": "open_channel", "params": [{"pubkey": "02abc..."}]}
+```
+
+Affected RPCs: `open_channel`, `list_channels`, `connect_peer`,
+`disconnect_peer`, `node_info`.
+
+### JSON serialization changes
+
+- `Attribute` enum variants are now snake_case: `FinalHtlcTimeout` → `final_htlc_timeout`
+- `HashAlgorithm` variants are now snake_case: `CkbHash` → `ckb_hash`
+- `CkbInvoice.signature` is now a hex string instead of a structured object
+- `ChannelState` flags format: `"OUR_INIT_SENT | THEIR_INIT_SENT"` (SCREAMING_SNAKE_CASE with pipes)
+- CCH invoice variants now carry encoded invoice strings instead of structured objects
+
+### CCH order status renames
+
+- `Succeeded` → `Success`
+- `OutgoingSucceeded` → `OutgoingSuccess`
+
+### Error behavior
+
+`connect_peer` and `disconnect_peer` now return proper RPC errors on failure
+instead of silently returning success.
+
+## Troubleshooting
+
+### Migration fails with "unexpected end of file"
+
+This usually means the database was written by a version newer than v0.7.x.
+Verify you're migrating from v0.7.0 or v0.7.1.
+
+### Node fails to start after migration
+
+1. Check the error message in the logs
+2. Restore from backup: `tar -xzf backup-fiber-dir.tar.gz`
+3. Re-run the migration tool
+4. If the problem persists, open an issue at
+   https://github.com/nervosnetwork/fiber/issues
+
+### Channels show as disconnected after upgrade
+
+This is expected. The node will automatically reconnect to peers and
+re-establish channels. Allow a few minutes for the network to stabilize.

--- a/docs/notes/v0.8.0-migration-guide.md
+++ b/docs/notes/v0.8.0-migration-guide.md
@@ -45,11 +45,11 @@ Or download the pre-built binaries from the
 ## Step 4: Run the migration tool
 
 ```bash
-./fnn-migrate -p /path/to/fiber-dir/store
+./fnn-migrate -d /path/to/fiber-dir
 ```
 
-The `-p` / `--path` flag takes the path to the RocksDB store directory (typically
-`<your-fiber-data-dir>/store`).
+The `-d` / `--dir` flag takes the Fiber data directory (same as `fnn -d`).
+The tool opens the RocksDB store at `<dir>/store` automatically.
 
 The tool applies all pending migrations in order. You will see log output for
 each migration step:

--- a/docs/notes/v0.8.0-migration-guide.md
+++ b/docs/notes/v0.8.0-migration-guide.md
@@ -45,8 +45,11 @@ Or download the pre-built binaries from the
 ## Step 4: Run the migration tool
 
 ```bash
-./fnn-migrate -d /path/to/fiber-dir
+./fnn-migrate -p /path/to/fiber-dir/store
 ```
+
+The `-p` / `--path` flag takes the path to the RocksDB store directory (typically
+`<your-fiber-data-dir>/store`).
 
 The tool applies all pending migrations in order. You will see log output for
 each migration step:

--- a/docs/notes/v0.8.0-migration-guide.md
+++ b/docs/notes/v0.8.0-migration-guide.md
@@ -36,7 +36,8 @@ Build from source:
 
 ```bash
 git checkout v0.8.0-rc1
-cargo build --release -p fnn -p fnn-migrate
+cargo build --release -p fnn
+cargo build --release --manifest-path migrate/Cargo.toml
 ```
 
 Or download the pre-built binaries from the

--- a/migrate/Cargo.lock
+++ b/migrate/Cargo.lock
@@ -902,7 +902,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acadba053fe4d1e5bd79924ea3a9602c0c55df57cf78dd60a2d4115573ebabb"
 dependencies = [
- "ckb-fixed-hash-core 1.0.2",
+ "ckb-fixed-hash-core 1.1.1",
  "ckb-fixed-hash-macros 1.0.1",
 ]
 
@@ -920,12 +920,12 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70974a8cb272e570c6f79b8efe2a98bdf6fe1a2e00deb5907286796aa1bd0465"
+checksum = "a30e802c13f15904d399d1f11d415a1185e9cd6ff25b66db5616d755576d74c4"
 dependencies = [
- "ckb_schemars",
  "faster-hex",
+ "schemars 1.2.1",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -948,7 +948,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bc1f0af31c893775c4b60e4bd0f9b356b59d4d96223dbb4091b5295da51941c"
 dependencies = [
- "ckb-fixed-hash-core 1.0.2",
+ "ckb-fixed-hash-core 1.1.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -1311,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-types"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5326563ecb732527a899d3c1f25ef7f5f7fc3f7e83e39456d33f508c93b50f3f"
+checksum = "bb1a584004fc6f2066a024b247e498305273cb37c14d34b23787977baefc018e"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -1328,7 +1328,7 @@ dependencies = [
  "derive_more 1.0.0",
  "golomb-coded-set",
  "merkle-cbt",
- "molecule 0.8.0",
+ "molecule 0.9.2",
  "numext-fixed-uint",
  "paste",
 ]
@@ -1380,7 +1380,7 @@ checksum = "1506d63311ded0645342c052b1eb21ba272177b32f55d8eb7e11255aed3e74c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.26.0",
  "syn 1.0.109",
 ]
 
@@ -2090,6 +2090,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiber-store"
+version = "0.8.0-rc1"
+dependencies = [
+ "anyhow",
+ "ckb-rocksdb",
+ "console",
+ "console_error_panic_hook",
+ "fiber-wasm-db-common 0.1.0",
+ "indicatif",
+ "thiserror 1.0.69",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "fiber-wasm-db-common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bincode 2.0.1",
+ "serde",
+ "web-sys",
+]
+
+[[package]]
 name = "fiber-wasm-db-common"
 version = "0.1.0"
 source = "git+https://github.com/nervosnetwork/fiber.git?branch=migrate%2Fv0.6.0#1cce085111eaa28f8062d5ea394c316bb67de7e6"
@@ -2357,9 +2383,10 @@ name = "fnn-migrate"
 version = "0.8.0-rc1"
 dependencies = [
  "bincode 1.3.3",
- "ckb-types 1.0.2",
+ "ckb-types 1.1.0",
  "clap",
  "console",
+ "fiber-store",
  "fnn 0.6.0",
  "fnn 0.6.1",
  "fnn 0.7.0-rc1",
@@ -5052,8 +5079,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals 0.29.1",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5270,6 +5310,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/migrate/Cargo.toml
+++ b/migrate/Cargo.toml
@@ -19,6 +19,7 @@ ckb-types = "1"
 fiber_v060 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.6.0" }
 fiber_v061 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.6.1", features = ["sample"] }
 fiber_v070 = { package = "fnn", git = "https://github.com/nervosnetwork/fiber.git", branch = "migrate/v0.7.0", features = ["sample"]}
+fiber-store = { path = "../crates/fiber-store", features = ["rocksdb"] }
 serde_json = "1.0.135"
 ouroboros = "0.18.5"
 

--- a/migrate/src/main.rs
+++ b/migrate/src/main.rs
@@ -33,9 +33,9 @@ fn init_db_migrate(db: Store) -> DbAndDbMigrate {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Path to the database
-    #[arg(short, long)]
-    path: String,
+    /// Fiber data directory (the store is at <dir>/store)
+    #[arg(short = 'd', long = "dir")]
+    dir: String,
 
     /// Skip confirmation prompts
     #[arg(short, long, default_value_t = false)]
@@ -98,13 +98,13 @@ fn main() {
         .init();
 
     let args = Args::parse();
-    let path = Path::new(&args.path);
+    let store_path = Path::new(&args.dir).join("store");
     let skip_confirm = args.skip_confirm;
 
-    let db = Store::open_db(path).expect("failed to open db");
+    let db = Store::open_db(&store_path).expect("failed to open db");
     let migrate = init_db_migrate(db);
 
-    if let Err(err) = run_migrate(migrate, path, skip_confirm) {
+    if let Err(err) = run_migrate(migrate, &store_path, skip_confirm) {
         eprintln!("{}", err);
         exit(1);
     }

--- a/migrate/src/main.rs
+++ b/migrate/src/main.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
-use fiber_v070::store::{db_migrate::DbMigrate, Store};
+use fiber_store::{db_migrate::DbMigrate, Store};
 use fnn_migrate::migrations::*;
 use fnn_migrate::util::prompt;
+use std::cmp::Ordering;
 use std::path::Path;
 use std::process::exit;
-use std::{cmp::Ordering, sync::Arc};
+use std::sync::Arc;
 use tracing::error;
-use tracing_subscriber;
 
 include!(concat!(env!("OUT_DIR"), "/migrations.rs"));
 
@@ -38,12 +38,8 @@ struct Args {
     path: String,
 
     /// Skip confirmation prompts
-    #[arg(short, long, default_value_t = false, group = "mode")]
+    #[arg(short, long, default_value_t = false)]
     skip_confirm: bool,
-
-    /// Run db validation
-    #[arg(short, long, default_value_t = false, group = "mode")]
-    check_validate: bool,
 }
 
 fn run_migrate<P: AsRef<Path>>(
@@ -51,7 +47,11 @@ fn run_migrate<P: AsRef<Path>>(
     path: P,
     skip_confirm: bool,
 ) -> Result<DbAndDbMigrate, String> {
-    if let Err(_) = migrate.borrow_migrate().init_or_check(path.as_ref()) {
+    if migrate
+        .borrow_migrate()
+        .init_or_check(path.as_ref())
+        .is_err()
+    {
         let result = migrate.borrow_migrate().check();
         if result == Ordering::Less {
             if migrate.borrow_migrate().is_any_break_change() {
@@ -101,21 +101,11 @@ fn main() {
     let path = Path::new(&args.path);
     let skip_confirm = args.skip_confirm;
 
-    if args.check_validate {
-        if let Err(err) = Store::check_validate(path) {
-            eprintln!("db validate failed:\n{}", err);
-            exit(1);
-        } else {
-            println!("db validate success");
-            exit(0);
-        }
-    } else {
-        let db = Store::open_db(path).expect("failed to open db");
-        let migrate = init_db_migrate(db);
+    let db = Store::open_db(path).expect("failed to open db");
+    let migrate = init_db_migrate(db);
 
-        if let Err(err) = run_migrate(migrate, path, skip_confirm) {
-            eprintln!("{}", err);
-            exit(1);
-        }
+    if let Err(err) = run_migrate(migrate, path, skip_confirm) {
+        eprintln!("{}", err);
+        exit(1);
     }
 }

--- a/migrate/src/migrations/mig_20250724.rs
+++ b/migrate/src/migrations/mig_20250724.rs
@@ -1,7 +1,4 @@
-use fiber_v070::{
-    store::{migration::Migration, Store},
-    Error,
-};
+use fiber_store::{migration::Migration, Store, StoreError};
 use indicatif::ProgressBar;
 use std::sync::Arc;
 
@@ -10,6 +7,12 @@ const MIGRATION_DB_VERSION: &str = "20250724111111";
 
 pub struct MigrationObj {
     version: String,
+}
+
+impl Default for MigrationObj {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MigrationObj {
@@ -25,7 +28,7 @@ impl Migration for MigrationObj {
         &self,
         db: &'a Store,
         _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
-    ) -> Result<&'a Store, Error> {
+    ) -> Result<&'a Store, StoreError> {
         eprintln!("MigrationObj::migrate .....{}....", MIGRATION_DB_VERSION);
         Ok(db)
     }

--- a/migrate/src/migrations/mig_20251219.rs
+++ b/migrate/src/migrations/mig_20251219.rs
@@ -1,7 +1,4 @@
-use fiber_v070::{
-    store::{migration::Migration, Store},
-    Error,
-};
+use fiber_store::{migration::Migration, StorageBackend, Store, StoreError};
 use indicatif::ProgressBar;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -28,6 +25,12 @@ pub struct MigrationObj {
     version: String,
 }
 
+impl Default for MigrationObj {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MigrationObj {
     pub fn new() -> Self {
         Self {
@@ -41,7 +44,7 @@ impl Migration for MigrationObj {
         &self,
         db: &'a Store,
         _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
-    ) -> Result<&'a Store, Error> {
+    ) -> Result<&'a Store, StoreError> {
         info!(
             "MigrationObj::migrate to {} ...........",
             MIGRATION_DB_VERSION

--- a/migrate/src/migrations/mig_20260203_channel_index.rs
+++ b/migrate/src/migrations/mig_20260203_channel_index.rs
@@ -1,9 +1,6 @@
 use ckb_types::prelude::Entity;
-use fiber_v070::{
-    fiber::payment::{Attempt, PaymentSession},
-    store::{migration::Migration, Store},
-    Error,
-};
+use fiber_store::{migration::Migration, BatchWriter, StorageBackend, Store, StoreError};
+use fiber_v070::fiber::payment::{Attempt, PaymentSession};
 use indicatif::ProgressBar;
 use std::sync::Arc;
 use tracing::info;
@@ -21,6 +18,12 @@ pub struct MigrationObj {
     version: String,
 }
 
+impl Default for MigrationObj {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MigrationObj {
     pub fn new() -> Self {
         Self {
@@ -34,7 +37,7 @@ impl Migration for MigrationObj {
         &self,
         db: &'a Store,
         _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
-    ) -> Result<&'a Store, Error> {
+    ) -> Result<&'a Store, StoreError> {
         info!(
             "MigrationObj::migrate to {} - building channel index for non-final payments ...",
             MIGRATION_DB_VERSION

--- a/migrate/src/migrations/mig_20260203_trampoline.rs
+++ b/migrate/src/migrations/mig_20260203_trampoline.rs
@@ -1,4 +1,5 @@
 use crate::util::convert;
+use fiber_store::{migration::Migration, StorageBackend, Store, StoreError};
 use fiber_v061::fiber::channel::{
     AddTlcCommand as OldAddTlcCommand, ChannelActorState as OldChannelActorState,
     RetryableTlcOperation as OldRetryableTlcOperation, TlcInfo as OldTlcInfo,
@@ -19,8 +20,6 @@ use fiber_v070::{
         SendPaymentData as NewSendPaymentData,
     },
     fiber::types::PaymentHopData as NewPaymentHopData,
-    store::{migration::Migration, Store},
-    Error,
 };
 use indicatif::ProgressBar;
 use std::collections::VecDeque;
@@ -32,6 +31,12 @@ const MIGRATION_DB_VERSION: &str = "20260203152333";
 
 pub struct MigrationObj {
     version: String,
+}
+
+impl Default for MigrationObj {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MigrationObj {
@@ -47,7 +52,7 @@ impl Migration for MigrationObj {
         &self,
         db: &'a Store,
         _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
-    ) -> Result<&'a Store, Error> {
+    ) -> Result<&'a Store, StoreError> {
         info!(
             "MigrationObj::migrate to {} ...........",
             MIGRATION_DB_VERSION

--- a/migrate/src/migrations/mig_20260204_pubkey_channel_index.rs
+++ b/migrate/src/migrations/mig_20260204_pubkey_channel_index.rs
@@ -68,7 +68,12 @@ impl Migration for MigrationObj {
             };
 
             let pubkey_bytes = state.remote_pubkey.serialize();
-            let index_key = [&[PUBKEY_CHANNEL_ID_PREFIX][..], &pubkey_bytes[..], channel_id].concat();
+            let index_key = [
+                &[PUBKEY_CHANNEL_ID_PREFIX][..],
+                &pubkey_bytes[..],
+                channel_id,
+            ]
+            .concat();
             let index_value =
                 bincode::serialize(&state.state).expect("serialize ChannelState should be OK");
             batch.put(index_key, index_value);

--- a/migrate/src/migrations/mig_20260204_pubkey_channel_index.rs
+++ b/migrate/src/migrations/mig_20260204_pubkey_channel_index.rs
@@ -1,8 +1,5 @@
-use fiber_v070::{
-    fiber::channel::ChannelActorState,
-    store::{migration::Migration, Store},
-    Error,
-};
+use fiber_store::{migration::Migration, BatchWriter, StorageBackend, Store, StoreError};
+use fiber_v070::fiber::channel::ChannelActorState;
 use indicatif::ProgressBar;
 use std::sync::Arc;
 use tracing::info;
@@ -13,6 +10,12 @@ const PUBKEY_CHANNEL_ID_PREFIX: u8 = 64;
 
 pub struct MigrationObj {
     version: String,
+}
+
+impl Default for MigrationObj {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MigrationObj {
@@ -28,7 +31,7 @@ impl Migration for MigrationObj {
         &self,
         db: &'a Store,
         _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
-    ) -> Result<&'a Store, Error> {
+    ) -> Result<&'a Store, StoreError> {
         info!(
             "MigrationObj::migrate to {} - rebuilding peer/channel index with pubkey keys ...",
             MIGRATION_DB_VERSION
@@ -44,7 +47,7 @@ impl Migration for MigrationObj {
             .prefix_iterator(index_prefix.as_slice())
             .take_while(|(key, _)| key.starts_with(index_prefix.as_slice()))
         {
-            batch.delete(key.to_vec());
+            batch.delete(&key);
             deleted_old_index_count += 1;
         }
 

--- a/migrate/src/migrations/mig_20260301_network_state_pubkey.rs
+++ b/migrate/src/migrations/mig_20260301_network_state_pubkey.rs
@@ -1,7 +1,4 @@
-use fiber_v070::{
-    store::{migration::Migration, Store},
-    Error,
-};
+use fiber_store::{migration::Migration, BatchWriter, StorageBackend, Store, StoreError};
 use indicatif::ProgressBar;
 use std::sync::Arc;
 use tracing::info;
@@ -11,6 +8,12 @@ const PUBLIC_KEY_NETWORK_ACTOR_STATE_PREFIX: u8 = 16;
 
 pub struct MigrationObj {
     version: String,
+}
+
+impl Default for MigrationObj {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MigrationObj {
@@ -26,7 +29,7 @@ impl Migration for MigrationObj {
         &self,
         db: &'a Store,
         _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
-    ) -> Result<&'a Store, Error> {
+    ) -> Result<&'a Store, StoreError> {
         info!(
             "MigrationObj::migrate to {} - clearing legacy network actor state entries ...",
             MIGRATION_DB_VERSION
@@ -39,7 +42,7 @@ impl Migration for MigrationObj {
             .prefix_iterator(prefix.as_slice())
             .take_while(|(key, _)| key.starts_with(prefix.as_slice()))
         {
-            batch.delete(key.to_vec());
+            batch.delete(&key);
             deleted_count += 1;
         }
         batch.commit();

--- a/migrate/src/migrations/mig_20260302_channel_open_record.rs
+++ b/migrate/src/migrations/mig_20260302_channel_open_record.rs
@@ -1,0 +1,71 @@
+use fiber_v070::{
+    store::{migration::Migration, Store},
+    Error,
+};
+use indicatif::ProgressBar;
+use std::sync::Arc;
+use tracing::info;
+
+/// Delete all `ChannelOpenRecord` entries (prefix 201).
+///
+/// These are ephemeral records that track in-progress channel openings.
+/// The v0.8.0-rc1 schema changed the `peer_id: PeerId` field to
+/// `pubkey: Pubkey`, making the old binary format incompatible.
+/// Since these records are transient status indicators (not long-lived data),
+/// deleting them is safe—any ongoing channel opens will simply lose their
+/// progress-tracking state and will be re-created on the next attempt.
+const MIGRATION_DB_VERSION: &str = "20260302100001";
+const CHANNEL_OPEN_RECORD_PREFIX: u8 = 201;
+
+pub struct MigrationObj {
+    version: String,
+}
+
+impl Default for MigrationObj {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MigrationObj {
+    pub fn new() -> Self {
+        Self {
+            version: MIGRATION_DB_VERSION.to_string(),
+        }
+    }
+}
+
+impl Migration for MigrationObj {
+    fn migrate<'a>(
+        &self,
+        db: &'a Store,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<&'a Store, Error> {
+        info!(
+            "MigrationObj::migrate to {} - clearing channel open record entries ...",
+            MIGRATION_DB_VERSION
+        );
+
+        let prefix = vec![CHANNEL_OPEN_RECORD_PREFIX];
+        let mut batch = db.batch();
+        let mut deleted_count = 0;
+        for (key, _) in db
+            .prefix_iterator(prefix.as_slice())
+            .take_while(|(key, _)| key.starts_with(prefix.as_slice()))
+        {
+            batch.delete(&key);
+            deleted_count += 1;
+        }
+        batch.commit();
+
+        info!(
+            "MigrationObj::migrate to {} - removed {} channel open record entries",
+            MIGRATION_DB_VERSION, deleted_count
+        );
+        Ok(db)
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+}

--- a/migrate/src/migrations/mig_20260302_channel_open_record.rs
+++ b/migrate/src/migrations/mig_20260302_channel_open_record.rs
@@ -1,7 +1,4 @@
-use fiber_v070::{
-    store::{migration::Migration, Store},
-    Error,
-};
+use fiber_store::{migration::Migration, BatchWriter, StorageBackend, Store, StoreError};
 use indicatif::ProgressBar;
 use std::sync::Arc;
 use tracing::info;
@@ -40,7 +37,7 @@ impl Migration for MigrationObj {
         &self,
         db: &'a Store,
         _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
-    ) -> Result<&'a Store, Error> {
+    ) -> Result<&'a Store, StoreError> {
         info!(
             "MigrationObj::migrate to {} - clearing channel open record entries ...",
             MIGRATION_DB_VERSION

--- a/migrate/src/migrations/mig_20260302_channel_replay_fields.rs
+++ b/migrate/src/migrations/mig_20260302_channel_replay_fields.rs
@@ -1,0 +1,105 @@
+use fiber_v070::{
+    fiber::channel::ChannelActorState,
+    store::{migration::Migration, Store},
+    Error,
+};
+use indicatif::ProgressBar;
+use std::sync::Arc;
+use tracing::info;
+
+/// Append two new trailing fields to every serialized `ChannelActorData`:
+///
+///   - `pending_replay_updates: Vec<TlcReplayUpdate>` (default: empty vec)
+///   - `last_was_revoke: bool`                        (default: false)
+///
+/// bincode 1.x serializes `Vec::new()` as 8 zero bytes (u64 length = 0)
+/// and `false` as a single 0u8 byte, totalling 9 bytes.
+///
+/// Detection: deserialize as the old v0.7.0 `ChannelActorState`, re-serialize,
+/// and compare lengths. If the stored value already has extra bytes beyond the
+/// v0.7.0 size, the entry was already migrated—skip it.
+const MIGRATION_DB_VERSION: &str = "20260302100000";
+const CHANNEL_ACTOR_STATE_PREFIX: u8 = 0;
+
+/// bincode encoding of the two new default-value fields:
+///   - `Vec::<_>::new()`: 8 bytes (u64 length = 0)
+///   - `false`:           1 byte  (0u8)
+const NEW_FIELD_SUFFIX: [u8; 9] = [0u8; 9];
+
+pub struct MigrationObj {
+    version: String,
+}
+
+impl Default for MigrationObj {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MigrationObj {
+    pub fn new() -> Self {
+        Self {
+            version: MIGRATION_DB_VERSION.to_string(),
+        }
+    }
+}
+
+impl Migration for MigrationObj {
+    fn migrate<'a>(
+        &self,
+        db: &'a Store,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<&'a Store, Error> {
+        info!(
+            "MigrationObj::migrate to {} - appending replay fields to channel actor state ...",
+            MIGRATION_DB_VERSION
+        );
+
+        let prefix = vec![CHANNEL_ACTOR_STATE_PREFIX];
+        let mut migrated_count = 0;
+        let mut skipped_count = 0;
+
+        for (key, value) in db
+            .prefix_iterator(prefix.as_slice())
+            .take_while(|(key, _)| key.starts_with(prefix.as_slice()))
+        {
+            // Try to deserialize as v0.7.0 format to validate the entry and
+            // compute the expected serialized length without the new fields.
+            let old_state: ChannelActorState = match bincode::deserialize(&value) {
+                Ok(s) => s,
+                Err(_) => {
+                    // Cannot parse as v0.7.0 — entry is either already migrated,
+                    // corrupt, or from a newer format.  Skip it.
+                    skipped_count += 1;
+                    continue;
+                }
+            };
+
+            let old_bytes =
+                bincode::serialize(&old_state).expect("re-serialize v0.7.0 ChannelActorState");
+
+            if value.len() > old_bytes.len() {
+                // Already has extra bytes (likely already migrated).
+                skipped_count += 1;
+                continue;
+            }
+
+            // Append the 9-byte suffix for the two new default fields.
+            let mut new_bytes = value.to_vec();
+            new_bytes.extend_from_slice(&NEW_FIELD_SUFFIX);
+            db.put(key, new_bytes);
+            migrated_count += 1;
+        }
+
+        info!(
+            "MigrationObj::migrate to {} - migrated {} channel actor states, skipped {}",
+            MIGRATION_DB_VERSION, migrated_count, skipped_count
+        );
+
+        Ok(db)
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+}

--- a/migrate/src/migrations/mig_20260302_channel_replay_fields.rs
+++ b/migrate/src/migrations/mig_20260302_channel_replay_fields.rs
@@ -1,8 +1,5 @@
-use fiber_v070::{
-    fiber::channel::ChannelActorState,
-    store::{migration::Migration, Store},
-    Error,
-};
+use fiber_store::{migration::Migration, StorageBackend, Store, StoreError};
+use fiber_v070::fiber::channel::ChannelActorState;
 use indicatif::ProgressBar;
 use std::sync::Arc;
 use tracing::info;
@@ -49,7 +46,7 @@ impl Migration for MigrationObj {
         &self,
         db: &'a Store,
         _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
-    ) -> Result<&'a Store, Error> {
+    ) -> Result<&'a Store, StoreError> {
         info!(
             "MigrationObj::migrate to {} - appending replay fields to channel actor state ...",
             MIGRATION_DB_VERSION

--- a/migrate/src/migrations/mod.rs
+++ b/migrate/src/migrations/mod.rs
@@ -2,7 +2,9 @@ pub mod mig_20250724;
 // following new migration should be added here ...
 // pub(crate) mod sample;
 pub mod mig_20251219;
-pub mod mig_20260203_trampoline;
 pub mod mig_20260203_channel_index;
+pub mod mig_20260203_trampoline;
 pub mod mig_20260204_pubkey_channel_index;
 pub mod mig_20260301_network_state_pubkey;
+pub mod mig_20260302_channel_open_record;
+pub mod mig_20260302_channel_replay_fields;


### PR DESCRIPTION
- CHANGELOG.md: comprehensive changelog covering all breaking changes, features, bug fixes, and refactoring between v0.7.1 and v0.8.0-rc1
- docs/notes/v0.8.0-migration-guide.md: user-facing guide for in-place database migration via fnn-migrate (no channel closing required)
- mig_20260302_channel_replay_fields: append pending_replay_updates and last_was_revoke default values to channel actor state (prefix 0)
- mig_20260302_channel_open_record: delete ephemeral channel open records (prefix 201) incompatible due to PeerId-to-Pubkey field change
- refactor: use local fiber-store for migration infra, move check_validate to fnn binary