### PR TITLE
fix: validate chain_hash on individual gossip messages before persisting

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -68,6 +68,7 @@ use fiber_types::{
     NodeAnnouncement, Pubkey,
 };
 
+
 // The maximum duration drift between the broadcast message timestamp and latest cursor in store.
 pub(crate) const MAX_MISSING_BROADCAST_MESSAGE_TIMESTAMP_DRIFT: Duration =
     Duration::from_secs(60 * 60 * 2);
@@ -1789,6 +1790,19 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
         pubkey: &Pubkey,
         message: &BroadcastMessage,
     ) -> Result<InsertMessageStatus, GossipMessageProcessingError> {
+        let msg_chain_hash = match message {
+            BroadcastMessage::NodeAnnouncement(msg) => msg.chain_hash,
+            BroadcastMessage::ChannelAnnouncement(msg) => msg.chain_hash,
+            BroadcastMessage::ChannelUpdate(msg) => msg.chain_hash,
+        };
+        if msg_chain_hash != get_chain_hash() {
+            return Err(GossipMessageProcessingError::ProcessingError(format!(
+                "Invalid chain hash: expected {:?}, got {:?}",
+                get_chain_hash(),
+                msg_chain_hash
+            )));
+        }
+
         if let Some(existing_messages) = self.messages_to_be_saved.get(pubkey) {
             if existing_messages.contains(message) {
                 return Ok(InsertMessageStatus::Duplicate);
@@ -2801,6 +2815,19 @@ async fn verify_and_save_broadcast_message<S: GossipMessageStore>(
     chain: &ActorRef<CkbChainMessage>,
     client: &impl CkbChainClient,
 ) -> Result<(BroadcastMessageWithTimestamp, bool), VerifyBroadcastMessageError> {
+    let msg_chain_hash = match message {
+        BroadcastMessage::NodeAnnouncement(msg) => msg.chain_hash,
+        BroadcastMessage::ChannelAnnouncement(msg) => msg.chain_hash,
+        BroadcastMessage::ChannelUpdate(msg) => msg.chain_hash,
+    };
+    if msg_chain_hash != get_chain_hash() {
+        return Err(VerifyBroadcastMessageError::InvalidParameter(format!(
+            "Invalid chain hash: expected {:?}, got {:?}",
+            get_chain_hash(),
+            msg_chain_hash
+        )));
+    }
+
     let (timestamp, is_newly_applied) = match message {
         BroadcastMessage::ChannelAnnouncement(channel_announcement) => {
             let on_chain_info =

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -68,7 +68,6 @@ use fiber_types::{
     NodeAnnouncement, Pubkey,
 };
 
-
 // The maximum duration drift between the broadcast message timestamp and latest cursor in store.
 pub(crate) const MAX_MISSING_BROADCAST_MESSAGE_TIMESTAMP_DRIFT: Duration =
     Duration::from_secs(60 * 60 * 2);

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -580,7 +580,6 @@ where
             return false;
         }
         for message in messages {
-            self.update_latest_cursor(message.cursor());
             if message.chain_hash() != get_chain_hash() {
                 warn!(
                     "Chain hash mismatch: having {:?}, expecting {:?}, full message {:?}",
@@ -590,6 +589,7 @@ where
                 );
                 continue;
             }
+            self.update_latest_cursor(message.cursor());
             match message {
                 BroadcastMessageWithTimestamp::ChannelAnnouncement(
                     timestamp,


### PR DESCRIPTION
## Summary
- Fix GHSA-p557-4332-x4c8: per-message chain_hash validation for gossip messages

## Problem
Gossip request wrappers (`BroadcastMessagesFilter`, `GetBroadcastMessages`, `QueryBroadcastMessages`) validated `chain_hash`, but individual messages within results were not checked. A malicious peer could inject self-signed `NodeAnnouncement` messages from the wrong chain, causing:
1. Persistence of wrong-chain gossip in the local store
2. Rebroadcast to other peers
3. Poisoned sync cursors (cursor advanced before chain_hash check)

## Fix (3 changes)

| File | Change |
|------|--------|
| `gossip.rs:insert_message_to_be_saved_list` | Reject message before queueing if `chain_hash` doesn't match |
| `gossip.rs:verify_and_save_broadcast_message` | Reject message before persisting to store |
| `graph.rs:update_for_messages` | Move `update_latest_cursor` AFTER chain_hash check |

## Risk
Low — wrong-chain messages were already rejected by the graph layer; this just moves rejection earlier (before store writes and cursor advancement).