### PR TITLE
Fix auto accept pending limits

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,10 +8,10 @@ threads-required = 2
 
 # channel tests
 [[profile.default.overrides]]
-filter = 'test(/^tests::channel::/)'
+filter = 'test(/^(fiber::)?tests::channel::/)'
 threads-required = 2
 
 # payment tests
 [[profile.default.overrides]]
-filter = 'test(/^tests::payment::/)'
+filter = 'test(/^(fiber::)?tests::payment::/)'
 threads-required = 2

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -363,12 +363,12 @@ pub struct FiberConfig {
     #[arg(skip)]
     pub wasm_key_pair: Option<KeyPair>,
 
-    /// Max allowed number of channels to be accepted from one peer. [default: 20]
+    /// Max allowed number of pending channel openings from one peer. [default: 20]
     #[arg(
         name = "FIBER_TO_BE_ACCEPTED_CHANNELS_NUMBER_LIMIT",
         long = "fiber-to-be-accepted-channels-number-limit",
         env,
-        help = "Max allowed number of channels to be accepted from one peer. [default: 20]"
+        help = "Max allowed number of pending channel openings from one peer. [default: 20]"
     )]
     pub to_be_accepted_channels_number_limit: Option<usize>,
 

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -381,6 +381,15 @@ pub struct FiberConfig {
     )]
     pub to_be_accepted_channels_bytes_limit: Option<usize>,
 
+    /// Max allowed number of pending channel openings globally. [default: 100]
+    #[arg(
+        name = "FIBER_PENDING_CHANNELS_NUMBER_LIMIT",
+        long = "fiber-pending-channels-number-limit",
+        env,
+        help = "Max allowed number of pending channel openings globally. [default: 100]"
+    )]
+    pub pending_channels_number_limit: Option<usize>,
+
     /// Default timeout to auto close a funding channel. [default: 1 day]
     #[arg(
         name = "FIBER_FUNDING_TIMEOUT_SECONDS",

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -267,6 +267,8 @@ struct PeerChannelIndexState {
     peer_id_to_pubkey_map: HashMap<PeerId, Pubkey>,
     // Map from channel id to peer pubkey.
     channel_id_to_peer_map: HashMap<Hash256, Pubkey>,
+    // Channel actors that have been accepted/created but have not reached ChannelReady yet.
+    opening_channels: HashSet<Hash256>,
 }
 
 impl PeerChannelIndexState {
@@ -275,11 +277,15 @@ impl PeerChannelIndexState {
         S: ChannelActorStateStore,
     {
         let mut peer_channels_map = HashMap::<Pubkey, HashSet<Hash256>>::new();
-        for (pubkey, channel_id, _channel_state) in store.get_active_channel_states(None) {
+        let mut opening_channels = HashSet::new();
+        for (pubkey, channel_id, channel_state) in store.get_active_channel_states(None) {
             peer_channels_map
                 .entry(pubkey)
                 .or_default()
                 .insert(channel_id);
+            if is_pending_channel_state(&channel_state) {
+                opening_channels.insert(channel_id);
+            }
         }
         let peer_id_to_pubkey_map = peer_channels_map
             .keys()
@@ -300,6 +306,7 @@ impl PeerChannelIndexState {
             peer_channels_map,
             peer_id_to_pubkey_map,
             channel_id_to_peer_map,
+            opening_channels,
         }
     }
 }
@@ -339,6 +346,7 @@ impl PeerChannelIndex {
             }
         }
         state.channel_id_to_peer_map.remove(channel_id);
+        state.opening_channels.remove(channel_id);
         if is_empty {
             let peer_id = pubkey_to_tentacle(*pubkey).peer_id();
             state.peer_channels_map.remove(pubkey);
@@ -380,7 +388,34 @@ impl PeerChannelIndex {
             channels.insert(new);
             state.channel_id_to_peer_map.remove(&old);
             state.channel_id_to_peer_map.insert(new, pubkey);
+            if state.opening_channels.remove(&old) {
+                state.opening_channels.insert(new);
+            }
         }
+    }
+
+    pub(crate) fn mark_channel_opening(&self, channel_id: Hash256) {
+        self.inner
+            .write()
+            .expect("peer channel index write lock")
+            .opening_channels
+            .insert(channel_id);
+    }
+
+    pub(crate) fn mark_channel_ready(&self, channel_id: &Hash256) {
+        self.inner
+            .write()
+            .expect("peer channel index write lock")
+            .opening_channels
+            .remove(channel_id);
+    }
+
+    pub(crate) fn opening_channel_count(&self) -> usize {
+        self.inner
+            .read()
+            .expect("peer channel index read lock")
+            .opening_channels
+            .len()
     }
 
     pub(crate) fn get_pubkey(&self, peer_id: &PeerId) -> Option<Pubkey> {
@@ -400,6 +435,17 @@ impl PeerChannelIndex {
             .get(channel_id)
             .cloned()
     }
+}
+
+fn is_pending_channel_state(state: &ChannelState) -> bool {
+    matches!(
+        state,
+        ChannelState::NegotiatingFunding(_)
+            | ChannelState::CollaboratingFundingTx(_)
+            | ChannelState::SigningCommitment(_)
+            | ChannelState::AwaitingTxSignatures(_)
+            | ChannelState::AwaitingChannelReady(_)
+    )
 }
 
 #[derive(Debug)]
@@ -1376,6 +1422,7 @@ where
                     "Channel ({:?}) to peer {:?} is now ready",
                     channel_id, pubkey
                 );
+                state.peer_channel_index.mark_channel_ready(&channel_id);
 
                 // Mark the opening record as ChannelReady (terminal success state).
                 if let Some(mut record) = state.store.get_channel_open_record(&channel_id) {
@@ -3795,6 +3842,7 @@ pub struct NetworkActorState<S, C> {
     open_channel_auto_accept_min_ckb_funding_amount: u64,
     // The default amount of CKB to be funded when auto accepting a channel.
     auto_accept_channel_ckb_funding_amount: u64,
+    pending_channels_number_limit: usize,
     // The default expiry delta to forward tlcs.
     tlc_expiry_delta: u64,
     // The default tlc min and max value of tlcs to be accepted.
@@ -4433,6 +4481,20 @@ where
             .is_some_and(|peer| self.peer_session_map.contains_key(&peer))
     }
 
+    fn check_pending_channel_limit(&self) -> ProcessingChannelResult {
+        let limit = self.pending_channels_number_limit;
+        let total_count = self.peer_channel_index.opening_channel_count()
+            + self.to_be_accepted_channels.map.len();
+
+        if total_count.saturating_add(1) > limit {
+            return Err(ProcessingChannelError::ToBeAcceptedChannelsExceedLimit(
+                format!("Global pending channel count exceeds the limit {limit}"),
+            ));
+        }
+
+        Ok(())
+    }
+
     fn check_feature_compatibility(&self, pubkey: &Pubkey) -> ProcessingChannelResult {
         if let Some(peer_features) = self
             .peer_session_map
@@ -4988,6 +5050,9 @@ where
         if let Some(outpoint) = channel_actor_state.get_funding_transaction_outpoint() {
             self.outpoint_channel_map.insert(outpoint, channel_id);
         }
+        if is_pending_channel_state(&channel_actor_state.state) {
+            self.peer_channel_index.mark_channel_opening(channel_id);
+        }
         debug!("channel {:x} restored offline successfully", &channel_id);
 
         Ok(channel)
@@ -5200,6 +5265,7 @@ where
         actor: ActorRef<ChannelActorMessage>,
     ) {
         self.register_channel_actor(id, pubkey, actor);
+        self.peer_channel_index.mark_channel_opening(id);
         debug!("Channel {:x} created", &id);
         // Notify outside observers.
         self.network
@@ -5416,6 +5482,7 @@ where
             open_channel.max_tlc_number_in_flight,
         )
         .and_then(|_| {
+            self.check_pending_channel_limit()?;
             self.to_be_accepted_channels
                 .try_insert(id, peer_pubkey, open_channel)
         });
@@ -5994,6 +6061,9 @@ where
             open_channel_auto_accept_min_ckb_funding_amount: config
                 .open_channel_auto_accept_min_ckb_funding_amount(),
             auto_accept_channel_ckb_funding_amount: config.auto_accept_channel_ckb_funding_amount(),
+            pending_channels_number_limit: config
+                .pending_channels_number_limit
+                .unwrap_or(DEFAULT_PENDING_CHANNELS_NUMBER_LIMIT),
             tlc_expiry_delta: config.tlc_expiry_delta(),
             tlc_min_value: config.tlc_min_value(),
             tlc_fee_proportional_millionths: config.tlc_fee_proportional_millionths(),
@@ -6426,8 +6496,10 @@ impl Default for ToBeAcceptedChannels {
 
 // Remember to sync fiber/config.rs
 const DEFAULT_TO_BE_ACCEPTED_CHANNELS_NUMBER_LIMIT: usize = 20;
+// Remember to sync fiber/config.rs. 50KB.
+const DEFAULT_TO_BE_ACCEPTED_CHANNELS_BYTES_LIMIT: usize = 51200;
 // Remember to sync fiber/config.rs
-const DEFAULT_TO_BE_ACCEPTED_CHANNELS_BYTES_LIMIT: usize = 51200; // 50KB
+const DEFAULT_PENDING_CHANNELS_NUMBER_LIMIT: usize = 100;
 
 impl ToBeAcceptedChannels {
     fn new_with_config(config: &FiberConfig) -> Self {

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -418,6 +418,16 @@ impl PeerChannelIndex {
             .len()
     }
 
+    pub(crate) fn opening_channel_count_by_peer(&self, pubkey: &Pubkey) -> usize {
+        let state = self.inner.read().expect("peer channel index read lock");
+        state.peer_channels_map.get(pubkey).map_or(0, |channels| {
+            channels
+                .iter()
+                .filter(|channel_id| state.opening_channels.contains(channel_id))
+                .count()
+        })
+    }
+
     pub(crate) fn get_pubkey(&self, peer_id: &PeerId) -> Option<Pubkey> {
         self.inner
             .read()
@@ -4481,14 +4491,28 @@ where
             .is_some_and(|peer| self.peer_session_map.contains_key(&peer))
     }
 
-    fn check_pending_channel_limit(&self) -> ProcessingChannelResult {
-        let limit = self.pending_channels_number_limit;
+    fn check_pending_channel_limit(&self, peer_pubkey: Pubkey) -> ProcessingChannelResult {
+        let global_limit = self.pending_channels_number_limit;
         let total_count = self.peer_channel_index.opening_channel_count()
             + self.to_be_accepted_channels.map.len();
 
-        if total_count.saturating_add(1) > limit {
+        if total_count.saturating_add(1) > global_limit {
             return Err(ProcessingChannelError::ToBeAcceptedChannelsExceedLimit(
-                format!("Global pending channel count exceeds the limit {limit}"),
+                format!("Global pending channel count exceeds the limit {global_limit}"),
+            ));
+        }
+
+        let peer_limit = self.to_be_accepted_channels.total_number_limit;
+        let peer_count = self
+            .peer_channel_index
+            .opening_channel_count_by_peer(&peer_pubkey)
+            + self
+                .to_be_accepted_channels
+                .pending_accept_count(&peer_pubkey);
+
+        if peer_count.saturating_add(1) > peer_limit {
+            return Err(ProcessingChannelError::ToBeAcceptedChannelsExceedLimit(
+                format!("Peer pending channel count exceeds the limit {peer_limit}"),
             ));
         }
 
@@ -5482,7 +5506,9 @@ where
             open_channel.max_tlc_number_in_flight,
         )
         .and_then(|_| {
-            self.check_pending_channel_limit()?;
+            if !self.to_be_accepted_channels.map.contains_key(&id) {
+                self.check_pending_channel_limit(peer_pubkey)?;
+            }
             self.to_be_accepted_channels
                 .try_insert(id, peer_pubkey, open_channel)
         });
@@ -6516,6 +6542,13 @@ impl ToBeAcceptedChannels {
 
     fn remove(&mut self, id: &Hash256) -> Option<(Pubkey, OpenChannel)> {
         self.map.remove(id)
+    }
+
+    fn pending_accept_count(&self, pubkey: &Pubkey) -> usize {
+        self.map
+            .values()
+            .filter(|(saved_pubkey, _)| saved_pubkey == pubkey)
+            .count()
     }
 
     // insert and apply throttle control

--- a/crates/fiber-lib/src/fiber/settle_tlc_set_command.rs
+++ b/crates/fiber-lib/src/fiber/settle_tlc_set_command.rs
@@ -136,6 +136,10 @@ where
             return self.reject_all(error_code);
         }
 
+        if self.should_skip_received_hold_set(&invoice_status) {
+            return self.skip_all();
+        }
+
         let mut rejected = self.leave_just_fulfilled_tlcs(&invoice);
         if self.tlcs.is_empty() {
             return rejected;
@@ -249,9 +253,7 @@ where
                 }
             }
             CkbInvoiceStatus::Received => {
-                if self.is_hold_tlc_set && self.allow_received_invoice {
-                    // Only preimage-reveal/retry paths may settle a Received hold set. Newly
-                    // arrived TLCs for an already Received invoice must be rejected as duplicates.
+                if self.is_hold_tlc_set {
                     Ok(())
                 } else {
                     Err(TlcErrorCode::HoldTlcTimeout)
@@ -261,6 +263,15 @@ where
             CkbInvoiceStatus::Cancelled => Err(TlcErrorCode::InvoiceCancelled),
             CkbInvoiceStatus::Paid => Err(TlcErrorCode::HoldTlcTimeout),
         }
+    }
+
+    fn should_skip_received_hold_set(&self, invoice_status: &CkbInvoiceStatus) -> bool {
+        // Multiple channel actors can enqueue SettleHoldTlcSet for the same MPP hold invoice.
+        // Once one command marks the invoice Received, later stale commands must not reject the
+        // already-held TLCs. Preimage reveal uses the explicit received-hold path below.
+        *invoice_status == CkbInvoiceStatus::Received
+            && self.is_hold_tlc_set
+            && !self.allow_received_invoice
     }
 
     fn verify_mpp_tlcs_have_consistent_total_amount(

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -8119,62 +8119,26 @@ async fn test_reestablish_restores_send_nonce() {
     let (mut node_a, mut node_b, channel_id) =
         create_nodes_with_established_channel(100000000000, 100000000000, true).await;
 
-    // Trigger payment A -> B and restart one peer while the payment is still
-    // inflight. This test focuses on restoring the missing send nonce during
-    // reestablish; payment completion is covered by broader reestablish tests.
-    let payment_hash = node_a
-        .send_payment_keysend(&node_b, 1000, false)
-        .await
-        .unwrap()
-        .payment_hash;
+    node_a.stop().await;
 
-    let start = std::time::Instant::now();
-    let restart_node_a = loop {
-        let state_a_before_restart = node_a.get_channel_actor_state(channel_id);
-        let state_b_before_restart = node_b.get_channel_actor_state(channel_id);
-        if node_a.get_inflight_payment_count().await == 1 {
-            if state_a_before_restart
-                .remote_revocation_nonce_for_send
-                .is_none()
-                && state_a_before_restart.last_revoke_ack_msg.is_some()
-            {
-                break true;
-            }
-            if state_b_before_restart
-                .remote_revocation_nonce_for_send
-                .is_none()
-                && state_b_before_restart.last_revoke_ack_msg.is_some()
-            {
-                break false;
-            }
-        }
-        assert!(
-            start.elapsed() < Duration::from_secs(5),
-            "Payment did not reach the pre-restart reestablish state in time"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    };
-    let pre_restart_status = node_a.get_payment_status(payment_hash).await;
-    debug!(
-        ?pre_restart_status,
-        "Initial payment status before restarting remote peer"
+    let mut state = node_a.get_channel_actor_state(channel_id);
+    assert!(
+        state.remote_revocation_nonce_for_send.is_some(),
+        "established channel should start with a send nonce"
     );
-    assert_ne!(
-        pre_restart_status,
-        PaymentStatus::Failed,
-        "initial payment should not fail before reestablish"
+    assert!(
+        state.remote_revocation_nonce_for_verify.is_some()
+            || state.remote_revocation_nonce_for_next.is_some(),
+        "established channel should have a nonce source for reestablish recovery"
     );
-    assert_eq!(node_a.get_inflight_payment_count().await, 1);
 
-    // Restart the peer that actually lost the send nonce to make the
-    // reestablish scenario deterministic across scheduler interleavings.
-    if restart_node_a {
-        node_a.restart().await;
-        node_a.connect_to(&mut node_b).await;
-    } else {
-        node_b.restart().await;
-        node_b.connect_to(&mut node_a).await;
-    }
+    state.remote_revocation_nonce_for_send = None;
+    state.last_revoke_ack_msg = None;
+    node_a.store.insert_channel_actor_state(state);
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    node_a.start().await;
+    node_a.connect_to(&mut node_b).await;
 
     node_a
         .expect_debug_event("Reestablished channel in ChannelReady")
@@ -8184,7 +8148,7 @@ async fn test_reestablish_restores_send_nonce() {
         .await;
 
     // Wait until both peers persist the recovered send nonce after reestablish.
-    let now = std::time::Instant::now();
+    let start = std::time::Instant::now();
     loop {
         let node_b_state = node_b.get_channel_actor_state(channel_id);
         let node_a_state = node_a.get_channel_actor_state(channel_id);
@@ -8194,18 +8158,11 @@ async fn test_reestablish_restores_send_nonce() {
             break;
         }
         assert!(
-            now.elapsed() < Duration::from_secs(5),
+            start.elapsed() < Duration::from_secs(5),
             "reestablish did not restore send nonce in time"
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
-
-    node_a.wait_until_success(payment_hash).await;
-    assert_eq!(node_a.get_inflight_payment_count().await, 0);
-    assert_eq!(
-        node_a.get_payment_status(payment_hash).await,
-        PaymentStatus::Success
-    );
 
     let state = node_b.get_channel_actor_state(channel_id);
     assert!(

--- a/crates/fiber-lib/src/fiber/tests/history.rs
+++ b/crates/fiber-lib/src/fiber/tests/history.rs
@@ -327,15 +327,14 @@ fn test_history_internal_result_fail_pair() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-fn test_history_trampoline_failed_uses_error_code() {
+fn test_history_trampoline_failed_skips_outer_route_history() {
     let source = gen_rand_fiber_public_key();
     let trampoline = gen_rand_fiber_public_key();
-    let channel_outpoint = gen_rand_channel_outpoint();
     let route = vec![
         SessionRouteNode {
             pubkey: source,
             amount: 10,
-            channel_outpoint: channel_outpoint.clone(),
+            channel_outpoint: gen_rand_channel_outpoint(),
         },
         SessionRouteNode {
             pubkey: trampoline,
@@ -343,63 +342,28 @@ fn test_history_trampoline_failed_uses_error_code() {
             channel_outpoint: gen_rand_channel_outpoint(),
         },
     ];
-    let (direction, rev_direction) = output_direction(source, trampoline);
 
-    let mut internal_result = InternalResult::default();
-    let need_retry = internal_result.record_payment_fail(
-        &route,
-        TlcErr {
-            error_code: TlcErrorCode::TemporaryNodeFailure,
-            extra_data: Some(TlcErrData::TrampolineFailed {
-                node_id: trampoline,
-                inner_error_packet: vec![1, 2, 3],
-            }),
-        },
-    );
+    for error_code in [
+        TlcErrorCode::TemporaryNodeFailure,
+        TlcErrorCode::HoldTlcTimeout,
+    ] {
+        let mut internal_result = InternalResult::default();
+        let need_retry = internal_result.record_payment_fail(
+            &route,
+            TlcErr {
+                error_code,
+                extra_data: Some(TlcErrData::TrampolineFailed {
+                    node_id: trampoline,
+                    inner_error_packet: vec![1, 2, 3],
+                }),
+            },
+        );
 
-    assert!(need_retry);
-    assert_eq!(internal_result.fail_node, Some(trampoline));
-    assert_eq!(internal_result.pairs.len(), 2);
-    assert!(
-        !internal_result
-            .pairs
-            .get(&(channel_outpoint.clone(), direction))
-            .expect("forward pair")
-            .success
-    );
-    assert!(
-        !internal_result
-            .pairs
-            .get(&(channel_outpoint.clone(), rev_direction))
-            .expect("reverse pair")
-            .success
-    );
-
-    let mut internal_result = InternalResult::default();
-    let need_retry = internal_result.record_payment_fail(
-        &route,
-        TlcErr {
-            error_code: TlcErrorCode::HoldTlcTimeout,
-            extra_data: Some(TlcErrData::TrampolineFailed {
-                node_id: trampoline,
-                inner_error_packet: vec![1, 2, 3],
-            }),
-        },
-    );
-
-    assert!(!need_retry);
-    assert!(internal_result.fail_node.is_none());
-    assert_eq!(internal_result.pairs.len(), 1);
-    let pair = internal_result
-        .pairs
-        .get(&(channel_outpoint.clone(), direction))
-        .expect("success pair");
-    assert!(pair.success);
-    assert_eq!(pair.amount, 10);
-    assert_ne!(pair.time, 0);
-    assert!(!internal_result
-        .pairs
-        .contains_key(&(channel_outpoint, rev_direction)));
+        assert!(!need_retry);
+        assert!(internal_result.fail_node.is_none());
+        assert!(internal_result.pairs.is_empty());
+        assert!(internal_result.nodes_to_channel_map.is_empty());
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -7,6 +7,7 @@ use crate::{
         CkbChainMessage, CkbTxTracingResult,
     },
     fiber::{
+        config::DEFAULT_AUTO_ACCEPT_CHANNEL_CKB_FUNDING_AMOUNT,
         gossip::{GossipActorMessage, GossipMessageStore},
         graph::ChannelUpdateInfo,
         network::{
@@ -2062,6 +2063,85 @@ async fn test_to_be_accepted_channels_number_limit() {
     call!(peer.network_actor, message)
         .expect("peer alive")
         .expect("open channel");
+    node.expect_debug_event("ChannelPendingToBeRejected").await;
+
+    let mut another_peer = NetworkNode::new().await;
+    node.connect_to(&mut another_peer).await;
+    open_channel_from_peer(&another_peer, node.pubkey, funding_amount).await;
+    node.expect_event(|event| match event {
+        NetworkServiceEvent::ChannelPendingToBeAccepted(pubkey, _channel_id) => {
+            assert_eq!(pubkey, &another_peer.pubkey);
+            true
+        }
+        _ => false,
+    })
+    .await;
+}
+
+async fn open_channel_from_peer(peer: &NetworkNode, target_pubkey: Pubkey, funding_amount: u128) {
+    let message = |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::OpenChannel(
+            OpenChannelCommand {
+                pubkey: target_pubkey,
+                public: true,
+                one_way: false,
+                shutdown_script: None,
+                funding_amount,
+                funding_udt_type_script: None,
+                commitment_fee_rate: None,
+                commitment_delay_epoch: None,
+                funding_fee_rate: None,
+                tlc_expiry_delta: None,
+                tlc_min_value: None,
+                tlc_fee_proportional_millionths: None,
+                max_tlc_number_in_flight: None,
+                max_tlc_value_in_flight: None,
+            },
+            rpc_reply,
+        ))
+    };
+
+    call!(peer.network_actor, message)
+        .expect("peer alive")
+        .expect("open channel");
+}
+
+async fn expect_channel_created(node: &mut NetworkNode, pubkey: Pubkey) {
+    node.expect_event(|event| {
+        matches!(
+            event,
+            NetworkServiceEvent::ChannelCreated(event_pubkey, _) if event_pubkey == &pubkey
+        )
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_auto_accept_pending_channels_global_number_limit() {
+    let funding_amount = 100_000_000_000u128;
+    let mut node = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.pending_channels_number_limit = Some(2);
+                config.auto_accept_channel_ckb_funding_amount =
+                    Some(DEFAULT_AUTO_ACCEPT_CHANNEL_CKB_FUNDING_AMOUNT);
+            })
+            .build(),
+    )
+    .await;
+    let mut first_peer = NetworkNode::new().await;
+    let mut second_peer = NetworkNode::new().await;
+
+    first_peer.connect_to(&mut node).await;
+    second_peer.connect_to(&mut node).await;
+
+    open_channel_from_peer(&first_peer, node.pubkey, funding_amount).await;
+    expect_channel_created(&mut node, first_peer.pubkey).await;
+
+    open_channel_from_peer(&first_peer, node.pubkey, funding_amount).await;
+    expect_channel_created(&mut node, first_peer.pubkey).await;
+
+    open_channel_from_peer(&second_peer, node.pubkey, funding_amount).await;
     node.expect_debug_event("ChannelPendingToBeRejected").await;
 }
 

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -2146,6 +2146,39 @@ async fn test_auto_accept_pending_channels_global_number_limit() {
 }
 
 #[tokio::test]
+async fn test_auto_accept_pending_channels_peer_number_limit() {
+    let funding_amount = 100_000_000_000u128;
+    let mut node = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.to_be_accepted_channels_number_limit = Some(2);
+                config.pending_channels_number_limit = Some(10);
+                config.auto_accept_channel_ckb_funding_amount =
+                    Some(DEFAULT_AUTO_ACCEPT_CHANNEL_CKB_FUNDING_AMOUNT);
+            })
+            .build(),
+    )
+    .await;
+    let mut first_peer = NetworkNode::new().await;
+    let mut second_peer = NetworkNode::new().await;
+
+    first_peer.connect_to(&mut node).await;
+    second_peer.connect_to(&mut node).await;
+
+    open_channel_from_peer(&first_peer, node.pubkey, funding_amount).await;
+    expect_channel_created(&mut node, first_peer.pubkey).await;
+
+    open_channel_from_peer(&first_peer, node.pubkey, funding_amount).await;
+    expect_channel_created(&mut node, first_peer.pubkey).await;
+
+    open_channel_from_peer(&first_peer, node.pubkey, funding_amount).await;
+    node.expect_debug_event("ChannelPendingToBeRejected").await;
+
+    open_channel_from_peer(&second_peer, node.pubkey, funding_amount).await;
+    expect_channel_created(&mut node, second_peer.pubkey).await;
+}
+
+#[tokio::test]
 async fn test_to_be_accepted_channels_bytes_limit() {
     init_tracing();
 

--- a/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
@@ -512,14 +512,12 @@ fn test_open_invoice_proceeds_to_settlement() {
 }
 
 #[test]
-fn test_received_hold_invoice_from_new_tlc_rejects() {
-    let preimage = gen_rand_sha256_hash();
-    let payment_hash = Hash256::from(ckb_hash::blake2b_256(preimage));
+fn test_duplicate_received_hold_set_is_noop() {
+    let payment_hash = gen_rand_sha256_hash();
     let invoice = create_test_invoice(payment_hash, Some(1000), false);
     let channel_id = gen_rand_sha256_hash();
     let store = MockStore::new()
         .with_invoice(invoice, CkbInvoiceStatus::Received)
-        .with_preimage(payment_hash, preimage)
         .with_hold_tlc(payment_hash, channel_id, 0)
         .with_channel_state(create_test_channel_state_with_tlc(
             channel_id,
@@ -532,12 +530,8 @@ fn test_received_hold_invoice_from_new_tlc_rejects() {
     let command = SettleTlcSetCommand::new_hold_tlc_set(payment_hash, &store);
     let settlements = command.run();
 
-    assert_eq!(settlements.len(), 1);
-    assert!(!is_fulfill_settlement(&settlements[0]));
-    assert_eq!(
-        get_error_code(&settlements[0]),
-        Some(TlcErrorCode::HoldTlcTimeout)
-    );
+    assert!(settlements.is_empty());
+    assert_eq!(store.get_payment_hold_tlcs(payment_hash).len(), 1);
 }
 
 #[test]

--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -751,7 +751,9 @@ fn test_direct_trampoline_failed_wrapper_uses_outer_shared_secret() {
     let session_key = SecretKey::from_slice(&[0x43; 32]).expect("32 bytes, within curve order");
     let hops_keys: Vec<PublicKey> = hops_path.iter().map(|k| k.into()).collect();
     let hops_ss: Vec<[u8; 32]> =
-        OnionSharedSecretIter::new(hops_keys.iter(), session_key, SECP256K1).collect();
+        OnionSharedSecretIter::new(hops_keys.iter(), session_key, SECP256K1)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("valid blinding factors for hard-coded session key");
     let inner_error_packet = TlcErrPacket::new(
         TlcErr::new(TlcErrorCode::TemporaryNodeFailure),
         &NO_SHARED_SECRET,
@@ -1239,12 +1241,7 @@ fn test_trampoline_peel_rejects_unknown_forward_hash_algorithm() {
     let result =
         TrampolineOnionPacket::new(sphinx_packet.into_bytes()).peel(&hop_key, None, SECP256K1);
 
-    assert!(matches!(
-        result,
-        Err(crate::fiber::types::Error::OnionPacket(
-            OnionPacketError::InvalidHopData
-        ))
-    ));
+    assert!(matches!(result, Err(OnionPacketError::InvalidHopData)));
 }
 
 fn trampoline_forward_payload_with_hash_algorithm_byte(


### PR DESCRIPTION
This PR adds limits for pending channel openings.

1. Per-peer limit

The existing `to_be_accepted_channels_number_limit` config is reused and its meaning is
extended. It now limits the total number of channels from the same peer that are either waiting
to be accepted or already accepted/created but not `ChannelReady` yet.

2. Global limit

A new `pending_channels_number_limit` config is added to limit the total number of pending
channel openings across all peers.

----------------

This PR also includes following fixes:

  1. Refresh stale test/config expectations after upstream changes
     - Update `nextest` filters so channel/payment test overrides still match test names with the
  new optional `fiber::` prefix.
     - Adjust trampoline failure history tests to match #1361: `TrampolineFailed` represents an
  error beyond the visible outer route, so it should not update or penalize outer route history.
     - Update affected tests for current `fiber-sphinx` behavior and make the reestablish nonce
  test deterministic.

  2. Fix an MPP hold invoice settlement race
     - Multiple channel actors can enqueue `SettleHoldTlcSet` for the same payment hash.
     - The first processed trigger may mark the invoice as `Received` once all MPP parts are
  already stored.
     - Later queued triggers should be treated as idempotent no-ops instead of rejecting the held
  TLCs.
     - The explicit preimage reveal path still uses `SettleReceivedHoldTlcSet` and continues to
  fulfill held TLCs.