### PR TITLE
fix: push limit to DB layer in list_payments to avoid unbounded memory usage

### DIFF
--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -162,7 +162,7 @@ pub fn check_validate<P: AsRef<Path>>(path: P) -> Result<(), String> {
         }
     }
 
-    for (key, value) in store.prefix_iterator(&[]) {
+    for (key, value) in store.prefix_iterator([]) {
         if key.is_empty() {
             errors.insert("Encountered empty key".to_string());
             continue;
@@ -851,42 +851,21 @@ impl NetworkGraphStateStore for Store {
         status: Option<PaymentStatus>,
     ) -> Vec<PaymentSession> {
         let prefix = [PAYMENT_SESSION_PREFIX];
-        match after {
-            Some(after_hash) => {
-                let start_key = [&[PAYMENT_SESSION_PREFIX], after_hash.as_ref()].concat();
-                // Start from the `after` key and skip it (exclusive cursor)
-                self.collect_by_prefix_with(
-                    &prefix,
-                    PrefixIterOptions::new()
-                        .start_key(&start_key)
-                        .start_key_exclusive(),
-                )
-                .into_iter()
-                .filter_map(|kv| {
-                    let session: PaymentSession =
-                        deserialize_from(kv.value.as_ref(), "PaymentSession");
-                    match status {
-                        Some(ref s) if session.status != *s => None,
-                        _ => Some(session.init_attempts(self)),
-                    }
-                })
-                .take(limit)
-                .collect()
+        let start_key = after.map(|h| [&[PAYMENT_SESSION_PREFIX], h.as_ref()].concat());
+        let iter = match start_key {
+            Some(key) => self.prefix_iterator_from(prefix, key),
+            None => self.prefix_iterator(prefix),
+        };
+
+        iter.filter_map(|(_key, value)| {
+            let session: PaymentSession = deserialize_from(&value, "PaymentSession");
+            match status {
+                Some(ref s) if session.status != *s => None,
+                _ => Some(session.init_attempts(self)),
             }
-            None => self
-                .collect_by_prefix(&prefix)
-                .into_iter()
-                .filter_map(|kv| {
-                    let session: PaymentSession =
-                        deserialize_from(kv.value.as_ref(), "PaymentSession");
-                    match status {
-                        Some(ref s) if session.status != *s => None,
-                        _ => Some(session.init_attempts(self)),
-                    }
-                })
-                .take(limit)
-                .collect(),
-        }
+        })
+        .take(limit)
+        .collect()
     }
 
     fn insert_payment_session(&self, session: PaymentSession) {

--- a/crates/fiber-store/src/backend.rs
+++ b/crates/fiber-store/src/backend.rs
@@ -59,7 +59,17 @@ pub trait StorageBackend: Send + Sync {
     ///
     /// The default implementation batches calls to [`Self::collect_iterator`]
     /// so that only a bounded number of entries are held in memory at any time.
-    fn prefix_iterator(&self, prefix: &[u8]) -> PrefixIterator<'_, Self> {
-        PrefixIterator::new(self, prefix.to_vec())
+    fn prefix_iterator(&self, prefix: impl Into<Vec<u8>>) -> PrefixIterator<'_, Self> {
+        PrefixIterator::new(self, prefix.into())
+    }
+
+    /// Like [`prefix_iterator`](Self::prefix_iterator), but starts iteration
+    /// **after** `start_key` (exclusive cursor).
+    fn prefix_iterator_from(
+        &self,
+        prefix: impl Into<Vec<u8>>,
+        start_key: impl Into<Vec<u8>>,
+    ) -> PrefixIterator<'_, Self> {
+        PrefixIterator::new_from(self, prefix.into(), start_key.into())
     }
 }

--- a/crates/fiber-store/src/iterator.rs
+++ b/crates/fiber-store/src/iterator.rs
@@ -53,8 +53,7 @@ impl<'a, S: crate::backend::StorageBackend + ?Sized> PrefixIterator<'a, S> {
         iter
     }
 
-    /// Create a `PrefixIterator` that starts **after** `start_key` (exclusive
-    /// cursor).
+    /// Create a `PrefixIterator` that starts **after** `start_key` (exclusive cursor).
     pub fn new_from(store: &'a S, prefix: Vec<u8>, start_key: Vec<u8>) -> Self {
         let mut iter = Self {
             store,

--- a/crates/fiber-store/src/iterator.rs
+++ b/crates/fiber-store/src/iterator.rs
@@ -53,6 +53,20 @@ impl<'a, S: crate::backend::StorageBackend + ?Sized> PrefixIterator<'a, S> {
         iter
     }
 
+    /// Create a `PrefixIterator` that starts **after** `start_key` (exclusive
+    /// cursor).
+    pub fn new_from(store: &'a S, prefix: Vec<u8>, start_key: Vec<u8>) -> Self {
+        let mut iter = Self {
+            store,
+            prefix,
+            buffer: Vec::new().into_iter(),
+            last_key: Some(start_key),
+            exhausted: false,
+        };
+        iter.fetch_batch();
+        iter
+    }
+
     /// Fetch the next batch of items from the backend.
     fn fetch_batch(&mut self) {
         let start = match self.last_key.take() {


### PR DESCRIPTION
get_payment_sessions_with_limit previously called collect_by_prefix without a limit, loading ALL payment session KV pairs into memory before applying .filter_map().take(limit) as iterator adapters.

Rewrite get_payment_sessions_with_limit as a simple iterator chain using the lazy batched PrefixIterator, which fetches only 100 entries at a time and stops as soon as enough results are collected.