### PR TITLE
Trigger gossip sync immediately on peer connection

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -2682,6 +2682,13 @@ where
                 state
                     .peer_states
                     .insert(pubkey, PeerState::new(session.id, session.ty));
+                // Immediately trigger network maintenance to start syncing with
+                // the new peer, rather than waiting for the next periodic
+                // TickNetworkMaintenance (up to 60s in production).
+                // This eliminates the initial gossip sync delay after connecting
+                // to a bootnode, which is critical for WASM nodes that need
+                // peer addresses from gossip data quickly.
+                myself.send_message(GossipActorMessage::TickNetworkMaintenance)?;
             }
             GossipActorMessage::PeerDisconnected(pubkey, _session) => {
                 state.peer_states.remove(&pubkey);

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -2673,6 +2673,12 @@ where
         match message {
             GossipActorMessage::ReceivedControl(control) => {
                 state.control = Some(control);
+                // If peers have already connected before control was received,
+                // immediately trigger network maintenance so we don't wait for
+                // the next periodic tick (up to 60s) to start syncing.
+                if !state.peer_states.is_empty() {
+                    myself.send_message(GossipActorMessage::TickNetworkMaintenance)?;
+                }
             }
 
             GossipActorMessage::PeerConnected(pubkey, session) => {
@@ -2688,7 +2694,12 @@ where
                 // This eliminates the initial gossip sync delay after connecting
                 // to a bootnode, which is critical for WASM nodes that need
                 // peer addresses from gossip data quickly.
-                myself.send_message(GossipActorMessage::TickNetworkMaintenance)?;
+                // Only send the tick if control is already available; otherwise
+                // the tick will be sent from the ReceivedControl handler once
+                // control arrives (to avoid a panic in send_message_to_peer).
+                if state.control.is_some() {
+                    myself.send_message(GossipActorMessage::TickNetworkMaintenance)?;
+                }
             }
             GossipActorMessage::PeerDisconnected(pubkey, _session) => {
                 state.peer_states.remove(&pubkey);

--- a/crates/fiber-lib/src/fiber/tests/gossip.rs
+++ b/crates/fiber-lib/src/fiber/tests/gossip.rs
@@ -9,7 +9,9 @@ use molecule::prelude::Byte;
 use ractor::{concurrency::Duration, Actor, ActorProcessingErr, ActorRef};
 use tokio::sync::RwLock;
 
-use crate::tests::test_utils::{establish_channel_between_nodes, ChannelParameters, NetworkNode};
+use crate::tests::test_utils::{
+    establish_channel_between_nodes, ChannelParameters, NetworkNode, NetworkNodeConfigBuilder,
+};
 use crate::{
     ckb::tests::test_utils::MockCkbChainClient,
     fiber::gossip::{GossipActorMessage, GossipConfig, GossipService},
@@ -699,6 +701,63 @@ async fn test_our_own_channel_gossip_message_propagated() {
         })
         .await;
     }
+}
+
+// Regression test: verify that gossip syncing starts immediately when a peer
+// connects, without waiting for the periodic TickNetworkMaintenance interval.
+// With a 1-hour maintenance interval, syncing would be severely delayed unless
+// PeerConnected triggers an immediate tick (as introduced by this fix).
+#[tokio::test]
+async fn test_gossip_sync_starts_immediately_on_peer_connect() {
+    crate::tests::test_utils::init_tracing();
+
+    // Use a very large gossip maintenance interval to ensure sync is driven by
+    // the immediate PeerConnected trigger, not the periodic tick.
+    const LARGE_INTERVAL_MS: u64 = 3_600_000; // 1 hour
+
+    // Create node A with large maintenance interval and inject a node announcement
+    // before connecting node B, so B must sync it via active sync on connection.
+    let mut node_a = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(move |c| {
+                c.gossip_network_maintenance_interval_ms = Some(LARGE_INTERVAL_MS);
+            })
+            .build(),
+    )
+    .await;
+
+    let (_, announcement) = gen_rand_node_announcement();
+    node_a.send_message_to_gossip_actor(GossipActorMessage::TryBroadcastMessages(vec![
+        BroadcastMessageWithTimestamp::NodeAnnouncement(announcement.clone()),
+    ]));
+
+    // Give node A a moment to store the announcement before node B connects.
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let mut node_b = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(move |c| {
+                c.gossip_network_maintenance_interval_ms = Some(LARGE_INTERVAL_MS);
+            })
+            .build(),
+    )
+    .await;
+
+    // Connect B to A: this should immediately trigger active sync on B.
+    node_b.connect_to(&mut node_a).await;
+
+    // Wait a short time (well under the 1-hour maintenance interval).
+    // With the fix, B should have actively synced A's announcement by now.
+    tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
+
+    let synced = node_b
+        .get_store()
+        .get_latest_node_announcement(&announcement.node_id);
+    assert!(
+        synced.is_some(),
+        "node B should have synced the gossip announcement from node A immediately after connecting, \
+         without waiting for the periodic maintenance interval"
+    );
 }
 
 // We may need to run this test multiple times to check if the gossip messages are really propagated.


### PR DESCRIPTION
Send TickNetworkMaintenance to self when a new peer connects, eliminating the initial 0-60s wait before gossip data sync begins. This is critical for WASM nodes that need peer address data from gossip shortly after connecting to a bootnode.

Fixes: nervosnetwork/fiber#1269