### PR TITLE
fix: redact secret keys from fiber worker startup log

### DIFF
--- a/fiber-js/src/fiber.worker.ts
+++ b/fiber-js/src/fiber.worker.ts
@@ -9,7 +9,14 @@ onmessage = async (evt) => {
 
     if (fiber === undefined) {
         const data = evt.data as FiberWorkerInitializationOptions;
-        console.debug("Starting fiber, configuration: ", data);
+        console.debug(
+            "Starting fiber: logLevel=",
+            data.logLevel,
+            ", databasePrefix=",
+            data.databasePrefix,
+            ", hasChainSpec=",
+            !!(data.chainSpec),
+        );
         fiber = await import("fiber-wasm");
         fiber.default.set_shared_array(data.inputBuffer, data.outputBuffer
         );


### PR DESCRIPTION
## Summary
- Fix GHSA-jhg9-jv83-p8qf: fiber-js worker startup logging exposes Fiber and CKB secret keys

## Changes
- Replace `console.debug("Starting fiber, configuration: ", data)` with a redacted log that only includes non-sensitive fields (`logLevel`, `databasePrefix`, `hasChainSpec`)
- The previous log logged the full `FiberWorkerInitializationOptions` object including `fiberKeyPair: Uint8Array` and optional `ckbSecretKey: Uint8Array`

## Risk
Low — only changes what gets printed to `console.debug`, no functional impact on worker initialization or WASM bridge.