### PR TITLE
fix: clean stale funding exclusions and stabilize external-funding handshake CI

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -586,7 +586,6 @@ where
             }
             FiberChannelMessage::TxUpdate(tx) => {
                 if state.ephemeral_config.external_funding.enabled
-                    && state.ephemeral_config.external_funding.signed_submitted
                     && state.state.is_awaiting_external_funding()
                 {
                     self.handle_external_funding_tx_sync(myself, state, tx.tx)
@@ -618,6 +617,22 @@ where
                     .await
             }
             FiberChannelMessage::TxComplete(tx) => {
+                if state.ephemeral_config.external_funding.enabled
+                    && state.ephemeral_config.external_funding.signed_submitted
+                    && matches!(
+                        state.state,
+                        ChannelState::SigningCommitment(_)
+                            | ChannelState::AwaitingTxSignatures(_)
+                            | ChannelState::AwaitingChannelReady(_)
+                            | ChannelState::ChannelReady
+                    )
+                {
+                    debug!(
+                        "Ignoring duplicate external funding TxComplete for channel {:?} after signed tx submission",
+                        state.get_id()
+                    );
+                    return Ok(());
+                }
                 state
                     .handle_tx_collaboration_msg(myself, TxCollaborationMsg::TxComplete(tx))
                     .await?;
@@ -7273,6 +7288,17 @@ impl ChannelActorState {
             }
             ChannelState::CollaboratingFundingTx(flags) => {
                 if flags.contains(CollaboratingFundingTxFlags::THEIR_TX_COMPLETE_SENT) {
+                    if self.ephemeral_config.external_funding.enabled
+                        && self.ephemeral_config.external_funding.signed_submitted
+                        && is_complete_message
+                    {
+                        debug!(
+                            "Ignoring duplicate external funding TxComplete for channel {:?} in state {:?}",
+                            self.get_id(),
+                            self.state
+                        );
+                        return Ok(());
+                    }
                     return Err(ProcessingChannelError::InvalidState(format!(
                         "Received a tx collaboration message {:?}, but we are already in the state {:?} where the remote has sent a complete message",
                         &msg, &self.state

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -3586,6 +3586,17 @@ where
             request.funding_fee_rate,
             request.udt_type_script.is_some(),
         );
+        let prev_funding_tx_hash = state
+            .store
+            .get_channel_actor_state(&channel_id)
+            .and_then(|s| {
+                s.funding_tx
+                    .as_ref()
+                    .map(|tx| {
+                        let hash: Hash256 = tx.calc_tx_hash().into();
+                        hash
+                    })
+            });
         let tx_for_retry = transaction.clone();
         let request_for_retry = request.clone();
         let old_tx = transaction.into_view();
@@ -3596,7 +3607,14 @@ where
             .await
             .and_then(|tx| tx.into_inner().ok_or(FundingError::AbsentTx))
         {
-            Ok(tx) => tx,
+            Ok(tx) => {
+                if let Some(prev_hash) = prev_funding_tx_hash {
+                    let _ = self
+                        .chain_actor
+                        .send_message(CkbChainMessage::RemoveFundingTx(prev_hash));
+                }
+                tx
+            }
             Err(err) => {
                 let should_abort = schedule_funding_retry(
                     myself,

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -3590,12 +3590,10 @@ where
             .store
             .get_channel_actor_state(&channel_id)
             .and_then(|s| {
-                s.funding_tx
-                    .as_ref()
-                    .map(|tx| {
-                        let hash: Hash256 = tx.calc_tx_hash().into();
-                        hash
-                    })
+                s.funding_tx.as_ref().map(|tx| {
+                    let hash: Hash256 = tx.calc_tx_hash().into();
+                    hash
+                })
             });
         let tx_for_retry = transaction.clone();
         let request_for_retry = request.clone();
@@ -3608,7 +3606,9 @@ where
             .and_then(|tx| tx.into_inner().ok_or(FundingError::AbsentTx))
         {
             Ok(tx) => {
-                if let Some(prev_hash) = prev_funding_tx_hash {
+                let new_funding_tx_hash: Hash256 = tx.hash().into();
+                if let Some(prev_hash) = prev_funding_tx_hash.filter(|h| *h != new_funding_tx_hash)
+                {
                     let _ = self
                         .chain_actor
                         .send_message(CkbChainMessage::RemoveFundingTx(prev_hash));

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -9113,6 +9113,69 @@ async fn test_submit_signed_funding_tx_unblocks_acceptor_commitment_handshake() 
 }
 
 #[tokio::test]
+async fn test_external_funding_duplicate_tx_complete_after_signed_submit_is_ignored() {
+    init_tracing();
+
+    let [node_a, node_b] = new_2_nodes_with_auto_accept().await;
+    let (channel_id, unsigned_tx) =
+        open_external_funding_channel(&node_a, &node_b, 100_000_000_000).await;
+    let signed_tx = mock_sign_external_funding_tx(&unsigned_tx);
+
+    let submit_message = |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::SubmitSignedFundingTx {
+            channel_id,
+            signed_tx: signed_tx.clone(),
+            reply: rpc_reply,
+        })
+    };
+    call!(node_a.network_actor, submit_message)
+        .expect("node_a alive")
+        .expect("submit signed funding tx success");
+
+    let progressed = wait_for_external_funding_post_submit_progress(&node_a, channel_id).await;
+    assert!(
+        matches!(
+            progressed.state,
+            ChannelState::AwaitingTxSignatures(_)
+                | ChannelState::AwaitingChannelReady(_)
+                | ChannelState::ChannelReady
+        ),
+        "channel should progress beyond tx collaboration after signed submit, got {:?}",
+        progressed.state
+    );
+
+    let duplicate_tx_complete = FiberMessage::tx_complete(crate::fiber::types::TxComplete {
+        channel_id,
+        next_commitment_nonce: musig2::SecNonceBuilder::new([3u8; 32])
+            .build()
+            .public_nonce(),
+    });
+    node_b
+        .network_actor
+        .send_message(NetworkActorMessage::Command(
+            NetworkActorCommand::SendFiberMessage(FiberMessageWithTarget::new(
+                node_a.pubkey,
+                duplicate_tx_complete,
+            )),
+        ))
+        .expect("send duplicate tx_complete");
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let state_after_duplicate = node_a.get_channel_actor_state(channel_id);
+    assert!(
+        matches!(
+            state_after_duplicate.state,
+            ChannelState::AwaitingTxSignatures(_)
+                | ChannelState::AwaitingChannelReady(_)
+                | ChannelState::ChannelReady
+        ),
+        "duplicate tx_complete should be ignored after signed submit, got {:?}",
+        state_after_duplicate.state
+    );
+}
+
+#[tokio::test]
 async fn test_submit_signed_funding_tx_wrong_state() {
     init_tracing();
 


### PR DESCRIPTION
When a peer TxUpdate replaces the local funding transaction, `do_update_channel_funding` creates a fresh `FundingTx` and re-adds inputs to the `LiveCellsExclusionMap`. However, the old funding tx hash was never removed, leaving stale exclusion entries that could lock otherwise-usable cells after channel abort.

This fix looks up the previous funding tx hash from the channel actor state before rebuilding, and sends `RemoveFundingTx` to the CKB chain actor after the new funding tx is built successfully.

Additionally, this PR includes the external-funding handshake idempotency adjustment needed to resolve CI failures after rebasing, so post-submit duplicate `TxComplete` handling no longer causes the external-funding flow to stall.