### PR TITLE
Reject unsupported required peer features

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -1213,7 +1213,6 @@ where
                 }
             }
             FiberMessage::ChannelNormalOperation(msg) => {
-                state.check_feature_compatibility(&peer_pubkey)?;
                 let channel_id = msg.get_channel_id();
                 let mut found = state
                     .peer_channel_index

--- a/crates/fiber-lib/src/fiber/tests/features.rs
+++ b/crates/fiber-lib/src/fiber/tests/features.rs
@@ -189,6 +189,14 @@ fn test_feature_compatibility() {
     assert!(vector.compatible_with(&vector2));
     vector2.unset_gossip_queries_required();
     assert!(!vector.compatible_with(&vector2));
+
+    vector2.set_gossip_queries_optional();
+    vector2.set_feature(100);
+    assert!(!vector.compatible_with(&vector2));
+    vector2.unset_feature(100);
+    assert!(vector.compatible_with(&vector2));
+    vector2.set_feature(101);
+    assert!(vector.compatible_with(&vector2));
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/fiber-types/src/protocol.rs
+++ b/crates/fiber-types/src/protocol.rs
@@ -338,15 +338,15 @@ impl FeatureVector {
         self.is_set(bit) || self.is_set(bit ^ 1)
     }
 
-    pub fn compatible_with(&self, other: &Self) -> bool {
-        if self
-            .enabled_features()
+    fn has_unsupported_required_features(&self, other: &Self) -> bool {
+        self.enabled_features()
             .iter()
             .any(|&bit| self.requires_feature(bit) && !other.supports_feature(bit))
-        {
-            return false;
-        }
-        true
+    }
+
+    pub fn compatible_with(&self, other: &Self) -> bool {
+        !self.has_unsupported_required_features(other)
+            && !other.has_unsupported_required_features(self)
     }
 }
 


### PR DESCRIPTION
Both peer side will call `compatible_with`, but it's better to be more strict on each side.
