### PR TITLE
Fix release Docker rc architecture tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,45 +7,6 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  release-docker-metadata:
-    name: Release Docker Metadata (${{ matrix.arch }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-    steps:
-      - name: Extract Docker metadata for rc tag
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            nervos/fiber
-          flavor: |
-            latest=false
-          tags: |
-            type=semver,pattern={{version}},suffix=-${{ matrix.arch }},value=v0.9.0-rc1
-            type=sha,format=short,suffix=-${{ matrix.arch }}
-      - name: Check rc tags include architecture suffix
-        shell: bash
-        env:
-          ARCH: ${{ matrix.arch }}
-          DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          expected_ghcr="ghcr.io/${GITHUB_REPOSITORY}:0.9.0-rc1-${ARCH}"
-          expected_dockerhub="nervos/fiber:0.9.0-rc1-${ARCH}"
-          plain_ghcr="ghcr.io/${GITHUB_REPOSITORY}:0.9.0-rc1"
-          plain_dockerhub="nervos/fiber:0.9.0-rc1"
-
-          grep -Fxq "${expected_ghcr}" <<< "${DOCKER_TAGS}"
-          grep -Fxq "${expected_dockerhub}" <<< "${DOCKER_TAGS}"
-
-          if grep -Fxq "${plain_ghcr}" <<< "${DOCKER_TAGS}" || grep -Fxq "${plain_dockerhub}" <<< "${DOCKER_TAGS}"; then
-            echo "rc Docker metadata must not emit unsuffixed architecture image tags"
-            echo "${DOCKER_TAGS}"
-            exit 1
-          fi
-
   changes:
     name: Detect channel_restart_stress Changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,45 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  release-docker-metadata:
+    name: Release Docker Metadata (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Extract Docker metadata for rc tag
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            nervos/fiber
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},suffix=-${{ matrix.arch }},value=v0.9.0-rc1
+            type=sha,format=short,suffix=-${{ matrix.arch }}
+      - name: Check rc tags include architecture suffix
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          expected_ghcr="ghcr.io/${GITHUB_REPOSITORY}:0.9.0-rc1-${ARCH}"
+          expected_dockerhub="nervos/fiber:0.9.0-rc1-${ARCH}"
+          plain_ghcr="ghcr.io/${GITHUB_REPOSITORY}:0.9.0-rc1"
+          plain_dockerhub="nervos/fiber:0.9.0-rc1"
+
+          grep -Fxq "${expected_ghcr}" <<< "${DOCKER_TAGS}"
+          grep -Fxq "${expected_dockerhub}" <<< "${DOCKER_TAGS}"
+
+          if grep -Fxq "${plain_ghcr}" <<< "${DOCKER_TAGS}" || grep -Fxq "${plain_dockerhub}" <<< "${DOCKER_TAGS}"; then
+            echo "rc Docker metadata must not emit unsuffixed architecture image tags"
+            echo "${DOCKER_TAGS}"
+            exit 1
+          fi
+
   changes:
     name: Detect channel_restart_stress Changes
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,9 +188,9 @@ jobs:
           latest=false
         tags: |
           type=raw,value=edge-${{ matrix.arch }},enable=${{ github.ref == 'refs/heads/playground/release' }}
-          type=semver,pattern={{version}}-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-          type=semver,pattern={{major}}.{{minor}}-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
-          type=semver,pattern={{major}}-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+          type=semver,pattern={{version}},suffix=-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+          type=semver,pattern={{major}},suffix=-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
           type=raw,value=latest-${{ matrix.arch }},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
           type=sha,format=short,suffix=-${{ matrix.arch }}
     - name: Build and Push Docker Images


### PR DESCRIPTION
## Summary

- Fix release Docker architecture tags by using docker/metadata-action suffix attributes instead of embedding the architecture in semver patterns.

## Root Cause

docker/metadata-action treats pre-release semver tags specially and rewrites non-raw semver patterns back to {{version}}. The previous pattern={{version}}-${{ matrix.arch }} therefore produced 0.9.0-rc1 instead of 0.9.0-rc1-amd64/arm64, so the manifest job looked for tags that were never pushed.

## Validation

- git diff --check
- YAML parse for .github/workflows/ci.yml and .github/workflows/release.yml
- actionlint for the touched workflows, ignoring two pre-existing repository warnings: the existing if: false job and softprops/action-gh-release@v1
- Temporary PR-only Docker metadata checks passed for both amd64 and arm64 before being removed from the final diff
