### PR TITLE
fix: abort funding immediately on insufficient UDT cells

### DIFF
--- a/crates/fiber-lib/src/ckb/error.rs
+++ b/crates/fiber-lib/src/ckb/error.rs
@@ -24,6 +24,9 @@ pub enum FundingError {
     #[error("Peer sent us an invalid funding tx")]
     InvalidPeerFundingTx,
 
+    #[error("Insufficient cells available for funding: {0}")]
+    InsufficientCells(String),
+
     #[error("Failed to call CKB RPC: {0}")]
     CkbRpcError(#[from] RpcError),
 
@@ -88,10 +91,12 @@ impl FundingError {
     /// For `CkbTxBuilderError` and `CkbTxUnlockError` the cause chain is
     /// inspected: the error is considered temporary only when a transient inner
     /// error (e.g. `std::io::Error` or `ckb_sdk::RpcError`) is found.
+    ///
     pub fn is_temporary(&self) -> bool {
         use FundingError::*;
         match self {
-            CkbRpcError(_) | RactorError(_) | IoError(_) | SerdeError(_) | FromUtf8Error(_) => true,
+            AbsentTx | CkbRpcError(_) | RactorError(_) | IoError(_) | SerdeError(_)
+            | FromUtf8Error(_) => true,
             CkbTxBuilderError(e) => error_chain_has_transient(e),
             CkbTxUnlockError(e) => error_chain_has_transient(e),
             _ => false,
@@ -103,80 +108,4 @@ impl FundingError {
 pub enum CkbChainError {
     #[error("Funding error: {0}")]
     FundingError(#[from] FundingError),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ckb_sdk::traits::CellCollectorError;
-
-    #[test]
-    fn tx_builder_error_with_io_cause_is_temporary() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "connection reset");
-        let inner = CellCollectorError::Internal(io_err.into());
-        let err = FundingError::CkbTxBuilderError(TxBuilderError::CellCollector(inner));
-        assert!(err.is_temporary());
-    }
-
-    #[test]
-    fn tx_builder_error_without_transient_cause_is_not_temporary() {
-        let err = FundingError::CkbTxBuilderError(TxBuilderError::InvalidParameter(
-            anyhow::anyhow!("capacity overflow"),
-        ));
-        assert!(!err.is_temporary());
-    }
-
-    #[test]
-    fn tx_builder_error_transient_display_fallback_without_io_in_chain() {
-        #[derive(Debug)]
-        struct OpaqueSdkError;
-
-        impl std::fmt::Display for OpaqueSdkError {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "cell collector: connection reset by peer")
-            }
-        }
-
-        impl std::error::Error for OpaqueSdkError {}
-
-        let err = FundingError::CkbTxBuilderError(TxBuilderError::InvalidParameter(
-            anyhow::Error::new(OpaqueSdkError),
-        ));
-        assert!(err.is_temporary());
-    }
-
-    #[test]
-    fn unlock_error_with_io_cause_is_temporary() {
-        let io_err =
-            std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "connection refused");
-        let err = FundingError::CkbTxUnlockError(UnlockError::Other(io_err.into()));
-        assert!(err.is_temporary());
-    }
-
-    #[test]
-    fn unlock_error_without_transient_cause_is_not_temporary() {
-        let err = FundingError::CkbTxUnlockError(UnlockError::SignContextTypeIncorrect);
-        assert!(!err.is_temporary());
-    }
-
-    #[test]
-    fn always_temporary_variants() {
-        let io_err = FundingError::IoError(std::io::Error::new(
-            std::io::ErrorKind::BrokenPipe,
-            "broken",
-        ));
-        assert!(io_err.is_temporary());
-
-        let serde_err: Result<(), _> = serde_json::from_str::<()>("bad");
-        let serde_err = FundingError::SerdeError(serde_err.unwrap_err());
-        assert!(serde_err.is_temporary());
-    }
-
-    #[test]
-    fn never_temporary_variants() {
-        assert!(!FundingError::AbsentTx.is_temporary());
-        assert!(!FundingError::DeadCell.is_temporary());
-        assert!(!FundingError::OverflowError.is_temporary());
-        assert!(!FundingError::InvalidPeerFundingTx.is_temporary());
-    }
 }

--- a/crates/fiber-lib/src/ckb/funding/funding_tx.rs
+++ b/crates/fiber-lib/src/ckb/funding/funding_tx.rs
@@ -35,6 +35,18 @@ use tracing::debug;
 // Number of blocks to keep the committed funding tx in the exclusion map.
 // It is the same with the value used in the CKB SDK.
 const KEEP_BLOCK_PERIOD: u64 = 13;
+
+const INSUFFICIENT_UDT_CELLS_MSG: &str =
+    "can not find enough UDT owner cells for funding transaction";
+
+pub(crate) fn map_tx_builder_error(e: TxBuilderError) -> FundingError {
+    if e.to_string().contains(INSUFFICIENT_UDT_CELLS_MSG) {
+        FundingError::InsufficientCells(e.to_string())
+    } else {
+        FundingError::from(e)
+    }
+}
+
 // SecpSighash uses a 65-byte recoverable signature in `WitnessArgs.lock`:
 // 64-byte compact signature + 1-byte recovery id. The full serialized witness
 // is larger because it also includes Molecule table/bytes headers.
@@ -363,9 +375,7 @@ impl FundingTxBuilder {
                 }
             }
         }
-        Err(TxBuilderError::Other(anyhow!(
-            "can not find enough UDT owner cells for funding transaction"
-        )))
+        Err(TxBuilderError::Other(anyhow!(INSUFFICIENT_UDT_CELLS_MSG)))
     }
 
     async fn build_base_from_funding_cell(
@@ -474,16 +484,16 @@ impl FundingTxBuilder {
             .map_err(|err| FundingError::CkbTxBuilderError(TxBuilderError::Other(err.into())))?;
 
         #[cfg(not(target_arch = "wasm32"))]
-        let (tx, _) = self.build_unlocked(
+        let build_result = self.build_unlocked(
             &mut cell_collector,
             &cell_dep_resolver,
             &header_dep_resolver,
             &tx_dep_provider,
             &balancer,
             &unlockers,
-        )?;
+        );
         #[cfg(target_arch = "wasm32")]
-        let (tx, _) = self
+        let build_result = self
             .build_unlocked_async(
                 &mut cell_collector,
                 &cell_dep_resolver,
@@ -492,7 +502,8 @@ impl FundingTxBuilder {
                 &balancer,
                 &unlockers,
             )
-            .await?;
+            .await;
+        let (tx, _) = build_result.map_err(map_tx_builder_error)?;
 
         Ok(tx)
     }

--- a/crates/fiber-lib/src/ckb/funding/mod.rs
+++ b/crates/fiber-lib/src/ckb/funding/mod.rs
@@ -1,5 +1,7 @@
 mod funding_tx;
 
+#[cfg(test)]
+pub(crate) use funding_tx::map_tx_builder_error;
 pub(crate) use funding_tx::{
     is_secp_sighash_placeholder_witness, FundingContext, LiveCellsExclusionMap,
 };

--- a/crates/fiber-lib/src/ckb/tests/error.rs
+++ b/crates/fiber-lib/src/ckb/tests/error.rs
@@ -1,0 +1,142 @@
+use crate::ckb::error::FundingError;
+use crate::ckb::funding::map_tx_builder_error;
+use ckb_sdk::{traits::CellCollectorError, tx_builder::TxBuilderError, unlock::UnlockError};
+
+#[test]
+fn tx_builder_error_with_io_cause_is_temporary() {
+    let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "connection reset");
+    let inner = CellCollectorError::Internal(io_err.into());
+    let err = FundingError::CkbTxBuilderError(TxBuilderError::CellCollector(inner));
+    assert!(err.is_temporary());
+}
+
+#[test]
+fn tx_builder_error_without_transient_cause_is_not_temporary() {
+    let err = FundingError::CkbTxBuilderError(TxBuilderError::InvalidParameter(anyhow::anyhow!(
+        "capacity overflow"
+    )));
+    assert!(!err.is_temporary());
+}
+
+#[test]
+fn tx_builder_error_transient_display_fallback_without_io_in_chain() {
+    #[derive(Debug)]
+    struct OpaqueSdkError;
+
+    impl std::fmt::Display for OpaqueSdkError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "cell collector: connection reset by peer")
+        }
+    }
+
+    impl std::error::Error for OpaqueSdkError {}
+
+    let err = FundingError::CkbTxBuilderError(TxBuilderError::InvalidParameter(
+        anyhow::Error::new(OpaqueSdkError),
+    ));
+    assert!(err.is_temporary());
+}
+
+#[test]
+fn unlock_error_with_io_cause_is_temporary() {
+    let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "connection refused");
+    let err = FundingError::CkbTxUnlockError(UnlockError::Other(io_err.into()));
+    assert!(err.is_temporary());
+}
+
+#[test]
+fn unlock_error_without_transient_cause_is_not_temporary() {
+    let err = FundingError::CkbTxUnlockError(UnlockError::SignContextTypeIncorrect);
+    assert!(!err.is_temporary());
+}
+
+#[test]
+fn always_temporary_variants() {
+    let io_err = FundingError::IoError(std::io::Error::new(
+        std::io::ErrorKind::BrokenPipe,
+        "broken",
+    ));
+    assert!(io_err.is_temporary());
+
+    let serde_err: Result<(), _> = serde_json::from_str::<()>("bad");
+    let serde_err = FundingError::SerdeError(serde_err.unwrap_err());
+    assert!(serde_err.is_temporary());
+}
+
+#[test]
+fn never_temporary_variants() {
+    assert!(!FundingError::DeadCell.is_temporary());
+    assert!(!FundingError::OverflowError.is_temporary());
+    assert!(!FundingError::InvalidPeerFundingTx.is_temporary());
+}
+
+#[test]
+fn absent_tx_is_temporary() {
+    assert!(FundingError::AbsentTx.is_temporary());
+}
+
+#[test]
+fn insufficient_cells_is_not_temporary() {
+    let err = FundingError::InsufficientCells(
+        "can not find enough UDT owner cells for funding transaction".to_string(),
+    );
+    assert!(!err.is_temporary());
+}
+
+#[test]
+fn insufficient_cells_display_includes_detail() {
+    let detail = "can not find enough UDT owner cells for funding transaction";
+    let err = FundingError::InsufficientCells(detail.to_string());
+    let msg = err.to_string();
+    assert!(
+        msg.contains(detail),
+        "expected display to contain detail, got: {msg}"
+    );
+}
+
+#[test]
+fn map_tx_builder_error_converts_insufficient_udt_cells() {
+    let inner = TxBuilderError::Other(anyhow::anyhow!(
+        "can not find enough UDT owner cells for funding transaction"
+    ));
+    let err = map_tx_builder_error(inner);
+    assert!(
+        matches!(err, FundingError::InsufficientCells(_)),
+        "expected InsufficientCells, got: {err:?}"
+    );
+    assert!(!err.is_temporary());
+}
+
+#[test]
+fn map_tx_builder_error_preserves_other_errors() {
+    let inner = TxBuilderError::InvalidParameter(anyhow::anyhow!("bad param"));
+    let err = map_tx_builder_error(inner);
+    assert!(
+        matches!(err, FundingError::CkbTxBuilderError(_)),
+        "expected CkbTxBuilderError, got: {err:?}"
+    );
+}
+
+#[test]
+fn map_tx_builder_error_preserves_transient_error() {
+    let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "connection reset");
+    let inner = TxBuilderError::CellCollector(CellCollectorError::Internal(io_err.into()));
+    let err = map_tx_builder_error(inner);
+    assert!(
+        matches!(err, FundingError::CkbTxBuilderError(_)),
+        "expected CkbTxBuilderError, got: {err:?}"
+    );
+    assert!(err.is_temporary());
+}
+
+#[test]
+fn map_tx_builder_error_matches_substring_in_wrapped_message() {
+    let inner = TxBuilderError::Other(anyhow::anyhow!(
+        "tx build failed: can not find enough UDT owner cells for funding transaction (checked 0 cells)"
+    ));
+    let err = map_tx_builder_error(inner);
+    assert!(
+        matches!(err, FundingError::InsufficientCells(_)),
+        "expected InsufficientCells for message containing the sentinel, got: {err:?}"
+    );
+}

--- a/crates/fiber-lib/src/ckb/tests/mod.rs
+++ b/crates/fiber-lib/src/ckb/tests/mod.rs
@@ -2,5 +2,7 @@
 mod actor;
 #[cfg(not(any(feature = "bench")))]
 mod config;
+#[cfg(test)]
+mod error;
 
 pub mod test_utils;

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -3161,14 +3161,12 @@ where
         let old_tx = transaction.into_view();
         let mut tx = FundingTx::new();
         tx.update_for_self(old_tx);
-        let tx = match self.fund(tx, request).await {
-            Ok(tx) => match tx.into_inner() {
-                Some(tx) => tx,
-                _ => {
-                    error!("Obtained empty funding tx (attempt {})", retry_count + 1);
-                    return Ok(());
-                }
-            },
+        let tx = match self
+            .fund(tx, request)
+            .await
+            .and_then(|tx| tx.into_inner().ok_or(FundingError::AbsentTx))
+        {
+            Ok(tx) => tx,
             Err(err) => {
                 let should_abort = schedule_funding_retry(
                     myself,


### PR DESCRIPTION
## Summary

Fixes #1195

- Add `FundingError::InsufficientCells` variant (non-temporary) so `schedule_funding_retry` aborts the channel immediately instead of silently stalling when UDT cells are unavailable
- Reclassify `AbsentTx` as temporary so empty funding tx results are retried via the existing backoff mechanism, covering the indexer-lag race condition
- Extract `map_tx_builder_error` to convert the "can not find enough UDT owner cells" sentinel into `InsufficientCells` before it reaches retry logic
- Move `FundingError` tests to a dedicated `tests/error.rs` module and add coverage for the new error mapping, classification, and display

## Test plan

- [x] All 16 error unit tests pass (`cargo nextest run -p fnn --features sqlite -E 'test(~error)'`)
- [x] Verify on devnet that opening a UDT channel with unindexed cells returns an error instead of stalling
- [x] Verify on devnet that a transient empty funding result is retried and eventually succeeds


Made with [Cursor](https://cursor.com)