### PR TITLE
fix: reject NodeAnnouncement addresses with mismatched /p2p peer ID

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -27,6 +27,8 @@ use tentacle::{
     builder::MetaBuilder,
     bytes::Bytes,
     context::{ProtocolContext, ProtocolContextMutRef, SessionContext},
+    multiaddr::Protocol,
+    secio::PeerId,
     service::{ProtocolHandle, ProtocolMeta, ServiceAsyncControl, SessionType},
     traits::ServiceProtocol,
     SessionId,
@@ -1817,6 +1819,23 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
                     timestamp,
                     max_acceptable_gossip_message_timestamp,
                 ));
+            }
+        }
+
+        if let BroadcastMessage::NodeAnnouncement(node_announcement) = &message {
+            let expected_peer_id = PeerId::from_public_key(&super::types::pubkey_to_tentacle(
+                node_announcement.node_id,
+            ));
+            for addr in &node_announcement.addresses {
+                for proto in addr.iter() {
+                    if let Protocol::P2P(ref peer_id_bytes) = proto {
+                        if peer_id_bytes.as_ref() != expected_peer_id.as_bytes() {
+                            return Err(GossipMessageProcessingError::ProcessingError(
+                                "NodeAnnouncement address /p2p does not match node_id".to_string(),
+                            ));
+                        }
+                    }
+                }
             }
         }
 

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -35,7 +35,10 @@ use std::collections::{HashMap, HashSet};
 #[cfg(all(test, not(target_arch = "wasm32")))]
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tentacle::multiaddr::MultiAddr;
+use tentacle::{
+    multiaddr::{MultiAddr, Protocol},
+    secio::PeerId,
+};
 use thiserror::Error;
 use tracing::log::error;
 use tracing::{debug, info, trace, warn};
@@ -844,6 +847,18 @@ where
         mut node_announcement: NodeAnnouncement,
     ) -> Option<Cursor> {
         debug!("Processing node announcement: {:?}", &node_announcement);
+
+        let expected_peer_id =
+            PeerId::from_public_key(&super::types::pubkey_to_tentacle(node_announcement.node_id));
+        node_announcement.addresses.retain(|addr| {
+            addr.iter().all(|proto| {
+                if let Protocol::P2P(ref peer_id_bytes) = proto {
+                    return peer_id_bytes.as_ref() == expected_peer_id.as_bytes();
+                }
+                true
+            })
+        });
+
         if !self.announce_private_addr {
             node_announcement
                 .addresses

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -119,10 +119,11 @@ fn create_fake_channel_announcement_message(
 
 fn create_node_announcement_message_with_priv_key(priv_key: &Privkey) -> NodeAnnouncement {
     let node_name = "fake node";
-    let addresses = ["/ip4/1.1.1.1/tcp/8346/p2p/QmaFDJb9CkMrXy7nhTWBY5y9mvuykre3EzzRsCJUAVXprZ"]
-        .iter()
-        .map(|x| MultiAddr::from_str(x).expect("valid multiaddr"))
-        .collect();
+    let expected_peer_id =
+        PeerId::from_public_key(&crate::fiber::types::pubkey_to_tentacle(priv_key.pubkey()));
+    let mut address = MultiAddr::from_str("/ip4/1.1.1.1/tcp/8346").expect("valid multiaddr");
+    address.push(Protocol::P2P(Cow::Owned(expected_peer_id.into_bytes())));
+    let addresses = vec![address];
     NodeAnnouncement::new_signed(
         node_name.into(),
         FeatureVector::default(),


### PR DESCRIPTION
## Summary
- Fix GHSA-xjfm-j93j-6qq5: validate `/p2p` peer ID in NodeAnnouncement addresses matches the announced node_id

## Problem
`NodeAnnouncement` addresses with `/p2p` components were not validated against the announcement's `node_id`. A malicious (but otherwise valid) node could advertise addresses pointing to unrelated peers, causing victims to misdirect connections and waste outbound peer slots.

## Fix
Two-layer validation:

| Layer | File | Behavior |
|-------|------|----------|
| Gossip ingestion | `gossip.rs:insert_message_to_be_saved_list` | Reject entire message if any address has mismatched `/p2p` |
| Graph processing | `graph.rs:process_node_announcement` | Strip mismatched addresses before storing |

Addresses without `/p2p` are unaffected (backward compatible).

## Risk
Low — the fiber node itself always appends `/p2p` matching its own peer ID to all announced addresses. Legitimate peers following the same convention are unaffected.