### PR TITLE
fix: validate shutdown fee against the actual peer close_script

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1799,7 +1799,7 @@ where
             }
         };
 
-        if !state.check_shutdown_fee_valid(shutdown.fee_rate.as_u64()) {
+        if !state.check_shutdown_fee_valid(&shutdown.close_script, shutdown.fee_rate.as_u64()) {
             return Err(ProcessingChannelError::InvalidParameter(
                 "Shutdown fee is invalid".to_string(),
             ));
@@ -6702,12 +6702,12 @@ impl ChannelActorState {
         &self.get_remote_channel_public_keys().funding_pubkey
     }
 
-    fn check_shutdown_fee_valid(&self, remote_fee_rate: u64) -> bool {
+    fn check_shutdown_fee_valid(&self, remote_close_script: &Script, remote_fee_rate: u64) -> bool {
         let remote_shutdown_fee = match checked_calculate_shutdown_tx_fee(
             remote_fee_rate,
             &self.funding_udt_type_script,
             (
-                self.get_remote_shutdown_script(),
+                remote_close_script.clone(),
                 self.get_local_shutdown_script(),
             ),
         ) {
@@ -6715,7 +6715,7 @@ impl ChannelActorState {
             Err(_) => return false,
         };
         let occupied_capacity = match occupied_capacity(
-            &self.get_remote_shutdown_script(),
+            remote_close_script,
             &self.funding_udt_type_script,
         ) {
             Ok(capacity) => capacity.as_u64(),

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -6714,13 +6714,11 @@ impl ChannelActorState {
             Ok(fee) => fee,
             Err(_) => return false,
         };
-        let occupied_capacity = match occupied_capacity(
-            remote_close_script,
-            &self.funding_udt_type_script,
-        ) {
-            Ok(capacity) => capacity.as_u64(),
-            Err(_) => return false,
-        };
+        let occupied_capacity =
+            match occupied_capacity(remote_close_script, &self.funding_udt_type_script) {
+                Ok(capacity) => capacity.as_u64(),
+                Err(_) => return false,
+            };
         let remote_available_max_fee = if self.funding_udt_type_script.is_none() {
             match Self::checked_ckb_amount_with_reserved(
                 self.to_remote_amount,


### PR DESCRIPTION
## Summary
- Fix GHSA-74ch-xcgm-jm6g: shutdown fee validated against stale peer script

## Problem
`check_shutdown_fee_valid` used `self.remote_shutdown_script` (the negotiated script from channel open) to calculate the remote shutdown fee and occupied capacity. But `build_shutdown_tx` later uses `remote_shutdown_info.close_script` (the script from the incoming `Shutdown` message).

A peer could send a `Shutdown` with a large/expensive `close_script` and a `fee_rate` that passes validation against the small old script, then force the victim to sign a cooperative close with fees computed on the oversized actual script.

## Fix
Add `remote_close_script` parameter to `check_shutdown_fee_valid` so it validates against the incoming `Shutdown.close_script` directly, matching what `build_shutdown_tx` will later use.

## Change
`channel.rs` — 4 lines changed in `check_shutdown_fee_valid` signature and body, 1 line at call site.