### PR TITLE
chore(deps): bump fiber-sphinx to 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,6 +2332,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiber-sphinx"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827476eed3d2915d79c9809e71a7089f44cde5d9a4fa7c7045cd0f2d5e56fb95"
+dependencies = [
+ "chacha20",
+ "hmac 0.12.1",
+ "secp256k1 0.30.0",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fiber-store"
 version = "0.9.0-rc2"
 dependencies = [
@@ -2367,7 +2380,7 @@ dependencies = [
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-sphinx",
+ "fiber-sphinx 2.3.0",
  "getrandom 0.2.17",
  "hex",
  "molecule",
@@ -2402,7 +2415,7 @@ dependencies = [
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-sphinx",
+ "fiber-sphinx 3.0.0",
  "getrandom 0.2.17",
  "hex",
  "lightning-invoice",
@@ -2439,7 +2452,7 @@ dependencies = [
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-sphinx",
+ "fiber-sphinx 2.3.0",
  "getrandom 0.2.17",
  "hex",
  "molecule",
@@ -2564,7 +2577,7 @@ dependencies = [
  "criterion",
  "either",
  "fiber-json-types",
- "fiber-sphinx",
+ "fiber-sphinx 3.0.0",
  "fiber-store",
  "fiber-types 0.9.0-rc2",
  "futures",

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -22,7 +22,7 @@ ckb-types = "1"
 clap = { version = "4.5.2", features = ["derive", "env", "string"] }
 clap-serde-derive = "0.2.1"
 either = "1.15.0"
-fiber-sphinx = "2.3"
+fiber-sphinx = "3"
 fiber-json-types = { path = "../fiber-json-types", features = ["all"] }
 fiber-store = { path = "../fiber-store", default-features = false }
 fiber-types = { path = "../fiber-types", features = ["cch", "watchtower"] }

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -13,15 +13,18 @@ use crate::fiber::fee::calculate_tlc_forward_fee;
 use crate::fiber::history::SentNode;
 use crate::fiber::key::KeyPair;
 use crate::fiber::path::NodeHeapElement;
-use crate::fiber::types::{TrampolineHopPayload, TrampolineOnionPacket};
+use crate::fiber::types::{
+    TrampolineHopPayload, TrampolineOnionPacket, ONION_SESSION_KEY_MAX_ATTEMPTS,
+};
 use crate::now_timestamp_as_millis_u64;
 use ckb_types::packed::{OutPoint, Script};
+use fiber_sphinx::SphinxError;
 use fiber_types::protocol::AnnouncedNodeName;
 pub use fiber_types::ChannelUpdateInfo;
 use fiber_types::{
     Attempt, BroadcastMessageID, ChannelAnnouncement, ChannelUpdate, Cursor, FeatureVector,
-    Hash256, HopHint, NodeAnnouncement, PaymentHopData, PaymentSession, PaymentStatus, Privkey,
-    Pubkey, RouterHop, SendPaymentData, TlcErr, UdtCfgInfos,
+    Hash256, HopHint, NodeAnnouncement, OnionPacketError, PaymentHopData, PaymentSession,
+    PaymentStatus, Privkey, Pubkey, RouterHop, SendPaymentData, TlcErr, UdtCfgInfos,
 };
 use parking_lot::Mutex;
 use rand::{thread_rng, Rng};
@@ -1474,19 +1477,45 @@ where
             custom_records: payment_data.custom_records.clone(),
         });
 
-        let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
         let mut trampoline_path: Vec<Pubkey> = hops.to_vec();
 
         trampoline_path.push(target);
-        let trampoline_onion = TrampolineOnionPacket::create(
-            session_key,
-            trampoline_path,
-            payloads,
-            Some(payment_data.payment_hash.as_ref().to_vec()),
-            SECP256K1,
-        )
-        .map_err(|_| PathFindError::NoPathFound)?
-        .into_bytes();
+        // Retry with a fresh session key on the cryptographically improbable
+        // `InvalidBlindingFactor` event from fiber-sphinx.
+        let mut trampoline_onion: Option<Vec<u8>> = None;
+        let mut last_blinding_err: Option<SphinxError> = None;
+        for _ in 0..ONION_SESSION_KEY_MAX_ATTEMPTS {
+            let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
+            match TrampolineOnionPacket::create(
+                session_key,
+                trampoline_path.clone(),
+                payloads.clone(),
+                Some(payment_data.payment_hash.as_ref().to_vec()),
+                SECP256K1,
+            ) {
+                Ok(packet) => {
+                    trampoline_onion = Some(packet.into_bytes());
+                    break;
+                }
+                Err(crate::fiber::types::Error::OnionPacket(OnionPacketError::Sphinx(
+                    err @ SphinxError::InvalidBlindingFactor,
+                ))) => {
+                    last_blinding_err = Some(err);
+                    continue;
+                }
+                Err(err) => {
+                    return Err(PathFindError::Other(format!(
+                        "failed to build trampoline onion packet: {err}"
+                    )));
+                }
+            }
+        }
+        let trampoline_onion = trampoline_onion.ok_or_else(|| {
+            PathFindError::Other(format!(
+                "failed to build trampoline onion packet after {ONION_SESSION_KEY_MAX_ATTEMPTS} attempts: {}",
+                last_blinding_err.expect("loop exits via Ok or sets last_blinding_err")
+            ))
+        })?;
 
         return Ok(ResolvedRoute {
             hops: route_to_trampoline,

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -13,18 +13,15 @@ use crate::fiber::fee::calculate_tlc_forward_fee;
 use crate::fiber::history::SentNode;
 use crate::fiber::key::KeyPair;
 use crate::fiber::path::NodeHeapElement;
-use crate::fiber::types::{
-    TrampolineHopPayload, TrampolineOnionPacket, ONION_SESSION_KEY_MAX_ATTEMPTS,
-};
+use crate::fiber::types::{TrampolineHopPayload, TrampolineOnionPacket};
 use crate::now_timestamp_as_millis_u64;
 use ckb_types::packed::{OutPoint, Script};
-use fiber_sphinx::SphinxError;
 use fiber_types::protocol::AnnouncedNodeName;
 pub use fiber_types::ChannelUpdateInfo;
 use fiber_types::{
     Attempt, BroadcastMessageID, ChannelAnnouncement, ChannelUpdate, Cursor, FeatureVector,
-    Hash256, HopHint, NodeAnnouncement, OnionPacketError, PaymentHopData, PaymentSession,
-    PaymentStatus, Privkey, Pubkey, RouterHop, SendPaymentData, TlcErr, UdtCfgInfos,
+    Hash256, HopHint, NodeAnnouncement, PaymentHopData, PaymentSession, PaymentStatus, Privkey,
+    Pubkey, RouterHop, SendPaymentData, TlcErr, UdtCfgInfos,
 };
 use parking_lot::Mutex;
 use rand::{thread_rng, Rng};
@@ -1480,40 +1477,17 @@ where
         let mut trampoline_path: Vec<Pubkey> = hops.to_vec();
 
         trampoline_path.push(target);
-        // Retry with a fresh session key on the cryptographically improbable
-        // `InvalidBlindingFactor` event from fiber-sphinx.
-        let mut trampoline_onion: Option<Vec<u8>> = None;
-        let mut last_blinding_err: Option<SphinxError> = None;
-        for _ in 0..ONION_SESSION_KEY_MAX_ATTEMPTS {
-            let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
-            match TrampolineOnionPacket::create(
-                session_key,
-                trampoline_path.clone(),
-                payloads.clone(),
-                Some(payment_data.payment_hash.as_ref().to_vec()),
-                SECP256K1,
-            ) {
-                Ok(packet) => {
-                    trampoline_onion = Some(packet.into_bytes());
-                    break;
-                }
-                Err(OnionPacketError::Sphinx(err @ SphinxError::InvalidBlindingFactor)) => {
-                    last_blinding_err = Some(err);
-                    continue;
-                }
-                Err(err) => {
-                    return Err(PathFindError::Other(format!(
-                        "failed to build trampoline onion packet: {err}"
-                    )));
-                }
-            }
-        }
-        let trampoline_onion = trampoline_onion.ok_or_else(|| {
-            PathFindError::Other(format!(
-                "failed to build trampoline onion packet after {ONION_SESSION_KEY_MAX_ATTEMPTS} attempts: {}",
-                last_blinding_err.expect("loop exits via Ok or sets last_blinding_err")
-            ))
+        let (trampoline_packet, _session_key) = TrampolineOnionPacket::create_with_session_key_fn(
+            || Privkey::from_slice(KeyPair::generate_random_key().as_ref()),
+            trampoline_path,
+            payloads,
+            Some(payment_data.payment_hash.as_ref().to_vec()),
+            SECP256K1,
+        )
+        .map_err(|err| {
+            PathFindError::Other(format!("failed to build trampoline onion packet: {err}"))
         })?;
+        let trampoline_onion = trampoline_packet.into_bytes();
 
         return Ok(ResolvedRoute {
             hops: route_to_trampoline,

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1497,9 +1497,7 @@ where
                     trampoline_onion = Some(packet.into_bytes());
                     break;
                 }
-                Err(crate::fiber::types::Error::OnionPacket(OnionPacketError::Sphinx(
-                    err @ SphinxError::InvalidBlindingFactor,
-                ))) => {
+                Err(OnionPacketError::Sphinx(err @ SphinxError::InvalidBlindingFactor)) => {
                     last_blinding_err = Some(err);
                     continue;
                 }

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use super::network::{SendOnionPacketCommand, SendPaymentResponse, ASSUME_NETWORK_MYSELF_ALIVE};
 use super::types::BroadcastMessageWithTimestamp;
+use super::types::ONION_SESSION_KEY_MAX_ATTEMPTS;
 use crate::fiber::channel::{ChannelActorStateStore, ProcessingChannelError};
 use crate::fiber::config::{
     DEFAULT_FINAL_TLC_EXPIRY_DELTA, MAX_PAYMENT_TLC_EXPIRY_LIMIT, MIN_TLC_EXPIRY_DELTA,
@@ -26,13 +27,14 @@ use crate::Error;
 use crate::{debug_event, now_timestamp_as_millis_u64};
 use ckb_hash::blake2b_256;
 use ckb_types::packed::{OutPoint, Script};
+use fiber_sphinx::SphinxError;
 pub use fiber_types::PaymentSession;
 pub use fiber_types::SendPaymentData;
 use fiber_types::{
-    Attempt, BasicMppPaymentData, EntityHex, Hash256, HashAlgorithm, HopHint, PaymentCustomRecords,
-    PaymentHopData, PaymentStatus, PeeledPaymentOnionPacket, Privkey, Pubkey, RemoveTlcReason,
-    RouterHop, TlcErr, TlcErrData, TlcErrorCode, TrampolineContext, DEFAULT_MAX_PARTS,
-    DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT, USER_CUSTOM_RECORDS_MAX_INDEX,
+    Attempt, BasicMppPaymentData, EntityHex, Hash256, HashAlgorithm, HopHint, OnionPacketError,
+    PaymentCustomRecords, PaymentHopData, PaymentStatus, PeeledPaymentOnionPacket, Privkey, Pubkey,
+    RemoveTlcReason, RouterHop, TlcErr, TlcErrData, TlcErrorCode, TrampolineContext,
+    DEFAULT_MAX_PARTS, DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT, USER_CUSTOM_RECORDS_MAX_INDEX,
 };
 use ractor::{call_t, Actor, ActorProcessingErr};
 use ractor::{concurrency::Duration, ActorRef, RpcReplyPort};
@@ -1394,19 +1396,44 @@ where
         session: &mut PaymentSession,
         attempt: &mut Attempt,
     ) -> Result<(), Error> {
-        let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
         assert_ne!(attempt.route_hops[0].funding_tx_hash, Hash256::default());
 
-        attempt.session_key.copy_from_slice(session_key.as_ref());
-
-        let peeled_onion_packet = match PeeledPaymentOnionPacket::create(
-            session_key,
-            attempt.route_hops.clone(),
-            Some(attempt.hash.as_ref().to_vec()),
-            &Secp256k1::signing_only(),
-        ) {
-            Ok(packet) => packet,
-            Err(e) => {
+        // Retry with a fresh session key on the cryptographically improbable
+        // `InvalidBlindingFactor` event from fiber-sphinx.
+        let mut peeled_onion_packet: Option<PeeledPaymentOnionPacket> = None;
+        let mut last_err: Option<OnionPacketError> = None;
+        let mut chosen_session_key: Option<Privkey> = None;
+        for _ in 0..ONION_SESSION_KEY_MAX_ATTEMPTS {
+            let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
+            match PeeledPaymentOnionPacket::create(
+                session_key.clone(),
+                attempt.route_hops.clone(),
+                Some(attempt.hash.as_ref().to_vec()),
+                &Secp256k1::signing_only(),
+            ) {
+                Ok(packet) => {
+                    chosen_session_key = Some(session_key);
+                    peeled_onion_packet = Some(packet);
+                    break;
+                }
+                Err(OnionPacketError::Sphinx(SphinxError::InvalidBlindingFactor)) => {
+                    // Pick a different session key and retry.
+                    continue;
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    break;
+                }
+            }
+        }
+        let peeled_onion_packet = match (peeled_onion_packet, chosen_session_key) {
+            (Some(packet), Some(session_key)) => {
+                attempt.session_key.copy_from_slice(session_key.as_ref());
+                packet
+            }
+            _ => {
+                let e = last_err
+                    .unwrap_or(OnionPacketError::Sphinx(SphinxError::InvalidBlindingFactor));
                 let err = format!(
                     "Failed to create onion packet: {:?}, error: {:?}",
                     attempt.hash, e

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use super::network::{SendOnionPacketCommand, SendPaymentResponse, ASSUME_NETWORK_MYSELF_ALIVE};
 use super::types::BroadcastMessageWithTimestamp;
-use super::types::ONION_SESSION_KEY_MAX_ATTEMPTS;
 use crate::fiber::channel::{ChannelActorStateStore, ProcessingChannelError};
 use crate::fiber::config::{
     DEFAULT_FINAL_TLC_EXPIRY_DELTA, MAX_PAYMENT_TLC_EXPIRY_LIMIT, MIN_TLC_EXPIRY_DELTA,
@@ -27,14 +26,13 @@ use crate::Error;
 use crate::{debug_event, now_timestamp_as_millis_u64};
 use ckb_hash::blake2b_256;
 use ckb_types::packed::{OutPoint, Script};
-use fiber_sphinx::SphinxError;
 pub use fiber_types::PaymentSession;
 pub use fiber_types::SendPaymentData;
 use fiber_types::{
-    Attempt, BasicMppPaymentData, EntityHex, Hash256, HashAlgorithm, HopHint, OnionPacketError,
-    PaymentCustomRecords, PaymentHopData, PaymentStatus, PeeledPaymentOnionPacket, Privkey, Pubkey,
-    RemoveTlcReason, RouterHop, TlcErr, TlcErrData, TlcErrorCode, TrampolineContext,
-    DEFAULT_MAX_PARTS, DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT, USER_CUSTOM_RECORDS_MAX_INDEX,
+    Attempt, BasicMppPaymentData, EntityHex, Hash256, HashAlgorithm, HopHint, PaymentCustomRecords,
+    PaymentHopData, PaymentStatus, PeeledPaymentOnionPacket, Privkey, Pubkey, RemoveTlcReason,
+    RouterHop, TlcErr, TlcErrData, TlcErrorCode, TrampolineContext, DEFAULT_MAX_PARTS,
+    DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT, USER_CUSTOM_RECORDS_MAX_INDEX,
 };
 use ractor::{call_t, Actor, ActorProcessingErr};
 use ractor::{concurrency::Duration, ActorRef, RpcReplyPort};
@@ -1398,42 +1396,17 @@ where
     ) -> Result<(), Error> {
         assert_ne!(attempt.route_hops[0].funding_tx_hash, Hash256::default());
 
-        // Retry with a fresh session key on the cryptographically improbable
-        // `InvalidBlindingFactor` event from fiber-sphinx.
-        let mut peeled_onion_packet: Option<PeeledPaymentOnionPacket> = None;
-        let mut last_err: Option<OnionPacketError> = None;
-        let mut chosen_session_key: Option<Privkey> = None;
-        for _ in 0..ONION_SESSION_KEY_MAX_ATTEMPTS {
-            let session_key = Privkey::from_slice(KeyPair::generate_random_key().as_ref());
-            match PeeledPaymentOnionPacket::create(
-                session_key.clone(),
-                attempt.route_hops.clone(),
-                Some(attempt.hash.as_ref().to_vec()),
-                &Secp256k1::signing_only(),
-            ) {
-                Ok(packet) => {
-                    chosen_session_key = Some(session_key);
-                    peeled_onion_packet = Some(packet);
-                    break;
-                }
-                Err(OnionPacketError::Sphinx(SphinxError::InvalidBlindingFactor)) => {
-                    // Pick a different session key and retry.
-                    continue;
-                }
-                Err(e) => {
-                    last_err = Some(e);
-                    break;
-                }
-            }
-        }
-        let peeled_onion_packet = match (peeled_onion_packet, chosen_session_key) {
-            (Some(packet), Some(session_key)) => {
+        let peeled_onion_packet = match PeeledPaymentOnionPacket::create_with_session_key_fn(
+            || Privkey::from_slice(KeyPair::generate_random_key().as_ref()),
+            attempt.route_hops.clone(),
+            Some(attempt.hash.as_ref().to_vec()),
+            &Secp256k1::signing_only(),
+        ) {
+            Ok((packet, session_key)) => {
                 attempt.session_key.copy_from_slice(session_key.as_ref());
                 packet
             }
-            _ => {
-                let e = last_err
-                    .unwrap_or(OnionPacketError::Sphinx(SphinxError::InvalidBlindingFactor));
+            Err(e) => {
                 let err = format!(
                     "Failed to create onion packet: {:?}, error: {:?}",
                     attempt.hash, e

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -665,7 +665,9 @@ fn test_tlc_err_packet_encryption() {
         .map(|k| PublicKey::from_slice(&k.0).expect("valid pubkey"))
         .collect();
     let hops_ss: Vec<[u8; 32]> =
-        OnionSharedSecretIter::new(hops_pubkeys.iter(), session_key, SECP256K1).collect();
+        OnionSharedSecretIter::new(hops_pubkeys.iter(), session_key, SECP256K1)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("valid blinding factors for hard-coded session key");
 
     let tlc_fail_detail = TlcErr::new(TlcErrorCode::InvalidOnionVersion);
     {
@@ -708,7 +710,9 @@ fn test_trampoline_failed_wrapper_is_decodable_by_payer() {
     let session_key = SecretKey::from_slice(&[0x42; 32]).expect("32 bytes, within curve order");
     let hops_keys: Vec<PublicKey> = hops_path.iter().map(|k| k.into()).collect();
     let hops_ss: Vec<[u8; 32]> =
-        OnionSharedSecretIter::new(hops_keys.iter(), session_key, SECP256K1).collect();
+        OnionSharedSecretIter::new(hops_keys.iter(), session_key, SECP256K1)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("valid blinding factors for hard-coded session key");
 
     // Pretend the downstream error originated beyond the trampoline boundary.
     let inner_err = TlcErr::new(TlcErrorCode::IncorrectOrUnknownPaymentDetails);

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -18,7 +18,7 @@ pub use fiber_types::{
     NodeAnnouncement, OnionPacketError, PartialSignatureAsBytes, PaymentCustomRecords,
     PaymentOnionPacket, PeeledPaymentOnionPacket, Privkey, PubNonceAsBytes, Pubkey, RemoveTlc,
     RemoveTlcReason, RevokeAndAck, TlcErr, UnknownHashAlgorithmError, CURSOR_SIZE,
-    ONION_PACKET_VERSION_V1,
+    ONION_PACKET_VERSION_V1, ONION_SESSION_KEY_MAX_ATTEMPTS,
 };
 
 use molecule::prelude::{Builder, Byte, Entity};
@@ -1858,15 +1858,6 @@ pub struct PeeledTrampolineOnionPacket {
 
 const TRAMPOLINE_PACKET_DATA_LEN: usize = 1300;
 
-/// Maximum number of times to retry generating an onion packet with a fresh
-/// session key when fiber-sphinx returns [`SphinxError::InvalidBlindingFactor`].
-///
-/// This event occurs when the SHA-256 derived blinding factor reduces to zero
-/// modulo the secp256k1 curve order. It is cryptographically improbable
-/// (probability ≈ 2⁻¹²⁸ per attempt), so 7 retries is effectively unreachable
-/// in practice while bounding the loop.
-pub const ONION_SESSION_KEY_MAX_ATTEMPTS: usize = 7;
-
 struct TrampolineSphinxCodec;
 
 impl fiber_types::onion::SphinxOnionCodec for TrampolineSphinxCodec {
@@ -1965,6 +1956,32 @@ impl TrampolineOnionPacket {
             secp_ctx,
         )?;
         Ok(TrampolineOnionPacket::new(bytes))
+    }
+
+    /// Like [`Self::create`], but obtains the session key from `gen_session_key`.
+    ///
+    /// Retries on the cryptographically improbable
+    /// [`fiber_sphinx::SphinxError::InvalidBlindingFactor`] event up to
+    /// [`ONION_SESSION_KEY_MAX_ATTEMPTS`] times. Returns the chosen session key
+    /// alongside the packet on success.
+    pub fn create_with_session_key_fn<C, F>(
+        gen_session_key: F,
+        hops_path: Vec<Pubkey>,
+        payloads: Vec<TrampolineHopPayload>,
+        assoc_data: Option<Vec<u8>>,
+        secp_ctx: &Secp256k1<C>,
+    ) -> Result<(Self, Privkey), OnionPacketError>
+    where
+        C: Signing,
+        F: FnMut() -> Privkey,
+    {
+        let (bytes, session_key) =
+            fiber_types::onion::create_sphinx_onion_with_session_key_fn::<
+                C,
+                TrampolineSphinxCodec,
+                _,
+            >(gen_session_key, hops_path, payloads, assoc_data, secp_ctx)?;
+        Ok((TrampolineOnionPacket::new(bytes), session_key))
     }
 }
 

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -8,7 +8,6 @@ use ckb_types::{
     prelude::{Pack, Unpack},
 };
 use core::fmt::{self, Formatter};
-use fiber_sphinx::SphinxError;
 use fiber_types::molecule_table_data_len;
 pub use fiber_types::{
     gen::fiber::{self as molecule_fiber, CustomRecordsOpt, PaymentPreimageOpt, PubNonceOpt},
@@ -25,7 +24,7 @@ pub use fiber_types::{
 use molecule::prelude::{Builder, Byte, Entity};
 use musig2::{PartialSignature, PubNonce};
 use secp256k1::Verification;
-use secp256k1::{PublicKey, Secp256k1, Signing};
+use secp256k1::{Secp256k1, Signing};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::convert::TryFrom;
@@ -1868,108 +1867,9 @@ const TRAMPOLINE_PACKET_DATA_LEN: usize = 1300;
 /// in practice while bounding the loop.
 pub const ONION_SESSION_KEY_MAX_ATTEMPTS: usize = 7;
 
-trait SphinxOnionCodec {
-    type Decoded;
-    type Current;
-
-    const PACKET_DATA_LEN: usize;
-    /// The onion packet version used when creating new packets.
-    const CURRENT_VERSION: u8;
-
-    /// Packs the decoded data for transmission. Must use `CURRENT_VERSION` format.
-    fn pack(decoded: &Self::Decoded) -> Vec<u8>;
-    /// Unpacks data received from the network. Must handle all versions allowed by `is_version_allowed`.
-    fn unpack(version: u8, buf: &[u8]) -> Option<Self::Decoded>;
-    fn to_current(decoded: Self::Decoded) -> Self::Current;
-    /// Returns true if the given version is allowed for this codec.
-    fn is_version_allowed(version: u8) -> bool;
-    /// Returns the total length of hop data (including any headers) for the specified version.
-    fn hop_data_len(version: u8, buf: &[u8]) -> Option<usize>;
-}
-
-struct SphinxPeeled<Current> {
-    current: Current,
-    shared_secret: [u8; 32],
-    next: Option<Vec<u8>>,
-}
-
-fn peel_sphinx_onion<C: Verification, Codec: SphinxOnionCodec>(
-    packet_bytes: Vec<u8>,
-    peeler: &Privkey,
-    assoc_data: Option<&[u8]>,
-    secp_ctx: &Secp256k1<C>,
-) -> Result<SphinxPeeled<Codec::Current>, Error> {
-    let sphinx_packet = fiber_sphinx::OnionPacket::from_bytes_with_packet_data_len(
-        packet_bytes,
-        Codec::PACKET_DATA_LEN,
-    )
-    .map_err(|err| Error::OnionPacket(err.into()))?;
-    let version = sphinx_packet.version;
-    if !Codec::is_version_allowed(version) {
-        return Err(Error::OnionPacket(OnionPacketError::UnknownVersion(
-            version,
-        )));
-    }
-    let shared_secret = sphinx_packet.shared_secret(&peeler.0);
-
-    let (new_current, new_next) = sphinx_packet
-        .peel(&peeler.0, assoc_data, secp_ctx, |buf| {
-            Codec::hop_data_len(version, buf)
-        })
-        .map_err(|err| Error::OnionPacket(err.into()))?;
-
-    let decoded = Codec::unpack(version, &new_current)
-        .ok_or_else(|| Error::OnionPacket(OnionPacketError::InvalidHopData))?;
-    let current = Codec::to_current(decoded);
-
-    // All zeros hmac indicates the last hop.
-    let next = new_next
-        .hmac
-        .iter()
-        .any(|b| *b != 0)
-        .then(|| new_next.into_bytes());
-
-    Ok(SphinxPeeled {
-        current,
-        shared_secret,
-        next,
-    })
-}
-
-fn create_sphinx_onion<C: Signing, Codec: SphinxOnionCodec>(
-    session_key: Privkey,
-    hops_path: Vec<Pubkey>,
-    payloads: Vec<Codec::Decoded>,
-    assoc_data: Option<Vec<u8>>,
-    secp_ctx: &Secp256k1<C>,
-) -> Result<Vec<u8>, Error> {
-    if hops_path.is_empty() {
-        return Err(Error::OnionPacket(SphinxError::HopsIsEmpty.into()));
-    }
-    if hops_path.len() != payloads.len() {
-        return Err(Error::OnionPacket(OnionPacketError::InvalidHopData));
-    }
-
-    let hops_path: Vec<PublicKey> = hops_path.into_iter().map(Into::into).collect();
-    let hops_data = payloads.iter().map(Codec::pack).collect();
-
-    let mut sphinx_packet = fiber_sphinx::OnionPacket::create(
-        session_key.into(),
-        hops_path,
-        hops_data,
-        assoc_data,
-        Codec::PACKET_DATA_LEN,
-        secp_ctx,
-    )
-    .map_err(|err| Error::OnionPacket(err.into()))?;
-    // Set the version to indicate which hop data format is used
-    sphinx_packet.version = Codec::CURRENT_VERSION;
-    Ok(sphinx_packet.into_bytes())
-}
-
 struct TrampolineSphinxCodec;
 
-impl SphinxOnionCodec for TrampolineSphinxCodec {
+impl fiber_types::onion::SphinxOnionCodec for TrampolineSphinxCodec {
     type Decoded = TrampolineHopPayload;
     type Current = TrampolineHopPayload;
 
@@ -2023,12 +1923,12 @@ impl TrampolineOnionPacket {
         self.data
     }
 
-    pub fn into_sphinx_onion_packet(self) -> Result<fiber_sphinx::OnionPacket, Error> {
+    pub fn into_sphinx_onion_packet(self) -> Result<fiber_sphinx::OnionPacket, OnionPacketError> {
         fiber_sphinx::OnionPacket::from_bytes_with_packet_data_len(
             self.data,
             TRAMPOLINE_PACKET_DATA_LEN,
         )
-        .map_err(|err| Error::OnionPacket(err.into()))
+        .map_err(OnionPacketError::Sphinx)
     }
 
     pub fn peel<C: Verification>(
@@ -2036,9 +1936,10 @@ impl TrampolineOnionPacket {
         peeler: &Privkey,
         assoc_data: Option<&[u8]>,
         secp_ctx: &Secp256k1<C>,
-    ) -> Result<PeeledTrampolineOnionPacket, Error> {
-        let peeled =
-            peel_sphinx_onion::<C, TrampolineSphinxCodec>(self.data, peeler, assoc_data, secp_ctx)?;
+    ) -> Result<PeeledTrampolineOnionPacket, OnionPacketError> {
+        let peeled = fiber_types::onion::peel_sphinx_onion::<C, TrampolineSphinxCodec>(
+            self.data, peeler, assoc_data, secp_ctx,
+        )?;
         Ok(PeeledTrampolineOnionPacket {
             current: peeled.current,
             next: peeled.next.map(TrampolineOnionPacket::new),
@@ -2055,17 +1956,15 @@ impl TrampolineOnionPacket {
         payloads: Vec<TrampolineHopPayload>,
         assoc_data: Option<Vec<u8>>,
         secp_ctx: &Secp256k1<C>,
-    ) -> Result<Self, Error> {
-        Ok(TrampolineOnionPacket::new(create_sphinx_onion::<
-            C,
-            TrampolineSphinxCodec,
-        >(
+    ) -> Result<Self, OnionPacketError> {
+        let bytes = fiber_types::onion::create_sphinx_onion::<C, TrampolineSphinxCodec>(
             session_key,
             hops_path,
             payloads,
             assoc_data,
             secp_ctx,
-        )?))
+        )?;
+        Ok(TrampolineOnionPacket::new(bytes))
     }
 }
 

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -1859,6 +1859,15 @@ pub struct PeeledTrampolineOnionPacket {
 
 const TRAMPOLINE_PACKET_DATA_LEN: usize = 1300;
 
+/// Maximum number of times to retry generating an onion packet with a fresh
+/// session key when fiber-sphinx returns [`SphinxError::InvalidBlindingFactor`].
+///
+/// This event occurs when the SHA-256 derived blinding factor reduces to zero
+/// modulo the secp256k1 curve order. It is cryptographically improbable
+/// (probability ≈ 2⁻¹²⁸ per attempt), so 7 retries is effectively unreachable
+/// in practice while bounding the loop.
+pub const ONION_SESSION_KEY_MAX_ATTEMPTS: usize = 7;
+
 trait SphinxOnionCodec {
     type Decoded;
     type Current;
@@ -1890,8 +1899,11 @@ fn peel_sphinx_onion<C: Verification, Codec: SphinxOnionCodec>(
     assoc_data: Option<&[u8]>,
     secp_ctx: &Secp256k1<C>,
 ) -> Result<SphinxPeeled<Codec::Current>, Error> {
-    let sphinx_packet = fiber_sphinx::OnionPacket::from_bytes(packet_bytes)
-        .map_err(|err| Error::OnionPacket(err.into()))?;
+    let sphinx_packet = fiber_sphinx::OnionPacket::from_bytes_with_packet_data_len(
+        packet_bytes,
+        Codec::PACKET_DATA_LEN,
+    )
+    .map_err(|err| Error::OnionPacket(err.into()))?;
     let version = sphinx_packet.version;
     if !Codec::is_version_allowed(version) {
         return Err(Error::OnionPacket(OnionPacketError::UnknownVersion(
@@ -2012,8 +2024,11 @@ impl TrampolineOnionPacket {
     }
 
     pub fn into_sphinx_onion_packet(self) -> Result<fiber_sphinx::OnionPacket, Error> {
-        fiber_sphinx::OnionPacket::from_bytes(self.data)
-            .map_err(|err| Error::OnionPacket(err.into()))
+        fiber_sphinx::OnionPacket::from_bytes_with_packet_data_len(
+            self.data,
+            TRAMPOLINE_PACKET_DATA_LEN,
+        )
+        .map_err(|err| Error::OnionPacket(err.into()))
     }
 
     pub fn peel<C: Verification>(

--- a/crates/fiber-types/Cargo.toml
+++ b/crates/fiber-types/Cargo.toml
@@ -31,7 +31,7 @@ lightning-invoice = { version = "0.33", optional = true }
 # Cryptography
 secp256k1 = { version = "0.30.0", features = ["serde", "recovery", "global-context", "rand"] }
 musig2 = { version = "0.2.4", features = ["secp256k1", "serde"] }
-fiber-sphinx = "2.3"
+fiber-sphinx = "3"
 
 # Macros
 paste = "1.0"

--- a/crates/fiber-types/src/onion.rs
+++ b/crates/fiber-types/src/onion.rs
@@ -193,7 +193,11 @@ impl PaymentOnionPacket {
 
     /// Convert into the raw Sphinx onion packet.
     pub fn into_sphinx_onion_packet(self) -> Result<fiber_sphinx::OnionPacket, OnionPacketError> {
-        fiber_sphinx::OnionPacket::from_bytes(self.data).map_err(OnionPacketError::Sphinx)
+        fiber_sphinx::OnionPacket::from_bytes_with_packet_data_len(
+            self.data,
+            PaymentSphinxCodec::PACKET_DATA_LEN,
+        )
+        .map_err(OnionPacketError::Sphinx)
     }
 
     /// Peels the next layer of the onion packet using the privkey of the current node.
@@ -330,8 +334,11 @@ pub fn peel_sphinx_onion<C: secp256k1::Verification, Codec: SphinxOnionCodec>(
     assoc_data: Option<&[u8]>,
     secp_ctx: &secp256k1::Secp256k1<C>,
 ) -> Result<SphinxPeeled<Codec::Current>, OnionPacketError> {
-    let sphinx_packet =
-        fiber_sphinx::OnionPacket::from_bytes(packet_bytes).map_err(OnionPacketError::Sphinx)?;
+    let sphinx_packet = fiber_sphinx::OnionPacket::from_bytes_with_packet_data_len(
+        packet_bytes,
+        Codec::PACKET_DATA_LEN,
+    )
+    .map_err(OnionPacketError::Sphinx)?;
     let version = sphinx_packet.version;
     if !Codec::is_version_allowed(version) {
         return Err(OnionPacketError::UnknownVersion(version));

--- a/crates/fiber-types/src/onion.rs
+++ b/crates/fiber-types/src/onion.rs
@@ -376,6 +376,15 @@ pub fn create_sphinx_onion<C: secp256k1::Signing, Codec: SphinxOnionCodec>(
     assoc_data: Option<Vec<u8>>,
     secp_ctx: &secp256k1::Secp256k1<C>,
 ) -> Result<Vec<u8>, OnionPacketError> {
+    if hops_path.is_empty() {
+        return Err(OnionPacketError::Sphinx(
+            fiber_sphinx::SphinxError::HopsIsEmpty,
+        ));
+    }
+    if hops_path.len() != payloads.len() {
+        return Err(OnionPacketError::InvalidHopData);
+    }
+
     let hops_path: Vec<secp256k1::PublicKey> = hops_path
         .into_iter()
         .map(|pk| secp256k1::PublicKey::from_slice(&pk.0).expect("valid public key"))

--- a/crates/fiber-types/src/onion.rs
+++ b/crates/fiber-types/src/onion.rs
@@ -36,6 +36,15 @@ pub struct TlcErrPacket {
 pub const NO_SHARED_SECRET: [u8; 32] = [0u8; 32];
 const NO_ERROR_PACKET_HMAC: [u8; 32] = [0u8; 32];
 
+/// Maximum number of times to retry generating an onion packet with a fresh
+/// session key when fiber-sphinx returns [`fiber_sphinx::SphinxError::InvalidBlindingFactor`].
+///
+/// This event occurs when the SHA-256 derived blinding factor reduces to zero
+/// modulo the secp256k1 curve order. It is cryptographically improbable
+/// (probability ≈ 2⁻¹²⁸ per attempt), so 7 retries is effectively unreachable
+/// in practice while bounding the loop.
+pub const ONION_SESSION_KEY_MAX_ATTEMPTS: usize = 7;
+
 impl TlcErrPacket {
     /// Create a new TlcErrPacket from raw payload bytes.
     /// Erring node creates the error packet using the shared secret used in forwarding onion packet.
@@ -248,28 +257,19 @@ impl PeeledPaymentOnionPacket {
             ));
         }
 
-        let hops_path: Vec<crate::Pubkey> = hops_infos
-            .iter()
-            .map(|h| h.next_hop())
-            .take_while(Option::is_some)
-            .map(|opt| opt.expect("must be some"))
-            .collect();
-
-        // Keep the original hop ordering for payloads.
+        let hops_path = peeled_payment_hops_path(&hops_infos);
         let current = hops_infos.remove(0);
         let payloads = hops_infos;
 
         let next = if !hops_path.is_empty() {
-            Some(PaymentOnionPacket::new(create_sphinx_onion::<
-                C,
-                PaymentSphinxCodec,
-            >(
+            let bytes = create_sphinx_onion::<C, PaymentSphinxCodec>(
                 session_key,
                 hops_path,
                 payloads,
                 assoc_data,
                 secp_ctx,
-            )?))
+            )?;
+            Some(PaymentOnionPacket::new(bytes))
         } else {
             None
         };
@@ -280,6 +280,61 @@ impl PeeledPaymentOnionPacket {
             // Use all zeros for the sender
             shared_secret: NO_SHARED_SECRET,
         })
+    }
+
+    /// Like [`Self::create`], but obtains the session key from `gen_session_key`.
+    ///
+    /// Retries with a fresh session key from `gen_session_key` on the
+    /// cryptographically improbable
+    /// [`fiber_sphinx::SphinxError::InvalidBlindingFactor`] event, up to
+    /// [`ONION_SESSION_KEY_MAX_ATTEMPTS`] times. Returns the chosen session key
+    /// alongside the packet on success so the caller can record which key was
+    /// used.
+    ///
+    /// Requires `hops_infos` to describe at least one downstream hop (so that
+    /// a sphinx onion is actually generated and a session key can be returned).
+    pub fn create_with_session_key_fn<C, F>(
+        gen_session_key: F,
+        mut hops_infos: Vec<PaymentHopData>,
+        assoc_data: Option<Vec<u8>>,
+        secp_ctx: &secp256k1::Secp256k1<C>,
+    ) -> Result<(Self, crate::Privkey), OnionPacketError>
+    where
+        C: secp256k1::Signing,
+        F: FnMut() -> crate::Privkey,
+    {
+        if hops_infos.is_empty() {
+            return Err(OnionPacketError::Sphinx(
+                fiber_sphinx::SphinxError::HopsIsEmpty,
+            ));
+        }
+
+        let hops_path = peeled_payment_hops_path(&hops_infos);
+        if hops_path.is_empty() {
+            return Err(OnionPacketError::Sphinx(
+                fiber_sphinx::SphinxError::HopsIsEmpty,
+            ));
+        }
+        let current = hops_infos.remove(0);
+        let payloads = hops_infos;
+
+        let (bytes, session_key) = create_sphinx_onion_with_session_key_fn::<
+            C,
+            PaymentSphinxCodec,
+            _,
+        >(
+            gen_session_key, hops_path, payloads, assoc_data, secp_ctx
+        )?;
+
+        Ok((
+            PeeledPaymentOnionPacket {
+                current: current.into(),
+                next: Some(PaymentOnionPacket::new(bytes)),
+                // Use all zeros for the sender
+                shared_secret: NO_SHARED_SECRET,
+            },
+            session_key,
+        ))
     }
 
     /// Returns true if this is the peeled packet for the last destination.
@@ -294,6 +349,15 @@ impl PeeledPaymentOnionPacket {
             .as_ref()
             .and_then(BasicMppPaymentData::read)
     }
+}
+
+fn peeled_payment_hops_path(hops_infos: &[PaymentHopData]) -> Vec<crate::Pubkey> {
+    hops_infos
+        .iter()
+        .map(|h| h.next_hop())
+        .take_while(Option::is_some)
+        .map(|opt| opt.expect("must be some"))
+        .collect()
 }
 
 /// Trait for encoding/decoding Sphinx onion packet hop data.
@@ -402,6 +466,52 @@ pub fn create_sphinx_onion<C: secp256k1::Signing, Codec: SphinxOnionCodec>(
     // Set the version to indicate which hop data format is used
     packet.version = Codec::CURRENT_VERSION;
     Ok(packet.into_bytes())
+}
+
+/// Creates a Sphinx onion packet, retrying with fresh session keys on
+/// [`fiber_sphinx::SphinxError::InvalidBlindingFactor`].
+///
+/// Calls `gen_session_key` to obtain each candidate session key. Retries are
+/// bounded by [`ONION_SESSION_KEY_MAX_ATTEMPTS`]; on exhaustion the last
+/// `InvalidBlindingFactor` error is returned. Any other error short-circuits.
+/// On success returns the encoded packet bytes together with the session key
+/// that produced it.
+pub fn create_sphinx_onion_with_session_key_fn<C, Codec, F>(
+    mut gen_session_key: F,
+    hops_path: Vec<crate::Pubkey>,
+    payloads: Vec<Codec::Decoded>,
+    assoc_data: Option<Vec<u8>>,
+    secp_ctx: &secp256k1::Secp256k1<C>,
+) -> Result<(Vec<u8>, crate::Privkey), OnionPacketError>
+where
+    C: secp256k1::Signing,
+    Codec: SphinxOnionCodec,
+    Codec::Decoded: Clone,
+    F: FnMut() -> crate::Privkey,
+{
+    let mut last_err: Option<fiber_sphinx::SphinxError> = None;
+    for _ in 0..ONION_SESSION_KEY_MAX_ATTEMPTS {
+        let session_key = gen_session_key();
+        match create_sphinx_onion::<C, Codec>(
+            session_key.clone(),
+            hops_path.clone(),
+            payloads.clone(),
+            assoc_data.clone(),
+            secp_ctx,
+        ) {
+            Ok(bytes) => return Ok((bytes, session_key)),
+            Err(OnionPacketError::Sphinx(
+                err @ fiber_sphinx::SphinxError::InvalidBlindingFactor,
+            )) => {
+                last_err = Some(err);
+                continue;
+            }
+            Err(other) => return Err(other),
+        }
+    }
+    Err(OnionPacketError::Sphinx(last_err.expect(
+        "ONION_SESSION_KEY_MAX_ATTEMPTS is non-zero, so at least one attempt ran",
+    )))
 }
 
 /// Codec for payment onion packets (used by the outer payment onion layer).

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -1951,6 +1951,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiber-sphinx"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827476eed3d2915d79c9809e71a7089f44cde5d9a4fa7c7045cd0f2d5e56fb95"
+dependencies = [
+ "chacha20",
+ "hmac 0.12.1",
+ "secp256k1 0.30.0",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fiber-store"
 version = "0.9.0-rc2"
 dependencies = [
@@ -1984,7 +1997,7 @@ dependencies = [
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-sphinx",
+ "fiber-sphinx 2.3.0",
  "getrandom 0.2.17",
  "hex",
  "molecule",
@@ -2019,7 +2032,7 @@ dependencies = [
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-sphinx",
+ "fiber-sphinx 3.0.0",
  "getrandom 0.2.17",
  "hex",
  "lightning-invoice",
@@ -2056,7 +2069,7 @@ dependencies = [
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-sphinx",
+ "fiber-sphinx 2.3.0",
  "getrandom 0.2.17",
  "hex",
  "molecule",
@@ -2129,7 +2142,7 @@ dependencies = [
  "clap-serde-derive",
  "either",
  "fiber-json-types",
- "fiber-sphinx",
+ "fiber-sphinx 3.0.0",
  "fiber-store",
  "fiber-types 0.9.0-rc2",
  "futures",


### PR DESCRIPTION
## Summary

Upgrade `fiber-sphinx` from 2.3 to 3.0 and adapt to the new API.

The v3 release:
- Replaces `OnionPacket::from_bytes` with `OnionPacket::from_bytes_with_packet_data_len`, requiring callers to pass the expected packet data length explicitly.
- Changes `OnionSharedSecretIter` to yield `Result<[u8; 32], SphinxError>` so blinding-factor failures during traversal are observable.
- Introduces `SphinxError::InvalidBlindingFactor`, which session-key generation can hit probabilistically.

## Changes

- Pass each codec's `PACKET_DATA_LEN` (6500 for payment, 1300 for trampoline) when decoding sphinx packets in `fiber-types` and `fiber-lib`.
- Collect the new `Result` items from `OnionSharedSecretIter` in the affected tests.
- Retry `PeeledPaymentOnionPacket::create` (in `payment.rs`) and `TrampolineOnionPacket::create` (in `graph.rs`) up to `ONION_SESSION_KEY_MAX_ATTEMPTS` (7) times with a fresh session key when `InvalidBlindingFactor` is returned. If all attempts fail, the original sphinx error is propagated transparently (no new error variant).

## Test plan

- `cargo build`
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all -- --check`
- `RUST_LOG=off cargo nextest run --no-fail-fast -p fnn -p fiber-bin -p fnn-cli -p fiber-store -p fiber-json-types` (967 passed)
- Same with `--no-default-features --features sqlite` (967 passed)
- `RUST_LOG=off cargo nextest run --no-fail-fast -p fiber-types` (9 passed)

---

_This PR description was generated by AI._