### PR TITLE
fix: prevent RPC panic on invalid watchtower private keys

### DIFF
--- a/crates/fiber-json-types/src/convert.rs
+++ b/crates/fiber-json-types/src/convert.rs
@@ -96,7 +96,8 @@ impl TryFrom<JsonPrivkey> for fiber_types::Privkey {
     type Error = String;
 
     fn try_from(jp: JsonPrivkey) -> Result<Self, Self::Error> {
-        Ok(fiber_types::Privkey::from_slice(jp.as_bytes()))
+        fiber_types::Privkey::try_from_slice(jp.as_bytes())
+            .map_err(|e| format!("Invalid private key: {e}"))
     }
 }
 

--- a/crates/fiber-types/src/primitives.rs
+++ b/crates/fiber-types/src/primitives.rs
@@ -396,6 +396,12 @@ impl Privkey {
             .into()
     }
 
+    /// Create a `Privkey` from a 32-byte slice, returning an error if the
+    /// bytes do not represent a valid secp256k1 secret key.
+    pub fn try_from_slice(key: &[u8]) -> Result<Self, secp256k1::Error> {
+        Ok(SecretKey::from_slice(key)?.into())
+    }
+
     pub fn pubkey(&self) -> Pubkey {
         Pubkey::from(self.0.public_key(SECP256K1))
     }


### PR DESCRIPTION
## Summary
- Fix GHSA-xwjm-m8pp-4x8q: watchtower RPC panics on invalid secp256k1 private keys

## Problem
`Privkey::from_slice` used `.expect("Invalid secret key")` on `SecretKey::from_slice()`. Watchtower RPC endpoints accept `Privkey` fields (e.g. `local_settlement_key`, `settlement_data.tlcs[].local_key`), and a caller could submit a 32-byte hex-valid but secp256k1-invalid scalar (e.g. all zeroes), triggering a panic instead of a structured RPC error.

## Fix
- Add `Privkey::try_from_slice` that returns `Result<Self, secp256k1::Error>`
- Update `TryFrom<JsonPrivkey> for fiber_types::Privkey` to use `try_from_slice`, returning a validation error string instead of panicking

## Changes
| File | Change |
|------|--------|
| `fiber-types/src/primitives.rs` | Add `try_from_slice` method |
| `fiber-json-types/src/convert.rs` | Use `try_from_slice` in `TryFrom` |

## Risk
Low — `from_slice` is preserved for internal callers with known-good keys. Only the JSON RPC conversion path uses the new fallible method.