### PR TITLE
fix: propagate custom_records from SendPaymentWithRouterCommand to SendPaymentData

### DIFF
--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -726,6 +726,7 @@ impl SendPaymentWithRouterCommand {
             amount: Some(amount),
             keysend: self.keysend,
             udt_type_script: self.udt_type_script.clone(),
+            custom_records: self.custom_records.clone(),
             ..Default::default()
         };
 


### PR DESCRIPTION
Closes nervosnetwork/fiber#1380