### PR TITLE
fix: reject peer TxUpdate while awaiting external funding submission

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -583,7 +583,7 @@ where
             }
             FiberChannelMessage::TxUpdate(tx) => {
                 if state.ephemeral_config.external_funding.enabled
-                    && !state.ephemeral_config.external_funding.signed_submitted
+                    && state.ephemeral_config.external_funding.signed_submitted
                     && state.state.is_awaiting_external_funding()
                 {
                     self.handle_external_funding_tx_sync(myself, state, tx.tx)


### PR DESCRIPTION
External funding channels in `AWAITING_EXTERNAL_FUNDING` state with `signed_submitted=false` would accept a peer `TxUpdate` as a valid signed funding transaction, bypassing the wallet signature requirement. Only allow the sync path after local signed submission has occurred.