### PR TITLE
Deduct outer route fee from trampoline budget in routing logic

### DIFF
--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1452,6 +1452,24 @@ where
 
         let remaining_fee = max_fee_amount.saturating_sub(first_hop_fee);
 
+        if remaining_fee < low_total_trampoline_fee {
+            let high_total_trampoline_fee = self.estimate_trampoline_fee(final_amount, 10, hops)?;
+            let recommend_minimal_fee = checked_add_u128(
+                first_hop_fee,
+                low_total_trampoline_fee,
+                "trampoline minimal fee",
+            )?;
+            let maximal_fee = checked_add_u128(
+                first_hop_fee,
+                high_total_trampoline_fee,
+                "trampoline maximal fee",
+            )?;
+            return Err(PathFindError::Other(format!(
+                "max_fee_amount is too low for trampoline routing: recommend_minimal_fee={}, maximal_fee={} current_fee={}",
+                recommend_minimal_fee, maximal_fee, max_fee_amount
+            )));
+        }
+
         let slots = fees.len() as u128;
         let base = remaining_fee / slots;
         let remainder = (remaining_fee % slots) as usize;

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1403,7 +1403,7 @@ where
                 max_fee_amount,
                 "trampoline route amount",
             )?),
-            None,
+            Some(max_fee_amount),
             payment_data.udt_type_script.clone(),
             self.trampoline_forward_expiry_delta(
                 payment_data.final_tlc_expiry_delta,
@@ -1417,22 +1417,41 @@ where
             false,
         )?;
 
-        let first_hop_fee = final_amount
-            .saturating_sub(route_to_trampoline.last().map_or(0, |h| h.amount_received));
+        if route_to_trampoline.is_empty() {
+            return Err(PathFindError::NoPathFound);
+        }
 
-        if first_hop_fee >= max_fee_amount {
+        let source_side_amount = route_to_trampoline[0].amount_received;
+        let first_trampoline_amount = route_to_trampoline
+            .last()
+            .expect("already checked")
+            .amount_received;
+        let first_hop_fee =
+            source_side_amount
+                .checked_sub(first_trampoline_amount)
+                .ok_or_else(|| {
+                    PathFindError::Other(format!(
+                        "invalid trampoline route amounts: source_side_amount={} first_trampoline_amount={}",
+                        source_side_amount, first_trampoline_amount
+                    ))
+                })?;
+
+        if first_hop_fee > max_fee_amount {
             return Err(PathFindError::Other(format!(
                 "max_fee_amount is too low for trampoline routing: first_hop_fee={} current_fee={}",
                 first_hop_fee, max_fee_amount
             )));
-        } else {
-            // adjust the amount_received by removing the first hop fee
-            for r in route_to_trampoline.iter_mut() {
-                r.amount_received = r.amount_received.saturating_sub(first_hop_fee);
-            }
+        }
+
+        // The outer route was found with the full fee budget delivered to the first trampoline.
+        // Deduct the outer route fee from every visible hop so the source-side amount remains
+        // final_amount + max_fee_amount while the first trampoline only receives the inner budget.
+        for r in route_to_trampoline.iter_mut() {
+            r.amount_received = r.amount_received.saturating_sub(first_hop_fee);
         }
 
         let remaining_fee = max_fee_amount.saturating_sub(first_hop_fee);
+
         let slots = fees.len() as u128;
         let base = remaining_fee / slots;
         let remainder = (remaining_fee % slots) as usize;

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -857,6 +857,59 @@ fn test_graph_trampoline_routing_no_sender_precheck_to_final() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_trampoline_routing_outer_route_fee_is_deducted_from_budget() {
+    init_tracing();
+
+    // Topology:
+    //   sender(A)=node1 --(public)--> relay(B)=node2 --(public)--> trampoline(C)=node3
+    //   final(D)=node4 is intentionally disconnected from the graph.
+    //
+    // The B->C forwarding fee must consume part of max_fee_amount before the remaining
+    // budget is allocated to the inner trampoline payload.
+    let mut network = MockNetworkGraph::new(4);
+    network.graph.set_add_rand_expiry_delta(false);
+
+    let sender = network.keys[1];
+    network.set_source(sender);
+    let relay = network.keys[2];
+    let trampoline = network.keys[3];
+    let final_recipient = network.keys[4];
+
+    network.add_edge(1, 2, Some(10_000), Some(0));
+    network.add_edge(2, 3, Some(10_000), Some(10_000));
+
+    let final_amount: u128 = 1000;
+    let max_fee_amount: u128 = 20;
+    let payment_state: SendPaymentState =
+        SendPaymentDataBuilder::new(final_recipient.into(), final_amount, Hash256::default())
+            .final_tlc_expiry_delta(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)
+            .tlc_expiry_limit(MAX_PAYMENT_TLC_EXPIRY_LIMIT)
+            .max_fee_amount(Some(max_fee_amount))
+            .trampoline_hops(Some(vec![trampoline.into()]))
+            .build()
+            .expect("valid payment_data")
+            .into();
+
+    let route = network
+        .graph
+        .build_route(payment_state.amount, None, None, &payment_state)
+        .expect("trampoline route should be built");
+
+    assert_eq!(route.len(), 3);
+    assert_eq!(route[0].next_hop, Some(relay.into()));
+    assert_eq!(route[1].next_hop, Some(trampoline.into()));
+    assert!(route.last().unwrap().trampoline_onion().is_some());
+
+    let amounts = route.iter().map(|hop| hop.amount).collect::<Vec<_>>();
+    assert_eq!(amounts, vec![1020, 1009, 1009]);
+
+    assert_eq!(route.first().unwrap().amount - final_amount, max_fee_amount);
+    assert_eq!(route[0].amount - route[1].amount, 11);
+    assert_eq!(route[1].amount - final_amount, 9);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 fn test_graph_build_router_fee_rate_optimize() {
     let mut network = MockNetworkGraph::new(10);
 

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -910,6 +910,43 @@ fn test_graph_trampoline_routing_outer_route_fee_is_deducted_from_budget() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_trampoline_routing_outer_route_fee_can_exhaust_inner_budget() {
+    init_tracing();
+
+    let mut network = MockNetworkGraph::new(4);
+    network.graph.set_add_rand_expiry_delta(false);
+
+    let sender = network.keys[1];
+    network.set_source(sender);
+    let trampoline = network.keys[3];
+    let final_recipient = network.keys[4];
+
+    network.add_edge(1, 2, Some(10_000), Some(0));
+    network.add_edge(2, 3, Some(10_000), Some(10_000));
+
+    let payment_state: SendPaymentState =
+        SendPaymentDataBuilder::new(final_recipient.into(), 1000, Hash256::default())
+            .final_tlc_expiry_delta(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)
+            .tlc_expiry_limit(MAX_PAYMENT_TLC_EXPIRY_LIMIT)
+            .max_fee_amount(Some(11))
+            .trampoline_hops(Some(vec![trampoline.into()]))
+            .build()
+            .expect("valid payment_data")
+            .into();
+
+    let err = network
+        .graph
+        .build_route(payment_state.amount, None, None, &payment_state)
+        .expect_err("outer route fee should leave insufficient inner trampoline budget");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("recommend_minimal_fee=12") && msg.contains("current_fee=11"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 fn test_graph_build_router_fee_rate_optimize() {
     let mut network = MockNetworkGraph::new(10);
 


### PR DESCRIPTION
When building a trampoline-routed payment, Fiber uses the payer's full max_fee_amount both as part of the amount sent to the first trampoline hop and as the budget allocated to inner trampoline forwarding. The route fee needed to reach the first trampoline is not deducted from the user's fee cap.

