### PR TITLE
fix: validate chain_hash before persisting inbound ChannelOpenRecord

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -5517,6 +5517,15 @@ where
     ) -> ProcessingChannelResult {
         let id = open_channel.channel_id;
         let remote_funding_amount = open_channel.funding_amount;
+
+        if open_channel.chain_hash != get_chain_hash() {
+            return Err(ProcessingChannelError::InvalidParameter(format!(
+                "Invalid chain hash {:?}, expected {:?}",
+                open_channel.chain_hash,
+                get_chain_hash()
+            )));
+        }
+
         let result = check_open_channel_parameters(
             &open_channel.funding_udt_type_script,
             &open_channel.shutdown_script,


### PR DESCRIPTION
## Summary
- Fix GHSA-7657-cq4f-3mhj: validate `chain_hash` in `on_open_channel_msg` before persisting `ChannelOpenRecord`

## Problem
`on_open_channel_msg` (inbound `OpenChannel` handler) persisted a durable `ChannelOpenRecord` before checking whether the `chain_hash` matches the local chain. The chain_hash check only happened later inside the channel actor startup, after the record was already persisted and the pending entry was removed from `to_be_accepted_channels`.

A remote peer could:
1. Establish a valid peer session
2. Send `OpenChannel` with the correct `chain_hash` → auto-accept triggers
3. The channel actor starts and immediately fails on chain_hash check
4. The `ChannelOpenRecord` remains in the store permanently

This is a persistent storage DoS vector — repeated attacks leave durable garbage records without locking any funds.

## Fix
Add a `chain_hash` check at the top of `on_open_channel_msg`, before any state mutation (before `check_open_channel_parameters`, `to_be_accepted_channels` insert, or `ChannelOpenRecord` persist).

## Risk
Low — the channel actor already rejected wrong-chain `OpenChannel` messages. This just moves the check earlier so the rejection happens before durable writes.