### PR TITLE
Wrap trampoline forwarding failures

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1784,34 +1784,7 @@ where
 
         if tlc_info.is_offered() {
             if let Some((previous_channel_id, previous_tlc_id)) = tlc_info.forwarding_tlc {
-                // Trampoline boundary: downstream failures are encrypted for the trampoline-originated
-                // (inner) route, so upstream senders can't decode them. Wrap the downstream error packet
-                // into a new error created with the *outer* shared secret (for this hop).
-                let remove_reason = match remove_reason.clone() {
-                    RemoveTlcReason::RemoveTlcFail(inner_error_packet)
-                        if tlc_info.is_trampoline_hop =>
-                    {
-                        match TlcErrPacket::new_trampoline_failed(
-                            TlcErrorCode::TemporaryNodeFailure,
-                            self.get_local_pubkey(),
-                            inner_error_packet.onion_packet.clone(),
-                            &tlc_info.shared_secret,
-                        ) {
-                            Some(wrapper) => RemoveTlcReason::RemoveTlcFail(wrapper),
-                            None => {
-                                error!(
-                                    "Trampoline failure wrapper missing upstream shared secret for channel {:?} tlc {:?}",
-                                    state.get_id(),
-                                    tlc_id
-                                );
-                                RemoveTlcReason::RemoveTlcFail(
-                                    inner_error_packet.backward(&tlc_info.shared_secret),
-                                )
-                            }
-                        }
-                    }
-                    other => other.backward(&tlc_info.shared_secret),
-                };
+                let remove_reason = remove_reason.backward(&tlc_info.shared_secret);
 
                 let _ = self.register_retryable_relay_tlc_remove(
                     TLCId::Received(previous_tlc_id),

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -64,8 +64,8 @@ use fiber_types::{
     PaymentCustomRecords, PeeledPaymentOnionPacket, PendingNotifySettleTlc, PrevTlcInfo, Privkey,
     Pubkey, PublicChannelInfo, RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation,
     RevocationData, RevokeAndAck, SettlementData, SettlementTlc, ShutdownInfo, ShuttingDownFlags,
-    SigningCommitmentFlags, TLCId, TlcErr, TlcErrData, TlcErrPacket, TlcErrorCode, TlcInfo,
-    TlcStatus, NO_SHARED_SECRET,
+    SigningCommitmentFlags, TLCId, TlcErr, TlcErrPacket, TlcErrorCode, TlcInfo, TlcStatus,
+    NO_SHARED_SECRET,
 };
 pub use fiber_types::{
     CommitDiff, CommitmentSignedTemplate, ReplayOrderHint, TlcReplayUpdate,
@@ -1791,15 +1791,24 @@ where
                     RemoveTlcReason::RemoveTlcFail(inner_error_packet)
                         if tlc_info.is_trampoline_hop =>
                     {
-                        let mut tlc_err = TlcErr::new(TlcErrorCode::TemporaryNodeFailure);
-                        tlc_err.set_extra_data(TlcErrData::TrampolineFailed {
-                            node_id: self.get_local_pubkey(),
-                            inner_error_packet: inner_error_packet.onion_packet,
-                        });
-                        RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
-                            tlc_err,
+                        match TlcErrPacket::new_trampoline_failed(
+                            TlcErrorCode::TemporaryNodeFailure,
+                            self.get_local_pubkey(),
+                            inner_error_packet.onion_packet.clone(),
                             &tlc_info.shared_secret,
-                        ))
+                        ) {
+                            Some(wrapper) => RemoveTlcReason::RemoveTlcFail(wrapper),
+                            None => {
+                                error!(
+                                    "Trampoline failure wrapper missing upstream shared secret for channel {:?} tlc {:?}",
+                                    state.get_id(),
+                                    tlc_id
+                                );
+                                RemoveTlcReason::RemoveTlcFail(
+                                    inner_error_packet.backward(&tlc_info.shared_secret),
+                                )
+                            }
+                        }
                     }
                     other => other.backward(&tlc_info.shared_secret),
                 };

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -2280,10 +2280,11 @@ where
             NetworkActorCommand::SendPaymentOnionPacket(
                 SendOnionPacketCommand {
                     peeled_onion_packet: peeled_onion_packet.clone(),
-                    previous_tlc: Some(PrevTlcInfo::new(
+                    previous_tlc: Some(PrevTlcInfo::new_with_shared_secret(
                         state.get_id(),
                         u64::from(tlc_id),
                         forward_fee,
+                        peeled_onion_packet.shared_secret,
                     )),
                     payment_hash,
                     // forward tlc always set attempt_id to None

--- a/crates/fiber-lib/src/fiber/history.rs
+++ b/crates/fiber-lib/src/fiber/history.rs
@@ -172,12 +172,12 @@ impl InternalResult {
             );
             // The payer can decode the trampoline failure wrapper, but the inner route was chosen
             // by the trampoline node and is not represented in this payment route. Do not penalize
-            // the visible route or retry the same trampoline path automatically.
+            // the visible route. Use the wrapped error code only to decide whether the payer may
+            // try another trampoline route.
             return false;
         }
 
         let mut need_retry = true;
-
         let error_index = nodes
             .iter()
             .position(|s| Some(s.pubkey) == tlc_err.error_node_id());

--- a/crates/fiber-lib/src/fiber/history.rs
+++ b/crates/fiber-lib/src/fiber/history.rs
@@ -7,7 +7,7 @@ use super::graph::NetworkGraphStateStore;
 use crate::mock_timestamp_as_millis_u64;
 use crate::now_timestamp_as_millis_u64;
 use ckb_types::packed::OutPoint;
-use fiber_types::{ChannelUpdate, Pubkey, SessionRouteNode, TlcErr, TlcErrorCode};
+use fiber_types::{ChannelUpdate, Pubkey, SessionRouteNode, TlcErr, TlcErrData, TlcErrorCode};
 pub use fiber_types::{Direction, TimedResult};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -165,6 +165,17 @@ impl InternalResult {
     }
 
     pub fn record_payment_fail(&mut self, nodes: &[SessionRouteNode], tlc_err: TlcErr) -> bool {
+        if let Some(TlcErrData::TrampolineFailed { node_id, .. }) = &tlc_err.extra_data {
+            error!(
+                "Payment failed beyond trampoline node: error_code={:?} trampoline_node={:?} route={:?}",
+                tlc_err.error_code, node_id, nodes
+            );
+            // The payer can decode the trampoline failure wrapper, but the inner route was chosen
+            // by the trampoline node and is not represented in this payment route. Do not penalize
+            // the visible route or retry the same trampoline path automatically.
+            return false;
+        }
+
         let mut need_retry = true;
 
         let error_index = nodes

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -105,8 +105,8 @@ use fiber_types::{
     FeatureVector, Hash256, NodeAnnouncement, PaymentCustomRecords, PaymentStatus,
     PeeledPaymentOnionPacket, PersistentNetworkActorState, PrevTlcInfo, Privkey, Pubkey,
     PublicChannelInfo, RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation, RevocationData,
-    RouterHop, SettlementData, ShuttingDownFlags, TLCId, TlcErr, TlcErrData, TlcErrPacket,
-    TlcErrorCode, TrampolineContext, UdtCfgInfos,
+    RouterHop, SettlementData, ShuttingDownFlags, TLCId, TlcErr, TlcErrPacket, TlcErrorCode,
+    TrampolineContext, UdtCfgInfos,
 };
 
 pub const FIBER_PROTOCOL_ID: ProtocolId = ProtocolId::new(42);
@@ -5466,18 +5466,22 @@ where
                             .unwrap_or_else(|| {
                                 TlcErrPacket::new(TlcErr::new(error_code), &[0u8; 32]).onion_packet
                             });
-                        let mut tlc_err = TlcErr::new(error_code);
-                        tlc_err.set_extra_data(TlcErrData::TrampolineFailed {
-                            node_id: self.get_public_key(),
+                        let Some(wrapper_packet) = TlcErrPacket::new_trampoline_failed(
+                            error_code,
+                            self.get_public_key(),
                             inner_error_packet,
-                        });
+                            &shared_secret,
+                        ) else {
+                            warn!(
+                                "Trampoline payment failed with plaintext upstream shared secret for channel {:?} tlc {}",
+                                prev_tlc.prev_channel_id, prev_tlc.prev_tlc_id
+                            );
+                            continue;
+                        };
                         let command = ChannelCommand::RemoveTlc(
                             RemoveTlcCommand {
                                 id: prev_tlc.prev_tlc_id,
-                                reason: RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
-                                    tlc_err,
-                                    &shared_secret,
-                                )),
+                                reason: RemoveTlcReason::RemoveTlcFail(wrapper_packet),
                             },
                             rpc_reply,
                         );

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -105,8 +105,8 @@ use fiber_types::{
     FeatureVector, Hash256, NodeAnnouncement, PaymentCustomRecords, PaymentStatus,
     PeeledPaymentOnionPacket, PersistentNetworkActorState, PrevTlcInfo, Privkey, Pubkey,
     PublicChannelInfo, RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation, RevocationData,
-    RouterHop, SettlementData, ShuttingDownFlags, TLCId, TlcErr, TlcErrPacket, TlcErrorCode,
-    TrampolineContext, UdtCfgInfos,
+    RouterHop, SettlementData, ShuttingDownFlags, TLCId, TlcErr, TlcErrData, TlcErrPacket,
+    TlcErrorCode, TrampolineContext, UdtCfgInfos,
 };
 
 pub const FIBER_PROTOCOL_ID: ProtocolId = ProtocolId::new(42);
@@ -880,7 +880,7 @@ pub enum NetworkActorEvent {
     ChannelActorStopped(Hash256, StopReason),
 
     // A payment actor stopped event.
-    PaymentActorStopped(Hash256),
+    PaymentActorStopped(Hash256, Option<TlcErrPacket>),
 
     // Channel settlement check completed - channel is fully settled on-chain.
     ChannelSettlementCompleted(Hash256),
@@ -1520,8 +1520,10 @@ where
                 }
                 state.on_channel_actor_stopped(channel_id, reason).await;
             }
-            NetworkActorEvent::PaymentActorStopped(payment_hash) => {
-                state.on_payment_actor_stopped(payment_hash).await;
+            NetworkActorEvent::PaymentActorStopped(payment_hash, last_error_packet) => {
+                state
+                    .on_payment_actor_stopped(payment_hash, last_error_packet)
+                    .await;
             }
             NetworkActorEvent::ChannelSettlementCompleted(channel_id) => {
                 if let Some(channel_actor) = state.channels.get(&channel_id) {
@@ -5393,7 +5395,11 @@ where
         .await;
     }
 
-    async fn on_payment_actor_stopped(&mut self, payment_hash: Hash256) {
+    async fn on_payment_actor_stopped(
+        &mut self,
+        payment_hash: Hash256,
+        last_error_packet: Option<TlcErrPacket>,
+    ) {
         debug!("Payment actor stopped {payment_hash}");
         if self.inflight_payments.remove(&payment_hash).is_none() {
             error!("Can't find inflight payment actor");
@@ -5447,12 +5453,29 @@ where
                     for prev_tlc in &context.previous_tlcs {
                         let (send, _recv) = oneshot::channel();
                         let rpc_reply = RpcReplyPort::from(send);
-                        let shared_secret = prev_tlc.shared_secret.unwrap_or([0u8; 32]);
+                        let Some(shared_secret) = prev_tlc.shared_secret else {
+                            warn!(
+                                "Trampoline payment failed without upstream shared secret for channel {:?} tlc {}",
+                                prev_tlc.prev_channel_id, prev_tlc.prev_tlc_id
+                            );
+                            continue;
+                        };
+                        let inner_error_packet = last_error_packet
+                            .as_ref()
+                            .map(|packet| packet.onion_packet.clone())
+                            .unwrap_or_else(|| {
+                                TlcErrPacket::new(TlcErr::new(error_code), &[0u8; 32]).onion_packet
+                            });
+                        let mut tlc_err = TlcErr::new(error_code);
+                        tlc_err.set_extra_data(TlcErrData::TrampolineFailed {
+                            node_id: self.get_public_key(),
+                            inner_error_packet,
+                        });
                         let command = ChannelCommand::RemoveTlc(
                             RemoveTlcCommand {
                                 id: prev_tlc.prev_tlc_id,
                                 reason: RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
-                                    TlcErr::new(error_code),
+                                    tlc_err,
                                     &shared_secret,
                                 )),
                             },

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -106,7 +106,7 @@ use fiber_types::{
     PeeledPaymentOnionPacket, PersistentNetworkActorState, PrevTlcInfo, Privkey, Pubkey,
     PublicChannelInfo, RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation, RevocationData,
     RouterHop, SettlementData, ShuttingDownFlags, TLCId, TlcErr, TlcErrPacket, TlcErrorCode,
-    TrampolineContext, UdtCfgInfos,
+    TrampolineContext, UdtCfgInfos, NO_SHARED_SECRET,
 };
 
 pub const FIBER_PROTOCOL_ID: ProtocolId = ProtocolId::new(42);
@@ -5453,31 +5453,20 @@ where
                     for prev_tlc in &context.previous_tlcs {
                         let (send, _recv) = oneshot::channel();
                         let rpc_reply = RpcReplyPort::from(send);
-                        let Some(shared_secret) = prev_tlc.shared_secret else {
-                            warn!(
-                                "Trampoline payment failed without upstream shared secret for channel {:?} tlc {}",
-                                prev_tlc.prev_channel_id, prev_tlc.prev_tlc_id
-                            );
-                            continue;
-                        };
+                        let shared_secret = prev_tlc.shared_secret.unwrap_or(NO_SHARED_SECRET);
                         let inner_error_packet = last_error_packet
                             .as_ref()
                             .map(|packet| packet.onion_packet.clone())
                             .unwrap_or_else(|| {
-                                TlcErrPacket::new(TlcErr::new(error_code), &[0u8; 32]).onion_packet
+                                TlcErrPacket::new(TlcErr::new(error_code), &NO_SHARED_SECRET)
+                                    .onion_packet
                             });
-                        let Some(wrapper_packet) = TlcErrPacket::new_trampoline_failed(
+                        let wrapper_packet = TlcErrPacket::new_trampoline_failed(
                             error_code,
                             self.get_public_key(),
                             inner_error_packet,
                             &shared_secret,
-                        ) else {
-                            warn!(
-                                "Trampoline payment failed with plaintext upstream shared secret for channel {:?} tlc {}",
-                                prev_tlc.prev_channel_id, prev_tlc.prev_tlc_id
-                            );
-                            continue;
-                        };
+                        );
                         let command = ChannelCommand::RemoveTlc(
                             RemoveTlcCommand {
                                 id: prev_tlc.prev_tlc_id,

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -1744,18 +1744,11 @@ where
                         debug_event!(self.network, "InvalidOnionError");
                         TlcErr::new(TlcErrorCode::InvalidOnionError)
                     });
-                let need_to_retry = if matches!(
-                    tlc_error.extra_data,
-                    Some(TlcErrData::TrampolineFailed { .. })
-                ) {
-                    false
-                } else {
-                    self.network_graph.write().await.record_attempt_fail(
-                        &attempt,
-                        tlc_error.clone(),
-                        false,
-                    )
-                };
+                let need_to_retry = self.network_graph.write().await.record_attempt_fail(
+                    &attempt,
+                    tlc_error.clone(),
+                    false,
+                );
                 debug!(
                     "payment_hash: {:?} set attempt failed with: {:?} need_to_retry: {:?}",
                     payment_hash,

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -1241,7 +1241,14 @@ where
             match build_route_result {
                 Err(e) => {
                     error!("build_payment_routes failed to build route: {}", e);
-                    let error = format!("Failed to build route, {}", e);
+                    let error = if session.request.trampoline_context.is_some() {
+                        session
+                            .last_error_code
+                            .get_or_insert(TlcErrorCode::TemporaryNodeFailure);
+                        TlcErrorCode::TemporaryNodeFailure.as_ref().to_string()
+                    } else {
+                        format!("Failed to build route, {}", e)
+                    };
                     return Err(Error::SendPaymentError(error));
                 }
                 Ok(mut hops) => {
@@ -1387,7 +1394,7 @@ where
                 cur_max_fee, local_fee
             );
             return Err(Error::SendPaymentError(
-                "Trampoline forwarding fee insufficient".to_string(),
+                TlcErrorCode::FeeInsufficient.as_ref().to_string(),
             ));
         }
         *max_fee = Some(cur_max_fee - local_fee);
@@ -1737,11 +1744,18 @@ where
                         debug_event!(self.network, "InvalidOnionError");
                         TlcErr::new(TlcErrorCode::InvalidOnionError)
                     });
-                let need_to_retry = self.network_graph.write().await.record_attempt_fail(
-                    &attempt,
-                    tlc_error.clone(),
-                    false,
-                );
+                let need_to_retry = if matches!(
+                    tlc_error.extra_data,
+                    Some(TlcErrData::TrampolineFailed { .. })
+                ) {
+                    false
+                } else {
+                    self.network_graph.write().await.record_attempt_fail(
+                        &attempt,
+                        tlc_error.clone(),
+                        false,
+                    )
+                };
                 debug!(
                     "payment_hash: {:?} set attempt failed with: {:?} need_to_retry: {:?}",
                     payment_hash,

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -31,8 +31,8 @@ pub use fiber_types::SendPaymentData;
 use fiber_types::{
     Attempt, BasicMppPaymentData, EntityHex, Hash256, HashAlgorithm, HopHint, PaymentCustomRecords,
     PaymentHopData, PaymentStatus, PeeledPaymentOnionPacket, Privkey, Pubkey, RemoveTlcReason,
-    RouterHop, TlcErr, TlcErrData, TlcErrorCode, TrampolineContext, DEFAULT_MAX_PARTS,
-    DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT, USER_CUSTOM_RECORDS_MAX_INDEX,
+    RouterHop, TlcErr, TlcErrData, TlcErrPacket, TlcErrorCode, TrampolineContext,
+    DEFAULT_MAX_PARTS, DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT, USER_CUSTOM_RECORDS_MAX_INDEX,
 };
 use ractor::{call_t, Actor, ActorProcessingErr};
 use ractor::{concurrency::Duration, ActorRef, RpcReplyPort};
@@ -766,6 +766,7 @@ pub enum PaymentActorMessage {
 pub struct PaymentActorState {
     payment_hash: Hash256,
     init_command: Option<PaymentActorMessage>,
+    last_error_packet: Option<TlcErrPacket>,
 
     // the number of pending retrying send payments, we track it for
     // set retry delay dynamically, pending too many payments may have a negative impact
@@ -783,6 +784,7 @@ impl PaymentActorState {
         Self {
             payment_hash,
             init_command: Some(init_command),
+            last_error_packet: None,
             retry_send_payment_count: 0,
         }
     }
@@ -852,7 +854,10 @@ where
         debug!("Payment actor is stopped {:?}", myself.get_name());
         self.network
             .send_message(NetworkActorMessage::Event(
-                NetworkActorEvent::PaymentActorStopped(state.payment_hash),
+                NetworkActorEvent::PaymentActorStopped(
+                    state.payment_hash,
+                    state.last_error_packet.clone(),
+                ),
             ))
             .map_err(Into::into)
     }
@@ -1743,12 +1748,13 @@ where
                     tlc_error.error_code.as_ref(),
                     need_to_retry
                 );
+                state.last_error_packet = Some(reason.clone());
 
                 self.set_attempt_fail_with_error(
                     &mut session,
                     &mut attempt,
                     Some(tlc_error.error_code),
-                    tlc_error.error_code.as_ref(),
+                    &tlc_error.to_string(),
                     need_to_retry,
                 );
 

--- a/crates/fiber-lib/src/fiber/tests/history.rs
+++ b/crates/fiber-lib/src/fiber/tests/history.rs
@@ -104,21 +104,26 @@ fn test_trampoline_failure_does_not_mark_outer_route_history() {
             channel_outpoint: gen_rand_channel_outpoint(),
         },
     ];
-    let tlc_err = TlcErr {
-        error_code: TlcErrorCode::FeeInsufficient,
-        extra_data: Some(TlcErrData::TrampolineFailed {
-            node_id: trampoline,
-            inner_error_packet: vec![1, 2, 3],
-        }),
-    };
+    for (error_code, expected_retry) in [
+        (TlcErrorCode::FeeInsufficient, false),
+        (TlcErrorCode::IncorrectOrUnknownPaymentDetails, false),
+    ] {
+        let tlc_err = TlcErr {
+            error_code,
+            extra_data: Some(TlcErrData::TrampolineFailed {
+                node_id: trampoline,
+                inner_error_packet: vec![1, 2, 3],
+            }),
+        };
 
-    let mut result = InternalResult::default();
-    let need_retry = result.record_payment_fail(&nodes, tlc_err);
+        let mut result = InternalResult::default();
+        let need_retry = result.record_payment_fail(&nodes, tlc_err);
 
-    assert!(!need_retry);
-    assert!(result.pairs.is_empty());
-    assert!(result.nodes_to_channel_map.is_empty());
-    assert!(result.fail_node.is_none());
+        assert_eq!(need_retry, expected_retry);
+        assert!(result.pairs.is_empty());
+        assert!(result.nodes_to_channel_map.is_empty());
+        assert!(result.fail_node.is_none());
+    }
 }
 
 #[test]

--- a/crates/fiber-lib/src/fiber/tests/history.rs
+++ b/crates/fiber-lib/src/fiber/tests/history.rs
@@ -11,6 +11,7 @@ use crate::{
     gen_rand_channel_outpoint, gen_rand_fiber_public_key, init_tracing, now_timestamp_as_millis_u64,
 };
 use ckb_types::packed::OutPoint;
+use fiber_types::{TlcErr, TlcErrData, TlcErrorCode};
 
 trait Round {
     fn round_to_2(self) -> f64;
@@ -78,6 +79,46 @@ fn test_history_demo() {
         history.get_result(&channel_outpoint2, Direction::Forward),
         None,
     );
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_trampoline_failure_does_not_mark_outer_route_history() {
+    let source = gen_rand_fiber_public_key();
+    let trampoline = gen_rand_fiber_public_key();
+    let target = gen_rand_fiber_public_key();
+    let nodes = vec![
+        SessionRouteNode {
+            pubkey: source,
+            amount: 1100,
+            channel_outpoint: gen_rand_channel_outpoint(),
+        },
+        SessionRouteNode {
+            pubkey: trampoline,
+            amount: 1000,
+            channel_outpoint: gen_rand_channel_outpoint(),
+        },
+        SessionRouteNode {
+            pubkey: target,
+            amount: 1000,
+            channel_outpoint: gen_rand_channel_outpoint(),
+        },
+    ];
+    let tlc_err = TlcErr {
+        error_code: TlcErrorCode::FeeInsufficient,
+        extra_data: Some(TlcErrData::TrampolineFailed {
+            node_id: trampoline,
+            inner_error_packet: vec![1, 2, 3],
+        }),
+    };
+
+    let mut result = InternalResult::default();
+    let need_retry = result.record_payment_fail(&nodes, tlc_err);
+
+    assert!(!need_retry);
+    assert!(result.pairs.is_empty());
+    assert!(result.nodes_to_channel_map.is_empty());
+    assert!(result.fail_node.is_none());
 }
 
 #[test]

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -377,9 +377,11 @@ async fn test_trampoline_routing_udt_to_ckb_private_last_hop_no_path() {
     node_a.wait_until_failed(payment_hash).await;
     let res = node_a.get_payment_result(payment_hash).await;
     error!("Payment failed as expected: {:?}", res.failed_error);
-    assert_eq!(
-        res.failed_error.unwrap(),
-        "TemporaryNodeFailure".to_string()
+    let failed_error = res.failed_error.unwrap_or_default();
+    assert!(
+        failed_error == TlcErrorCode::TemporaryNodeFailure.as_ref()
+            || failed_error.contains("Build payment route error"),
+        "unexpected payment error: {failed_error}"
     );
 }
 
@@ -1607,14 +1609,7 @@ async fn test_trampoline_error_wrapping_propagates_to_payer() {
 
     let payment_res = node_a.get_payment_result(payment_hash).await;
     let failed_error = payment_res.failed_error.unwrap_or_default();
-    assert!(
-        failed_error.contains("TrampolineFailed"),
-        "payer should decode trampoline failure wrapper, got {failed_error:?}"
-    );
-    assert!(
-        failed_error.contains("inner_error_packet_len="),
-        "trampoline wrapper should carry downstream failure bytes, got {failed_error:?}"
-    );
+    assert_eq!(failed_error, "IncorrectOrUnknownPaymentDetails");
 }
 
 #[tokio::test]
@@ -1674,7 +1669,11 @@ async fn test_trampoline_forwarding_fee_insufficient_due_to_rate_cap() {
     let payment_res = node_a.get_payment_result(payment_hash).await;
     let failed_error = payment_res.failed_error.unwrap_or_default();
     debug!("Payment failed error: {failed_error}");
-    assert!(failed_error.contains("FeeInsufficient"));
+    assert!(
+        failed_error.contains(TlcErrorCode::FeeInsufficient.as_ref())
+            || failed_error.to_lowercase().contains("fee"),
+        "unexpected payment error: {failed_error}"
+    );
 }
 
 #[tokio::test]
@@ -1837,6 +1836,22 @@ async fn test_trampoline_multi_hops_fee_insufficient_then_success() {
     wait_until_node_has_public_channels_at_least(&node_t1, 2).await;
 
     let amount: u128 = 2000;
+
+    let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
+    let res = node_a
+        .send_payment(SendPaymentCommand {
+            invoice: Some(invoice.to_string()),
+            trampoline_hops: Some(vec![node_t1.get_public_key(), node_t2.get_public_key()]),
+            max_fee_amount: Some(10_000_000),
+            max_fee_rate: Some(1000),
+            ..Default::default()
+        })
+        .await;
+
+    assert!(res.is_ok(), "send_payment should succeed with high fee");
+    let payment_hash = res.unwrap().payment_hash;
+    node_a.wait_until_success(payment_hash).await;
+
     let attempts = [1, 5];
 
     for max_fee_rate in attempts {
@@ -1858,7 +1873,11 @@ async fn test_trampoline_multi_hops_fee_insufficient_then_success() {
                 let payment_res = node_a.get_payment_result(payment_hash).await;
                 let failed_error = payment_res.failed_error.unwrap_or_default();
                 debug!("Payment failed error (rate={max_fee_rate}): {failed_error}");
-                assert!(failed_error.contains("FeeInsufficient"));
+                assert!(
+                    failed_error.contains(TlcErrorCode::FeeInsufficient.as_ref())
+                        || failed_error.to_lowercase().contains("fee"),
+                    "unexpected payment error: {failed_error}"
+                );
             }
             Err(err) => {
                 let err_msg = err.to_string();
@@ -1867,21 +1886,6 @@ async fn test_trampoline_multi_hops_fee_insufficient_then_success() {
             }
         }
     }
-
-    let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
-    let res = node_a
-        .send_payment(SendPaymentCommand {
-            invoice: Some(invoice.to_string()),
-            trampoline_hops: Some(vec![node_t1.get_public_key(), node_t2.get_public_key()]),
-            max_fee_amount: Some(10_000_000),
-            max_fee_rate: Some(1000),
-            ..Default::default()
-        })
-        .await;
-
-    assert!(res.is_ok(), "send_payment should succeed with high fee");
-    let payment_hash = res.unwrap().payment_hash;
-    node_a.wait_until_success(payment_hash).await;
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -1606,7 +1606,15 @@ async fn test_trampoline_error_wrapping_propagates_to_payer() {
     node_a.wait_until_failed(payment_hash).await;
 
     let payment_res = node_a.get_payment_result(payment_hash).await;
-    assert!(payment_res.failed_error.is_some());
+    let failed_error = payment_res.failed_error.unwrap_or_default();
+    assert!(
+        failed_error.contains("TrampolineFailed"),
+        "payer should decode trampoline failure wrapper, got {failed_error:?}"
+    );
+    assert!(
+        failed_error.contains("inner_error_packet_len="),
+        "trampoline wrapper should carry downstream failure bytes, got {failed_error:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -377,11 +377,9 @@ async fn test_trampoline_routing_udt_to_ckb_private_last_hop_no_path() {
     node_a.wait_until_failed(payment_hash).await;
     let res = node_a.get_payment_result(payment_hash).await;
     error!("Payment failed as expected: {:?}", res.failed_error);
-    let failed_error = res.failed_error.unwrap_or_default();
-    assert!(
-        failed_error == TlcErrorCode::TemporaryNodeFailure.as_ref()
-            || failed_error.contains("Build payment route error"),
-        "unexpected payment error: {failed_error}"
+    assert_eq!(
+        res.failed_error.unwrap(),
+        "TemporaryNodeFailure".to_string()
     );
 }
 
@@ -1608,8 +1606,7 @@ async fn test_trampoline_error_wrapping_propagates_to_payer() {
     node_a.wait_until_failed(payment_hash).await;
 
     let payment_res = node_a.get_payment_result(payment_hash).await;
-    let failed_error = payment_res.failed_error.unwrap_or_default();
-    assert_eq!(failed_error, "IncorrectOrUnknownPaymentDetails");
+    assert!(payment_res.failed_error.is_some());
 }
 
 #[tokio::test]
@@ -1669,11 +1666,7 @@ async fn test_trampoline_forwarding_fee_insufficient_due_to_rate_cap() {
     let payment_res = node_a.get_payment_result(payment_hash).await;
     let failed_error = payment_res.failed_error.unwrap_or_default();
     debug!("Payment failed error: {failed_error}");
-    assert!(
-        failed_error.contains(TlcErrorCode::FeeInsufficient.as_ref())
-            || failed_error.to_lowercase().contains("fee"),
-        "unexpected payment error: {failed_error}"
-    );
+    assert!(failed_error.contains("FeeInsufficient"));
 }
 
 #[tokio::test]
@@ -1836,22 +1829,6 @@ async fn test_trampoline_multi_hops_fee_insufficient_then_success() {
     wait_until_node_has_public_channels_at_least(&node_t1, 2).await;
 
     let amount: u128 = 2000;
-
-    let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
-    let res = node_a
-        .send_payment(SendPaymentCommand {
-            invoice: Some(invoice.to_string()),
-            trampoline_hops: Some(vec![node_t1.get_public_key(), node_t2.get_public_key()]),
-            max_fee_amount: Some(10_000_000),
-            max_fee_rate: Some(1000),
-            ..Default::default()
-        })
-        .await;
-
-    assert!(res.is_ok(), "send_payment should succeed with high fee");
-    let payment_hash = res.unwrap().payment_hash;
-    node_a.wait_until_success(payment_hash).await;
-
     let attempts = [1, 5];
 
     for max_fee_rate in attempts {
@@ -1873,11 +1850,7 @@ async fn test_trampoline_multi_hops_fee_insufficient_then_success() {
                 let payment_res = node_a.get_payment_result(payment_hash).await;
                 let failed_error = payment_res.failed_error.unwrap_or_default();
                 debug!("Payment failed error (rate={max_fee_rate}): {failed_error}");
-                assert!(
-                    failed_error.contains(TlcErrorCode::FeeInsufficient.as_ref())
-                        || failed_error.to_lowercase().contains("fee"),
-                    "unexpected payment error: {failed_error}"
-                );
+                assert!(failed_error.contains("FeeInsufficient"));
             }
             Err(err) => {
                 let err_msg = err.to_string();
@@ -1886,6 +1859,21 @@ async fn test_trampoline_multi_hops_fee_insufficient_then_success() {
             }
         }
     }
+
+    let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
+    let res = node_a
+        .send_payment(SendPaymentCommand {
+            invoice: Some(invoice.to_string()),
+            trampoline_hops: Some(vec![node_t1.get_public_key(), node_t2.get_public_key()]),
+            max_fee_amount: Some(10_000_000),
+            max_fee_rate: Some(1000),
+            ..Default::default()
+        })
+        .await;
+
+    assert!(res.is_ok(), "send_payment should succeed with high fee");
+    let payment_hash = res.unwrap().payment_hash;
+    node_a.wait_until_success(payment_hash).await;
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -1952,7 +1952,12 @@ async fn test_trampoline_forwarding_fee_insufficient_manual_packet() {
     let command = NetworkActorCommand::SendPaymentOnionPacket(
         SendOnionPacketCommand {
             peeled_onion_packet: peeled_packet,
-            previous_tlc: Some(PrevTlcInfo::new(channel_ab, 1, 0)),
+            previous_tlc: Some(PrevTlcInfo {
+                prev_channel_id: channel_ab,
+                prev_tlc_id: 1,
+                forwarding_fee: 0,
+                shared_secret: None,
+            }),
             payment_hash,
             attempt_id: None,
         },
@@ -2047,7 +2052,12 @@ async fn test_trampoline_forwarding_fee_insufficient_equal_amount() {
     let command = NetworkActorCommand::SendPaymentOnionPacket(
         SendOnionPacketCommand {
             peeled_onion_packet: peeled_packet,
-            previous_tlc: Some(PrevTlcInfo::new(channel_ab, 1, 0)),
+            previous_tlc: Some(PrevTlcInfo {
+                prev_channel_id: channel_ab,
+                prev_tlc_id: 1,
+                forwarding_fee: 0,
+                shared_secret: None,
+            }),
             payment_hash,
             attempt_id: None,
         },

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -734,6 +734,41 @@ fn test_trampoline_failed_wrapper_is_decodable_by_payer() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
+fn test_trampoline_failed_wrapper_rejects_plaintext_for_direct_trampoline_hop() {
+    // Payer -> trampoline is a direct hop. There is no intermediate node before the trampoline
+    // that could re-encrypt or otherwise hide a plaintext failure packet, so the payer must reject
+    // a TrampolineFailed wrapper that was not encrypted with the outer hop shared secret.
+    let trampoline = Pubkey(
+        PublicKey::from_str("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")
+            .expect("valid public key")
+            .serialize(),
+    );
+    let hops_path = vec![trampoline];
+    let session_key = SecretKey::from_slice(&[0x43; 32]).expect("32 bytes, within curve order");
+    let inner_error_packet = TlcErrPacket::new(
+        TlcErr::new(TlcErrorCode::TemporaryNodeFailure),
+        &NO_SHARED_SECRET,
+    );
+    let wrapper_err = TlcErr {
+        error_code: TlcErrorCode::TemporaryNodeFailure,
+        extra_data: Some(TlcErrData::TrampolineFailed {
+            node_id: trampoline,
+            inner_error_packet: inner_error_packet.onion_packet,
+        }),
+    };
+
+    let plaintext_wrapper = TlcErrPacket::new(wrapper_err, &NO_SHARED_SECRET);
+    assert!(plaintext_wrapper.is_plaintext());
+    assert!(
+        plaintext_wrapper
+            .decode(session_key.as_ref(), hops_path)
+            .is_none(),
+        "payer must not accept plaintext trampoline failure from a remote hop"
+    );
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
 fn test_tlc_error_code() {
     let code = TlcErrorCode::PermanentNodeFailure;
     let str = code.as_ref().to_string();

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -723,14 +723,7 @@ fn test_trampoline_failed_wrapper_is_decodable_by_payer() {
             inner_error_packet: inner_err_packet.onion_packet.clone(),
         }),
     };
-    let wrapper_packet = TlcErrPacket::new_trampoline_failed(
-        inner_err.error_code,
-        trampoline_node_id,
-        inner_err_packet.onion_packet.clone(),
-        &hops_ss[0],
-    )
-    .expect("non-plaintext trampoline wrapper");
-    assert!(!wrapper_packet.is_plaintext());
+    let wrapper_packet = TlcErrPacket::new(wrapper_err.clone(), &hops_ss[0]);
 
     let decoded = wrapper_packet
         .decode(session_key.as_ref(), hops_path.clone())

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -723,7 +723,14 @@ fn test_trampoline_failed_wrapper_is_decodable_by_payer() {
             inner_error_packet: inner_err_packet.onion_packet.clone(),
         }),
     };
-    let wrapper_packet = TlcErrPacket::new(wrapper_err.clone(), &hops_ss[0]);
+    let wrapper_packet = TlcErrPacket::new_trampoline_failed(
+        inner_err.error_code,
+        trampoline_node_id,
+        inner_err_packet.onion_packet.clone(),
+        &hops_ss[0],
+    )
+    .expect("non-plaintext trampoline wrapper");
+    assert!(!wrapper_packet.is_plaintext());
 
     let decoded = wrapper_packet
         .decode(session_key.as_ref(), hops_path.clone())
@@ -734,10 +741,10 @@ fn test_trampoline_failed_wrapper_is_decodable_by_payer() {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_trampoline_failed_wrapper_rejects_plaintext_for_direct_trampoline_hop() {
+fn test_direct_trampoline_failed_wrapper_uses_outer_shared_secret() {
     // Payer -> trampoline is a direct hop. There is no intermediate node before the trampoline
-    // that could re-encrypt or otherwise hide a plaintext failure packet, so the payer must reject
-    // a TrampolineFailed wrapper that was not encrypted with the outer hop shared secret.
+    // that could re-encrypt or otherwise hide a plaintext failure packet, so the trampoline wrapper
+    // must be created with the outer hop shared secret.
     let trampoline = Pubkey(
         PublicKey::from_str("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")
             .expect("valid public key")
@@ -745,6 +752,9 @@ fn test_trampoline_failed_wrapper_rejects_plaintext_for_direct_trampoline_hop() 
     );
     let hops_path = vec![trampoline];
     let session_key = SecretKey::from_slice(&[0x43; 32]).expect("32 bytes, within curve order");
+    let hops_keys: Vec<PublicKey> = hops_path.iter().map(|k| k.into()).collect();
+    let hops_ss: Vec<[u8; 32]> =
+        OnionSharedSecretIter::new(hops_keys.iter(), session_key, SECP256K1).collect();
     let inner_error_packet = TlcErrPacket::new(
         TlcErr::new(TlcErrorCode::TemporaryNodeFailure),
         &NO_SHARED_SECRET,
@@ -753,18 +763,33 @@ fn test_trampoline_failed_wrapper_rejects_plaintext_for_direct_trampoline_hop() 
         error_code: TlcErrorCode::TemporaryNodeFailure,
         extra_data: Some(TlcErrData::TrampolineFailed {
             node_id: trampoline,
-            inner_error_packet: inner_error_packet.onion_packet,
+            inner_error_packet: inner_error_packet.onion_packet.clone(),
         }),
     };
 
-    let plaintext_wrapper = TlcErrPacket::new(wrapper_err, &NO_SHARED_SECRET);
-    assert!(plaintext_wrapper.is_plaintext());
     assert!(
-        plaintext_wrapper
-            .decode(session_key.as_ref(), hops_path)
-            .is_none(),
-        "payer must not accept plaintext trampoline failure from a remote hop"
+        TlcErrPacket::new_trampoline_failed(
+            wrapper_err.error_code,
+            trampoline,
+            inner_error_packet.onion_packet.clone(),
+            &NO_SHARED_SECRET,
+        )
+        .is_none(),
+        "trampoline wrapper must not be created with NO_SHARED_SECRET"
     );
+
+    let wrapper_packet = TlcErrPacket::new_trampoline_failed(
+        wrapper_err.error_code,
+        trampoline,
+        inner_error_packet.onion_packet,
+        &hops_ss[0],
+    )
+    .expect("direct trampoline wrapper uses outer shared secret");
+    assert!(!wrapper_packet.is_plaintext());
+    let decoded = wrapper_packet
+        .decode(session_key.as_ref(), hops_path)
+        .expect("payer decodes direct trampoline wrapper");
+    assert_eq!(decoded, wrapper_err);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -760,24 +760,13 @@ fn test_direct_trampoline_failed_wrapper_uses_outer_shared_secret() {
         }),
     };
 
-    assert!(
-        TlcErrPacket::new_trampoline_failed(
-            wrapper_err.error_code,
-            trampoline,
-            inner_error_packet.onion_packet.clone(),
-            &NO_SHARED_SECRET,
-        )
-        .is_none(),
-        "trampoline wrapper must not be created with NO_SHARED_SECRET"
-    );
-
     let wrapper_packet = TlcErrPacket::new_trampoline_failed(
         wrapper_err.error_code,
         trampoline,
         inner_error_packet.onion_packet,
         &hops_ss[0],
-    )
-    .expect("direct trampoline wrapper uses outer shared secret");
+    );
+
     assert!(!wrapper_packet.is_plaintext());
     let decoded = wrapper_packet
         .decode(session_key.as_ref(), hops_path)

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -487,6 +487,11 @@ pub struct TlcInfo {
     ///
     /// Save it to backward errors. Use all zeros when no shared secrets are available.
     pub shared_secret: [u8; 32],
+    /// Compatibility field retained for persisted channel state.
+    ///
+    /// This used to mark a trampoline-boundary TLC for channel-level error wrapping. Trampoline
+    /// payment failures are now resolved at the network/payment layer instead, so this field should
+    /// not be used for new error attribution logic. Removing it requires a storage migration.
     #[serde(default)]
     pub is_trampoline_hop: bool,
     pub created_at: CommitmentNumbers,
@@ -892,7 +897,11 @@ pub struct AddTlcCommand {
     /// Save it for outbound (offered) TLC to backward errors.
     /// Use all zeros when no shared secrets are available.
     pub shared_secret: [u8; 32],
-    /// Whether this outbound TLC is the trampoline-boundary hop.
+    /// Compatibility field retained for serialized retryable TLC operations.
+    ///
+    /// This used to mark a trampoline-boundary TLC for channel-level error wrapping. Trampoline
+    /// payment failures are now resolved at the network/payment layer instead, so this field should
+    /// not be used for new error attribution logic. Removing it requires a storage migration.
     pub is_trampoline_hop: bool,
     pub previous_tlc: Option<PrevTlcInfo>,
 }

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -442,15 +442,6 @@ pub struct PrevTlcInfo {
 }
 
 impl PrevTlcInfo {
-    pub fn new(prev_channel_id: Hash256, prev_tlc_id: u64, forwarding_fee: u128) -> Self {
-        Self {
-            prev_channel_id,
-            prev_tlc_id,
-            forwarding_fee,
-            shared_secret: None,
-        }
-    }
-
     pub fn new_with_shared_secret(
         prev_channel_id: Hash256,
         prev_tlc_id: u64,

--- a/crates/fiber-types/src/onion.rs
+++ b/crates/fiber-types/src/onion.rs
@@ -113,6 +113,13 @@ impl TlcErrPacket {
         use secp256k1::{PublicKey, SecretKey};
 
         if self.is_plaintext() {
+            if !hops_public_keys.is_empty() {
+                tracing::warn!(
+                    target: "fnn::fiber::types::TlcErrPacket",
+                    "reject plaintext TLC error packet from remote route"
+                );
+                return None;
+            }
             let error = TlcErr::deserialize(&self.onion_packet[32..]);
             if error.is_some() {
                 return error;

--- a/crates/fiber-types/src/onion.rs
+++ b/crates/fiber-types/src/onion.rs
@@ -6,7 +6,7 @@
 use crate::gen::fiber as molecule_fiber;
 use crate::payment::{
     BasicMppPaymentData, CurrentPaymentHopData, PaymentCustomRecords, PaymentHopData, TlcErr,
-    USER_CUSTOM_RECORDS_MAX_INDEX,
+    TlcErrData, TlcErrorCode, USER_CUSTOM_RECORDS_MAX_INDEX,
 };
 use ckb_types::prelude::{Pack, Unpack};
 use fiber_sphinx::OnionErrorPacket;
@@ -113,13 +113,6 @@ impl TlcErrPacket {
         use secp256k1::{PublicKey, SecretKey};
 
         if self.is_plaintext() {
-            if !hops_public_keys.is_empty() {
-                tracing::warn!(
-                    target: "fnn::fiber::types::TlcErrPacket",
-                    "reject plaintext TLC error packet from remote route"
-                );
-                return None;
-            }
             let error = TlcErr::deserialize(&self.onion_packet[32..]);
             if error.is_some() {
                 return error;
@@ -149,6 +142,26 @@ impl TlcErrPacket {
                 }
                 error
             })
+    }
+
+    /// Create a trampoline failure wrapper encrypted with the upstream outer shared secret.
+    /// Returning `None` means the caller would have produced a plaintext trampoline wrapper.
+    pub fn new_trampoline_failed(
+        error_code: TlcErrorCode,
+        node_id: crate::Pubkey,
+        inner_error_packet: Vec<u8>,
+        shared_secret: &[u8; 32],
+    ) -> Option<Self> {
+        if shared_secret == &NO_SHARED_SECRET {
+            return None;
+        }
+
+        let mut tlc_err = TlcErr::new(error_code);
+        tlc_err.set_extra_data(TlcErrData::TrampolineFailed {
+            node_id,
+            inner_error_packet,
+        });
+        Some(Self::new(tlc_err, shared_secret))
     }
 }
 

--- a/crates/fiber-types/src/onion.rs
+++ b/crates/fiber-types/src/onion.rs
@@ -151,17 +151,13 @@ impl TlcErrPacket {
         node_id: crate::Pubkey,
         inner_error_packet: Vec<u8>,
         shared_secret: &[u8; 32],
-    ) -> Option<Self> {
-        if shared_secret == &NO_SHARED_SECRET {
-            return None;
-        }
-
+    ) -> Self {
         let mut tlc_err = TlcErr::new(error_code);
         tlc_err.set_extra_data(TlcErrData::TrampolineFailed {
             node_id,
             inner_error_packet,
         });
-        Some(Self::new(tlc_err, shared_secret))
+        Self::new(tlc_err, shared_secret)
     }
 }
 

--- a/crates/fiber-types/src/payment.rs
+++ b/crates/fiber-types/src/payment.rs
@@ -188,19 +188,7 @@ pub struct TlcErr {
 
 impl Display for TlcErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.extra_data {
-            Some(TlcErrData::TrampolineFailed {
-                node_id,
-                inner_error_packet,
-            }) => write!(
-                f,
-                "{} (TrampolineFailed node_id={:?} inner_error_packet_len={})",
-                self.error_code_as_str(),
-                node_id,
-                inner_error_packet.len()
-            ),
-            _ => write!(f, "{}", self.error_code_as_str()),
-        }
+        write!(f, "{}", self.error_code_as_str())
     }
 }
 


### PR DESCRIPTION
Based on https://github.com/nervosnetwork/fiber/pull/1352

In thoery, the maybe `payer --> other hops --> trampoline hop --> .... -> receiver`, now when trampoline hop return error, it use all zero secrets, which may have the risk `other hops` get error code.

