### PR TITLE
feat: handle on-chain TLC settlement for force-closed channels

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3153,7 +3153,9 @@ where
             })
             .collect();
 
-        if !fulfilled.is_empty() {
+        let has_fulfilled = !fulfilled.is_empty();
+
+        if has_fulfilled {
             debug!(
                 "Channel {:?} settling {} on-chain fulfilled TLC(s): {:?}",
                 channel_id,
@@ -3203,7 +3205,12 @@ where
             self.settle_onchain_invoice_if_fulfilled(state, tlc.payment_hash);
         }
 
-        self.sync_already_fulfilled_onchain_tlcs(state);
+        // Synchronize TLC status and invoice state for any previously-fulfilled
+        // TLCs that still need removal applied.  When no new on-chain fulfillments
+        // were discovered this tick there is nothing to sync.
+        if has_fulfilled {
+            self.sync_already_fulfilled_onchain_tlcs(state);
+        }
     }
 
     /// Sync TLC status fields and invoice state for TLCs already marked fulfilled (for example

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3661,11 +3661,13 @@ where
                 } else {
                     self.maintain_waiting_onchain_settlement_tlcs(state);
                 }
-                // The watchtower may observe an on-chain preimage before this channel transitions
-                // to `Closed(WAITING_ONCHAIN_SETTLEMENT)` (e.g. the counterparty force-closed
-                // first). Fulfill those TLCs on every maintenance tick so invoices and payments
-                // are not blocked on the state transition.
-                self.settle_onchain_fulfilled_tlcs(state);
+                // Only closed or shutting-down channels can have on-chain TLC settlement
+                // signals. Scanning all TLCs against the watchtower store every tick on a
+                // healthy ready channel degrades payment throughput (see the benchmark
+                // regression in PR #1254).
+                if state.is_closed() || matches!(state.state, ChannelState::ShuttingDown(_)) {
+                    self.settle_onchain_fulfilled_tlcs(state);
+                }
             }
             ChannelEvent::OnChainSettlementCompleted => {
                 self.finalize_onchain_settlement(myself, state).await?;

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3079,7 +3079,12 @@ where
             .collect();
         for (forwarding_channel_id, forwarding_tlc_id, payment_hash, shared_secret) in expired_tlcs
         {
-            if self.store.is_tlc_settled(&state.id, &payment_hash) {
+            if self.store.is_tlc_settled_on_chain(&state.id, &payment_hash)
+                && self
+                    .store
+                    .get_on_chain_discovered_preimage(&state.id, &payment_hash)
+                    .is_none()
+            {
                 let (send, _recv) = oneshot::channel();
                 let rpc_reply = RpcReplyPort::from(send);
                 if let Err(err) = self.network.send_message(NetworkActorMessage::Command(
@@ -3103,6 +3108,191 @@ where
                     );
                 }
             }
+        }
+    }
+
+    /// Settle TLCs on a force-closed channel whose payment preimage was revealed on-chain.
+    ///
+    /// For every TLC the watchtower observed being claimed on-chain with a preimage, this marks
+    /// the TLC as fulfilled in the channel state (so it is no longer re-collected and is reflected
+    /// in queries/persistence) and propagates the fulfillment: a forwarded TLC is relayed upstream,
+    /// the original payer's payment session is notified, and a now fully-fulfilled invoice is
+    /// marked paid. On-chain preimage discovery is mutually exclusive with the on-chain fail
+    /// marker, so this never overlaps the fail path handled above.
+    fn settle_onchain_fulfilled_tlcs(&self, state: &mut ChannelActorState) {
+        let channel_id = state.get_id();
+        // Collect first so we don't borrow `tlc_state` across the state mutations and message sends.
+        let fulfilled: Vec<OnChainFulfilledTlc> = state
+            .tlc_state
+            .all_tlcs()
+            .filter(|tlc| {
+                if tlc.removed_reason.is_some() || tlc.removed_confirmed_at.is_some() {
+                    return false;
+                }
+                // Only TLCs that made it onto the on-chain commitment can be settled on-chain.
+                if tlc.is_offered() {
+                    tlc.outbound_status() != OutboundTlcStatus::LocalAnnounced
+                } else {
+                    matches!(
+                        tlc.inbound_status(),
+                        InboundTlcStatus::AnnounceWaitAck | InboundTlcStatus::Committed
+                    )
+                }
+            })
+            .filter_map(|tlc| {
+                let preimage = self
+                    .store
+                    .get_on_chain_discovered_preimage(&channel_id, &tlc.payment_hash)?;
+                Some(OnChainFulfilledTlc {
+                    tlc_id: tlc.tlc_id,
+                    forwarding_tlc: tlc.forwarding_tlc,
+                    payment_hash: tlc.payment_hash,
+                    attempt_id: tlc.attempt_id,
+                    preimage,
+                })
+            })
+            .collect();
+
+        if !fulfilled.is_empty() {
+            debug!(
+                "Channel {:?} settling {} on-chain fulfilled TLC(s): {:?}",
+                channel_id,
+                fulfilled.len(),
+                fulfilled
+                    .iter()
+                    .map(|tlc| tlc.payment_hash)
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        for tlc in fulfilled {
+            let fulfill = RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
+                payment_preimage: tlc.preimage,
+            });
+
+            match tlc.tlc_id {
+                TLCId::Offered(id) => {
+                    state.tlc_state.set_offered_tlc_removed(id, fulfill.clone());
+                    if let Some((forwarding_channel_id, forwarding_tlc_id)) = tlc.forwarding_tlc {
+                        // Forwarded TLC: relay the fulfillment upstream. The retryable relay keeps
+                        // trying if the upstream channel is momentarily unavailable.
+                        let _ = self.register_retryable_relay_tlc_remove(
+                            TLCId::Received(forwarding_tlc_id),
+                            forwarding_channel_id,
+                            fulfill.clone(),
+                        );
+                    } else {
+                        // Original payer: drive the payment session to success.
+                        self.network
+                            .send_message(NetworkActorMessage::new_event(
+                                NetworkActorEvent::TlcRemoveReceived(
+                                    tlc.payment_hash,
+                                    tlc.attempt_id,
+                                    fulfill,
+                                ),
+                            ))
+                            .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+                    }
+                }
+                TLCId::Received(id) => {
+                    state.tlc_state.set_received_tlc_removed(id, fulfill);
+                }
+            }
+
+            // A TLC was just marked fulfilled; settle the invoice if it is now fully paid.
+            self.settle_onchain_invoice_if_fulfilled(state, tlc.payment_hash);
+        }
+
+        self.sync_already_fulfilled_onchain_tlcs(state);
+    }
+
+    /// Sync TLC status fields and invoice state for TLCs already marked fulfilled (for example
+    /// after a partial off-chain fulfill on a closing channel) but not yet reflected in RPC state.
+    fn sync_already_fulfilled_onchain_tlcs(&self, state: &mut ChannelActorState) {
+        let offered_updates: Vec<(u64, RemoveTlcReason)> = state
+            .tlc_state
+            .offered_tlcs
+            .tlcs
+            .iter()
+            .filter(|tlc| {
+                matches!(
+                    tlc.removed_reason,
+                    Some(RemoveTlcReason::RemoveTlcFulfill(_))
+                ) && matches!(tlc.outbound_status(), OutboundTlcStatus::Committed)
+            })
+            .filter_map(|tlc| {
+                let TLCId::Offered(id) = tlc.tlc_id else {
+                    return None;
+                };
+                Some((id, tlc.removed_reason.clone()?))
+            })
+            .collect();
+        for (id, reason) in offered_updates {
+            state.tlc_state.set_offered_tlc_removed(id, reason);
+        }
+
+        let received_updates: Vec<(u64, RemoveTlcReason)> = state
+            .tlc_state
+            .received_tlcs
+            .tlcs
+            .iter()
+            .filter(|tlc| {
+                matches!(
+                    tlc.removed_reason,
+                    Some(RemoveTlcReason::RemoveTlcFulfill(_))
+                ) && matches!(tlc.inbound_status(), InboundTlcStatus::Committed)
+            })
+            .filter_map(|tlc| {
+                let TLCId::Received(id) = tlc.tlc_id else {
+                    return None;
+                };
+                Some((id, tlc.removed_reason.clone()?))
+            })
+            .collect();
+        for (id, reason) in received_updates {
+            state.tlc_state.set_received_tlc_removed(id, reason);
+        }
+
+        for tlc in state.tlc_state.received_tlcs.tlcs.iter() {
+            if matches!(
+                tlc.removed_reason,
+                Some(RemoveTlcReason::RemoveTlcFulfill(_))
+            ) {
+                self.settle_onchain_invoice_if_fulfilled(state, tlc.payment_hash);
+            }
+        }
+    }
+
+    /// Mark an invoice paid when its received TLCs on this force-closed channel have been fulfilled
+    /// on-chain and together satisfy the invoice amount. No-op when there is no local invoice for the
+    /// payment hash (e.g. forwarded or payer TLCs) or it is already paid.
+    fn settle_onchain_invoice_if_fulfilled(
+        &self,
+        state: &ChannelActorState,
+        payment_hash: Hash256,
+    ) {
+        let Some(invoice) = self.store.get_invoice(&payment_hash) else {
+            return;
+        };
+        if self.store.get_invoice_status(&payment_hash) == Some(CkbInvoiceStatus::Paid) {
+            return;
+        }
+        let fulfilled_received_tlcs = state.tlc_state.received_tlcs.tlcs.iter().filter(|tlc| {
+            tlc.payment_hash == payment_hash
+                && matches!(
+                    tlc.removed_reason,
+                    Some(RemoveTlcReason::RemoveTlcFulfill(_))
+                )
+        });
+        if is_invoice_fulfilled(&invoice, fulfilled_received_tlcs) {
+            debug!(
+                "Channel {:?} marking invoice {:?} paid from on-chain fulfilled TLCs",
+                state.get_id(),
+                payment_hash
+            );
+            self.store
+                .update_invoice_status(&payment_hash, CkbInvoiceStatus::Paid)
+                .expect("update invoice status failed");
         }
     }
 
@@ -3471,6 +3661,11 @@ where
                 } else {
                     self.maintain_waiting_onchain_settlement_tlcs(state);
                 }
+                // The watchtower may observe an on-chain preimage before this channel transitions
+                // to `Closed(WAITING_ONCHAIN_SETTLEMENT)` (e.g. the counterparty force-closed
+                // first). Fulfill those TLCs on every maintenance tick so invoices and payments
+                // are not blocked on the state transition.
+                self.settle_onchain_fulfilled_tlcs(state);
             }
             ChannelEvent::OnChainSettlementCompleted => {
                 self.finalize_onchain_settlement(myself, state).await?;
@@ -4879,6 +5074,48 @@ pub(crate) fn tlc_expiry_delay(delay_epoch: &EpochNumberWithFraction) -> u64 {
         * MILLI_SECONDS_PER_EPOCH as f64
         * 2.0
         / 3.0) as u64
+}
+
+/// A TLC on a force-closed channel whose preimage the watchtower observed being revealed on-chain.
+struct OnChainFulfilledTlc {
+    tlc_id: TLCId,
+    forwarding_tlc: Option<(Hash256, u64)>,
+    payment_hash: Hash256,
+    attempt_id: Option<u64>,
+    preimage: Hash256,
+}
+
+/// Collect the upstream forwarded TLCs on a force-closed channel that can be fulfilled because the
+/// watchtower observed their preimage being revealed on-chain. Returns
+/// `(upstream_channel_id, upstream_tlc_id, payment_preimage)` for each claimable TLC.
+///
+/// The on-chain preimage discovery is the success signal; it is mutually exclusive with the
+/// on-chain fail marker when no preimage was discovered, so this never overlaps the fail path. This
+/// is used by the network actor's `CheckChannels` sweep as a relay-only fallback for channels with
+/// no live actor (e.g. a preimage revealed after settlement was finalized); the live channel actor
+/// instead uses `settle_onchain_fulfilled_tlcs`, which additionally updates channel, payment, and
+/// invoice state.
+pub(crate) fn collect_onchain_fulfillable_upstream_tlcs(
+    state: &ChannelActorState,
+    store: &impl ChannelActorStateStore,
+) -> Vec<(Hash256, u64, Hash256)> {
+    state
+        .tlc_state
+        .offered_tlcs
+        .tlcs
+        .iter()
+        .filter(|tlc| {
+            tlc.outbound_status() != OutboundTlcStatus::LocalAnnounced
+                && tlc.removed_reason.is_none()
+                && tlc.removed_confirmed_at.is_none()
+        })
+        .filter_map(|tlc| {
+            let (forwarding_channel_id, forwarding_tlc_id) = tlc.forwarding_tlc?;
+            let preimage =
+                store.get_on_chain_discovered_preimage(&state.get_id(), &tlc.payment_hash)?;
+            Some((forwarding_channel_id, forwarding_tlc_id, preimage))
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -9726,8 +9963,30 @@ pub trait ChannelActorStateStore {
     fn remove_payment_hold_tlc(&self, payment_hash: &Hash256, channel_id: &Hash256, tlc_id: u64);
     fn get_payment_hold_tlcs(&self, payment_hash: Hash256) -> Vec<HoldTlc>;
     fn get_node_hold_tlcs(&self) -> HashMap<Hash256, Vec<HoldTlc>>;
-    /// Check if a tlc is settled on chain
-    fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool;
+    /// Returns whether the watchtower has recorded this TLC as settled on-chain without a preimage.
+    ///
+    /// This reads state populated by the in-process watchtower. When the watchtower is disabled or
+    /// not running, this always returns `false`. Features that depend on on-chain settlement
+    /// signals—including updating TLC, invoice, and payment status, and resolving or rejecting
+    /// upstream forwarding TLCs—will not work in that configuration.
+    fn is_tlc_settled_on_chain(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool {
+        let _ = (channel_id, payment_hash);
+        false
+    }
+    /// Returns the payment preimage the watchtower observed being revealed on-chain for this TLC.
+    ///
+    /// This reads state populated by the in-process watchtower. When the watchtower is disabled or
+    /// not running, this always returns `None`. Features that depend on on-chain preimage
+    /// discovery—including updating TLC, invoice, and payment status, and resolving upstream
+    /// forwarding TLCs—will not work in that configuration.
+    fn get_on_chain_discovered_preimage(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<Hash256> {
+        let _ = (channel_id, payment_hash);
+        None
+    }
 
     /// Store a pending CommitDiff for channel reestablishment
     fn store_pending_commit_diff(&self, channel_id: &Hash256, diff: &CommitDiff);

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -73,8 +73,8 @@ use crate::ckb::contracts::{
 };
 use crate::ckb::{CkbChainMessage, FundingError, FundingRequest, FundingTx, GetShutdownTxResponse};
 use crate::fiber::channel::{
-    tlc_expiry_delay, AddTlcResponse, ChannelActorState, ChannelEphemeralConfig,
-    ChannelInitializationOperation, OfflineChannelRestoreMode,
+    collect_onchain_fulfillable_upstream_tlcs, tlc_expiry_delay, AddTlcResponse, ChannelActorState,
+    ChannelEphemeralConfig, ChannelInitializationOperation, OfflineChannelRestoreMode,
     OpenChannelWithExternalFundingParameter, TxCollaborationCommand, TxUpdateCommand,
     MAX_TLC_NUMBER_IN_FLIGHT,
 };
@@ -2298,7 +2298,17 @@ where
                                 shared_secret,
                             ) in expired_tlcs
                             {
-                                if self.store.is_tlc_settled(&channel_id, &payment_hash) {
+                                if self
+                                    .store
+                                    .is_tlc_settled_on_chain(&channel_id, &payment_hash)
+                                    && self
+                                        .store
+                                        .get_on_chain_discovered_preimage(
+                                            &channel_id,
+                                            &payment_hash,
+                                        )
+                                        .is_none()
+                                {
                                     if let Err(err) = self
                                         .send_remove_tlc_to_channel(
                                             state,
@@ -2320,6 +2330,37 @@ where
                                             forwarding_tlc_id, forwarding_channel_id, err
                                         );
                                     }
+                                }
+                            }
+
+                            // Fulfill upstream forwarded TLCs whose preimage is now known
+                            // (e.g. discovered on-chain by the watchtower). Acts as soon as the
+                            // preimage is available, without waiting for expiry, and is mutually
+                            // exclusive with the on-chain fail path above when no preimage exists.
+                            let fulfilled_tlcs = collect_onchain_fulfillable_upstream_tlcs(
+                                &actor_state,
+                                &self.store,
+                            );
+                            for (forwarding_channel_id, forwarding_tlc_id, payment_preimage) in
+                                fulfilled_tlcs
+                            {
+                                if let Err(err) = self
+                                    .send_remove_tlc_to_channel(
+                                        state,
+                                        forwarding_channel_id,
+                                        RemoveTlcCommand {
+                                            id: forwarding_tlc_id,
+                                            reason: RemoveTlcReason::RemoveTlcFulfill(
+                                                RemoveTlcFulfill { payment_preimage },
+                                            ),
+                                        },
+                                    )
+                                    .await
+                                {
+                                    error!(
+                                        "Failed to fulfill upstream tlc {:?} for channel {:?}: {}",
+                                        forwarding_tlc_id, forwarding_channel_id, err
+                                    );
                                 }
                             }
                         }

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -4780,6 +4780,324 @@ async fn test_closed_channel_upstream_settlement_does_not_depend_on_check_channe
     ));
 }
 
+// When the downstream force-closed channel reveals a preimage on-chain, the watchtower stores it
+// in the watch-preimage table. The forwarding node must read that preimage and fulfill (not fail)
+// the upstream TLC so the payment succeeds. The success path keys off the on-chain preimage marker
+// only and must not depend on the `WithoutPreimage` on-chain fail marker.
+#[cfg(feature = "watchtower")]
+#[tokio::test]
+async fn test_closed_channel_upstream_fulfillment_from_onchain_preimage() {
+    init_tracing();
+
+    let (nodes, channels) = create_n_nodes_network(
+        &[
+            ((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
+            ((1, 2), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT)),
+        ],
+        3,
+    )
+    .await;
+    let [node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
+
+    // Use a hold invoice so node_2 keeps the downstream TLC pending until we force-close, leaving an
+    // offered TLC on node_1's downstream channel that can only be resolved on-chain.
+    let hold_preimage = gen_rand_sha256_hash();
+    let hold_invoice = InvoiceBuilder::new(Currency::Fibd)
+        .amount(Some(1000))
+        .payment_preimage(hold_preimage)
+        .payee_pub_key(node_2.pubkey.into())
+        .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, &node_2.private_key.0))
+        .expect("build hold invoice");
+    node_2.insert_invoice(hold_invoice.clone(), None);
+
+    let payment_hash = *hold_invoice.payment_hash();
+    let payment = node_0
+        .send_payment(SendPaymentCommand {
+            amount: Some(1000),
+            max_fee_rate: Some(1000),
+            invoice: Some(hold_invoice.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("send payment to hold invoice");
+    assert_eq!(payment.payment_hash, payment_hash);
+    node_0.wait_until_inflight(payment_hash).await;
+
+    wait_until(|| {
+        node_1
+            .get_channel_actor_state(channels[1])
+            .tlc_state
+            .offered_tlcs
+            .tlcs
+            .iter()
+            .any(|tlc| tlc.payment_hash == payment_hash)
+    })
+    .await;
+
+    let closed_downstream_state = node_1.get_channel_actor_state(channels[1]);
+    let downstream_tlc = closed_downstream_state
+        .tlc_state
+        .offered_tlcs
+        .tlcs
+        .iter()
+        .find(|tlc| tlc.payment_hash == payment_hash)
+        .cloned()
+        .expect("downstream tlc exists");
+    let (previous_channel_id, previous_tlc_id) = downstream_tlc
+        .forwarding_tlc
+        .expect("downstream tlc should track the upstream forwarding tlc");
+    assert_eq!(previous_channel_id, channels[0]);
+
+    node_1
+        .send_shutdown(channels[1], true)
+        .await
+        .expect("force shutdown downstream channel");
+
+    wait_until(|| {
+        matches!(
+            node_1.get_channel_actor_state(channels[1]).state,
+            ChannelState::Closed(flags)
+                if flags.contains(CloseFlags::UNCOOPERATIVE_LOCAL)
+                    && flags.contains(CloseFlags::WAITING_ONCHAIN_SETTLEMENT)
+        )
+    })
+    .await;
+
+    // Simulate watchtower on-chain preimage discovery: only the preimage is stored, NOT the
+    // `WithoutPreimage` (no-preimage) marker. The two are mutually exclusive; writing the settled
+    // marker here would instead trip the fail path and drop the preimage.
+    node_1
+        .store
+        .insert_watch_preimage(fiber_types::NodeId::local(), payment_hash, hold_preimage);
+
+    node_1
+        .network_actor
+        .send_message(NetworkActorMessage::new_command(
+            NetworkActorCommand::ControlFiberChannel(ChannelCommandWithId {
+                channel_id: channels[1],
+                command: ChannelCommand::NotifyEvent(ChannelEvent::MaintainChannelTlcs),
+            }),
+        ))
+        .expect("network actor alive");
+
+    // node_0 (the payer) only reaches Success once it receives a RemoveTlcFulfill on channels[0]
+    // from node_1, which proves the forwarding node fulfilled (not failed) the upstream TLC using
+    // the on-chain preimage.
+    wait_until_timeout(30_000, || {
+        node_0
+            .get_payment_session(payment_hash)
+            .is_some_and(|session| session.status == PaymentStatus::Success)
+    })
+    .await;
+
+    assert_eq!(
+        node_0.get_payment_status(payment_hash).await,
+        PaymentStatus::Success
+    );
+    // The upstream TLC must never be failed; once the fulfill handshake confirms, the TLC is pruned
+    // from state, so a remaining record (if any) must carry the fulfill reason.
+    assert!(matches!(
+        node_1
+            .get_tlc(channels[0], TLCId::Received(previous_tlc_id))
+            .and_then(|tlc| tlc.removed_reason),
+        None | Some(RemoveTlcReason::RemoveTlcFulfill(..))
+    ));
+}
+
+// When the payer's own channel is force-closed and the downstream hop claims the offered TLC
+// on-chain by revealing the preimage, the payer's watchtower stores it. The payer must read that
+// preimage, mark its offered TLC fulfilled in channel state, and drive the payment session to
+// Success (rather than letting it linger until it fails).
+#[cfg(feature = "watchtower")]
+#[tokio::test]
+async fn test_payer_payment_success_from_onchain_preimage() {
+    init_tracing();
+
+    let (nodes, channels) =
+        create_n_nodes_network(&[((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT))], 2).await;
+    let [node_0, node_1] = nodes.try_into().expect("2 nodes");
+
+    // Hold invoice keeps the TLC pending so the payer's offered TLC can only be resolved on-chain.
+    let hold_preimage = gen_rand_sha256_hash();
+    let hold_invoice = InvoiceBuilder::new(Currency::Fibd)
+        .amount(Some(1000))
+        .payment_preimage(hold_preimage)
+        .payee_pub_key(node_1.pubkey.into())
+        .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, &node_1.private_key.0))
+        .expect("build hold invoice");
+    node_1.insert_invoice(hold_invoice.clone(), None);
+
+    let payment_hash = *hold_invoice.payment_hash();
+    node_0
+        .send_payment(SendPaymentCommand {
+            amount: Some(1000),
+            max_fee_rate: Some(1000),
+            invoice: Some(hold_invoice.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("send payment to hold invoice");
+    node_0.wait_until_inflight(payment_hash).await;
+    wait_for_tlc_sync(&node_0, &node_1, channels[0], 1).await;
+
+    let offered_tlc_id = node_0
+        .get_channel_actor_state(channels[0])
+        .tlc_state
+        .offered_tlcs
+        .tlcs
+        .iter()
+        .find(|tlc| tlc.payment_hash == payment_hash)
+        .map(|tlc| tlc.tlc_id)
+        .expect("payer offered tlc exists");
+    assert!(matches!(offered_tlc_id, TLCId::Offered(_)));
+    assert_ne!(
+        node_0
+            .get_tlc(channels[0], offered_tlc_id)
+            .expect("payer offered tlc exists")
+            .outbound_status(),
+        fiber_types::OutboundTlcStatus::LocalAnnounced,
+        "TLC must be committed before force-close so on-chain fulfillment can settle it"
+    );
+
+    node_0
+        .send_shutdown(channels[0], true)
+        .await
+        .expect("force shutdown payer channel");
+    wait_until(|| {
+        matches!(
+            node_0.get_channel_actor_state(channels[0]).state,
+            ChannelState::Closed(flags)
+                if flags.contains(CloseFlags::WAITING_ONCHAIN_SETTLEMENT)
+        )
+    })
+    .await;
+
+    // Simulate the watchtower observing the preimage on-chain on the payer's own channel.
+    node_0
+        .store
+        .insert_watch_preimage(fiber_types::NodeId::local(), payment_hash, hold_preimage);
+
+    node_0
+        .network_actor
+        .send_message(NetworkActorMessage::new_command(
+            NetworkActorCommand::ControlFiberChannel(ChannelCommandWithId {
+                channel_id: channels[0],
+                command: ChannelCommand::NotifyEvent(ChannelEvent::MaintainChannelTlcs),
+            }),
+        ))
+        .expect("network actor alive");
+
+    wait_until_timeout(30_000, || {
+        node_0
+            .get_payment_session(payment_hash)
+            .is_some_and(|session| session.status == PaymentStatus::Success)
+    })
+    .await;
+    assert_eq!(
+        node_0.get_payment_status(payment_hash).await,
+        PaymentStatus::Success
+    );
+
+    // The offered TLC is marked fulfilled in the payer's (force-closed) channel state.
+    assert!(matches!(
+        node_0
+            .get_tlc(channels[0], offered_tlc_id)
+            .and_then(|tlc| tlc.removed_reason),
+        Some(RemoveTlcReason::RemoveTlcFulfill(..))
+    ));
+}
+
+// When the payee's channel is force-closed with a still-pending received TLC, the payee claims it
+// on-chain with the invoice preimage. Once the watchtower observes that on-chain settlement, the
+// payee must mark the received TLC fulfilled in channel state and, since the invoice is now fully
+// paid, move the invoice to `Paid`.
+#[cfg(feature = "watchtower")]
+#[tokio::test]
+async fn test_payee_invoice_paid_from_onchain_preimage() {
+    init_tracing();
+
+    let (nodes, channels) =
+        create_n_nodes_network(&[((0, 1), (HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT))], 2).await;
+    let [node_0, node_1] = nodes.try_into().expect("2 nodes");
+
+    // Hold invoice so the payee keeps the received TLC pending until on-chain settlement.
+    let hold_preimage = gen_rand_sha256_hash();
+    let hold_invoice = InvoiceBuilder::new(Currency::Fibd)
+        .amount(Some(1000))
+        .payment_preimage(hold_preimage)
+        .payee_pub_key(node_1.pubkey.into())
+        .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, &node_1.private_key.0))
+        .expect("build hold invoice");
+    node_1.insert_invoice(hold_invoice.clone(), None);
+
+    let payment_hash = *hold_invoice.payment_hash();
+    node_0
+        .send_payment(SendPaymentCommand {
+            amount: Some(1000),
+            max_fee_rate: Some(1000),
+            invoice: Some(hold_invoice.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("send payment to hold invoice");
+    wait_for_tlc_sync(&node_0, &node_1, channels[0], 1).await;
+    let received_tlc_id = node_1
+        .get_channel_actor_state(channels[0])
+        .tlc_state
+        .received_tlcs
+        .tlcs
+        .iter()
+        .find(|tlc| tlc.payment_hash == payment_hash)
+        .map(|tlc| tlc.tlc_id)
+        .expect("payee received tlc exists");
+    assert!(matches!(received_tlc_id, TLCId::Received(_)));
+    assert_ne!(
+        node_1.get_invoice_status(&payment_hash),
+        Some(CkbInvoiceStatus::Paid)
+    );
+
+    node_1
+        .send_shutdown(channels[0], true)
+        .await
+        .expect("force shutdown payee channel");
+    wait_until_timeout(10_000, || {
+        matches!(
+            node_1.get_channel_actor_state(channels[0]).state,
+            ChannelState::Closed(flags)
+                if flags.contains(CloseFlags::WAITING_ONCHAIN_SETTLEMENT)
+        )
+    })
+    .await;
+
+    // Simulate the watchtower observing the payee's on-chain claim (preimage revealed on-chain).
+    node_1
+        .store
+        .insert_watch_preimage(fiber_types::NodeId::local(), payment_hash, hold_preimage);
+
+    node_1
+        .network_actor
+        .send_message(NetworkActorMessage::new_command(
+            NetworkActorCommand::ControlFiberChannel(ChannelCommandWithId {
+                channel_id: channels[0],
+                command: ChannelCommand::NotifyEvent(ChannelEvent::MaintainChannelTlcs),
+            }),
+        ))
+        .expect("network actor alive");
+
+    wait_until_timeout(30_000, || {
+        node_1.get_invoice_status(&payment_hash) == Some(CkbInvoiceStatus::Paid)
+    })
+    .await;
+
+    // The received TLC is marked fulfilled in the payee's (force-closed) channel state.
+    assert!(matches!(
+        node_1
+            .get_tlc(channels[0], received_tlc_id)
+            .and_then(|tlc| tlc.removed_reason),
+        Some(RemoveTlcReason::RemoveTlcFulfill(..))
+    ));
+}
+
 #[tokio::test]
 async fn test_forwarded_payment_relays_remove_to_upstream() {
     init_tracing();
@@ -4815,12 +5133,12 @@ async fn test_forwarded_payment_relays_remove_to_upstream() {
         .expect("send forwarded payment");
     assert_eq!(payment.payment_hash, payment_hash);
 
-    tokio::time::timeout(
-        Duration::from_secs(3),
-        node_0.wait_until_success(payment_hash),
-    )
-    .await
-    .expect("forwarded payment should settle back to the sender");
+    wait_until_timeout(30_000, || {
+        node_0
+            .get_payment_session(payment_hash)
+            .is_some_and(|session| session.status == PaymentStatus::Success)
+    })
+    .await;
     assert_eq!(
         node_0.get_payment_status(payment_hash).await,
         PaymentStatus::Success

--- a/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
@@ -195,8 +195,16 @@ impl ChannelActorStateStore for MockStore {
         HashMap::new()
     }
 
-    fn is_tlc_settled(&self, _channel_id: &Hash256, _payment_hash: &Hash256) -> bool {
+    fn is_tlc_settled_on_chain(&self, _channel_id: &Hash256, _payment_hash: &Hash256) -> bool {
         false
+    }
+
+    fn get_on_chain_discovered_preimage(
+        &self,
+        _channel_id: &Hash256,
+        _payment_hash: &Hash256,
+    ) -> Option<Hash256> {
+        None
     }
 
     fn store_pending_commit_diff(&self, _channel_id: &Hash256, _diff: &CommitDiff) {

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -564,6 +564,15 @@ impl StoreKeyValue for KeyValue {
 
 #[cfg(feature = "watchtower")]
 impl Store {
+    fn tlc_on_chain_settled_key(channel_id: &Hash256, payment_hash: &[u8; 20]) -> Vec<u8> {
+        [
+            &[WATCHTOWER_TLC_SETTLED_PREFIX],
+            channel_id.as_ref(),
+            payment_hash.as_ref(),
+        ]
+        .concat()
+    }
+
     fn watchtower_preimage_key(node_id: &NodeId, payment_hash: &Hash256) -> Vec<u8> {
         [
             &[WATCHTOWER_PREIMAGE_PREFIX],
@@ -926,14 +935,33 @@ impl ChannelActorStateStore for Store {
             )
     }
 
-    fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool {
-        let key = [
-            &[WATCHTOWER_TLC_SETTLED_PREFIX],
-            channel_id.as_ref(),
-            &payment_hash.as_ref()[0..20],
-        ]
-        .concat();
-        self.get(key).is_some()
+    fn is_tlc_settled_on_chain(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool {
+        #[cfg(feature = "watchtower")]
+        {
+            WatchtowerStore::is_tlc_settled(self, channel_id, payment_hash)
+        }
+        #[cfg(not(feature = "watchtower"))]
+        {
+            let _ = (channel_id, payment_hash);
+            false
+        }
+    }
+
+    fn get_on_chain_discovered_preimage(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<Hash256> {
+        #[cfg(feature = "watchtower")]
+        {
+            let _ = channel_id;
+            WatchtowerStore::get_watch_preimage(self, &NodeId::local(), payment_hash)
+        }
+        #[cfg(not(feature = "watchtower"))]
+        {
+            let _ = (channel_id, payment_hash);
+            None
+        }
     }
 
     fn store_pending_commit_diff(&self, channel_id: &Hash256, diff: &CommitDiff) {
@@ -1533,18 +1561,26 @@ impl WatchtowerStore for Store {
 
     fn update_tlc_settled(&self, channel_id: &Hash256, payment_hash: [u8; 20]) {
         let mut batch = self.batch();
-        let key = [
-            &[WATCHTOWER_TLC_SETTLED_PREFIX],
-            channel_id.as_ref(),
-            payment_hash.as_ref(),
-        ]
-        .concat();
-        batch.put(key, []);
+        batch.put(
+            Self::tlc_on_chain_settled_key(channel_id, &payment_hash),
+            [],
+        );
         batch.commit();
         self.cleanup_unused_watch_preimages(
             None,
             WatchtowerPreimageCleanupTarget::TlcPaymentHash(&payment_hash),
         );
+    }
+
+    fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool {
+        let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
+            .try_into()
+            .expect("payment hash prefix");
+        self.get(Store::tlc_on_chain_settled_key(
+            channel_id,
+            &payment_hash_prefix,
+        ))
+        .is_some()
     }
 }
 

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -880,6 +880,13 @@ fn find_preimages<S: WatchtowerStore>(
                                     let preimage = unlock.preimage.unwrap();
                                     let payment_hash = tlc.hash_algorithm().hash(preimage.as_ref());
                                     if payment_hash.starts_with(&tlc.payment_hash) {
+                                        debug!(
+                                            "watchtower observed on-chain preimage for channel {:?} tlc index {} payment_hash_prefix {:?} tx {:?}",
+                                            channel_id,
+                                            unlock.unlock_type,
+                                            tlc.payment_hash,
+                                            tx.calc_tx_hash(),
+                                        );
                                         store.insert_watch_preimage(
                                             self_node_id.clone(),
                                             payment_hash.into(),
@@ -889,10 +896,24 @@ fn find_preimages<S: WatchtowerStore>(
                                         warn!("Found a preimage for payment hash: {:?}, but not match the tlc, tx hash: {:?}", payment_hash, tx.calc_tx_hash());
                                     }
                                 } else {
+                                    debug!(
+                                        "watchtower observed on-chain TLC settled without preimage for channel {:?} tlc index {} payment_hash_prefix {:?} tx {:?}",
+                                        channel_id,
+                                        unlock.unlock_type,
+                                        tlc.payment_hash,
+                                        tx.calc_tx_hash(),
+                                    );
                                     store.update_tlc_settled(channel_id, tlc.payment_hash);
                                 }
                             }
                         } else {
+                            debug!(
+                                "watchtower observed final party unlock 0x{:02x} for channel {:?} with {} pending TLCs tx {:?}",
+                                unlock.unlock_type,
+                                channel_id,
+                                settlement_witness.pending_htlcs.len(),
+                                tx.calc_tx_hash(),
+                            );
                             settlement_witness.pending_htlcs.iter().for_each(|tlc| {
                                 store.update_tlc_settled(channel_id, tlc.payment_hash);
                             })
@@ -2175,6 +2196,17 @@ mod tests {
                 .expect("lock poisoned")
                 .push((*channel_id, payment_hash));
         }
+
+        fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool {
+            let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
+                .try_into()
+                .expect("payment hash prefix");
+            self.settled_tlcs
+                .lock()
+                .expect("lock poisoned")
+                .iter()
+                .any(|(id, hash_prefix)| id == channel_id && hash_prefix == &payment_hash_prefix)
+        }
     }
 
     fn commitment_lock_prefix() -> Script {
@@ -2193,6 +2225,18 @@ mod tests {
     }
 
     fn settlement_witness(payment_hash: [u8; 20]) -> Vec<u8> {
+        settlement_witness_with_unlock(
+            payment_hash,
+            Unlock {
+                unlock_type: 0,
+                with_preimage: false,
+                signature: [0u8; 65],
+                preimage: None,
+            },
+        )
+    }
+
+    fn settlement_witness_with_unlock(payment_hash: [u8; 20], unlock: Unlock) -> Vec<u8> {
         let settlement_witness = SettlementWitness {
             pending_htlc_count: 1,
             pending_htlcs: vec![Htlc {
@@ -2209,8 +2253,41 @@ mod tests {
             settlement_local_amount: 3_000,
             unlocks: vec![],
         };
+
+        [
+            XUDT_COMPATIBLE_WITNESS.as_slice(),
+            &[0x01],
+            settlement_witness.to_witness().as_slice(),
+            unlock.to_witness().as_slice(),
+        ]
+        .concat()
+    }
+
+    fn settlement_witness_final_party_unlock(
+        payment_hashes: [[u8; 20]; 2],
+        unlock_type: u8,
+    ) -> Vec<u8> {
+        let settlement_witness = SettlementWitness {
+            pending_htlc_count: 2,
+            pending_htlcs: payment_hashes
+                .into_iter()
+                .map(|payment_hash| Htlc {
+                    htlc_type: 0,
+                    payment_amount: 1_000,
+                    payment_hash,
+                    remote_htlc_pubkey_hash: [4u8; 20],
+                    local_htlc_pubkey_hash: [5u8; 20],
+                    htlc_expiry: 0,
+                })
+                .collect(),
+            settlement_remote_pubkey_hash: [6u8; 20],
+            settlement_remote_amount: 2_000,
+            settlement_local_pubkey_hash: [7u8; 20],
+            settlement_local_amount: 3_000,
+            unlocks: vec![],
+        };
         let unlock = Unlock {
-            unlock_type: 0,
+            unlock_type,
             with_preimage: false,
             signature: [0u8; 65],
             preimage: None,
@@ -2351,6 +2428,42 @@ mod tests {
         assert_eq!(processed, Some(0));
         assert_eq!(store.settled_tlcs(), vec![(channel_id, payment_hash)]);
         assert!(watched_outpoints.contains(&OutPoint::new(tx.calc_tx_hash(), 0)));
+    }
+
+    #[test]
+    fn final_party_unlock_marks_pending_tlcs_without_preimage() {
+        let lock_prefix = commitment_lock_prefix();
+        let channel_id: Hash256 = [9u8; 32].into();
+        let payment_hashes = [[41u8; 20], [42u8; 20]];
+        let first_commitment_out_point = OutPoint::new([7u8; 32].pack(), 0);
+        let tx = tx_with_input_output_and_witness(
+            first_commitment_out_point.clone(),
+            settlement_lock(&lock_prefix),
+            Some(settlement_witness_final_party_unlock(payment_hashes, 0xFE)),
+        );
+        let mut watched_outpoints = HashSet::from([first_commitment_out_point]);
+        let mut processed_tx_hashes = HashSet::new();
+        let store = TestWatchtowerStore::default();
+        let self_node_id = NodeId::local();
+
+        let processed = process_watched_settlement_tx(
+            &tx,
+            &mut watched_outpoints,
+            &mut processed_tx_hashes,
+            &lock_prefix,
+            &channel_id,
+            &store,
+            &self_node_id,
+        );
+
+        assert_eq!(processed, Some(0));
+        assert_eq!(
+            store.settled_tlcs(),
+            vec![
+                (channel_id, payment_hashes[0]),
+                (channel_id, payment_hashes[1])
+            ]
+        );
     }
 
     #[test]

--- a/crates/fiber-lib/src/watchtower/store.rs
+++ b/crates/fiber-lib/src/watchtower/store.rs
@@ -69,8 +69,11 @@ pub trait WatchtowerStore {
     /// Search for the stored preimage with the given payment hash prefix, should be the first 20 bytes of the payment hash.
     fn search_preimage(&self, node_id: &NodeId, payment_hash_prefix: &[u8]) -> Option<Hash256>;
 
-    /// Mark a tlc as settled on chain
+    /// Mark a TLC as settled on-chain without a preimage.
     fn update_tlc_settled(&self, channel_id: &Hash256, payment_hash: [u8; 20]);
+
+    /// Returns whether the watchtower has recorded this TLC as settled on-chain without a preimage.
+    fn is_tlc_settled(&self, channel_id: &Hash256, payment_hash: &Hash256) -> bool;
 }
 
 /// Compute the x-only aggregated public key for a channel.


### PR DESCRIPTION
Closes #1222

## Summary

When a force-closed channel settles an HTLC on-chain, the watchtower already records whether the claim included a preimage or not. This PR wires those signals into channel and payment state so off-chain flows can complete after an on-chain settlement.

- **Success path (preimage revealed on-chain):** On every `MaintainChannelTlcs` tick, `settle_onchain_fulfilled_tlcs` looks up watchtower-discovered preimages, marks the local TLC fulfilled, relays fulfillment upstream for forwarded TLCs, notifies the payer payment session, and marks the payee invoice paid when fulfilled received TLCs satisfy the invoice amount.
- **Fail path (settled without preimage):** Expired forwarded TLCs are failed only when `is_tlc_settled_on_chain` is set and no on-chain preimage was discovered — the two signals are mutually exclusive.
- **Network fallback:** `CheckChannels` uses `collect_onchain_fulfillable_upstream_tlcs` to fulfill upstream forwarded TLCs for force-closed channels whose actor is no longer live (e.g. after settlement is finalized).
- **Restart / partial fulfill:** `sync_already_fulfilled_onchain_tlcs` reconciles TLC status and invoice state for TLCs already marked fulfilled (e.g. after a partial off-chain fulfill on a closing channel).
- **Store / watchtower:** Split channel-store access into `is_tlc_settled_on_chain` and `get_on_chain_discovered_preimage`; add `WatchtowerStore::is_tlc_settled` and watchtower logging plus unit tests for preimage vs without-preimage on-chain claims.

## Test plan

- [x] `cargo nextest run -p fnn -p fiber-bin`
- [x] `test_closed_channel_upstream_fulfillment_from_onchain_preimage` — forwarding node fulfills upstream TLC from watchtower preimage
- [x] `test_payer_payment_success_from_onchain_preimage` — payer payment session reaches `Success`
- [x] `test_payee_invoice_paid_from_onchain_preimage` — payee invoice status updated to `Paid`
- [x] `test_onchain_settlement_restart_restores_upstream_waiting_commitment_actor` — node restart after downstream force-close still drives upstream fulfillment
- [x] Watchtower unit tests for on-chain preimage discovery and without-preimage settlement markers