### PR TITLE
Fix docker image building slow issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
           ghcr.io/${{ github.repository }}
           nervos/fiber
         flavor: |
+          # Keep auto latest disabled; the explicit latest tag below is only for stable releases.
           latest=false
         tags: |
           type=raw,value=edge-${{ matrix.arch }},enable=${{ github.ref == 'refs/heads/playground/release' }}
@@ -231,6 +232,7 @@ jobs:
           ghcr.io/${{ github.repository }}
           nervos/fiber
         flavor: |
+          # Keep auto latest disabled; the explicit latest tag below is only for stable releases.
           latest=false
         tags: |
           type=raw,value=edge,enable=${{ github.ref == 'refs/heads/playground/release' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,14 +147,69 @@ jobs:
         draft: true
         files: |
           ${{ steps.get_package.outputs.PKGNAME }}
-  release-docker:
-    name: Build & Publish Docker Images
-    runs-on: ubuntu-24.04
+  release-docker-build:
+    name: Build & Publish Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            os: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            os: ubuntu-22.04-arm
     steps:
     - name: Checkout the Repository
       uses: actions/checkout@v6
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ghcr.io/${{ github.repository }}
+          nervos/fiber
+        flavor: |
+          latest=false
+        tags: |
+          type=raw,value=edge-${{ matrix.arch }},enable=${{ github.ref == 'refs/heads/playground/release' }}
+          type=semver,pattern={{version}}-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          type=semver,pattern={{major}}.{{minor}}-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+          type=semver,pattern={{major}}-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+          type=raw,value=latest-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+          type=sha,format=short,suffix=-${{ matrix.arch }}
+    - name: Build and Push Docker Images
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./docker/Dockerfile
+        platforms: ${{ matrix.platform }}
+        push: true
+        provenance: true
+        sbom: true
+        cache-from: type=gha,scope=docker-${{ matrix.arch }}
+        cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
+        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.meta.outputs.tags }}
+  release-docker-manifest:
+    name: Publish Docker Manifests
+    runs-on: ubuntu-24.04
+    needs: release-docker-build
+    steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Log in to GitHub Container Registry
@@ -184,16 +239,18 @@ jobs:
           type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
           type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
           type=sha,format=short
-    - name: Build and Push Docker Images
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: ./docker/Dockerfile
-        platforms: linux/amd64,linux/arm64
-        push: true
-        provenance: true
-        sbom: true
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        labels: ${{ steps.meta.outputs.labels }}
-        tags: ${{ steps.meta.outputs.tags }}
+    - name: Create and Push Docker Manifests
+      shell: bash
+      env:
+        DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
+      run: |
+        while IFS= read -r tag; do
+          if [[ -z "$tag" ]]; then
+            continue
+          fi
+
+          docker buildx imagetools create \
+            --tag "$tag" \
+            "${tag}-amd64" \
+            "${tag}-arm64"
+        done <<< "$DOCKER_TAGS"


### PR DESCRIPTION
Docker image building is too slow because of `qemu`.
we should build on native.