### PR TITLE
fix: prevent watchtower RPC errors from killing event-processing task

### DIFF
--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -340,7 +340,15 @@ async fn run_node(
                                         }
                                     }
                                     if let Some(watchtower_client) = watchtower_client.as_ref() {
-                                        forward_event_to_client(event.clone(), watchtower_client).await;
+                                        if let Err(err) =
+                                            forward_event_to_client(event.clone(), watchtower_client)
+                                                .await
+                                        {
+                                            error!(
+                                                "Failed to forward event to standalone watchtower: {}",
+                                                err
+                                            );
+                                        }
                                     }
                                     if let Some(watchtower_actor) = watchtower_actor.as_ref() {
                                         forward_event_to_actor(event, watchtower_actor);

--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -32,9 +32,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::select;
 use tokio::sync::{mpsc, RwLock};
-#[cfg(debug_assertions)]
-use tracing::error;
-use tracing::{debug, info, info_span, trace};
+use tracing::{debug, error, info, info_span, trace};
 use tracing_subscriber::{field::MakeExt, fmt, fmt::format, EnvFilter};
 
 const ASSUME_WATCHTOWER_ACTOR_ALIVE: &str = "watchtower actor must be alive";

--- a/crates/fiber-lib/src/event_handler.rs
+++ b/crates/fiber-lib/src/event_handler.rs
@@ -25,17 +25,18 @@ impl ExitMessage {
     }
 }
 
-const ASSUME_WATCHTOWER_CLIENT_CALL_OK: &str = "watchtower client call should be ok";
-
 /// Forward a [`NetworkServiceEvent`] to a remote watchtower via its RPC client.
 ///
 /// This is the shared implementation used by both native and WASM entry points.
 /// The concrete client type differs per platform (HTTP client vs WASM client),
 /// but both implement the generated [`WatchtowerRpcClient`] trait.
+///
+/// Returns an error string if the RPC call fails, allowing the caller to log the
+/// failure without panicking and killing the event-processing task.
 pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
     event: NetworkServiceEvent,
     watchtower_client: &T,
-) {
+) -> Result<(), String> {
     match event {
         NetworkServiceEvent::RemoteTxComplete(
             _peer_id,
@@ -58,7 +59,7 @@ pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
                     settlement_data: settlement_data.into(),
                 })
                 .await
-                .expect(ASSUME_WATCHTOWER_CLIENT_CALL_OK);
+                .map_err(|e| format!("Failed to create watch channel: {e}"))?;
         }
         NetworkServiceEvent::ChannelClosed(_, channel_id, _)
         | NetworkServiceEvent::ChannelAbandon(channel_id) => {
@@ -67,7 +68,7 @@ pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
                     channel_id: channel_id.into(),
                 })
                 .await
-                .expect(ASSUME_WATCHTOWER_CLIENT_CALL_OK);
+                .map_err(|e| format!("Failed to remove watch channel: {e}"))?;
         }
         NetworkServiceEvent::RevokeAndAckReceived(
             _peer_id,
@@ -82,7 +83,7 @@ pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
                     settlement_data: settlement_data.into(),
                 })
                 .await
-                .expect(ASSUME_WATCHTOWER_CLIENT_CALL_OK);
+                .map_err(|e| format!("Failed to update revocation: {e}"))?;
         }
         NetworkServiceEvent::RemoteCommitmentSigned(
             _peer_id,
@@ -96,7 +97,7 @@ pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
                     settlement_data: settlement_data.into(),
                 })
                 .await
-                .expect(ASSUME_WATCHTOWER_CLIENT_CALL_OK);
+                .map_err(|e| format!("Failed to update local settlement: {e}"))?;
         }
         NetworkServiceEvent::LocalCommitmentSigned(channel_id, settlement_data) => {
             watchtower_client
@@ -105,7 +106,7 @@ pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
                     settlement_data: settlement_data.into(),
                 })
                 .await
-                .expect(ASSUME_WATCHTOWER_CLIENT_CALL_OK);
+                .map_err(|e| format!("Failed to update pending remote settlement: {e}"))?;
         }
         NetworkServiceEvent::PreimageCreated(payment_hash, preimage) => {
             watchtower_client
@@ -114,7 +115,7 @@ pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
                     preimage: preimage.into(),
                 })
                 .await
-                .expect(ASSUME_WATCHTOWER_CLIENT_CALL_OK);
+                .map_err(|e| format!("Failed to create preimage: {e}"))?;
         }
         NetworkServiceEvent::PreimageRemoved(payment_hash) => {
             watchtower_client
@@ -122,10 +123,11 @@ pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
                     payment_hash: payment_hash.into(),
                 })
                 .await
-                .expect(ASSUME_WATCHTOWER_CLIENT_CALL_OK);
+                .map_err(|e| format!("Failed to remove preimage: {e}"))?;
         }
         _ => {
             // ignore other non-watchtower related events
         }
     }
+    Ok(())
 }

--- a/crates/fiber-wasm/src/lib.rs
+++ b/crates/fiber-wasm/src/lib.rs
@@ -34,7 +34,7 @@ use tokio::{
     select,
     sync::{RwLock, mpsc},
 };
-use tracing::{debug, info, trace};
+use tracing::{debug, error, info, trace};
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 pub mod api;
@@ -271,16 +271,17 @@ pub async fn fiber(
                                     break;
                                 }
                                 Some(event) => {
-                                    if let Some(watchtower_client) = watchtower_client.as_ref() {
-                                        if let Err(err) =
-                                            forward_event_to_client(event.clone(), watchtower_client)
-                                                .await
-                                        {
-                                            error!(
-                                                "Failed to forward event to standalone watchtower: {}",
-                                                err
-                                            );
-                                        }
+                                    if let Some(watchtower_client) = watchtower_client.as_ref()
+                                        && let Err(err) = forward_event_to_client(
+                                            event.clone(),
+                                            watchtower_client,
+                                        )
+                                        .await
+                                    {
+                                        error!(
+                                            "Failed to forward event to standalone watchtower: {}",
+                                            err
+                                        );
                                     }
                                 }
                             }

--- a/crates/fiber-wasm/src/lib.rs
+++ b/crates/fiber-wasm/src/lib.rs
@@ -272,7 +272,15 @@ pub async fn fiber(
                                 }
                                 Some(event) => {
                                     if let Some(watchtower_client) = watchtower_client.as_ref() {
-                                        forward_event_to_client(event.clone(), watchtower_client).await;
+                                        if let Err(err) =
+                                            forward_event_to_client(event.clone(), watchtower_client)
+                                                .await
+                                        {
+                                            error!(
+                                                "Failed to forward event to standalone watchtower: {}",
+                                                err
+                                            );
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- Fix GHSA-49ph-wf39-5prx: standalone watchtower RPC errors can permanently stop all event forwarding

## Problem
`forward_event_to_client` used `.expect()` on all 6 watchtower RPC calls. Any transient failure (network error, watchtower downtime, token expiry) would panic, killing the entire event-processing tokio task. Once dead, no further events were forwarded to either the standalone watchtower or the built-in watchtower actor.

## Fix
- `forward_event_to_client` return type changed from `()` to `Result<(), String>`
- 6 `.expect()` calls replaced with `.map_err(|e| format!(...))?`
- Native (`main.rs`) and WASM (`lib.rs`) callers log the error and continue the event loop

## Changes
| File | Change |
|------|--------|
| `crates/fiber-lib/src/event_handler.rs` | Return `Result`, `?` instead of `.expect()` |
| `crates/fiber-bin/src/main.rs` | Log error, don't block built-in watchtower actor |
| `crates/fiber-wasm/src/lib.rs` | Log error, keep event loop alive |

## Risk
Low — error path only triggers what was previously a panic. The built-in watchtower actor (native) is now independent of the standalone client outcome.