### PR TITLE
fix: use external funding lock script for peer input verification

### DIFF
--- a/crates/fiber-lib/src/ckb/actor.rs
+++ b/crates/fiber-lib/src/ckb/actor.rs
@@ -61,6 +61,7 @@ pub enum CkbChainMessage {
         remote_tx: packed::Transaction,
         funding_cell_lock_script: packed::Script,
         funding_udt_type_script: Option<packed::Script>,
+        funding_source_lock_script: Option<packed::Script>,
         reply: RpcReplyPort<Result<(), FundingError>>,
     },
     /// Add funding tx. This is used to reestablish a channel that is not ready yet.
@@ -143,8 +144,11 @@ impl Actor for CkbChainActor {
                     request.udt_type_script.is_some(),
                     tx.as_ref().is_some(),
                 );
-                let context = state
-                    .build_funding_context(request.script.clone(), request.udt_type_script.clone());
+                let context = state.build_funding_context(
+                    request.script.clone(),
+                    request.udt_type_script.clone(),
+                    None,
+                );
                 let result = match state.config.funding_tx_shell_builder_as_deref() {
                     None => {
                         tx.fulfill(request, context, &mut state.live_cells_exclusion_map)
@@ -211,6 +215,7 @@ impl Actor for CkbChainActor {
                 remote_tx,
                 funding_cell_lock_script,
                 funding_udt_type_script,
+                funding_source_lock_script,
                 reply,
             } => {
                 let local_tx_hash = local_tx.calc_tx_hash();
@@ -222,8 +227,11 @@ impl Actor for CkbChainActor {
                     remote_tx_hash,
                 );
                 let mut funding_tx: FundingTx = local_tx.into();
-                let context =
-                    state.build_funding_context(funding_cell_lock_script, funding_udt_type_script);
+                let context = state.build_funding_context(
+                    funding_cell_lock_script,
+                    funding_udt_type_script,
+                    funding_source_lock_script,
+                );
                 let result = funding_tx
                     .update_for_peer(remote_tx.into_view(), context)
                     .await;
@@ -370,10 +378,12 @@ impl CkbChainState {
         &self,
         funding_cell_lock_script: packed::Script,
         funding_udt_type_script: Option<packed::Script>,
+        funding_source_lock_script: Option<packed::Script>,
     ) -> FundingContext {
         FundingContext {
             rpc_url: self.config.rpc_url.clone(),
-            funding_source_lock_script: self.funding_source_lock_script.clone(),
+            funding_source_lock_script: funding_source_lock_script
+                .unwrap_or_else(|| self.funding_source_lock_script.clone()),
             funding_source_lock_script_cell_deps: Vec::new(),
             funding_cell_lock_script,
             funding_udt_type_script,

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -7352,6 +7352,11 @@ impl ChannelActorState {
                         remote_tx: msg.tx.clone(),
                         funding_cell_lock_script: self.get_funding_lock_script(),
                         funding_udt_type_script: self.funding_udt_type_script.clone(),
+                        funding_source_lock_script: self
+                            .ephemeral_config
+                            .external_funding
+                            .funding_lock_script
+                            .clone(),
                         reply: tx
                     }
                 ))

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -644,6 +644,7 @@ pub enum NetworkActorCommand {
         remote_tx: Transaction,
         funding_cell_lock_script: Script,
         funding_udt_type_script: Option<Script>,
+        funding_source_lock_script: Option<Script>,
         reply: RpcReplyPort<Result<(), FundingError>>,
     },
     SignFundingTx(Pubkey, Hash256, Transaction, Option<Vec<Vec<u8>>>),
@@ -2366,6 +2367,7 @@ where
                 remote_tx,
                 funding_cell_lock_script,
                 funding_udt_type_script,
+                funding_source_lock_script,
                 reply,
             } => {
                 let _ = self
@@ -2376,6 +2378,7 @@ where
                         reply,
                         funding_cell_lock_script,
                         funding_udt_type_script,
+                        funding_source_lock_script,
                     });
             }
             NetworkActorCommand::NotifyFundingTx(tx) => {


### PR DESCRIPTION
## Summary
- Fix GHSA-5f44-gg3g-gr88: peer input verification uses wrong lock script for external funding

## Problem
`VerifyFundingTx` → `build_funding_context` always used the node's default internal `funding_source_lock_script` regardless of whether external funding was active. Peer-added inputs were checked against the wrong lock, letting a malicious peer append inputs owned by the external wallet without being rejected.

## Fix
Thread the channel's external `funding_lock_script` (when set) through the message chain:

```
ChannelActor → NetworkActorCommand → CkbChainMessage → build_funding_context
```

When `funding_source_lock_script` is `None` (normal funding), fall back to the node's default lock script — preserving existing behavior.

## Changes
| File | Change |
|------|--------|
| `channel.rs` | Pass `ephemeral_config.external_funding.funding_lock_script` |
| `network.rs` | Add `funding_source_lock_script` to `VerifyFundingTx` |
| `actor.rs` | Accept optional `funding_source_lock_script`, pass to `build_funding_context` |

## Risk
Low — normal funding paths pass `None` and fall through to existing behavior. Only external funding paths change.