### PR TITLE
add x402 facilitator MVP and payment preimage proof support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,7 @@ dependencies = [
  "ractor",
  "rand 0.8.6",
  "regex",
+ "reqwest",
  "scrypt",
  "secp256k1 0.30.0",
  "serde",
@@ -3305,6 +3306,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4071,6 +4073,12 @@ checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -5141,6 +5149,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5445,6 +5508,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5452,6 +5517,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
@@ -5459,6 +5525,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5611,6 +5678,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -7509,6 +7577,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/crates/fiber-json-types/src/payment.rs
+++ b/crates/fiber-json-types/src/payment.rs
@@ -63,6 +63,8 @@ pub struct SessionRoute {
 pub struct GetPaymentCommandResult {
     /// The payment hash of the payment
     pub payment_hash: Hash256,
+    /// The payment preimage when the payment succeeds.
+    pub payment_preimage: Option<Hash256>,
     /// The status of the payment
     pub status: PaymentStatus,
     #[serde_as(as = "U64Hex")]

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -137,6 +137,7 @@ jsonrpsee = { version = "0.25.1", features = [
   "macros",
   "http-client",
 ] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 fiber-store = { path = "../fiber-store", features = ["browser-test"] }

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -166,6 +166,7 @@ impl Actor for MockNetworkActor {
                     // Return success response - the executor will create CchTrackingEvent
                     let response = SendPaymentResponse {
                         payment_hash,
+                        payment_preimage: None,
                         status: PaymentStatus::Inflight,
                         created_at: SystemTime::now()
                             .duration_since(UNIX_EPOCH)

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -512,6 +512,7 @@ pub struct PendingAcceptChannel {
 #[derive(Debug)]
 pub struct SendPaymentResponse {
     pub payment_hash: Hash256,
+    pub payment_preimage: Option<Hash256>,
     pub status: PaymentStatus,
     pub created_at: u64,
     pub last_updated_at: u64,

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -602,6 +602,10 @@ impl From<PaymentSession> for SendPaymentResponse {
 
         Self {
             payment_hash: session.request.payment_hash,
+            payment_preimage: session
+                .attempts()
+                .find(|a| a.is_success())
+                .and_then(|a| a.preimage),
             status,
             failed_error: session.last_error.clone(),
             created_at: session.created_at,

--- a/crates/fiber-lib/src/fiber/tests/mod.rs
+++ b/crates/fiber-lib/src/fiber/tests/mod.rs
@@ -26,3 +26,5 @@ mod tlc_op;
 mod trampoline;
 mod types;
 mod utils;
+#[cfg(not(target_arch = "wasm32"))]
+mod x402;

--- a/crates/fiber-lib/src/fiber/tests/rpc.rs
+++ b/crates/fiber-lib/src/fiber/tests/rpc.rs
@@ -14,7 +14,7 @@ use crate::{
         channel::{ListChannelsParams, ListChannelsResult},
         graph::{GraphNodesParams, GraphNodesResult},
         invoice::{InvoiceParams, InvoiceResult, NewInvoiceParams},
-        payment::{GetPaymentCommandParams, GetPaymentCommandResult},
+        payment::{GetPaymentCommandParams, GetPaymentCommandResult, SendPaymentCommandParams},
         peer::{ConnectPeerParams, DisconnectPeerParams, ListPeersResult},
     },
     NetworkServiceEvent,
@@ -1114,6 +1114,90 @@ async fn test_rpc_cors_headers() {
             .contains_key("access-control-allow-headers"),
         "Preflight response should contain Access-Control-Allow-Headers header"
     );
+}
+
+#[tokio::test]
+async fn test_get_payment_exposes_payment_preimage_after_success() {
+    let (nodes, _channels) = create_n_nodes_network_with_params(
+        &[(
+            (0, 1),
+            ChannelParameters {
+                public: true,
+                node_a_funding_amount: MIN_RESERVED_CKB + 10000000000,
+                node_b_funding_amount: MIN_RESERVED_CKB,
+                ..Default::default()
+            },
+        )],
+        2,
+        Some(gen_rpc_config()),
+    )
+    .await;
+    let [node_0, node_1] = nodes.try_into().expect("2 nodes");
+
+    let payment_preimage = gen_rand_sha256_hash();
+    let invoice_res: InvoiceResult = node_1
+        .send_rpc_request(
+            "new_invoice",
+            NewInvoiceParams {
+                amount: 1000,
+                description: Some("x402 proof test".to_string()),
+                currency: fiber_json_types::Currency::Fibd,
+                expiry: Some(3600),
+                fallback_address: None,
+                final_expiry_delta: None,
+                udt_type_script: None,
+                payment_preimage: Some(payment_preimage.into()),
+                payment_hash: None,
+                hash_algorithm: Some(fiber_json_types::HashAlgorithm::CkbHash),
+                allow_mpp: Some(false),
+                allow_trampoline_routing: Some(false),
+            },
+        )
+        .await
+        .unwrap();
+
+    let payment = node_0
+        .send_rpc_request::<_, GetPaymentCommandResult>(
+            "send_payment",
+            SendPaymentCommandParams {
+                target_pubkey: None,
+                amount: None,
+                payment_hash: None,
+                final_tlc_expiry_delta: None,
+                tlc_expiry_limit: None,
+                invoice: Some(invoice_res.invoice_address),
+                timeout: None,
+                max_fee_amount: None,
+                max_fee_rate: None,
+                max_parts: None,
+                trampoline_hops: None,
+                keysend: None,
+                udt_type_script: None,
+                allow_self_payment: None,
+                custom_records: None,
+                hop_hints: None,
+                dry_run: None,
+            },
+        )
+        .await
+        .unwrap();
+    node_0.wait_until_success(payment.payment_hash.into()).await;
+
+    let payment: GetPaymentCommandResult = node_0
+        .send_rpc_request(
+            "get_payment",
+            GetPaymentCommandParams {
+                payment_hash: payment.payment_hash,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        payment.status,
+        fiber_json_types::payment::PaymentStatus::Success
+    );
+    assert_eq!(payment.payment_preimage, Some(payment_preimage.into()));
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/x402.rs
+++ b/crates/fiber-lib/src/fiber/tests/x402.rs
@@ -1,0 +1,322 @@
+use crate::fiber::payment::SendPaymentCommand;
+use crate::gen_rand_sha256_hash;
+use crate::invoice::CkbInvoiceStatus;
+use crate::rpc::config::RpcConfig;
+use crate::tests::*;
+use fiber_json_types::{Currency, NewInvoiceParams};
+use fiber_types::Hash256;
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+const X402_ENABLED_MODULE: &str = "x402";
+
+fn gen_x402_rpc_config() -> RpcConfig {
+    let mut config = gen_rpc_config();
+    config.enabled_modules.push(X402_ENABLED_MODULE.to_string());
+    config
+}
+
+fn gen_x402_testnet_config(node_name: &str) -> NetworkNodeConfig {
+    NetworkNodeConfigBuilder::new()
+        .node_name(Some(node_name.to_string()))
+        .base_dir_prefix(&format!("test-fnn-node-{node_name}-"))
+        .rpc_config(Some(gen_x402_rpc_config()))
+        .fiber_config_updater(|config| {
+            config.chain = "testnet".to_string();
+        })
+        .build()
+}
+
+fn x402_verify_request(pay_to: String, invoice: String, payment_preimage: Hash256) -> Value {
+    json!({
+        "x402Version": 2,
+        "paymentPayload": {
+            "x402Version": 2,
+            "accepted": {
+                "scheme": "exact",
+                "network": "fiber:testnet",
+                "asset": "ckb",
+                "amount": "1000",
+                "payTo": pay_to,
+                "maxTimeoutSeconds": 60,
+                "extra": {},
+            },
+            "payload": {
+                "invoice": invoice,
+                "paymentPreimage": payment_preimage,
+            },
+        },
+        "paymentRequirements": {
+            "scheme": "exact",
+            "network": "fiber:testnet",
+            "asset": "ckb",
+            "amount": "1000",
+            "payTo": pay_to,
+            "maxTimeoutSeconds": 60,
+            "extra": {},
+        },
+    })
+}
+
+#[tokio::test]
+async fn test_x402_supported_lists_exact_fiber_kind() {
+    let node = NetworkNode::new_with_config(gen_x402_testnet_config("x402-supported-test")).await;
+
+    let rpc_addr = node
+        .rpc_server
+        .as_ref()
+        .map(|(_, addr)| addr)
+        .expect("RPC server should be running");
+
+    let response = reqwest::get(format!("http://{}/supported", rpc_addr))
+        .await
+        .expect("send request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json: Value = response.json().await.expect("parse supported response");
+
+    let kinds = json
+        .get("kinds")
+        .and_then(Value::as_array)
+        .expect("kinds array");
+    assert!(kinds.iter().any(|kind| {
+        kind.get("x402Version") == Some(&Value::from(2))
+            && kind.get("scheme") == Some(&Value::from("exact"))
+            && kind.get("network") == Some(&Value::from("fiber:testnet"))
+    }));
+}
+
+#[tokio::test]
+async fn test_x402_verify_rejects_invalid_preimage() {
+    let merchant =
+        NetworkNode::new_with_config(gen_x402_testnet_config("x402-verify-invalid")).await;
+
+    let invoice = merchant
+        .gen_invoice(NewInvoiceParams {
+            amount: 1000,
+            description: Some("x402 invalid proof".to_string()),
+            currency: Currency::Fibt,
+            ..Default::default()
+        })
+        .await;
+    let pay_to = hex::encode(merchant.get_public_key().serialize());
+
+    let rpc_addr = merchant
+        .rpc_server
+        .as_ref()
+        .map(|(_, addr)| addr)
+        .expect("RPC server should be running");
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/verify", rpc_addr))
+        .json(&x402_verify_request(
+            pay_to,
+            invoice.invoice_address,
+            gen_rand_sha256_hash(),
+        ))
+        .send()
+        .await
+        .expect("send verify request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json: Value = response.json().await.expect("parse verify response");
+    assert_eq!(json.get("isValid"), Some(&Value::Bool(false)));
+    assert_eq!(
+        json.get("invalidReason"),
+        Some(&Value::from("invalid_payment_preimage"))
+    );
+}
+
+#[tokio::test]
+async fn test_x402_verify_accepts_paid_invoice_proof() {
+    let mut payer =
+        NetworkNode::new_with_config(gen_x402_testnet_config("x402-verify-payer")).await;
+    let mut merchant =
+        NetworkNode::new_with_config(gen_x402_testnet_config("x402-verify-merchant")).await;
+
+    payer.connect_to(&mut merchant).await;
+
+    establish_channel_between_nodes(
+        &mut payer,
+        &mut merchant,
+        ChannelParameters {
+            public: true,
+            node_a_funding_amount: HUGE_CKB_AMOUNT,
+            node_b_funding_amount: HUGE_CKB_AMOUNT,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let expected_preimage = gen_rand_sha256_hash();
+    let pay_to = hex::encode(merchant.get_public_key().serialize());
+    let invoice = merchant
+        .gen_invoice(NewInvoiceParams {
+            amount: 1000,
+            description: Some("x402 paid proof".to_string()),
+            currency: Currency::Fibt,
+            payment_preimage: Some(expected_preimage.into()),
+            ..Default::default()
+        })
+        .await;
+
+    let payment = payer
+        .send_payment(SendPaymentCommand {
+            invoice: Some(invoice.invoice_address.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("pay invoice");
+    payer.wait_until_success(payment.payment_hash).await;
+
+    assert_eq!(
+        merchant.get_invoice_status(&payment.payment_hash),
+        Some(CkbInvoiceStatus::Paid)
+    );
+
+    let payment_preimage = payer
+        .get_payment_result(payment.payment_hash)
+        .await
+        .payment_preimage
+        .expect("payment preimage");
+
+    let rpc_addr = merchant
+        .rpc_server
+        .as_ref()
+        .map(|(_, addr)| addr)
+        .expect("RPC server should be running");
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/verify", rpc_addr))
+        .json(&x402_verify_request(
+            pay_to,
+            invoice.invoice_address,
+            payment_preimage,
+        ))
+        .send()
+        .await
+        .expect("send verify request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json: Value = response.json().await.expect("parse verify response");
+    assert_eq!(json.get("isValid"), Some(&Value::Bool(true)));
+    assert!(json.get("invalidReason").is_none());
+}
+
+#[tokio::test]
+async fn test_x402_settle_returns_receipt_for_verified_invoice() {
+    let mut payer =
+        NetworkNode::new_with_config(gen_x402_testnet_config("x402-settle-payer")).await;
+    let mut merchant =
+        NetworkNode::new_with_config(gen_x402_testnet_config("x402-settle-merchant")).await;
+
+    payer.connect_to(&mut merchant).await;
+
+    establish_channel_between_nodes(
+        &mut payer,
+        &mut merchant,
+        ChannelParameters {
+            public: true,
+            node_a_funding_amount: HUGE_CKB_AMOUNT,
+            node_b_funding_amount: HUGE_CKB_AMOUNT,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let expected_preimage = gen_rand_sha256_hash();
+    let pay_to = hex::encode(merchant.get_public_key().serialize());
+    let invoice = merchant
+        .gen_invoice(NewInvoiceParams {
+            amount: 1000,
+            description: Some("x402 settle proof".to_string()),
+            currency: Currency::Fibt,
+            payment_preimage: Some(expected_preimage.into()),
+            ..Default::default()
+        })
+        .await;
+
+    let payment = payer
+        .send_payment(SendPaymentCommand {
+            invoice: Some(invoice.invoice_address.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("pay invoice");
+    payer.wait_until_success(payment.payment_hash).await;
+
+    let payment_preimage = payer
+        .get_payment_result(payment.payment_hash)
+        .await
+        .payment_preimage
+        .expect("payment preimage");
+
+    let rpc_addr = merchant
+        .rpc_server
+        .as_ref()
+        .map(|(_, addr)| addr)
+        .expect("RPC server should be running");
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/settle", rpc_addr))
+        .json(&x402_verify_request(
+            pay_to,
+            invoice.invoice_address,
+            payment_preimage,
+        ))
+        .send()
+        .await
+        .expect("send settle request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json: Value = response.json().await.expect("parse settle response");
+    assert_eq!(json.get("success"), Some(&Value::Bool(true)));
+    assert_eq!(json.get("network"), Some(&Value::from("fiber:testnet")));
+    assert_eq!(json.get("amount"), Some(&Value::from("1000")));
+    assert!(json
+        .get("transaction")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.is_empty()));
+}
+
+#[tokio::test]
+async fn test_x402_settle_rejects_invalid_preimage() {
+    let merchant =
+        NetworkNode::new_with_config(gen_x402_testnet_config("x402-settle-invalid")).await;
+
+    let invoice = merchant
+        .gen_invoice(NewInvoiceParams {
+            amount: 1000,
+            description: Some("x402 invalid settle proof".to_string()),
+            currency: Currency::Fibt,
+            ..Default::default()
+        })
+        .await;
+    let pay_to = hex::encode(merchant.get_public_key().serialize());
+
+    let rpc_addr = merchant
+        .rpc_server
+        .as_ref()
+        .map(|(_, addr)| addr)
+        .expect("RPC server should be running");
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/settle", rpc_addr))
+        .json(&x402_verify_request(
+            pay_to,
+            invoice.invoice_address,
+            gen_rand_sha256_hash(),
+        ))
+        .send()
+        .await
+        .expect("send settle request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let json: Value = response.json().await.expect("parse settle response");
+    assert_eq!(json.get("success"), Some(&Value::Bool(false)));
+    assert_eq!(
+        json.get("errorReason"),
+        Some(&Value::from("invalid_payment_preimage"))
+    );
+    assert_eq!(json.get("transaction"), Some(&Value::from("")));
+}

--- a/crates/fiber-lib/src/lib.rs
+++ b/crates/fiber-lib/src/lib.rs
@@ -24,6 +24,8 @@ pub mod rpc;
 pub mod store;
 #[cfg(feature = "watchtower")]
 pub mod watchtower;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod x402;
 
 mod errors;
 pub use errors::{Error, Result};

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -825,6 +825,7 @@ Sends a payment to a peer.
 ##### Returns
 
 * `payment_hash` - <em>[Hash256](#type-hash256)</em>, The payment hash of the payment
+* `payment_preimage` - <em>Option<[Hash256](#type-hash256)></em>, The payment preimage when the payment succeeds.
 * `status` - <em>[PaymentStatus](#type-paymentstatus)</em>, The status of the payment
 * `created_at` - <em>`u64`</em>, The time the payment was created at, in milliseconds from UNIX epoch
 * `last_updated_at` - <em>`u64`</em>, The time the payment was last updated at, in milliseconds from UNIX epoch
@@ -854,6 +855,7 @@ Retrieves a payment.
 ##### Returns
 
 * `payment_hash` - <em>[Hash256](#type-hash256)</em>, The payment hash of the payment
+* `payment_preimage` - <em>Option<[Hash256](#type-hash256)></em>, The payment preimage when the payment succeeds.
 * `status` - <em>[PaymentStatus](#type-paymentstatus)</em>, The status of the payment
 * `created_at` - <em>`u64`</em>, The time the payment was created at, in milliseconds from UNIX epoch
 * `last_updated_at` - <em>`u64`</em>, The time the payment was last updated at, in milliseconds from UNIX epoch
@@ -945,6 +947,7 @@ Sends a payment to a peer with specified router.
 ##### Returns
 
 * `payment_hash` - <em>[Hash256](#type-hash256)</em>, The payment hash of the payment
+* `payment_preimage` - <em>Option<[Hash256](#type-hash256)></em>, The payment preimage when the payment succeeds.
 * `status` - <em>[PaymentStatus](#type-paymentstatus)</em>, The status of the payment
 * `created_at` - <em>`u64`</em>, The time the payment was created at, in milliseconds from UNIX epoch
 * `last_updated_at` - <em>`u64`</em>, The time the payment was last updated at, in milliseconds from UNIX epoch
@@ -1419,6 +1422,7 @@ The result of a get_payment command, which includes the payment hash, status, ti
 #### Fields
 
 * `payment_hash` - <em>[Hash256](#type-hash256)</em>, The payment hash of the payment
+* `payment_preimage` - <em>Option<[Hash256](#type-hash256)></em>, The payment preimage when the payment succeeds.
 * `status` - <em>[PaymentStatus](#type-paymentstatus)</em>, The status of the payment
 * `created_at` - <em>`u64`</em>, The time the payment was created at, in milliseconds from UNIX epoch
 * `last_updated_at` - <em>`u64`</em>, The time the payment was last updated at, in milliseconds from UNIX epoch

--- a/crates/fiber-lib/src/rpc/mod.rs
+++ b/crates/fiber-lib/src/rpc/mod.rs
@@ -40,6 +40,8 @@ pub mod server {
     use crate::rpc::peer::{PeerRpcServer, PeerRpcServerImpl};
     #[cfg(all(feature = "pprof", not(target_arch = "wasm32")))]
     use crate::rpc::prof::{ProfRpcServer, ProfRpcServerImpl};
+    use crate::x402::server::{settle_response, supported_response, verify_response};
+    use crate::x402::types::{SettleRequest, VerifyRequest};
     use crate::{
         cch::CchMessage,
         fiber::{
@@ -60,8 +62,12 @@ pub mod server {
     use anyhow::{bail, Result};
     #[cfg(debug_assertions)]
     use ckb_types::core::TransactionView;
+    use hyper::http::header::CONTENT_TYPE;
+    use hyper::http::{Method, StatusCode};
+    use jsonrpsee::core::http_helpers::read_body;
     use jsonrpsee::server::{
-        serve_with_graceful_shutdown, stop_channel, ServerHandle, StopHandle, TowerServiceBuilder,
+        serve_with_graceful_shutdown, stop_channel, HttpBody, HttpResponse, ServerHandle,
+        StopHandle, TowerServiceBuilder,
     };
     use jsonrpsee::ws_client::RpcServiceBuilder;
     use jsonrpsee::{Methods, RpcModule};
@@ -121,10 +127,12 @@ pub mod server {
     {
     }
 
-    async fn start_server(
+    async fn start_server<S: RpcServerStore + Clone + Send + Sync + 'static>(
         addr: &str,
         auth: Option<BiscuitAuth>,
         methods: impl Into<Methods>,
+        x402_fiber_config: Option<FiberConfig>,
+        x402_store: Option<S>,
         cors_enabled: bool,
         cors_allowed_origins: Vec<String>,
     ) -> Result<(ServerHandle, SocketAddr)> {
@@ -141,10 +149,12 @@ pub mod server {
         // Make sure that nothing expensive is cloned here
         // when doing this or use an `Arc`.
         #[derive(Clone)]
-        struct PerConnection<RpcMiddlewave, HttpMiddlewave> {
+        struct PerConnection<RpcMiddlewave, HttpMiddlewave, Store> {
             methods: Methods,
             stop_handle: StopHandle,
             svc_builder: TowerServiceBuilder<RpcMiddlewave, HttpMiddlewave>,
+            x402_fiber_config: Option<FiberConfig>,
+            x402_store: Option<Store>,
         }
 
         // Each RPC call/connection get its own `stop_handle`
@@ -158,6 +168,8 @@ pub mod server {
             methods: methods.into(),
             stop_handle: stop_handle.clone(),
             svc_builder: jsonrpsee::server::Server::builder().to_service_builder(),
+            x402_fiber_config,
+            x402_store,
         };
         let enable_auth = auth.is_some();
         let auth = Arc::new(auth.unwrap_or_else(BiscuitAuth::without_pubkey));
@@ -186,6 +198,8 @@ pub mod server {
                         methods,
                         stop_handle,
                         svc_builder,
+                        x402_fiber_config,
+                        x402_store,
                     } = per_conn2.clone();
 
                     let headers = req.headers().clone();
@@ -200,7 +214,113 @@ pub mod server {
                     let mut svc = svc_builder
                         .set_rpc_middleware(rpc_middleware)
                         .build(methods, stop_handle);
-                    async move { svc.call(req).await }
+                    async move {
+                        if let Some(fiber_config) = x402_fiber_config {
+                            if req.method() == Method::GET && req.uri().path() == "/supported" {
+                                let body = serde_json::to_vec(&supported_response(&fiber_config))
+                                    .expect("serialize x402 supported response");
+                                return Ok(HttpResponse::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "application/json")
+                                    .body(HttpBody::from(body))
+                                    .expect("build x402 supported response"));
+                            }
+
+                            if req.method() == Method::POST
+                                && (req.uri().path() == "/verify" || req.uri().path() == "/settle")
+                            {
+                                let Some(store) = x402_store else {
+                                    return Ok(HttpResponse::builder()
+                                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                                        .header(CONTENT_TYPE, "application/json")
+                                        .body(HttpBody::from(
+                                            serde_json::to_vec(&serde_json::json!({
+                                                "error": "x402 store unavailable"
+                                            }))
+                                            .expect("serialize x402 store error response"),
+                                        ))
+                                        .expect("build x402 store error response"));
+                                };
+
+                                let path = req.uri().path().to_string();
+                                let (parts, body) = req.into_parts();
+                                let (body, _) =
+                                    match read_body(&parts.headers, body, 10 * 1024 * 1024).await {
+                                        Ok(result) => result,
+                                        Err(_) => {
+                                            return Ok(HttpResponse::builder()
+                                                .status(StatusCode::BAD_REQUEST)
+                                                .header(CONTENT_TYPE, "application/json")
+                                                .body(HttpBody::from(
+                                                    serde_json::to_vec(&serde_json::json!({
+                                                        "error": "invalid request body"
+                                                    }))
+                                                    .expect("serialize x402 body error response"),
+                                                ))
+                                                .expect("build x402 body error response"));
+                                        }
+                                    };
+
+                                let body = if path == "/verify" {
+                                    let request: VerifyRequest = match serde_json::from_slice(&body)
+                                    {
+                                        Ok(request) => request,
+                                        Err(_) => {
+                                            return Ok(HttpResponse::builder()
+                                                .status(StatusCode::BAD_REQUEST)
+                                                .header(CONTENT_TYPE, "application/json")
+                                                .body(HttpBody::from(
+                                                    serde_json::to_vec(&serde_json::json!({
+                                                        "error": "invalid verify request"
+                                                    }))
+                                                    .expect("serialize x402 verify request error response"),
+                                                ))
+                                                .expect("build x402 verify request error response"));
+                                        }
+                                    };
+
+                                    serde_json::to_vec(&verify_response(
+                                        &store,
+                                        &fiber_config,
+                                        request,
+                                    ))
+                                    .expect("serialize x402 verify response")
+                                } else {
+                                    let request: SettleRequest = match serde_json::from_slice(&body)
+                                    {
+                                        Ok(request) => request,
+                                        Err(_) => {
+                                            return Ok(HttpResponse::builder()
+                                                .status(StatusCode::BAD_REQUEST)
+                                                .header(CONTENT_TYPE, "application/json")
+                                                .body(HttpBody::from(
+                                                    serde_json::to_vec(&serde_json::json!({
+                                                        "error": "invalid settle request"
+                                                    }))
+                                                    .expect("serialize x402 settle request error response"),
+                                                ))
+                                                .expect("build x402 settle request error response"));
+                                        }
+                                    };
+
+                                    serde_json::to_vec(&settle_response(
+                                        &store,
+                                        &fiber_config,
+                                        request,
+                                    ))
+                                    .expect("serialize x402 settle response")
+                                };
+
+                                return Ok(HttpResponse::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "application/json")
+                                    .body(HttpBody::from(body))
+                                    .expect("build x402 verify response"));
+                            }
+                        }
+
+                        svc.call(req).await
+                    }
                 });
 
                 // Conditionally wrap the service with CORS layer if enabled
@@ -299,8 +419,12 @@ pub mod server {
         if config.is_module_enabled("invoice") {
             modules
                 .merge(
-                    InvoiceRpcServerImpl::new(store.clone(), network_actor.clone(), fiber_config)
-                        .into_rpc(),
+                    InvoiceRpcServerImpl::new(
+                        store.clone(),
+                        network_actor.clone(),
+                        fiber_config.clone(),
+                    )
+                    .into_rpc(),
                 )
                 .unwrap();
         }
@@ -399,6 +523,16 @@ pub mod server {
             listening_addr,
             auth,
             modules,
+            if config.is_module_enabled("x402") {
+                fiber_config.clone()
+            } else {
+                None
+            },
+            if config.is_module_enabled("x402") {
+                Some(store.clone())
+            } else {
+                None
+            },
             config.cors_enabled,
             config.cors_allowed_origins.clone(),
         )

--- a/crates/fiber-lib/src/rpc/payment.rs
+++ b/crates/fiber-lib/src/rpc/payment.rs
@@ -142,6 +142,7 @@ fn send_payment_response_to_json(
 ) -> GetPaymentCommandResult {
     GetPaymentCommandResult {
         payment_hash: response.payment_hash.into(),
+        payment_preimage: response.payment_preimage.map(Into::into),
         status: response.status.into(),
         created_at: response.created_at,
         last_updated_at: response.last_updated_at,

--- a/crates/fiber-lib/src/x402/facilitator.rs
+++ b/crates/fiber-lib/src/x402/facilitator.rs
@@ -1,0 +1,361 @@
+use crate::fiber::types::pubkey_from_tentacle;
+use crate::invoice::InvoiceStore;
+use crate::x402::types::{
+    invoice_payee, verify_invoice_preimage, x402_asset_for_invoice, x402_network, FiberExactProof,
+    SettleRequest, SettleResponse, VerifyRequest, VerifyResponse, X402_SCHEME_EXACT, X402_VERSION,
+};
+use crate::FiberConfig;
+use std::str::FromStr;
+
+fn invalid(reason: &str, message: &str) -> VerifyResponse {
+    VerifyResponse {
+        is_valid: false,
+        invalid_reason: Some(reason.to_string()),
+        invalid_message: Some(message.to_string()),
+        payer: None,
+        extensions: None,
+    }
+}
+
+pub fn verify_exact_payment<S>(
+    store: &S,
+    config: &FiberConfig,
+    request: VerifyRequest,
+) -> VerifyResponse
+where
+    S: InvoiceStore,
+{
+    if request.x402_version != X402_VERSION || request.payment_payload.x402_version != X402_VERSION
+    {
+        return invalid("unsupported_x402_version", "unsupported x402 version");
+    }
+
+    if request.payment_requirements.scheme != X402_SCHEME_EXACT
+        || request.payment_payload.accepted.scheme != X402_SCHEME_EXACT
+    {
+        return invalid("unsupported_scheme", "unsupported payment scheme");
+    }
+
+    let expected_network = x402_network(config);
+    if request.payment_requirements.network != expected_network
+        || request.payment_payload.accepted.network != expected_network
+    {
+        return invalid("unsupported_network", "unsupported payment network");
+    }
+
+    let proof = match FiberExactProof::from_payload(&request.payment_payload.payload) {
+        Ok(proof) => proof,
+        Err(reason) => return invalid(&reason, "invalid payment proof payload"),
+    };
+
+    let invoice = match fiber_types::CkbInvoice::from_str(&proof.invoice) {
+        Ok(invoice) => invoice,
+        Err(_) => return invalid("invalid_invoice", "invalid invoice encoding"),
+    };
+
+    let expected_pay_to = hex::encode(pubkey_from_tentacle(config.public_key()).serialize());
+    let invoice_payee = match invoice_payee(&invoice) {
+        Ok(payee) => hex::encode(payee.serialize()),
+        Err(reason) => return invalid(&reason, "invoice payee is unavailable"),
+    };
+    if invoice_payee != expected_pay_to {
+        return invalid(
+            "invoice_payee_mismatch",
+            "invoice does not belong to this merchant",
+        );
+    }
+
+    if request.payment_requirements.pay_to != expected_pay_to
+        || request.payment_payload.accepted.pay_to != expected_pay_to
+    {
+        return invalid(
+            "pay_to_mismatch",
+            "payment recipient does not match invoice",
+        );
+    }
+
+    let amount = match invoice.amount() {
+        Some(amount) => amount,
+        None => return invalid("invalid_invoice_amount", "invoice amount is required"),
+    };
+    let expected_amount = amount.to_string();
+    if request.payment_requirements.amount != expected_amount
+        || request.payment_payload.accepted.amount != expected_amount
+    {
+        return invalid("amount_mismatch", "payment amount does not match invoice");
+    }
+
+    let expected_asset = x402_asset_for_invoice(&invoice);
+    if request.payment_requirements.asset != expected_asset
+        || request.payment_payload.accepted.asset != expected_asset
+    {
+        return invalid("asset_mismatch", "payment asset does not match invoice");
+    }
+
+    if !verify_invoice_preimage(&invoice, proof.payment_preimage) {
+        return invalid(
+            "invalid_payment_preimage",
+            "payment preimage does not match invoice payment hash",
+        );
+    }
+
+    let payment_hash = invoice.payment_hash();
+    if store.get_invoice(payment_hash).is_none() {
+        return invalid("invoice_not_found", "invoice not found in merchant store");
+    }
+
+    match store.get_invoice_status(payment_hash) {
+        Some(crate::invoice::CkbInvoiceStatus::Paid) => VerifyResponse {
+            is_valid: true,
+            invalid_reason: None,
+            invalid_message: None,
+            payer: None,
+            extensions: None,
+        },
+        Some(_) => invalid("invoice_not_paid", "invoice has not been paid"),
+        None => invalid(
+            "invoice_not_found",
+            "invoice status not found in merchant store",
+        ),
+    }
+}
+
+pub fn settle_exact_payment<S>(
+    store: &S,
+    config: &FiberConfig,
+    request: SettleRequest,
+) -> SettleResponse
+where
+    S: InvoiceStore,
+{
+    let verify_request = VerifyRequest {
+        x402_version: request.x402_version,
+        payment_payload: request.payment_payload.clone(),
+        payment_requirements: request.payment_requirements.clone(),
+    };
+
+    let verify = verify_exact_payment(store, config, verify_request);
+    if !verify.is_valid {
+        return SettleResponse {
+            success: false,
+            error_reason: verify.invalid_reason,
+            error_message: verify.invalid_message,
+            payer: verify.payer,
+            transaction: String::new(),
+            network: x402_network(config),
+            amount: None,
+            extensions: None,
+        };
+    }
+
+    let proof = FiberExactProof::from_payload(&request.payment_payload.payload)
+        .expect("verified settle request must contain valid proof");
+    let invoice = fiber_types::CkbInvoice::from_str(&proof.invoice)
+        .expect("verified settle request must contain valid invoice");
+
+    SettleResponse {
+        success: true,
+        error_reason: None,
+        error_message: None,
+        payer: None,
+        transaction: format!("fiber-receipt:{:x}", invoice.payment_hash()),
+        network: x402_network(config),
+        amount: invoice.amount().map(|amount| amount.to_string()),
+        extensions: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{settle_exact_payment, verify_exact_payment};
+    use crate::gen_rand_sha256_hash;
+    use crate::invoice::{
+        CkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder, InvoiceError, InvoiceStore,
+    };
+    use crate::tests::get_fiber_config;
+    use crate::x402::types::{SettleRequest, VerifyRequest};
+    use crate::FiberConfig;
+    use fiber_types::Hash256;
+    use secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use serde_json::json;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    struct MockStore {
+        invoices: RefCell<HashMap<Hash256, CkbInvoice>>,
+        invoice_statuses: RefCell<HashMap<Hash256, CkbInvoiceStatus>>,
+    }
+
+    impl MockStore {
+        fn with_invoice(self, invoice: CkbInvoice, status: CkbInvoiceStatus) -> Self {
+            let payment_hash = *invoice.payment_hash();
+            self.invoices.borrow_mut().insert(payment_hash, invoice);
+            self.invoice_statuses
+                .borrow_mut()
+                .insert(payment_hash, status);
+            self
+        }
+    }
+
+    impl Default for MockStore {
+        fn default() -> Self {
+            Self {
+                invoices: RefCell::new(HashMap::new()),
+                invoice_statuses: RefCell::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl InvoiceStore for MockStore {
+        fn get_invoice(&self, id: &Hash256) -> Option<CkbInvoice> {
+            self.invoices.borrow().get(id).cloned()
+        }
+
+        fn insert_invoice(
+            &self,
+            invoice: CkbInvoice,
+            _preimage: Option<Hash256>,
+        ) -> Result<(), InvoiceError> {
+            let payment_hash = *invoice.payment_hash();
+            self.invoices.borrow_mut().insert(payment_hash, invoice);
+            self.invoice_statuses
+                .borrow_mut()
+                .insert(payment_hash, CkbInvoiceStatus::Open);
+            Ok(())
+        }
+
+        fn update_invoice_status(
+            &self,
+            id: &Hash256,
+            status: CkbInvoiceStatus,
+        ) -> Result<(), InvoiceError> {
+            self.invoice_statuses.borrow_mut().insert(*id, status);
+            Ok(())
+        }
+
+        fn get_invoice_status(&self, id: &Hash256) -> Option<CkbInvoiceStatus> {
+            self.invoice_statuses.borrow().get(id).copied()
+        }
+    }
+
+    fn test_config(chain: &str) -> FiberConfig {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let mut config = get_fiber_config(&temp_dir, Some("x402-merchant"));
+        config.chain = chain.to_string();
+        config
+    }
+
+    fn build_invoice(
+        config: &FiberConfig,
+        amount: u128,
+        preimage: Hash256,
+    ) -> (CkbInvoice, String, String) {
+        let secret_key = SecretKey::from_slice(
+            config
+                .read_or_generate_secret_key()
+                .expect("merchant secret key")
+                .as_ref(),
+        )
+        .expect("valid secret key");
+        let public_key = PublicKey::from_secret_key(&Secp256k1::new(), &secret_key);
+        let invoice = InvoiceBuilder::new(Currency::Fibt)
+            .amount(Some(amount))
+            .payment_preimage(preimage)
+            .payee_pub_key(public_key)
+            .build_with_sign(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &secret_key))
+            .expect("build signed invoice");
+        let invoice_string = invoice.to_string();
+        let pay_to = hex::encode(public_key.serialize());
+        (invoice, invoice_string, pay_to)
+    }
+
+    fn verify_request(pay_to: &str, invoice: &str, payment_preimage: Hash256) -> VerifyRequest {
+        let requirements = json!({
+            "scheme": "exact",
+            "network": "fiber:testnet",
+            "asset": "ckb",
+            "amount": "1000",
+            "payTo": pay_to,
+            "maxTimeoutSeconds": 60,
+            "extra": {},
+        });
+        let payload = json!({
+            "x402Version": 2,
+            "accepted": requirements.clone(),
+            "payload": {
+                "invoice": invoice,
+                "paymentPreimage": payment_preimage,
+            }
+        });
+
+        serde_json::from_value(json!({
+            "x402Version": 2,
+            "paymentPayload": payload,
+            "paymentRequirements": requirements,
+        }))
+        .expect("deserialize verify request")
+    }
+
+    #[test]
+    fn test_x402_verify_rejects_pay_to_mismatch() {
+        let config = test_config("testnet");
+        let preimage = gen_rand_sha256_hash();
+        let (invoice, invoice_string, _pay_to) = build_invoice(&config, 1000, preimage);
+        let store = MockStore::default().with_invoice(invoice, CkbInvoiceStatus::Paid);
+
+        let response = verify_exact_payment(
+            &store,
+            &config,
+            verify_request(&hex::encode([7u8; 33]), &invoice_string, preimage),
+        );
+
+        assert!(!response.is_valid);
+        assert_eq!(response.invalid_reason.as_deref(), Some("pay_to_mismatch"));
+    }
+
+    #[test]
+    fn test_x402_verify_accepts_paid_invoice_proof_unit() {
+        let config = test_config("testnet");
+        let preimage = gen_rand_sha256_hash();
+        let (invoice, invoice_string, pay_to) = build_invoice(&config, 1000, preimage);
+        let store = MockStore::default().with_invoice(invoice, CkbInvoiceStatus::Paid);
+
+        let response = verify_exact_payment(
+            &store,
+            &config,
+            verify_request(&pay_to, &invoice_string, preimage),
+        );
+
+        assert!(response.is_valid);
+        assert!(response.invalid_reason.is_none());
+    }
+
+    #[test]
+    fn test_x402_settle_returns_deterministic_receipt_unit() {
+        let config = test_config("testnet");
+        let preimage = gen_rand_sha256_hash();
+        let (invoice, invoice_string, pay_to) = build_invoice(&config, 1000, preimage);
+        let payment_hash = *invoice.payment_hash();
+        let store = MockStore::default().with_invoice(invoice, CkbInvoiceStatus::Paid);
+
+        let verify = verify_request(&pay_to, &invoice_string, preimage);
+        let response = settle_exact_payment(
+            &store,
+            &config,
+            SettleRequest {
+                x402_version: verify.x402_version,
+                payment_payload: verify.payment_payload,
+                payment_requirements: verify.payment_requirements,
+            },
+        );
+
+        assert!(response.success);
+        assert_eq!(response.network, "fiber:testnet");
+        assert_eq!(response.amount.as_deref(), Some("1000"));
+        assert_eq!(
+            response.transaction,
+            format!("fiber-receipt:{:x}", payment_hash)
+        );
+    }
+}

--- a/crates/fiber-lib/src/x402/mod.rs
+++ b/crates/fiber-lib/src/x402/mod.rs
@@ -1,0 +1,6 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub mod facilitator;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod server;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod types;

--- a/crates/fiber-lib/src/x402/server.rs
+++ b/crates/fiber-lib/src/x402/server.rs
@@ -1,0 +1,40 @@
+use crate::fiber::types::pubkey_from_tentacle;
+use crate::invoice::InvoiceStore;
+use crate::x402::facilitator::{settle_exact_payment, verify_exact_payment};
+use crate::x402::types::{
+    x402_network, SettleRequest, SettleResponse, SupportedKind, SupportedResponse, VerifyRequest,
+    VerifyResponse, X402_SCHEME_EXACT, X402_VERSION,
+};
+use crate::FiberConfig;
+use std::collections::HashMap;
+
+pub fn supported_response(config: &FiberConfig) -> SupportedResponse {
+    let signer = pubkey_from_tentacle(config.public_key());
+    let mut signers = HashMap::new();
+    signers.insert("fiber:*".to_string(), vec![hex::encode(signer.serialize())]);
+
+    SupportedResponse {
+        kinds: vec![SupportedKind {
+            x402_version: X402_VERSION,
+            scheme: X402_SCHEME_EXACT.to_string(),
+            network: x402_network(config),
+            extra: None,
+        }],
+        extensions: Vec::new(),
+        signers,
+    }
+}
+
+pub fn verify_response<S>(store: &S, config: &FiberConfig, request: VerifyRequest) -> VerifyResponse
+where
+    S: InvoiceStore,
+{
+    verify_exact_payment(store, config, request)
+}
+
+pub fn settle_response<S>(store: &S, config: &FiberConfig, request: SettleRequest) -> SettleResponse
+where
+    S: InvoiceStore,
+{
+    settle_exact_payment(store, config, request)
+}

--- a/crates/fiber-lib/src/x402/types.rs
+++ b/crates/fiber-lib/src/x402/types.rs
@@ -1,0 +1,183 @@
+use crate::invoice::CkbInvoiceStatus;
+use crate::FiberConfig;
+use fiber_types::{CkbInvoice, Currency, Hash256, HashAlgorithm, Pubkey};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+pub const X402_VERSION: u32 = 2;
+pub const X402_SCHEME_EXACT: &str = "exact";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PaymentRequirements {
+    pub scheme: String,
+    pub network: String,
+    pub asset: String,
+    pub amount: String,
+    pub pay_to: String,
+    pub max_timeout_seconds: u64,
+    #[serde(default)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceInfo {
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PaymentPayload {
+    pub x402_version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<ResourceInfo>,
+    pub accepted: PaymentRequirements,
+    pub payload: HashMap<String, Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<HashMap<String, Value>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyRequest {
+    pub x402_version: u32,
+    pub payment_payload: PaymentPayload,
+    pub payment_requirements: PaymentRequirements,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyResponse {
+    pub is_valid: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalid_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalid_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<HashMap<String, Value>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SettleRequest {
+    pub x402_version: u32,
+    pub payment_payload: PaymentPayload,
+    pub payment_requirements: PaymentRequirements,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SettleResponse {
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payer: Option<String>,
+    pub transaction: String,
+    pub network: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amount: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<HashMap<String, Value>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SupportedKind {
+    pub x402_version: u32,
+    pub scheme: String,
+    pub network: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<HashMap<String, Value>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SupportedResponse {
+    pub kinds: Vec<SupportedKind>,
+    #[serde(default)]
+    pub extensions: Vec<String>,
+    #[serde(default)]
+    pub signers: HashMap<String, Vec<String>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FiberExactProof {
+    pub invoice: String,
+    pub payment_preimage: Hash256,
+}
+
+impl FiberExactProof {
+    pub fn from_payload(payload: &HashMap<String, Value>) -> Result<Self, String> {
+        let invoice = payload
+            .get("invoice")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "missing_invoice".to_string())?
+            .to_string();
+        let payment_preimage = payload
+            .get("paymentPreimage")
+            .or_else(|| payload.get("payment_preimage"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| "missing_payment_preimage".to_string())?;
+
+        let payment_preimage = Hash256::from_str(payment_preimage)
+            .map_err(|_| "invalid_payment_preimage".to_string())?;
+
+        Ok(Self {
+            invoice,
+            payment_preimage,
+        })
+    }
+}
+
+pub fn x402_network(config: &FiberConfig) -> String {
+    match config.chain.as_str() {
+        "mainnet" => "fiber:mainnet".to_string(),
+        "testnet" => "fiber:testnet".to_string(),
+        _ => "fiber:dev".to_string(),
+    }
+}
+
+pub fn x402_asset(currency: Currency) -> &'static str {
+    match currency {
+        Currency::Fibb | Currency::Fibt | Currency::Fibd => "ckb",
+    }
+}
+
+pub fn x402_asset_for_invoice(invoice: &CkbInvoice) -> &'static str {
+    x402_asset(invoice.currency)
+}
+
+pub fn invoice_payee(invoice: &CkbInvoice) -> Result<Pubkey, String> {
+    if let Some(payee) = invoice.payee_pub_key() {
+        return Ok((*payee).into());
+    }
+
+    invoice
+        .recover_payee_pub_key()
+        .map(Into::into)
+        .map_err(|_| "missing_payee_pubkey".to_string())
+}
+
+pub fn invoice_hash_algorithm(invoice: &CkbInvoice) -> HashAlgorithm {
+    invoice.hash_algorithm().copied().unwrap_or_default()
+}
+
+pub fn verify_invoice_preimage(invoice: &CkbInvoice, payment_preimage: Hash256) -> bool {
+    Hash256::from(invoice_hash_algorithm(invoice).hash(payment_preimage.as_ref()))
+        == *invoice.payment_hash()
+}
+
+pub fn is_invoice_paid(status: CkbInvoiceStatus) -> bool {
+    status == CkbInvoiceStatus::Paid
+}

--- a/docs/notes/x402-facilitator.md
+++ b/docs/notes/x402-facilitator.md
@@ -1,0 +1,93 @@
+# Note [x402 facilitator MVP]
+
+This note records the current x402 facilitator architecture in Fiber and the main tradeoffs behind the MVP.
+
+## Overview
+
+Fiber's x402 support is currently implemented as a thin HTTP layer on top of the existing RPC server and invoice store.
+
+The implementation adds three non-JSON-RPC HTTP routes to the RPC listener:
+
+- `GET /supported`
+- `POST /verify`
+- `POST /settle`
+
+These are intercepted before requests fall through to `jsonrpsee` JSON-RPC handling.
+
+## Why the MVP uses invoice plus preimage
+
+The current design does not ask the facilitator to originate a payment. Instead, it accepts an already-paid Fiber invoice plus the payment preimage as proof.
+
+This was chosen because Fiber already has the right primitives for this flow:
+
+- signed invoices with stable payment hashes
+- merchant-side invoice state in the store
+- paid-invoice status tracking
+- payment preimage availability after successful payment
+
+That means the facilitator can stay small and stateless relative to chain execution. It only needs to parse the invoice, verify the preimage binding, and confirm that the merchant has already observed the invoice as paid.
+
+## Route Placement
+
+The current x402 routes are implemented in `crates/fiber-lib/src/rpc/mod.rs` rather than a separate listener.
+
+Benefits:
+
+- minimal new service lifecycle wiring
+- reuses existing config and listener management
+- reuses the existing store and `FiberConfig` already available to RPC
+
+Tradeoff:
+
+- x402 currently shares the RPC listener, which is operationally convenient but not yet ideal for long-term separation of concerns
+
+## Verification Semantics
+
+Pure verification lives in `crates/fiber-lib/src/x402/facilitator.rs`.
+
+The current verifier checks:
+
+- x402 V2 only
+- `exact` scheme only
+- local CAIP-like network mapping only
+- invoice parse succeeds
+- invoice payee matches the configured merchant key
+- `payTo` matches the same merchant key
+- asset and amount match the invoice
+- preimage hashes to the invoice payment hash
+- invoice exists in the merchant store
+- invoice status is `Paid`
+
+This keeps the logic small and explicit instead of introducing a larger scheme registry or generalized settlement engine before the integration contract is proven.
+
+## Settlement Semantics
+
+The current `/settle` behavior is deliberately receipt-like.
+
+If verification passes and the invoice is already paid, settlement returns a deterministic string:
+
+`fiber-receipt:<payment-hash-hex>`
+
+This avoids the incorrect model of trying to "re-settle" a standard invoice after the payment already happened on the network.
+
+## Current Limits
+
+Important deferred items:
+
+- no `@x402/fiber` package yet
+- no hold-invoice or escrow-style flow
+- no delegated authorization flow
+- no extension support
+- no multi-asset expression
+- no dedicated x402 service config or separate listener
+- no richer settlement replay handling beyond invoice-paid checks
+
+## Likely Follow-up Work
+
+Natural next steps are:
+
+1. add explicit docs and examples for merchant-side integration
+2. decide whether x402 should remain on the RPC listener or move to its own service config
+3. add invalid `/settle` integration tests and additional pure verifier cases
+4. design a client helper package for exact Fiber proofs
+5. evaluate hold-invoice or delegated settlement flows for stronger purchase semantics

--- a/docs/plans/2026-04-22-x402-fiber-facilitator.md
+++ b/docs/plans/2026-04-22-x402-fiber-facilitator.md
@@ -1,0 +1,362 @@
+# x402 Fiber Facilitator Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a minimal x402-compatible Fiber facilitator that exposes `GET /supported`, `POST /verify`, and `POST /settle` so x402 resource servers can accept Fiber invoice payments.
+
+**Architecture:** Implement the facilitator as a small HTTP service in `fnn` backed by the existing Fiber store, invoice parsing, and payment/invoice state. The first milestone is invoice-based exact payments only: the client pays a normal Fiber invoice, then presents `invoice + preimage` to the facilitator; verification checks x402 request shape, invoice details, preimage binding, and merchant-side invoice state before settlement returns a receipt-like response.
+
+**Tech Stack:** Rust, hyper, tower, existing Fiber RPC/store/invoice types, tokio tests.
+
+## Delivered MVP Checklist
+
+- [x] `GET /supported` returns one exact Fiber kind for the local chain mapping
+- [x] `POST /verify` accepts invoice plus preimage proof payloads
+- [x] `/verify` enforces scheme, network, asset, amount, merchant `payTo`, invoice ownership, and paid invoice status
+- [x] `POST /settle` returns a deterministic receipt for already-paid invoices
+- [x] pure x402 verifier tests exist in addition to HTTP black-box tests
+- [x] focused x402 tests pass
+
+## Deferred Items
+
+- [ ] no TypeScript `@x402/fiber` package yet
+- [ ] no hold-invoice flow yet
+- [ ] no delegated authorization flow yet
+- [ ] no multi-asset x402 expression yet
+- [ ] no x402 extension support yet
+- [ ] no dedicated x402 listener or config section yet
+- [ ] no richer payer identity reporting yet
+
+---
+
+### Task 1: Add failing tests for x402 facilitator HTTP surface
+
+**Files:**
+- Modify: `crates/fiber-lib/src/fiber/tests/mod.rs`
+- Create: `crates/fiber-lib/src/fiber/tests/x402.rs`
+- Reference: `crates/fiber-lib/src/tests/test_utils.rs`
+
+**Step 1: Write the failing tests**
+
+Add black-box HTTP tests covering the MVP contract:
+
+```rust
+#[tokio::test]
+async fn test_x402_supported_lists_exact_fiber_kind() {
+    // start a test node with x402 facilitator enabled
+    // GET /supported
+    // assert 200
+    // assert kinds contains { x402Version: 2, scheme: "exact", network: "fiber:testnet" }
+}
+
+#[tokio::test]
+async fn test_x402_verify_rejects_invalid_preimage() {
+    // create merchant invoice
+    // POST /verify with wrong preimage
+    // assert 4xx/200-invalid according to chosen handler semantics
+    // assert invalidReason indicates proof mismatch
+}
+
+#[tokio::test]
+async fn test_x402_verify_accepts_paid_invoice_proof() {
+    // create merchant invoice with known preimage
+    // payer node pays invoice
+    // POST /verify with invoice + preimage proof
+    // assert isValid = true and payer is present
+}
+
+#[tokio::test]
+async fn test_x402_settle_returns_receipt_for_verified_invoice() {
+    // after invoice is paid
+    // POST /settle with same proof
+    // assert success = true, network = fiber:testnet, transaction is stable non-empty receipt id
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run x402_supported_lists_exact_fiber_kind x402_verify_rejects_invalid_preimage x402_verify_accepts_paid_invoice_proof x402_settle_returns_receipt_for_verified_invoice --no-fail-fast`
+
+Expected: FAIL because the x402 module/server/routes do not exist yet.
+
+**Step 3: Write minimal test helpers**
+
+If the tests need shared helpers, add only the minimal test-only helper functions to start the facilitator service and make HTTP requests.
+
+**Step 4: Run tests again**
+
+Run the same `cargo nextest run ...` command.
+
+Expected: still FAIL, but now for missing production code rather than test harness mistakes.
+
+**Step 5: Commit**
+
+Do not commit unless explicitly requested.
+
+### Task 2: Define x402 request/response types and Fiber proof model
+
+**Files:**
+- Create: `crates/fiber-lib/src/x402/types.rs`
+- Create: `crates/fiber-lib/src/x402/mod.rs`
+- Modify: `crates/fiber-lib/src/lib.rs`
+
+**Step 1: Write the failing unit tests**
+
+Add focused serialization/validation tests for:
+- `SupportedResponse`
+- `VerifyRequest` / `VerifyResponse`
+- `SettleRequest` / `SettleResponse`
+- Fiber exact proof payload shape
+
+Use the actual x402 V2 field names:
+
+```rust
+struct PaymentRequirements {
+    scheme: String,
+    network: String,
+    asset: String,
+    amount: String,
+    pay_to: String,
+    max_timeout_seconds: u64,
+    extra: serde_json::Map<String, Value>,
+}
+
+struct FiberExactProof {
+    invoice: String,
+    payment_preimage: String,
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run x402 --no-fail-fast`
+
+Expected: FAIL because the x402 module/types do not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement only the types and helpers needed by the tests:
+- x402 V2 request/response structs
+- network mapping helper returning `fiber:mainnet`, `fiber:testnet`, or `fiber:dev`
+- proof decoding helper that extracts `invoice` and `payment_preimage`
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run x402 --no-fail-fast`
+
+Expected: type-focused tests PASS.
+
+**Step 5: Commit**
+
+Do not commit unless explicitly requested.
+
+### Task 3: Expose payment preimage in existing payment result types
+
+**Files:**
+- Modify: `crates/fiber-lib/src/fiber/network.rs`
+- Modify: `crates/fiber-lib/src/fiber/payment.rs`
+- Modify: `crates/fiber-json-types/src/payment.rs`
+- Modify: `crates/fiber-lib/src/rpc/payment.rs`
+- Modify: `fiber-js/src/types/payment.ts`
+
+**Step 1: Write the failing tests**
+
+Add a regression test proving a successful invoice payment can be read back with its preimage in the payment result JSON type.
+
+```rust
+#[tokio::test]
+async fn test_get_payment_exposes_payment_preimage_after_success() {
+    // create invoice with known preimage
+    // pay it
+    // call get_payment
+    // assert payment_preimage == expected preimage
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run get_payment_exposes_payment_preimage_after_success --no-fail-fast`
+
+Expected: FAIL because `GetPaymentCommandResult` does not include `payment_preimage`.
+
+**Step 3: Write minimal implementation**
+
+Thread the winning attempt preimage through:
+- internal `SendPaymentResponse`
+- JSON RPC `GetPaymentCommandResult`
+- `send_payment_response_to_json`
+- JS type definitions
+
+Use the first successful attempt preimage if payment status is `Success`, otherwise `None`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run get_payment_exposes_payment_preimage_after_success --no-fail-fast`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+Do not commit unless explicitly requested.
+
+### Task 4: Implement pure verification logic for exact Fiber invoice proofs
+
+**Files:**
+- Create: `crates/fiber-lib/src/x402/facilitator.rs`
+- Modify: `crates/fiber-lib/src/x402/mod.rs`
+- Reference: `crates/fiber-lib/src/invoice/*`, `crates/fiber-types/src/invoice.rs`
+
+**Step 1: Write the failing unit tests**
+
+Cover pure verification rules without HTTP:
+- unsupported scheme rejected unless `scheme == "exact"`
+- unsupported network rejected unless it matches local chain mapping
+- malformed proof rejected if `invoice` or `payment_preimage` missing
+- preimage hash must match invoice payment hash
+- requirements amount/payTo/asset must match parsed invoice
+- invoice must belong to the configured merchant node
+- merchant store status must be `Paid` for standard invoices in MVP
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run x402_verify_ --no-fail-fast`
+
+Expected: FAIL because the verifier does not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement a verifier that:
+- parses the invoice string into `CkbInvoice`
+- computes hash using invoice hash algorithm (defaulting correctly)
+- compares invoice details to x402 requirements
+- checks merchant store invoice status
+- returns `VerifyResponse { isValid, invalidReason, payer }`
+
+Use a small error enum/string mapping; do not over-generalize.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run x402_verify_ --no-fail-fast`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+Do not commit unless explicitly requested.
+
+### Task 5: Add facilitator HTTP server and wire it into `fnn`
+
+**Files:**
+- Create: `crates/fiber-lib/src/x402/server.rs`
+- Modify: `crates/fiber-lib/src/config.rs`
+- Modify: `crates/fiber-bin/src/main.rs`
+- Modify: `crates/fiber-lib/Cargo.toml` if extra HTTP feature wiring is needed
+
+**Step 1: Write the failing integration tests**
+
+Extend the HTTP black-box tests to start the x402 facilitator server from a node config and hit:
+- `GET /supported`
+- `POST /verify`
+- `POST /settle`
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run x402_supported_ x402_verify_ x402_settle_ --no-fail-fast`
+
+Expected: FAIL because there is no HTTP service or config wiring.
+
+**Step 3: Write minimal implementation**
+
+Implement a tiny Hyper/Tower service with these routes:
+- `GET /supported`
+- `POST /verify`
+- `POST /settle`
+
+Wire it through a new config section on `Config`, parsed alongside existing services, and start/stop it in `fiber-bin` similarly to RPC lifecycle handling.
+
+For MVP settlement behavior:
+- re-run verify logic
+- if valid and invoice is already `Paid`, return success receipt immediately
+- `transaction` should be a deterministic receipt string derived from payment hash or invoice hash, not an empty string
+- do not attempt a second network-side settlement for already-paid standard invoices
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run x402_supported_ x402_verify_ x402_settle_ --no-fail-fast`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+Do not commit unless explicitly requested.
+
+### Task 6: Document MVP constraints and follow-up work
+
+**Files:**
+- Modify: `docs/plans/2026-04-22-x402-fiber-facilitator.md`
+- Create or modify: `docs/solutions/` or a focused `README` once implementation location is clear
+
+**Step 1: Write the failing docs checklist**
+
+Create a checklist in the doc for the delivered MVP and explicitly list deferred items:
+- no TypeScript `@x402/fiber` package yet
+- no hold-invoice or delegated authorization flow yet
+- no multi-asset x402 expression yet
+- no x402 extension support yet
+
+**Step 2: Run docs sanity check**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: PASS or formatting-only failures.
+
+**Step 3: Write/update docs**
+
+Document:
+- supported network strings
+- expected proof payload shape
+- exact verification semantics
+- MVP limitations
+
+**Step 4: Run docs-related verification**
+
+Run: `cargo fmt --all && cargo nextest run x402 --no-fail-fast`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+Do not commit unless explicitly requested.
+
+### Task 7: Final verification
+
+**Files:**
+- No code changes required unless verification fails
+
+**Step 1: Run focused test suite**
+
+Run: `cargo nextest run x402 --no-fail-fast`
+
+Expected: all x402 tests PASS.
+
+**Step 2: Run broader regression coverage**
+
+Run: `cargo nextest run rpc get_payment_exposes_payment_preimage_after_success --no-fail-fast`
+
+Expected: PASS.
+
+**Step 3: Run formatting**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: PASS.
+
+**Step 4: Run clippy on touched crates**
+
+Run: `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
+
+Expected: PASS.
+
+**Step 5: Summarize evidence**
+
+Record the exact commands run and whether each passed or failed before claiming completion.

--- a/docs/x402-integration-guide.md
+++ b/docs/x402-integration-guide.md
@@ -1,0 +1,145 @@
+# x402 Integration Guide
+
+This document describes how an x402-compatible resource server can use Fiber's current facilitator MVP.
+
+## What Fiber Provides
+
+Fiber currently provides a minimal x402 facilitator surface with:
+
+- `GET /supported`
+- `POST /verify`
+- `POST /settle`
+
+The supported payment model is invoice-based exact payment. The client pays a normal Fiber invoice first, then proves payment by sending the invoice string together with the payment preimage.
+
+## Current Payment Model
+
+This is not a delegated settlement model where the facilitator sends the payment for the client.
+
+Instead:
+
+1. The merchant creates a standard Fiber invoice.
+2. The client pays it using Fiber.
+3. The client submits an x402 proof payload containing the invoice and payment preimage.
+4. The facilitator verifies that proof against merchant-side invoice state.
+5. `/settle` returns a deterministic receipt-like response once the invoice is already paid.
+
+## Discover Capabilities
+
+Call `GET /supported` to learn the supported `(scheme, network)` pairs.
+
+Current MVP expectations:
+
+- `x402Version = 2`
+- `scheme = "exact"`
+- `network` is one of `fiber:mainnet`, `fiber:testnet`, or `fiber:dev`
+- `signers["fiber:*"]` contains the merchant public key hex
+
+## Payment Requirements
+
+For the current Fiber facilitator, `payTo` should be the merchant public key hex advertised by `/supported`.
+
+The current MVP expects:
+
+- `scheme = "exact"`
+- `network = fiber:<chain>`
+- `asset = "ckb"`
+- `amount = <invoice amount as decimal string>`
+- `payTo = <merchant pubkey hex>`
+
+## Payment Payload Proof
+
+The current proof payload shape is:
+
+```json
+{
+  "invoice": "<fiber invoice string>",
+  "paymentPreimage": "<32-byte hex preimage>"
+}
+```
+
+`payment_preimage` is also accepted for compatibility with snake_case producers.
+
+## Verify Request Example
+
+```json
+{
+  "x402Version": 2,
+  "paymentPayload": {
+    "x402Version": 2,
+    "accepted": {
+      "scheme": "exact",
+      "network": "fiber:testnet",
+      "asset": "ckb",
+      "amount": "1000",
+      "payTo": "<merchant-pubkey-hex>",
+      "maxTimeoutSeconds": 60,
+      "extra": {}
+    },
+    "payload": {
+      "invoice": "<fiber invoice string>",
+      "paymentPreimage": "<preimage hex>"
+    }
+  },
+  "paymentRequirements": {
+    "scheme": "exact",
+    "network": "fiber:testnet",
+    "asset": "ckb",
+    "amount": "1000",
+    "payTo": "<merchant-pubkey-hex>",
+    "maxTimeoutSeconds": 60,
+    "extra": {}
+  }
+}
+```
+
+## Verification Semantics
+
+The facilitator verifies:
+
+- x402 version is 2
+- scheme is `exact`
+- network matches the local Fiber chain
+- invoice parses successfully
+- invoice payee matches the configured merchant public key
+- `payTo` matches the same merchant public key
+- amount matches the invoice amount
+- asset matches `ckb`
+- `sha256-or-configured-hash(preimage) == invoice.payment_hash`
+- the invoice exists in the merchant store
+- the merchant store marks it as `Paid`
+
+The current MVP returns `200 OK` for verification responses, including invalid ones.
+
+## Settlement Semantics
+
+`POST /settle` does not submit another payment. It is a receipt step for already-paid invoices.
+
+If the proof is valid and the invoice is already paid, the facilitator returns:
+
+- `success = true`
+- `transaction = "fiber-receipt:<payment-hash-hex>"`
+- `network = fiber:<chain>`
+- `amount = <invoice amount>`
+
+If the proof is invalid, settlement returns `success = false` with `errorReason` and `errorMessage`.
+
+## Current MVP Constraints
+
+- no x402 client SDK package yet
+- no TypeScript `@x402/fiber` helper yet
+- no multi-asset pricing expression
+- no extensions support
+- no delegated authorization flow
+- no hold-invoice workflow
+- no richer payer identity reporting
+
+## Recommended Integration Strategy
+
+Use this facilitator when:
+
+- your merchant service already creates Fiber invoices
+- your client can pay those invoices directly
+- your resource server wants a simple x402 verification/receipt layer
+
+Keep the integration narrow for now: exact payments, one asset, one merchant signer, and already-paid invoice proofs.

--- a/docs/x402-operator-guide.md
+++ b/docs/x402-operator-guide.md
@@ -1,0 +1,172 @@
+# x402 Operator Guide
+
+This document explains how to enable the current x402 facilitator MVP on a Fiber node, what HTTP endpoints it exposes, and what behavior operators should expect.
+
+## Overview
+
+Fiber now exposes a minimal x402-compatible facilitator on the existing HTTP RPC listener when the `x402` RPC module is enabled. This MVP supports invoice-based exact payments only.
+
+The current facilitator exposes three HTTP endpoints on the same address as RPC:
+
+- `GET /supported`
+- `POST /verify`
+- `POST /settle`
+
+These routes are handled alongside the JSON-RPC server. They do not require a separate listener or service configuration.
+
+## Enable x402
+
+Enable x402 by adding `x402` to `rpc.enabled_modules`.
+
+Example config:
+
+```yaml
+rpc:
+  listening_addr: "127.0.0.1:8227"
+  enabled_modules:
+    - cch
+    - channel
+    - graph
+    - payment
+    - info
+    - invoice
+    - peer
+    - x402
+```
+
+Equivalent environment variable form:
+
+```bash
+export RPC_ENABLED_MODULES="cch,channel,graph,payment,info,invoice,peer,x402"
+```
+
+## Listener Behavior
+
+The x402 facilitator runs on the same HTTP server as JSON-RPC. If your RPC listener is `127.0.0.1:8227`, then:
+
+- `http://127.0.0.1:8227/supported`
+- `http://127.0.0.1:8227/verify`
+- `http://127.0.0.1:8227/settle`
+
+are served by the facilitator.
+
+JSON-RPC remains available on the same listener.
+
+If Biscuit auth is configured for RPC, keep in mind that x402 currently shares the same listener. The current implementation is intended for private or controlled deployments while the x402 surface is still MVP-level.
+
+## Supported Network Strings
+
+The facilitator advertises one x402 network string based on the local Fiber chain:
+
+- `mainnet` -> `fiber:mainnet`
+- `testnet` -> `fiber:testnet`
+- any other chain -> `fiber:dev`
+
+The current implementation supports only:
+
+- `scheme = "exact"`
+- `asset = "ckb"`
+
+## Supported Flow
+
+The current facilitator does not create or relay payments on behalf of clients.
+
+Instead, the supported flow is:
+
+1. The merchant creates a normal Fiber invoice.
+2. The client pays that invoice over Fiber.
+3. The client submits `invoice + paymentPreimage` to the facilitator.
+4. The facilitator verifies the proof against the merchant's local invoice store.
+5. The facilitator returns a receipt-like settlement response.
+
+This means the merchant node must already know the invoice and must already observe it as paid before `/settle` succeeds.
+
+## /supported
+
+`GET /supported` returns the currently advertised x402 capabilities.
+
+The current MVP returns one `kinds` entry for the local network and one `signers` entry keyed by `fiber:*` with the merchant public key hex.
+
+Example response shape:
+
+```json
+{
+  "kinds": [
+    {
+      "x402Version": 2,
+      "scheme": "exact",
+      "network": "fiber:testnet"
+    }
+  ],
+  "extensions": [],
+  "signers": {
+    "fiber:*": ["<merchant-pubkey-hex>"]
+  }
+}
+```
+
+## /verify
+
+`POST /verify` accepts an x402 V2 verification request.
+
+For the current MVP, the facilitator expects the proof payload to contain:
+
+- `invoice`: the full Fiber invoice string
+- `paymentPreimage` or `payment_preimage`: the payment preimage hex string
+
+Verification succeeds only if all of the following are true:
+
+- `x402Version == 2`
+- `scheme == "exact"`
+- `network` matches the local chain mapping
+- `asset == "ckb"`
+- `amount` matches the invoice amount
+- `payTo` matches the configured merchant public key hex
+- the invoice payee also matches that merchant
+- the preimage hashes to the invoice payment hash
+- the invoice exists in the merchant store
+- the merchant store marks the invoice as `Paid`
+
+If verification fails, the facilitator returns `200 OK` with `isValid: false` and an `invalidReason`.
+
+## /settle
+
+`POST /settle` re-runs the same exact verification logic.
+
+For the MVP, settlement does not trigger a second network-side payment. If the invoice is already paid and the proof is valid, the facilitator returns a deterministic receipt-like response immediately.
+
+Example success shape:
+
+```json
+{
+  "success": true,
+  "transaction": "fiber-receipt:<payment-hash-hex>",
+  "network": "fiber:testnet",
+  "amount": "1000"
+}
+```
+
+If validation fails, the facilitator returns `success: false` with `errorReason` and `errorMessage`.
+
+## Operational Limits
+
+Current MVP limitations:
+
+- no dedicated x402 listener; it shares the RPC HTTP listener
+- no TypeScript `@x402/fiber` package yet
+- no delegated payment authorization flow
+- no hold-invoice flow
+- no multi-asset x402 expression
+- no x402 extension support
+- no payer identity extraction in responses
+- no settlement replay protection beyond the existing invoice-paid check
+
+## Recommended Deployment Scope
+
+Use the current x402 MVP for:
+
+- local testing
+- private testnet deployments
+- controlled integrations where the merchant operates both the Fiber node and the resource server relationship
+
+Treat public exposure as experimental until the x402 surface gains more explicit configuration, auth policy, and documentation coverage.

--- a/fiber-js/src/types/payment.ts
+++ b/fiber-js/src/types/payment.ts
@@ -12,6 +12,7 @@ interface SessionRouteNode {
 }
 interface GetPaymentCommandResult {
     payment_hash: HexString;
+    payment_preimage?: HexString;
     status: PaymentSessionStatus;
     created_at: HexString;
     last_updated_at: HexString;


### PR DESCRIPTION
Enable Fiber to act as an x402 exact-payment backend by verifying paid invoices and returning deterministic receipts on the RPC HTTP listener. Expose successful payment preimages so clients can prove invoice payment, and document the MVP contract and limits.