### PR TITLE
Fix channel constraint TLC limit semantics

### DIFF
--- a/crates/fiber-json-types/src/channel.rs
+++ b/crates/fiber-json-types/src/channel.rs
@@ -155,13 +155,13 @@ pub struct OpenChannelParams {
     #[schemars(schema_with = "schema_as_uint_hex_optional")]
     pub tlc_fee_proportional_millionths: Option<u128>,
 
-    /// The maximum value in flight for TLCs, an optional parameter.
+    /// The maximum total value of in-flight TLCs our side will accept from the peer, an optional parameter.
     /// This parameter can not be updated after channel is opened.
     #[serde_as(as = "Option<U128Hex>")]
     #[schemars(schema_with = "schema_as_uint_hex_optional")]
     pub max_tlc_value_in_flight: Option<u128>,
 
-    /// The maximum number of TLCs that can be accepted, an optional parameter, default is 125
+    /// The maximum number of in-flight TLCs our side will accept from the peer, an optional parameter, default is 125
     /// This parameter can not be updated after channel is opened.
     #[serde_as(as = "Option<U64Hex>")]
     #[schemars(schema_with = "schema_as_uint_hex_optional")]
@@ -241,13 +241,13 @@ pub struct OpenChannelWithExternalFundingParams {
     #[schemars(schema_with = "schema_as_uint_hex_optional")]
     pub tlc_fee_proportional_millionths: Option<u128>,
 
-    /// The maximum value in flight for TLCs, an optional parameter.
+    /// The maximum total value of in-flight TLCs our side will accept from the peer, an optional parameter.
     /// This parameter can not be updated after channel is opened.
     #[serde_as(as = "Option<U128Hex>")]
     #[schemars(schema_with = "schema_as_uint_hex_optional")]
     pub max_tlc_value_in_flight: Option<u128>,
 
-    /// The maximum number of TLCs that can be accepted, an optional parameter, default is 125
+    /// The maximum number of in-flight TLCs our side will accept from the peer, an optional parameter, default is 125
     /// This parameter can not be updated after channel is opened.
     #[serde_as(as = "Option<U64Hex>")]
     #[schemars(schema_with = "schema_as_uint_hex_optional")]
@@ -307,13 +307,13 @@ pub struct AcceptChannelParams {
     /// default value is the secp256k1_blake160_sighash_all script corresponding to the configured private key
     pub shutdown_script: Option<Script>,
 
-    /// The max tlc sum value in flight for the channel, default is u128::MAX
+    /// The maximum total value of in-flight TLCs our side will accept from the peer, default is u128::MAX
     /// This parameter can not be updated after channel is opened.
     #[serde_as(as = "Option<U128Hex>")]
     #[schemars(schema_with = "schema_as_uint_hex_optional")]
     pub max_tlc_value_in_flight: Option<u128>,
 
-    /// The max tlc number in flight send from our side, default is 125
+    /// The maximum number of in-flight TLCs our side will accept from the peer, default is 125
     /// This parameter can not be updated after channel is opened.
     #[serde_as(as = "Option<U64Hex>")]
     #[schemars(schema_with = "schema_as_uint_hex_optional")]

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -6625,8 +6625,10 @@ impl ChannelActorState {
                 return Err(ProcessingChannelError::TlcAmountExceedLimit);
             }
 
+            // The remote peer's constraints are its advertised incoming TLC
+            // limits, so they constrain TLCs we offer to it.
             let active_offered_tls_number = self.get_all_offer_tlcs().count() as u64 + 1;
-            if active_offered_tls_number > self.local_constraints.max_tlc_number_in_flight {
+            if active_offered_tls_number > self.remote_constraints.max_tlc_number_in_flight {
                 return Err(ProcessingChannelError::TlcNumberExceedLimit);
             }
 
@@ -6634,7 +6636,7 @@ impl ChannelActorState {
                 .get_all_offer_tlcs()
                 .fold(0_u128, |sum, tlc| sum + tlc.amount)
                 + add_amount;
-            if active_offered_amount > self.local_constraints.max_tlc_value_in_flight {
+            if active_offered_amount > self.remote_constraints.max_tlc_value_in_flight {
                 return Err(ProcessingChannelError::TlcValueInflightExceedLimit);
             }
         } else {
@@ -6644,8 +6646,10 @@ impl ChannelActorState {
                 return Err(ProcessingChannelError::TlcAmountExceedLimit);
             }
 
+            // Our local constraints are our advertised incoming TLC limits,
+            // so they constrain TLCs the remote peer offers to us.
             let active_received_tls_number = self.get_all_received_tlcs().count() as u64 + 1;
-            if active_received_tls_number > self.remote_constraints.max_tlc_number_in_flight {
+            if active_received_tls_number > self.local_constraints.max_tlc_number_in_flight {
                 return Err(ProcessingChannelError::TlcNumberExceedLimit);
             }
 
@@ -6653,7 +6657,7 @@ impl ChannelActorState {
                 .get_all_received_tlcs()
                 .fold(0_u128, |sum, tlc| sum + tlc.amount)
                 + add_amount;
-            if active_received_amount > self.remote_constraints.max_tlc_value_in_flight {
+            if active_received_amount > self.local_constraints.max_tlc_value_in_flight {
                 return Err(ProcessingChannelError::TlcValueInflightExceedLimit);
             }
         }

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -3482,6 +3482,91 @@ async fn do_test_add_tlc_waiting_ack() {
 }
 
 #[tokio::test]
+async fn test_open_channel_constraints_limit_incoming_tlcs() {
+    let node_a_funding_amount = 100000000000;
+    let node_b_funding_amount = 100000000000;
+
+    let [mut node_a, mut node_b] = NetworkNode::new_n_interconnected_nodes().await;
+
+    let node_a_max_accepted_tlc_number = 2;
+    let (new_channel_id, _funding_tx_hash) = establish_channel_between_nodes(
+        &mut node_a,
+        &mut node_b,
+        ChannelParameters {
+            public: true,
+            node_a_funding_amount,
+            node_b_funding_amount,
+            a_max_tlc_number_in_flight: Some(node_a_max_accepted_tlc_number),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let tlc_amount = 1000000000;
+
+    // A's advertised max is A's incoming/accepted TLC limit, so it should not
+    // limit TLCs A offers to B.
+    for i in 1..=node_a_max_accepted_tlc_number + 1 {
+        let add_tlc_command = AddTlcCommand {
+            amount: tlc_amount,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            payment_hash: gen_rand_sha256_hash(),
+            attempt_id: None,
+            expiry: now_timestamp_as_millis_u64() + 100000000,
+            onion_packet: None,
+            shared_secret: NO_SHARED_SECRET,
+            is_trampoline_hop: false,
+            previous_tlc: None,
+        };
+        let add_tlc_result = call!(node_a.network_actor, |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
+                ChannelCommandWithId {
+                    channel_id: new_channel_id,
+                    command: ChannelCommand::AddTlc(add_tlc_command, rpc_reply),
+                },
+            ))
+        })
+        .expect("source node alive");
+
+        assert!(add_tlc_result.is_ok());
+        wait_for_tlc_sync(&node_a, &node_b, new_channel_id, i as usize).await;
+    }
+
+    // B offering TLCs to A consumes A's advertised incoming/accepted TLC limit.
+    for i in 1..=node_a_max_accepted_tlc_number + 1 {
+        let add_tlc_command = AddTlcCommand {
+            amount: tlc_amount,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            payment_hash: gen_rand_sha256_hash(),
+            attempt_id: None,
+            expiry: now_timestamp_as_millis_u64() + 100000000,
+            onion_packet: None,
+            shared_secret: NO_SHARED_SECRET,
+            is_trampoline_hop: false,
+            previous_tlc: None,
+        };
+        let add_tlc_result = call!(node_b.network_actor, |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
+                ChannelCommandWithId {
+                    channel_id: new_channel_id,
+                    command: ChannelCommand::AddTlc(add_tlc_command, rpc_reply),
+                },
+            ))
+        })
+        .expect("source node alive");
+
+        if i == node_a_max_accepted_tlc_number + 1 {
+            assert!(add_tlc_result.is_err());
+            let code = add_tlc_result.unwrap_err();
+            assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
+        } else {
+            assert!(add_tlc_result.is_ok());
+            wait_for_tlc_sync(&node_b, &node_a, new_channel_id, i as usize).await;
+        }
+    }
+}
+
+#[tokio::test]
 async fn do_test_add_tlc_with_number_limit() {
     let node_a_funding_amount = 100000000000;
     let node_b_funding_amount = 100000000000;
@@ -3504,7 +3589,7 @@ async fn do_test_add_tlc_with_number_limit() {
 
     let tlc_amount = 1000000000;
 
-    // A -> B will have tlc number limit 2
+    // A's max applies to incoming TLCs, so it should not limit A -> B.
     for i in 1..=node_a_max_tlc_number + 1 {
         let add_tlc_command = AddTlcCommand {
             amount: tlc_amount,
@@ -3526,18 +3611,12 @@ async fn do_test_add_tlc_with_number_limit() {
             ))
         })
         .expect("source node alive");
-        if i == node_a_max_tlc_number + 1 {
-            assert!(add_tlc_result.is_err());
-            let code = add_tlc_result.unwrap_err();
-            assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
-        } else {
-            dbg!(&add_tlc_result);
-            assert!(add_tlc_result.is_ok());
-            wait_for_tlc_sync(&node_a, &node_b, new_channel_id, i as usize).await;
-        }
+        dbg!(&add_tlc_result);
+        assert!(add_tlc_result.is_ok());
+        wait_for_tlc_sync(&node_a, &node_b, new_channel_id, i as usize).await;
     }
 
-    // B -> A can still add tlc
+    // B -> A consumes A's advertised incoming TLC limit.
     for i in 1..=node_a_max_tlc_number + 1 {
         let add_tlc_command = AddTlcCommand {
             amount: tlc_amount,
@@ -3559,9 +3638,15 @@ async fn do_test_add_tlc_with_number_limit() {
             ))
         })
         .expect("source node alive");
-        dbg!(&add_tlc_result);
-        assert!(add_tlc_result.is_ok());
-        wait_for_tlc_sync(&node_b, &node_a, new_channel_id, i as usize).await;
+        if i == node_a_max_tlc_number + 1 {
+            assert!(add_tlc_result.is_err());
+            let code = add_tlc_result.unwrap_err();
+            assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
+        } else {
+            dbg!(&add_tlc_result);
+            assert!(add_tlc_result.is_ok());
+            wait_for_tlc_sync(&node_b, &node_a, new_channel_id, i as usize).await;
+        }
     }
 }
 
@@ -3587,7 +3672,7 @@ async fn do_test_add_tlc_number_limit_reverse() {
     .await;
 
     let tlc_amount = 1000000000;
-    // B -> A will have tlc number limit 2
+    // B's max applies to incoming TLCs, so it should not limit B -> A.
     for i in 1..=node_b_max_tlc_number + 1 {
         let add_tlc_command = AddTlcCommand {
             amount: tlc_amount,
@@ -3609,18 +3694,12 @@ async fn do_test_add_tlc_number_limit_reverse() {
             ))
         })
         .expect("source node alive");
-        if i == node_b_max_tlc_number + 1 {
-            assert!(add_tlc_result.is_err());
-            let code = add_tlc_result.unwrap_err();
-            assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
-        } else {
-            dbg!(&add_tlc_result);
-            assert!(add_tlc_result.is_ok());
-            wait_for_tlc_sync(&node_b, &node_a, new_channel_id, i as usize).await;
-        }
+        dbg!(&add_tlc_result);
+        assert!(add_tlc_result.is_ok());
+        wait_for_tlc_sync(&node_b, &node_a, new_channel_id, i as usize).await;
     }
 
-    // A -> B can still add tlc
+    // A -> B consumes B's advertised incoming TLC limit.
     for i in 1..=node_b_max_tlc_number + 1 {
         let add_tlc_command = AddTlcCommand {
             amount: tlc_amount,
@@ -3642,9 +3721,15 @@ async fn do_test_add_tlc_number_limit_reverse() {
             ))
         })
         .expect("source node alive");
-        dbg!(&add_tlc_result);
-        assert!(add_tlc_result.is_ok());
-        wait_for_tlc_sync(&node_a, &node_b, new_channel_id, i as usize).await;
+        if i == node_b_max_tlc_number + 1 {
+            assert!(add_tlc_result.is_err());
+            let code = add_tlc_result.unwrap_err();
+            assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
+        } else {
+            dbg!(&add_tlc_result);
+            assert!(add_tlc_result.is_ok());
+            wait_for_tlc_sync(&node_a, &node_b, new_channel_id, i as usize).await;
+        }
     }
 }
 
@@ -3671,7 +3756,7 @@ async fn do_test_add_tlc_value_limit() {
 
     let tlc_amount = 1000000000;
 
-    // A -> B have tlc value limit 3_000_000_000
+    // A's max applies to incoming TLCs, so it should not limit A -> B.
     for i in 1..=max_tlc_number + 1 {
         let add_tlc_command = AddTlcCommand {
             amount: tlc_amount,
@@ -3693,6 +3778,32 @@ async fn do_test_add_tlc_value_limit() {
             ))
         })
         .expect("node_b alive");
+        assert!(add_tlc_result.is_ok());
+        wait_for_tlc_sync(&node_a, &node_b, new_channel_id, i as usize).await;
+    }
+
+    // B -> A consumes A's advertised incoming TLC value limit.
+    for i in 1..=max_tlc_number + 1 {
+        let add_tlc_command = AddTlcCommand {
+            amount: tlc_amount,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            payment_hash: gen_rand_sha256_hash(),
+            attempt_id: None,
+            expiry: now_timestamp_as_millis_u64() + 100000000,
+            onion_packet: None,
+            shared_secret: NO_SHARED_SECRET,
+            is_trampoline_hop: false,
+            previous_tlc: None,
+        };
+        let add_tlc_result = call!(node_b.network_actor, |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
+                ChannelCommandWithId {
+                    channel_id: new_channel_id,
+                    command: ChannelCommand::AddTlc(add_tlc_command, rpc_reply),
+                },
+            ))
+        })
+        .expect("node_b alive");
         if i == max_tlc_number + 1 {
             assert!(add_tlc_result.is_err());
             let code = add_tlc_result.unwrap_err();
@@ -3700,11 +3811,35 @@ async fn do_test_add_tlc_value_limit() {
             assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
         } else {
             assert!(add_tlc_result.is_ok());
-            wait_for_tlc_sync(&node_a, &node_b, new_channel_id, i as usize).await;
+            wait_for_tlc_sync(&node_b, &node_a, new_channel_id, i as usize).await;
         }
     }
+}
 
-    // B -> A can still add tlc
+#[tokio::test]
+async fn do_test_add_tlc_value_limit_reverse() {
+    let node_a_funding_amount = 100000000000;
+    let node_b_funding_amount = 100000000000;
+
+    let [mut node_a, mut node_b] = NetworkNode::new_n_interconnected_nodes().await;
+
+    let max_tlc_number = 3;
+    let (new_channel_id, _funding_tx_hash) = establish_channel_between_nodes(
+        &mut node_a,
+        &mut node_b,
+        ChannelParameters {
+            public: true,
+            node_a_funding_amount,
+            node_b_funding_amount,
+            b_max_tlc_value_in_flight: Some(3000000000),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let tlc_amount = 1000000000;
+
+    // B's max applies to incoming TLCs, so it should not limit B -> A.
     for i in 1..=max_tlc_number + 1 {
         let add_tlc_command = AddTlcCommand {
             amount: tlc_amount,
@@ -3729,6 +3864,91 @@ async fn do_test_add_tlc_value_limit() {
         assert!(add_tlc_result.is_ok());
         wait_for_tlc_sync(&node_b, &node_a, new_channel_id, i as usize).await;
     }
+
+    // A -> B consumes B's advertised incoming TLC value limit.
+    for i in 1..=max_tlc_number + 1 {
+        let add_tlc_command = AddTlcCommand {
+            amount: tlc_amount,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            payment_hash: gen_rand_sha256_hash(),
+            attempt_id: None,
+            expiry: now_timestamp_as_millis_u64() + 100000000,
+            onion_packet: None,
+            shared_secret: NO_SHARED_SECRET,
+            is_trampoline_hop: false,
+            previous_tlc: None,
+        };
+        let add_tlc_result = call!(node_a.network_actor, |rpc_reply| {
+            NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
+                ChannelCommandWithId {
+                    channel_id: new_channel_id,
+                    command: ChannelCommand::AddTlc(add_tlc_command, rpc_reply),
+                },
+            ))
+        })
+        .expect("node_a alive");
+        if i == max_tlc_number + 1 {
+            assert!(add_tlc_result.is_err());
+            let code = add_tlc_result.unwrap_err();
+
+            assert_eq!(code.error_code, TlcErrorCode::TemporaryChannelFailure);
+        } else {
+            assert!(add_tlc_result.is_ok());
+            wait_for_tlc_sync(&node_a, &node_b, new_channel_id, i as usize).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_peer_add_tlc_checks_local_incoming_constraints() {
+    let node_a_funding_amount = 100000000000;
+    let node_b_funding_amount = 100000000000;
+
+    let [mut node_a, mut node_b] = NetworkNode::new_n_interconnected_nodes().await;
+
+    let (new_channel_id, _funding_tx_hash) = establish_channel_between_nodes(
+        &mut node_a,
+        &mut node_b,
+        ChannelParameters {
+            public: true,
+            node_a_funding_amount,
+            node_b_funding_amount,
+            a_max_tlc_value_in_flight: Some(1000),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    node_b
+        .network_actor
+        .send_message(NetworkActorMessage::Command(
+            NetworkActorCommand::SendFiberMessage(FiberMessageWithTarget::new(
+                node_a.pubkey,
+                FiberMessage::add_tlc(AddTlc {
+                    channel_id: new_channel_id,
+                    tlc_id: 0,
+                    amount: 1001,
+                    payment_hash: gen_rand_sha256_hash(),
+                    expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                    hash_algorithm: HashAlgorithm::CkbHash,
+                    onion_packet: None,
+                }),
+            )),
+        ))
+        .expect("send add_tlc peer message");
+
+    node_a
+        .expect_event(|event| {
+            matches!(
+                event,
+                NetworkServiceEvent::DebugEvent(DebugEvent::Common(message))
+                    if message.contains("TlcValueInflightExceedLimit")
+            )
+        })
+        .await;
+
+    let node_a_state = node_a.get_channel_actor_state(new_channel_id);
+    assert_eq!(node_a_state.tlc_state.received_tlcs.tlcs.len(), 0);
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -3116,7 +3116,7 @@ async fn test_send_payment_max_value_in_flight_in_first_hop() {
                 public: true,
                 node_a_funding_amount: HUGE_CKB_AMOUNT,
                 node_b_funding_amount: HUGE_CKB_AMOUNT,
-                a_max_tlc_value_in_flight: Some(100000000),
+                b_max_tlc_value_in_flight: Some(100000000),
                 ..Default::default()
             },
         )
@@ -3151,7 +3151,7 @@ async fn test_send_payment_max_value_in_flight_in_first_hop() {
                 public: true,
                 node_a_funding_amount: HUGE_CKB_AMOUNT,
                 node_b_funding_amount: HUGE_CKB_AMOUNT,
-                a_max_tlc_value_in_flight: Some(100000000 + 2),
+                b_max_tlc_value_in_flight: Some(100000000 + 2),
                 ..Default::default()
             },
         )

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -230,9 +230,9 @@ Attempts to open a channel with a peer.
  Not that, we use outbound channel to calculate the fee for TLC forwarding. For example,
  if we have a path A -> B -> C, then the fee B requires for TLC forwarding, is calculated
  the channel configuration of B and C, not A and B.
-* `max_tlc_value_in_flight` - <em>`Option<u128>`</em>, The maximum value in flight for TLCs, an optional parameter.
+* `max_tlc_value_in_flight` - <em>`Option<u128>`</em>, The maximum total value of in-flight TLCs our side will accept from the peer, an optional parameter.
  This parameter can not be updated after channel is opened.
-* `max_tlc_number_in_flight` - <em>`Option<u64>`</em>, The maximum number of TLCs that can be accepted, an optional parameter, default is 125
+* `max_tlc_number_in_flight` - <em>`Option<u64>`</em>, The maximum number of in-flight TLCs our side will accept from the peer, an optional parameter, default is 125
  This parameter can not be updated after channel is opened.
 
 ##### Returns
@@ -254,9 +254,9 @@ Accepts a channel opening request from a peer.
 * `funding_amount` - <em>`u128`</em>, The amount of CKB or UDT to fund the channel with
 * `shutdown_script` - <em>`Option<Script>`</em>, The script used to receive the channel balance, an optional parameter,
  default value is the secp256k1_blake160_sighash_all script corresponding to the configured private key
-* `max_tlc_value_in_flight` - <em>`Option<u128>`</em>, The max tlc sum value in flight for the channel, default is u128::MAX
+* `max_tlc_value_in_flight` - <em>`Option<u128>`</em>, The maximum total value of in-flight TLCs our side will accept from the peer, default is u128::MAX
  This parameter can not be updated after channel is opened.
-* `max_tlc_number_in_flight` - <em>`Option<u64>`</em>, The max tlc number in flight send from our side, default is 125
+* `max_tlc_number_in_flight` - <em>`Option<u64>`</em>, The maximum number of in-flight TLCs our side will accept from the peer, default is 125
  This parameter can not be updated after channel is opened.
 * `tlc_min_value` - <em>`Option<u128>`</em>, The minimum value for a TLC our side can send,
  an optional parameter, default is 0, which means we can send any TLC is larger than 0.
@@ -402,9 +402,9 @@ Opens a channel with external funding. The node will negotiate the channel with 
 * `tlc_fee_proportional_millionths` - <em>`Option<u128>`</em>, The fee proportional millionths for a TLC, proportional to the amount of the forwarded tlc.
  The unit is millionths of the amount. default is 1000 which means 0.1%.
  This parameter can be updated with rpc `update_channel` later.
-* `max_tlc_value_in_flight` - <em>`Option<u128>`</em>, The maximum value in flight for TLCs, an optional parameter.
+* `max_tlc_value_in_flight` - <em>`Option<u128>`</em>, The maximum total value of in-flight TLCs our side will accept from the peer, an optional parameter.
  This parameter can not be updated after channel is opened.
-* `max_tlc_number_in_flight` - <em>`Option<u64>`</em>, The maximum number of TLCs that can be accepted, an optional parameter, default is 125
+* `max_tlc_number_in_flight` - <em>`Option<u64>`</em>, The maximum number of in-flight TLCs our side will accept from the peer, an optional parameter, default is 125
  This parameter can not be updated after channel is opened.
 
 ##### Returns

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -359,12 +359,12 @@ impl CommitmentNumbers {
     }
 }
 
-/// Channel constraints for TLC value and number limits.
+/// Channel constraints for TLC value and number limits accepted by a participant.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default)]
 pub struct ChannelConstraints {
-    /// The maximum value that can be in pending TLCs.
+    /// The maximum total value of pending TLCs this participant will accept.
     pub max_tlc_value_in_flight: u128,
-    /// The maximum number of TLCs that can be accepted.
+    /// The maximum number of pending TLCs this participant will accept.
     pub max_tlc_number_in_flight: u64,
 }
 


### PR DESCRIPTION
## Summary

Fixes the semantics of `ChannelConstraints` so the max in-flight TLC value/count represent the
TLCs a participant is willing to accept from its peer.

## Changes

- Updated TLC limit checks to apply local constraints to incoming peer TLCs and remote
constraints to outgoing TLCs.
- Clarified docs and comments for open/accept channel constraint parameters.
- Updated existing tests to match the corrected semantics.
- Added regression coverage for both value/count limits and direct peer `AddTlc` constraint
validation.