### PR TITLE
chore(test): refine comment for synthetic funding transactions

### DIFF
--- a/crates/fiber-lib/src/ckb/tests/test_utils.rs
+++ b/crates/fiber-lib/src/ckb/tests/test_utils.rs
@@ -581,9 +581,8 @@ impl Actor for MockChainActor {
                         }
                     }
 
-                    // If the transaction has no inputs, it's a funding transaction.
-                    // Skip script verification since the type script on the output
-                    // will be verified when it is consumed later.
+                    // The inputs will always not empty for production enviornment, but it may empty for test enviornment,
+                    // `MockChainActor` only used in testing, so we skip VM verification for these synthetic transactions
                     let has_inputs = !tx.inputs().is_empty();
                     let context = &mut MOCK_CONTEXT.write().unwrap().context;
                     let verify_result = if has_inputs {

--- a/crates/fiber-lib/src/ckb/tests/test_utils.rs
+++ b/crates/fiber-lib/src/ckb/tests/test_utils.rs
@@ -581,7 +581,7 @@ impl Actor for MockChainActor {
                         }
                     }
 
-                    // The inputs will always not empty for production enviornment, but it may empty for test enviornment,
+                    // The inputs will always not empty for production environment, but it may empty for test environment,
                     // `MockChainActor` only used in testing, so we skip VM verification for these synthetic transactions
                     let has_inputs = !tx.inputs().is_empty();
                     let context = &mut MOCK_CONTEXT.write().unwrap().context;


### PR DESCRIPTION
## Summary

This is a minor follow-up to PR #1387, addressing a post-merge review suggestion from @chenyukang.

While the previous comment stated *what* the code does (skipping script verification for input-less funding txs), this update provides the crucial *architectural context*: it clarifies that input-less transactions are strictly synthetic and only exist within the test environment (`MockChainActor`), whereas production transactions will always have inputs.

## Changes

- Refined the inline code comments in `crates/fiber-lib/src/ckb/tests/test_utils.rs` to better explain the synthetic nature of these test transactions.
- **Note:** This PR contains only comment updates; there are absolutely no logic changes.