### PR TITLE
Code cleanup for trampoline

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -64,8 +64,8 @@ use fiber_types::{
     PaymentCustomRecords, PeeledPaymentOnionPacket, PendingNotifySettleTlc, PrevTlcInfo, Privkey,
     Pubkey, PublicChannelInfo, RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation,
     RevocationData, RevokeAndAck, SettlementData, SettlementTlc, ShutdownInfo, ShuttingDownFlags,
-    SigningCommitmentFlags, TLCId, TlcErr, TlcErrData, TlcErrPacket, TlcErrorCode, TlcInfo,
-    TlcStatus, NO_SHARED_SECRET,
+    SigningCommitmentFlags, TLCId, TlcErr, TlcErrPacket, TlcErrorCode, TlcInfo, TlcStatus,
+    NO_SHARED_SECRET,
 };
 pub use fiber_types::{
     CommitDiff, CommitmentSignedTemplate, ReplayOrderHint, TlcReplayUpdate,
@@ -1784,25 +1784,7 @@ where
 
         if tlc_info.is_offered() {
             if let Some((previous_channel_id, previous_tlc_id)) = tlc_info.forwarding_tlc {
-                // Trampoline boundary: downstream failures are encrypted for the trampoline-originated
-                // (inner) route, so upstream senders can't decode them. Wrap the downstream error packet
-                // into a new error created with the *outer* shared secret (for this hop).
-                let remove_reason = match remove_reason.clone() {
-                    RemoveTlcReason::RemoveTlcFail(inner_error_packet)
-                        if tlc_info.is_trampoline_hop =>
-                    {
-                        let mut tlc_err = TlcErr::new(TlcErrorCode::TemporaryNodeFailure);
-                        tlc_err.set_extra_data(TlcErrData::TrampolineFailed {
-                            node_id: self.get_local_pubkey(),
-                            inner_error_packet: inner_error_packet.onion_packet,
-                        });
-                        RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
-                            tlc_err,
-                            &tlc_info.shared_secret,
-                        ))
-                    }
-                    other => other.backward(&tlc_info.shared_secret),
-                };
+                let remove_reason = remove_reason.backward(&tlc_info.shared_secret);
 
                 let _ = self.register_retryable_relay_tlc_remove(
                     TLCId::Received(previous_tlc_id),

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -487,6 +487,11 @@ pub struct TlcInfo {
     ///
     /// Save it to backward errors. Use all zeros when no shared secrets are available.
     pub shared_secret: [u8; 32],
+    /// Compatibility field retained for persisted channel state.
+    ///
+    /// This used to mark a trampoline-boundary TLC for channel-level error wrapping. Trampoline
+    /// payment failures are now resolved at the network/payment layer instead, so this field should
+    /// not be used for new error attribution logic. Removing it requires a storage migration.
     #[serde(default)]
     pub is_trampoline_hop: bool,
     pub created_at: CommitmentNumbers,
@@ -892,7 +897,11 @@ pub struct AddTlcCommand {
     /// Save it for outbound (offered) TLC to backward errors.
     /// Use all zeros when no shared secrets are available.
     pub shared_secret: [u8; 32],
-    /// Whether this outbound TLC is the trampoline-boundary hop.
+    /// Compatibility field retained for serialized retryable TLC operations.
+    ///
+    /// This used to mark a trampoline-boundary TLC for channel-level error wrapping. Trampoline
+    /// payment failures are now resolved at the network/payment layer instead, so this field should
+    /// not be used for new error attribution logic. Removing it requires a storage migration.
     pub is_trampoline_hop: bool,
     pub previous_tlc: Option<PrevTlcInfo>,
 }


### PR DESCRIPTION
If there is `forwarding_tlc`, it can not be a `Trampoline boundary`, we can remove this part of code.

`is_trampoline_hop` also can be removed, but need a migration, let's keep it for compatibility.