### PR TITLE
fix: stop Docker release building archived migrate tool

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,7 @@ COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --release --locked -p fiber-bin -p fnn-cli \
-    && cargo build --release --locked --manifest-path migrate/Cargo.toml
+    cargo build --release --locked -p fiber-bin -p fnn-cli
 
 FROM debian:bookworm-slim AS runtime
 
@@ -38,7 +37,6 @@ ENV FIBER_HOME=/fiber
 
 COPY --from=builder /usr/src/fiber/target/release/fnn /usr/local/bin/fnn
 COPY --from=builder /usr/src/fiber/target/release/fnn-cli /usr/local/bin/fnn-cli
-COPY --from=builder /usr/src/fiber/target/release/fnn-migrate /usr/local/bin/fnn-migrate
 COPY config /usr/local/share/fiber/config
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ If you prefer GHCR, replace the image reference with `ghcr.io/nervosnetwork/fibe
 
 On first start, the image copies the bundled testnet config to `/fiber/config.yml` if the file does not already exist. To bootstrap from the bundled mainnet config instead, set `FIBER_CONFIG_TEMPLATE=/usr/local/share/fiber/config/mainnet/config.yml`.
 
-The image also includes `fnn-cli` and `fnn-migrate` for administration and data migration tasks.
+The image also includes `fnn-cli` for administration tasks.
 
 The RPC service listens on `127.0.0.1:8227` in the bundled configs, so publishing port `8227` from the container is not enough by itself. If you need remote RPC access, update `rpc.listening_addr` in your mounted config first.
 
@@ -57,15 +57,15 @@ The full CLI reference is available in [../crates/fiber-cli/README.md](../crates
 
 ## Migrate data with Docker
 
-When upgrading between versions that require a storage migration, stop the node container first and back up the mounted data directory. With the default Docker layout shown above, the store path is `/fiber/fiber/store` inside the container.
+When upgrading between versions that require a storage migration, stop the node container first and back up the mounted data directory.
 
-Run the migration tool against the same mounted directory:
+Current releases run the unified migration system when `fnn` opens the store. If the existing database predates the unified migration epoch, upgrade it with the v0.8.x `fnn-migrate` binary before starting a current image:
 
 ```bash
-docker run --rm \
+docker run --rm -it \
   -v "$(pwd)/fiber-node:/fiber" \
-  nervos/fiber:<new-release-tag> \
-  fnn-migrate -p /fiber/fiber/store
+  nervos/fiber:<v0.8.x-release-tag> \
+  fnn-migrate -d /fiber
 ```
 
-After the migration finishes, start the new image version again with the same bind mount. If your config overrides the default store path, replace `/fiber/fiber/store` with that custom path.
+After the legacy migration finishes, start the new image version again with the same bind mount.


### PR DESCRIPTION
## Summary
- Stop the release Docker image build from invoking the removed `migrate/Cargo.toml` manifest.
- Remove `fnn-migrate` from the current Docker runtime image copy list.
- Update Docker docs to explain that current releases run unified migrations on store open, while pre-unified databases should use a v0.8.x `fnn-migrate` image first.

## Root Cause
The release Dockerfile still tried to build `migrate/Cargo.toml`, but the standalone migration tool was archived under `migrate_archive/` and is explicitly no longer compiled by CI. The release job therefore failed after the main Rust binaries built successfully with `error: manifest path migrate/Cargo.toml does not exist`.

## Validation
- `cargo check --locked -p fiber-bin -p fnn-cli`
- `git diff --check`
- pre-push hook: `cargo fmt --all -- --check`, clippy for native/sqlite/wasm targets, RPC doc check, and migrate check

## Notes
I could not run a local `docker build` because the local Docker daemon was not available.