### PR TITLE
fix: remove debug/trace logs exposing raw store key-value data

### DIFF
--- a/crates/fiber-wasm-db-worker/src/db.rs
+++ b/crates/fiber-wasm-db-worker/src/db.rs
@@ -125,7 +125,6 @@ pub(crate) async fn handle_db_command<F>(
 where
     F: Fn(&[u8]) -> bool,
 {
-    debug!("Handle command: {:?}", cmd);
     let tx_mode = match cmd {
         DbCommandRequest::Read { .. } | DbCommandRequest::Iterator { .. } => {
             TransactionMode::ReadOnly
@@ -161,7 +160,6 @@ where
             DbCommandResponse::Read { values: res }
         }
         DbCommandRequest::Put { kvs } => {
-            debug!("Putting: {:?}", kvs);
             for KV { key, value } in kvs {
                 let key = serde_wasm_bindgen::to_value(&key).unwrap();
                 let value = serde_wasm_bindgen::to_value(&value).unwrap();
@@ -192,18 +190,10 @@ where
             let kvs = collect_iterator(&store, &start, direction, invoke_take_while, limit)
                 .await
                 .with_context(|| anyhow!("Unable to handle iterator"))?;
-            debug!(
-                "Called iterator, args=<start={} bytes, {:?}, {:?}>, result_count={}",
-                start.len(),
-                direction,
-                limit,
-                kvs.len()
-            );
             DbCommandResponse::Iterator { kvs }
         }
     };
     assert_eq!(TransactionResult::Committed, tran.await.unwrap());
-    debug!("Command result={:?}", result);
     Ok(result)
 }
 

--- a/crates/fiber-wasm-db-worker/src/lib.rs
+++ b/crates/fiber-wasm-db-worker/src/lib.rs
@@ -99,7 +99,6 @@ pub async fn main_loop(log_level: &str) {
                 let db = db.as_ref().expect("Database not opened yet");
                 let result = handle_db_command(db, STORE_NAME, db_cmd, |key| {
                     input_i32_arr.set_index(0, InputCommand::Waiting as i32);
-                    debug!("Invoking request take while with args key={:?}", key,);
                     write_command_with_payload(
                         OutputCommand::RequestTakeWhile as i32,
                         key.to_vec(),
@@ -120,12 +119,10 @@ pub async fn main_loop(log_level: &str) {
 
                     let result =
                         read_command_payload::<bool>(&input_i32_arr, &input_u8_arr).unwrap();
-                    debug!("Received take while result {}", result);
                     input_i32_arr.set_index(0, InputCommand::Waiting as i32);
                     result
                 })
                 .await;
-                debug!("db command result: {:?}", result);
                 match result {
                     Ok(o) => write_command_with_payload(
                         OutputCommand::DbResponse as i32,

--- a/crates/fiber-wasm-db-worker/src/lib.rs
+++ b/crates/fiber-wasm-db-worker/src/lib.rs
@@ -5,7 +5,7 @@ use fiber_wasm_db_common::{
     InputCommand, KV, OutputCommand, read_command_payload, write_command_with_payload,
 };
 use idb::Database;
-use log::{debug, info};
+use log::info;
 use util::{wait_for_command, wait_for_command_sync};
 use wasm_bindgen::{JsCast, prelude::wasm_bindgen};
 use web_sys::{


### PR DESCRIPTION
## Summary
- Fix GHSA-hrc9-vrf5-jxrq: browser/WASM store debug/trace logs emit raw `DbCommandRequest`, `DbCommandResponse`, and `KV` values containing secret key material

## Changes
Remove 8 debug/trace log statements across 3 files that emit full store command/response payloads, including raw preimages, channel state, settlement keys, and payment session data.

| File | Removed |
|------|---------|
| `fiber-wasm-db-worker/src/db.rs` | `db.rs:128` `Handle command`, `db.rs:164` `Putting`, `db.rs:195` `Called iterator`, `db.rs:206` `Command result` |
| `fiber-wasm-db-worker/src/lib.rs` | `lib.rs:102` `take while key`, `lib.rs:123` `take while result`, `lib.rs:128` `db command result` |
| `fiber-store/src/browser.rs` | `browser.rs:315` `Dispatching command`, `browser.rs:343` `take while request` |

These logs had no diagnostic value — the native RocksDB/SQLite backends do not emit equivalent output.

## Risk
Zero functional impact. Only debug/trace log lines removed, no behavior changes.