### PR TITLE
fix: enforce private filesystem permissions on store directories and files

### DIFF
--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -510,8 +510,7 @@ impl FiberConfig {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ =
-                    fs::set_permissions(&path, fs::Permissions::from_mode(0o700));
+                let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o700));
             }
         }
         path

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -462,10 +462,14 @@ impl FiberConfig {
 
     pub fn create_base_dir(&self) -> Result<()> {
         if !self.base_dir().exists() {
-            fs::create_dir_all(self.base_dir()).map_err(Into::into)
-        } else {
-            Ok(())
+            fs::create_dir_all(self.base_dir())?;
         }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(self.base_dir(), fs::Permissions::from_mode(0o700));
+        }
+        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -499,8 +503,16 @@ impl FiberConfig {
     pub fn store_path(&self) -> PathBuf {
         let path = self.base_dir().join("store");
         #[cfg(not(target_arch = "wasm32"))]
-        if !path.exists() {
-            fs::create_dir_all(&path).expect("create store directory");
+        {
+            if !path.exists() {
+                fs::create_dir_all(&path).expect("create store directory");
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ =
+                    fs::set_permissions(&path, fs::Permissions::from_mode(0o700));
+            }
         }
         path
     }

--- a/crates/fiber-store/src/native.rs
+++ b/crates/fiber-store/src/native.rs
@@ -19,6 +19,19 @@ impl Store {
         options.create_if_missing(true);
         options.set_compression_type(DBCompressionType::Lz4);
         let db = Arc::new(DB::open(&options, path).map_err(|e| e.to_string())?);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+            if let Ok(entries) = std::fs::read_dir(path) {
+                for entry in entries.flatten() {
+                    let _ = std::fs::set_permissions(
+                        entry.path(),
+                        std::fs::Permissions::from_mode(0o600),
+                    );
+                }
+            }
+        }
         Ok(Self { db })
     }
 }

--- a/crates/fiber-store/src/sqlite.rs
+++ b/crates/fiber-store/src/sqlite.rs
@@ -24,16 +24,14 @@ impl Store {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ =
-                std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
         }
         let db_file = path.join("data.sqlite");
         let conn = Connection::open(&db_file).map_err(|e| e.to_string())?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ =
-                std::fs::set_permissions(&db_file, std::fs::Permissions::from_mode(0o600));
+            let _ = std::fs::set_permissions(&db_file, std::fs::Permissions::from_mode(0o600));
         }
 
         // Configure SQLite for performance

--- a/crates/fiber-store/src/sqlite.rs
+++ b/crates/fiber-store/src/sqlite.rs
@@ -21,8 +21,20 @@ impl Store {
         // Ensure the directory exists
         std::fs::create_dir_all(path)
             .map_err(|e| format!("failed to create database directory: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ =
+                std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+        }
         let db_file = path.join("data.sqlite");
         let conn = Connection::open(&db_file).map_err(|e| e.to_string())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ =
+                std::fs::set_permissions(&db_file, std::fs::Permissions::from_mode(0o600));
+        }
 
         // Configure SQLite for performance
         conn.execute_batch(


### PR DESCRIPTION
Store directory and database files were created with default filesystem permissions inherited from the process umask, potentially exposing channel signer keys, payment preimages, and watchtower secrets to other local users on shared hosts.

Changes:
- Set `0o700` on base directory and store directory after creation (and on existing dirs for upgrade)
- Set `0o700` on RocksDB directory, `0o600` on all RocksDB files
- Set `0o700` on SQLite directory, `0o600` on SQLite database file