### PR TITLE
Fix flake watchtower e2e test

### DIFF
--- a/tests/bruno/e2e/watchtower/force-close-preimage-multiple/10-node1-add-tlc1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-multiple/10-node1-add-tlc1.bru
@@ -37,8 +37,9 @@ assert {
 }
 
 script:pre-request {
-  // 10 seconds expiry
-  let expiry = "0x" + (Date.now() + 1000 * 10).toString(16);
+  // Keep this beyond the channel delay so periodic off-chain checks do not fail
+  // the TLC before this case reaches the force-close preimage settlement path.
+  let expiry = "0x" + (Date.now() + 1000 * 60 * 60 * 2).toString(16);
   bru.setVar("expiry", expiry);
 }
 

--- a/tests/bruno/e2e/watchtower/force-close-preimage-multiple/12-node1-add-tlc2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-multiple/12-node1-add-tlc2.bru
@@ -37,8 +37,9 @@ assert {
 }
 
 script:pre-request {
-  // 17 seconds expiry
-  let expiry = "0x" + (Date.now() + 1000 * 17).toString(16);
+  // Keep this beyond the channel delay so periodic off-chain checks do not fail
+  // the TLC before this case reaches the force-close preimage settlement path.
+  let expiry = "0x" + (Date.now() + 1000 * 60 * 60 * 2).toString(16);
   bru.setVar("expiry", expiry);
 }
 


### PR DESCRIPTION
Seems the delay is a copy paste bug, it's flaky when ci server is not fast enough.
