### PR TITLE
add debug and trace logs across funding flow

### DIFF
--- a/crates/fiber-lib/src/ckb/actor.rs
+++ b/crates/fiber-lib/src/ckb/actor.rs
@@ -2,7 +2,7 @@ use ckb_sdk::RpcError;
 use ckb_types::{core::TransactionView, packed, prelude::IntoTransactionView as _};
 use ractor::{concurrency::Duration, Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 use strum::AsRefStr;
-use tracing::debug;
+use tracing::{debug, trace};
 
 use crate::{
     ckb::contracts::{get_script_by_contract, Contract},
@@ -131,6 +131,17 @@ impl Actor for CkbChainActor {
         );
         match message {
             CkbChainMessage::Fund(tx, request, reply_port) => {
+                debug!(
+                    "[{}] Funding request received: local_amount={}, remote_amount={}, local_reserved_ckb={}, remote_reserved_ckb={}, fee_rate={}, has_udt={}, has_existing_tx={}",
+                    myself.get_name().unwrap_or_default(),
+                    request.local_amount,
+                    request.remote_amount,
+                    request.local_reserved_ckb_amount,
+                    request.remote_reserved_ckb_amount,
+                    request.funding_fee_rate,
+                    request.udt_type_script.is_some(),
+                    tx.as_ref().is_some(),
+                );
                 let context = state.build_funding_context(request.script.clone());
                 let result = match state.config.funding_tx_shell_builder_as_deref() {
                     None => {
@@ -139,6 +150,18 @@ impl Actor for CkbChainActor {
                     }
                     Some(shell_script) => fund_via_shell(shell_script, tx, request, context).await,
                 };
+                match &result {
+                    Ok(funding_tx) => debug!(
+                        "[{}] Funding request succeeded: tx_hash={:?}",
+                        myself.get_name().unwrap_or_default(),
+                        funding_tx.as_ref().map(|t| t.hash()),
+                    ),
+                    Err(err) => debug!(
+                        "[{}] Funding request failed: {}",
+                        myself.get_name().unwrap_or_default(),
+                        err,
+                    ),
+                }
                 let _ = reply_port.send(result);
             }
             CkbChainMessage::BuildUnsignedFundingTx {
@@ -149,6 +172,15 @@ impl Actor for CkbChainActor {
                 funding_cell_lock_script,
                 reply,
             } => {
+                debug!(
+                    "[{}] BuildUnsignedFundingTx: local_amount={}, remote_amount={}, fee_rate={}, has_udt={}, funding_source_lock_hash={}",
+                    myself.get_name().unwrap_or_default(),
+                    request.local_amount,
+                    request.remote_amount,
+                    request.funding_fee_rate,
+                    request.udt_type_script.is_some(),
+                    funding_source_lock_script.calc_script_hash(),
+                );
                 let context = FundingContext {
                     rpc_url: state.config.rpc_url.clone(),
                     funding_source_lock_script,
@@ -162,6 +194,13 @@ impl Actor for CkbChainActor {
                         &mut state.live_cells_exclusion_map,
                     )
                     .await;
+                if let Err(ref err) = result {
+                    debug!(
+                        "[{}] BuildUnsignedFundingTx failed: {}",
+                        myself.get_name().unwrap_or_default(),
+                        err,
+                    );
+                }
                 let _ = reply.send(result);
             }
             CkbChainMessage::VerifyFundingTx {
@@ -170,11 +209,27 @@ impl Actor for CkbChainActor {
                 funding_cell_lock_script,
                 reply,
             } => {
+                let local_tx_hash = local_tx.calc_tx_hash();
+                let remote_tx_hash = remote_tx.calc_tx_hash();
+                debug!(
+                    "[{}] VerifyFundingTx: local_tx_hash={}, remote_tx_hash={}",
+                    myself.get_name().unwrap_or_default(),
+                    local_tx_hash,
+                    remote_tx_hash,
+                );
                 let mut funding_tx: FundingTx = local_tx.into();
                 let context = state.build_funding_context(funding_cell_lock_script);
                 let result = funding_tx
                     .update_for_peer(remote_tx.into_view(), context)
                     .await;
+                if let Err(ref err) = result {
+                    debug!(
+                        "[{}] VerifyFundingTx failed for remote_tx_hash={}: {}",
+                        myself.get_name().unwrap_or_default(),
+                        remote_tx_hash,
+                        err,
+                    );
+                }
                 let _ = reply.send(result);
             }
             CkbChainMessage::AddFundingTx(tx) => {
@@ -190,8 +245,27 @@ impl Actor for CkbChainActor {
             }
             CkbChainMessage::Sign(tx, reply_port) => {
                 if !reply_port.is_closed() {
+                    let tx_hash = tx.as_ref().map(|t| t.hash());
+                    debug!(
+                        "[{}] Signing funding tx: tx_hash={:?}",
+                        myself.get_name().unwrap_or_default(),
+                        tx_hash,
+                    );
                     let rpc_url = state.config.rpc_url.clone();
                     let result = state.signer.sign_funding_tx(tx, rpc_url).await;
+                    match &result {
+                        Ok(signed) => debug!(
+                            "[{}] Funding tx signed: tx_hash={:?}",
+                            myself.get_name().unwrap_or_default(),
+                            signed.as_ref().map(|t| t.hash()),
+                        ),
+                        Err(err) => debug!(
+                            "[{}] Funding tx signing failed for {:?}: {}",
+                            myself.get_name().unwrap_or_default(),
+                            tx_hash,
+                            err,
+                        ),
+                    }
                     if !reply_port.is_closed() {
                         // ignore error
                         let _ = reply_port.send(result);
@@ -200,8 +274,20 @@ impl Actor for CkbChainActor {
             }
             CkbChainMessage::SendTx(tx, reply_port) => {
                 let ckb_client = state.config.ckb_rpc_client();
+                trace!(
+                    "[{}] Sending tx {} to CKB node",
+                    myself.get_name().unwrap_or_default(),
+                    tx.hash(),
+                );
                 let result = match ckb_client.send_transaction(tx.data().into(), None).await {
-                    Ok(_) => Ok(()),
+                    Ok(_) => {
+                        debug!(
+                            "[{}] Tx {} accepted by CKB node",
+                            myself.get_name().unwrap_or_default(),
+                            tx.hash(),
+                        );
+                        Ok(())
+                    }
                     Err(err) => {
                         //FIXME(yukang): RBF or duplicated transaction handling
                         match err {

--- a/crates/fiber-lib/src/ckb/funding/funding_tx.rs
+++ b/crates/fiber-lib/src/ckb/funding/funding_tx.rs
@@ -30,7 +30,7 @@ use molecule::{
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::{HashMap, HashSet};
-use tracing::debug;
+use tracing::{debug, trace};
 
 // Number of blocks to keep the committed funding tx in the exclusion map.
 // It is the same with the value used in the CKB SDK.
@@ -241,6 +241,15 @@ impl FundingTxBuilder {
             .as_ref()
             .map(|tx| !tx.outputs().is_empty())
             .unwrap_or(false);
+        debug!(
+            "Building funding cell: remote_funded={}, has_udt={}, local_amount={}, remote_amount={}, local_reserved_ckb={}, remote_reserved_ckb={}",
+            remote_funded,
+            self.request.udt_type_script.is_some(),
+            self.request.local_amount,
+            self.request.remote_amount,
+            self.request.local_reserved_ckb_amount,
+            self.request.remote_reserved_ckb_amount,
+        );
 
         match self.request.udt_type_script {
             Some(ref udt_type_script) => {
@@ -250,10 +259,23 @@ impl FundingTxBuilder {
                 if remote_funded {
                     udt_amount = udt_amount
                         .checked_add(self.request.remote_amount)
-                        .ok_or(FundingError::OverflowError)?;
+                        .ok_or_else(|| {
+                            debug!(
+                                "Overflow combining UDT amounts: local={} + remote={}",
+                                self.request.local_amount, self.request.remote_amount
+                            );
+                            FundingError::OverflowError
+                        })?;
                     ckb_amount = ckb_amount
                         .checked_add(self.request.remote_reserved_ckb_amount)
-                        .ok_or(FundingError::OverflowError)?;
+                        .ok_or_else(|| {
+                            debug!(
+                                "Overflow combining reserved CKB: local={} + remote={}",
+                                self.request.local_reserved_ckb_amount,
+                                self.request.remote_reserved_ckb_amount
+                            );
+                            FundingError::OverflowError
+                        })?;
                 }
 
                 let udt_output = packed::CellOutput::new_builder()
@@ -264,26 +286,59 @@ impl FundingTxBuilder {
                 let mut data = BytesMut::with_capacity(16);
                 data.put(&udt_amount.to_le_bytes()[..]);
 
+                debug!(
+                    "Built UDT funding cell: udt_amount={}, ckb_capacity={} shannons",
+                    udt_amount, ckb_amount
+                );
                 Ok((udt_output, data.freeze().pack()))
             }
             None => {
-                let local_amount = u64::try_from(self.request.local_amount)
-                    .map_err(|_| FundingError::OverflowError)?;
+                let local_amount = u64::try_from(self.request.local_amount).map_err(|_| {
+                    debug!(
+                        "Local amount {} does not fit into u64 for CKB funding",
+                        self.request.local_amount
+                    );
+                    FundingError::OverflowError
+                })?;
                 let mut ckb_amount = local_amount
                     .checked_add(self.request.local_reserved_ckb_amount)
-                    .ok_or(FundingError::OverflowError)?;
+                    .ok_or_else(|| {
+                        debug!(
+                            "Overflow adding local CKB amount {} + reserved {}",
+                            local_amount, self.request.local_reserved_ckb_amount
+                        );
+                        FundingError::OverflowError
+                    })?;
 
                 if remote_funded {
-                    let remote_amount = u64::try_from(self.request.remote_amount)
-                        .map_err(|_| FundingError::OverflowError)?;
+                    let remote_amount =
+                        u64::try_from(self.request.remote_amount).map_err(|_| {
+                            debug!(
+                                "Remote amount {} does not fit into u64 for CKB funding",
+                                self.request.remote_amount
+                            );
+                            FundingError::OverflowError
+                        })?;
                     ckb_amount = ckb_amount
                         .checked_add(remote_amount)
                         .and_then(|amount| {
                             amount.checked_add(self.request.remote_reserved_ckb_amount)
                         })
-                        .ok_or(FundingError::OverflowError)?;
+                        .ok_or_else(|| {
+                            debug!(
+                                "Overflow combining CKB amounts: local_total={} + remote={} + remote_reserved={}",
+                                ckb_amount,
+                                remote_amount,
+                                self.request.remote_reserved_ckb_amount
+                            );
+                            FundingError::OverflowError
+                        })?;
                 }
 
+                debug!(
+                    "Built CKB funding cell with capacity {} shannons",
+                    ckb_amount
+                );
                 let ckb_output = packed::CellOutput::new_builder()
                     .capacity(Capacity::shannons(ckb_amount).pack())
                     .lock(self.context.funding_cell_lock_script.clone())
@@ -303,6 +358,11 @@ impl FundingTxBuilder {
     ) -> Result<(), TxBuilderError> {
         let udt_amount = self.request.local_amount;
         if self.request.udt_type_script.is_none() || udt_amount == 0 {
+            trace!(
+                "Skipping UDT input collection: has_udt_type_script={}, udt_amount={}",
+                self.request.udt_type_script.is_some(),
+                udt_amount
+            );
             return Ok(());
         }
 
@@ -311,6 +371,12 @@ impl FundingTxBuilder {
         })?;
         let owner = self.context.funding_source_lock_script.clone();
         let mut found_udt_amount: u128 = 0;
+        debug!(
+            "Collecting UDT cells: target_udt_amount={}, owner_lock_hash={}, udt_type_hash={}",
+            udt_amount,
+            owner.calc_script_hash(),
+            udt_type_script.calc_script_hash(),
+        );
 
         let mut query = CellQueryOptions::new_lock(owner.clone());
         query.script_search_mode = Some(SearchMode::Exact);
@@ -322,8 +388,19 @@ impl FundingTxBuilder {
                 .collect_live_cells_async(&query, true)
                 .await?;
             if udt_cells.is_empty() {
+                trace!(
+                    "UDT cell collector returned no more cells; found_udt_amount={}, target={}",
+                    found_udt_amount,
+                    udt_amount
+                );
                 break;
             }
+            trace!(
+                "UDT cell collector returned {} cell(s) (found so far: {}/{})",
+                udt_cells.len(),
+                found_udt_amount,
+                udt_amount
+            );
             for cell in udt_cells.iter() {
                 let mut amount_bytes = [0u8; 16];
                 amount_bytes.copy_from_slice(&cell.output_data.as_ref()[0..16]);
@@ -364,6 +441,12 @@ impl FundingTxBuilder {
                         outputs_data.push(change_output_data);
                     }
 
+                    debug!(
+                        "Collected sufficient UDT cells: inputs={}, found_udt_amount={}, change_amount={}",
+                        inputs.len(),
+                        found_udt_amount,
+                        found_udt_amount - udt_amount,
+                    );
                     debug!("find proper UDT owner cells: {:?}", inputs);
                     let udt_cell_deps = get_udt_cell_deps(&udt_type_script)
                         .await
@@ -375,6 +458,10 @@ impl FundingTxBuilder {
                 }
             }
         }
+        debug!(
+            "Insufficient UDT cells: needed {}, found {}",
+            udt_amount, found_udt_amount
+        );
         Err(TxBuilderError::Other(anyhow!(INSUFFICIENT_UDT_CELLS_MSG)))
     }
 
@@ -419,13 +506,25 @@ impl FundingTxBuilder {
             .set_outputs_data(outputs_data)
             .set_cell_deps(cell_deps.into_iter().collect())
             .set_witnesses(vec![secp_sighash_placeholder_witness().as_bytes().pack()]);
-        Ok(tx_builder.build())
+        let built = tx_builder.build();
+        debug!(
+            "Assembled base funding tx: inputs={}, outputs={}, cell_deps={}",
+            built.inputs().len(),
+            built.outputs().len(),
+            built.cell_deps().len(),
+        );
+        Ok(built)
     }
 
     async fn build_and_balance_tx(
         &self,
         live_cells_exclusion_map: &mut LiveCellsExclusionMap,
     ) -> Result<TransactionView, FundingError> {
+        debug!(
+            "Balancing funding tx: funding_source_lock_hash={}, fee_rate={}",
+            self.context.funding_source_lock_script.calc_script_hash(),
+            self.request.funding_fee_rate,
+        );
         let signer = SecpCkbRawKeySigner::new_with_secret_keys(vec![]);
         let sighash_unlocker = SecpSighashUnlocker::from(Box::new(signer) as Box<_>);
         let sighash_script_id = ScriptId::new_type(SIGHASH_TYPE_HASH.clone());
@@ -478,6 +577,11 @@ impl FundingTxBuilder {
         let tx_dep_provider = DefaultTransactionDependencyProvider::new(&self.context.rpc_url, 10);
 
         let tip_block_number: u64 = ckb_client.get_tip_block_number().await?.into();
+        trace!(
+            "Funding tx balancing: tip_block_number={}, exclusion_map_size={}",
+            tip_block_number,
+            live_cells_exclusion_map.map.len(),
+        );
         live_cells_exclusion_map.truncate(tip_block_number);
         live_cells_exclusion_map
             .apply(&mut cell_collector)
@@ -503,8 +607,17 @@ impl FundingTxBuilder {
                 &unlockers,
             )
             .await;
-        let (tx, _) = build_result.map_err(map_tx_builder_error)?;
+        let (tx, _) = build_result.map_err(|err| {
+            debug!("Funding tx capacity balancing failed: {:?}", err);
+            map_tx_builder_error(err)
+        })?;
 
+        debug!(
+            "Funding tx balanced: tx_hash={}, inputs={}, outputs={}",
+            tx.hash(),
+            tx.inputs().len(),
+            tx.outputs().len(),
+        );
         Ok(tx)
     }
 
@@ -545,6 +658,11 @@ impl FundingTxBuilder {
         self,
         live_cells_exclusion_map: &mut LiveCellsExclusionMap,
     ) -> Result<FundingTx, FundingError> {
+        debug!(
+            "FundingTxBuilder::build starting: had_existing_tx={}, fee_rate={}",
+            self.funding_tx.tx.is_some(),
+            self.request.funding_fee_rate,
+        );
         let tx = self.build_and_balance_tx(live_cells_exclusion_map).await?;
         let tx = self.with_extra_cell_deps(tx);
         debug!("final tx_builder: {:?}", tx.as_advanced_builder());
@@ -628,9 +746,21 @@ impl FundingTx {
             Box::new(sighash_unlocker) as Box<dyn ScriptUnlocker>,
         );
         let tx = self.take().ok_or(FundingError::AbsentTx)?;
+        let tx_hash_before = tx.hash();
+        debug!("Signing funding tx: tx_hash={}", tx_hash_before);
         let tx_dep_provider = DefaultTransactionDependencyProvider::new(&rpc_url, 10);
 
-        let (tx, _) = unlock_tx_async(tx, &tx_dep_provider, &unlockers).await?;
+        let (tx, _) = unlock_tx_async(tx, &tx_dep_provider, &unlockers)
+            .await
+            .map_err(|err| {
+                debug!("Failed to sign funding tx {}: {:?}", tx_hash_before, err);
+                err
+            })?;
+        debug!(
+            "Signed funding tx: tx_hash={}, witnesses={}",
+            tx.hash(),
+            tx.witnesses().len()
+        );
         self.update_for_self(tx);
         Ok(self)
     }
@@ -655,6 +785,15 @@ impl FundingTx {
             .tx
             .clone()
             .unwrap_or_else(|| Transaction::default().into_view());
+        debug!(
+            "Verifying peer funding tx update: local_tx_hash={}, remote_tx_hash={}, local_inputs={}, remote_inputs={}, local_outputs={}, remote_outputs={}",
+            local_tx.hash(),
+            remote_tx.hash(),
+            local_tx.inputs().len(),
+            remote_tx.inputs().len(),
+            local_tx.outputs().len(),
+            remote_tx.outputs().len(),
+        );
 
         // Version MUST be the same
         if remote_tx.version() != local_tx.version() {

--- a/crates/fiber-lib/src/fiber/in_flight_ckb_tx_actor.rs
+++ b/crates/fiber-lib/src/fiber/in_flight_ckb_tx_actor.rs
@@ -37,7 +37,7 @@ fn is_permanent_error(err: &RpcError) -> bool {
 // Waiting for https://github.com/nervosnetwork/ckb/pull/4583/ to be released.
 const DUMMY_FUNDING_TX_INDEX: u32 = 0;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum InFlightCkbTxKind {
     /// Funding(channel_id)
     Funding(Hash256),
@@ -172,6 +172,13 @@ where
         myself: ActorRef<InFlightCkbTxActorMessage>,
         state: &mut InFlightCkbTxActorState,
     ) -> Result<(), ActorProcessingErr> {
+        tracing::debug!(
+            "InFlightCkbTxActor starting: tx_hash={}, tx_kind={:?}, confirmations={}, will_broadcast={}",
+            self.tx_hash,
+            self.tx_kind,
+            self.confirmations,
+            state.transaction.is_some(),
+        );
         // start tx tracer
         let tracing_request = |tx| {
             CkbChainMessage::CreateTxTracer(CkbTxTracer {
@@ -204,7 +211,7 @@ where
         &self,
         myself: ActorRef<InFlightCkbTxActorMessage>,
     ) -> Result<(), ActorProcessingErr> {
-        tracing::debug!("Executing send_tx_interval...");
+        tracing::debug!("Executing send_tx_interval for tx {}", self.tx_hash);
         let message = InFlightCkbTxActorMessage::Internal(InternalMessage::SendTx);
 
         // send once immediately
@@ -228,7 +235,11 @@ where
             Some(tx) => tx,
             None => return Ok(()),
         };
-        tracing::debug!("Executing send_tx...");
+        tracing::debug!(
+            "Executing send_tx for {} ({:?})",
+            self.tx_hash,
+            self.tx_kind
+        );
         match ractor::call_t!(
             self.chain_actor,
             CkbChainMessage::SendTx,
@@ -268,6 +279,12 @@ where
         myself: ActorRef<InFlightCkbTxActorMessage>,
         result: CkbTxTracingResult,
     ) -> Result<(), ActorProcessingErr> {
+        tracing::debug!(
+            "Reporting tracing result for tx {} ({:?}): status={:?}",
+            self.tx_hash,
+            self.tx_kind,
+            result.tx_status,
+        );
         let message = match (self.tx_kind.clone(), result.tx_status) {
             (
                 InFlightCkbTxKind::Funding(..),

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -3347,6 +3347,16 @@ where
         transaction: Transaction,
         request: FundingRequest,
     ) -> crate::Result<()> {
+        debug!(
+            "do_update_channel_funding: channel_id={:?}, attempt={}/{}, local_amount={}, remote_amount={}, fee_rate={}, has_udt={}",
+            channel_id,
+            retry_count + 1,
+            FUNDING_RETRY_MAX_TOTAL_ATTEMPTS,
+            request.local_amount,
+            request.remote_amount,
+            request.funding_fee_rate,
+            request.udt_type_script.is_some(),
+        );
         let tx_for_retry = transaction.clone();
         let request_for_retry = request.clone();
         let old_tx = transaction.into_view();
@@ -3414,6 +3424,15 @@ where
     ) -> crate::Result<()> {
         let tx_hash: Hash256 = funding_tx.calc_tx_hash().into();
         let has_partial_witnesses = partial_witnesses.is_some();
+        debug!(
+            "do_sign_funding_tx: channel_id={:?}, target={:?}, tx_hash={:?}, has_partial_witnesses={}, attempt={}/{}",
+            channel_id,
+            target,
+            tx_hash,
+            has_partial_witnesses,
+            retry_count + 1,
+            FUNDING_RETRY_MAX_TOTAL_ATTEMPTS,
+        );
 
         let funding_tx_for_retry = funding_tx.clone();
         let partial_witnesses_for_retry = partial_witnesses.clone();
@@ -3545,6 +3564,12 @@ where
         tx: FundingTx,
         request: FundingRequest,
     ) -> Result<FundingTx, FundingError> {
+        trace!(
+            "Forwarding Fund request to ckb chain actor: local_amount={}, remote_amount={}, fee_rate={}",
+            request.local_amount,
+            request.remote_amount,
+            request.funding_fee_rate,
+        );
         call_t!(
             self.chain_actor.clone(),
             CkbChainMessage::Fund,
@@ -4294,6 +4319,14 @@ where
         tx_kind: InFlightCkbTxKind,
     ) -> crate::Result<()> {
         let tx_hash = tx.hash().into();
+        debug!(
+            "Spawning InFlightCkbTxActor: tx_hash={:?}, tx_kind={:?}, confirmations={}, inputs={}, outputs={}",
+            tx_hash,
+            tx_kind,
+            CKB_TX_TRACING_CONFIRMATIONS,
+            tx.inputs().len(),
+            tx.outputs().len(),
+        );
 
         let handler = InFlightCkbTxActor {
             chain_actor: self.chain_actor.clone(),
@@ -4318,6 +4351,7 @@ where
     }
 
     pub async fn abort_funding(&mut self, channel_id_or_outpoint: Either<Hash256, OutPoint>) {
+        debug!("abort_funding called with {:?}", channel_id_or_outpoint);
         let channel_id = match channel_id_or_outpoint {
             Either::Left(channel_id) => channel_id,
             Either::Right(outpoint) => match self.pending_channels.remove(&outpoint) {


### PR DESCRIPTION
## Summary

Adds structured debug and trace level logs throughout the funding flow so
that channel-open failures can be diagnosed without reproducing under a
debugger. Previously, failures only surfaced at the retry scheduler with
the bare `FundingError`, leaving operators to guess which stage went
wrong (cell collection, balancing, signing, peer verification, broadcast,
or tracing).

## Changes

- **`ckb/funding/funding_tx.rs`**
  - Log entry context for `FundingTxBuilder::build`, `build_funding_cell`,
    `build_udt_inputs_outputs`, `build_base_from_funding_cell`, and
    `build_and_balance_tx` (amounts, reserves, fee rate, source lock hash,
    tip block, exclusion-map size).
  - Identify which `checked_add` overflowed in `build_funding_cell`.
  - Trace per-batch UDT cell collection and emit a debug log on the
    "insufficient UDT cells" path showing exact found vs needed.
  - Log balanced tx hash + input/output/cell-dep counts.
  - Log signing entry/exit and peer tx verification context with both
    local and remote tx hashes and counts.
- **`ckb/actor.rs`** — `Fund`, `BuildUnsignedFundingTx`, `VerifyFundingTx`,
  `Sign`, and `SendTx` handlers now log requests and outcomes.
- **`fiber/in_flight_ckb_tx_actor.rs`** — derive `Debug` for
  `InFlightCkbTxKind` and include `tx_hash` + `tx_kind` in `start`,
  `send_tx_interval`, `send_tx`, and `report_tracing_result` logs.
- **`fiber/network.rs`** — add entry context (channel_id, attempt,
  amounts, target peer, tx_hash) for `do_update_channel_funding`,
  `do_sign_funding_tx`, `fund`, `send_tx`, and `abort_funding`.

## Verification

- `cargo check -p fnn -p fiber-bin`
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all`

No behavioral changes; only logging additions and a single derived
`Debug` impl.

---

_This PR description was generated with AI assistance._
