### PR TITLE
fix: clamp unbounded list_payments limit to prevent resource exhaustion

### DIFF
--- a/crates/fiber-lib/src/rpc/payment.rs
+++ b/crates/fiber-lib/src/rpc/payment.rs
@@ -316,8 +316,12 @@ where
         &self,
         params: ListPaymentsParams,
     ) -> Result<ListPaymentsResult, ErrorObjectOwned> {
+        const MAX_LIST_PAYMENTS_LIMIT: u64 = 500;
         let default_limit: u64 = 15;
-        let limit = params.limit.unwrap_or(default_limit) as usize;
+        let limit = std::cmp::min(
+            params.limit.unwrap_or(default_limit),
+            MAX_LIST_PAYMENTS_LIMIT,
+        ) as usize;
 
         let after = params.after.map(fiber_types::Hash256::from);
         let status = params.status.map(fiber_types::PaymentStatus::from);


### PR DESCRIPTION
## Summary
- Fix GHSA-5hcw-vf4g-98fg: `list_payments` RPC accepts unbounded `limit` that can cause excessive resource consumption

## Problem
`ListPaymentsParams.limit` was `Option<u64>` with no upper bound. A client could request an arbitrarily large result set, forcing the node to iterate, deserialize, and allocate memory for up to N payment sessions with their attempts.

## Fix
Clamp the limit to `MAX_LIST_PAYMENTS_LIMIT = 500`, matching the convention used by `list_graph_nodes` in `graph.rs`.

## Change
`crates/fiber-lib/src/rpc/payment.rs` — one `std::cmp::min` wrapper

## Risk
Low — callers requesting a very large page will receive a capped response with a valid `last_cursor` for pagination. Callers requesting normal pages (default = 15, or reasonable values) are unaffected.