### PR TITLE
Fix: improve error handling and redaction in RPC methods

### DIFF
--- a/crates/fiber-json-types/src/lib.rs
+++ b/crates/fiber-json-types/src/lib.rs
@@ -26,6 +26,9 @@
 pub mod schema_helpers;
 pub mod serde_utils;
 
+#[cfg(test)]
+mod tests;
+
 #[cfg(feature = "conversion")]
 pub mod convert;
 

--- a/crates/fiber-json-types/src/serde_utils.rs
+++ b/crates/fiber-json-types/src/serde_utils.rs
@@ -322,7 +322,7 @@ impl From<Privkey> for [u8; 32] {
 
 impl core::fmt::Debug for Privkey {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Privkey({})", hex::encode(self.0))
+        write!(f, "Privkey(<redacted>)")
     }
 }
 

--- a/crates/fiber-json-types/src/tests/mod.rs
+++ b/crates/fiber-json-types/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod serde_utils;

--- a/crates/fiber-json-types/src/tests/serde_utils.rs
+++ b/crates/fiber-json-types/src/tests/serde_utils.rs
@@ -1,0 +1,11 @@
+use crate::serde_utils::Privkey;
+
+#[test]
+fn privkey_debug_is_redacted() {
+    let raw = [7u8; 32];
+    let raw_hex = hex::encode(raw);
+    let debug = format!("{:?}", Privkey(raw));
+
+    assert_eq!(debug, "Privkey(<redacted>)");
+    assert!(!debug.contains(&raw_hex));
+}

--- a/crates/fiber-lib/src/rpc/cch.rs
+++ b/crates/fiber-lib/src/rpc/cch.rs
@@ -76,7 +76,7 @@ impl CchRpcServerImpl {
                 currency,
             }
         )
-        .rpc_err_no_data()?;
+        .rpc_err()?;
 
         result.map(CchOrderResponse::from).map_err(Into::into)
     }
@@ -93,7 +93,7 @@ impl CchRpcServerImpl {
                 fiber_pay_req: params.fiber_pay_req,
             }
         )
-        .rpc_err_no_data()?;
+        .rpc_err()?;
 
         result.map(CchOrderResponse::from).map_err(Into::into)
     }
@@ -109,7 +109,7 @@ impl CchRpcServerImpl {
             TIMEOUT,
             payment_hash
         )
-        .rpc_err_no_data()?;
+        .rpc_err()?;
 
         result.map(CchOrderResponse::from).map_err(Into::into)
     }

--- a/crates/fiber-lib/src/rpc/channel.rs
+++ b/crates/fiber-lib/src/rpc/channel.rs
@@ -220,7 +220,7 @@ where
         &self,
         params: OpenChannelParams,
     ) -> Result<OpenChannelResult, ErrorObjectOwned> {
-        let pubkey = Pubkey::try_from(params.pubkey).rpc_err(&params)?;
+        let pubkey = Pubkey::try_from(params.pubkey).rpc_err()?;
         let message = |rpc_reply| {
             NetworkActorMessage::Command(NetworkActorCommand::OpenChannel(
                 OpenChannelCommand {
@@ -297,11 +297,7 @@ where
         let include_closed = params.include_closed.unwrap_or_default();
 
         // Convert the optional String pubkey filter to internal Pubkey
-        let filter_pubkey = params
-            .pubkey
-            .map(Pubkey::try_from)
-            .transpose()
-            .rpc_err(&params)?;
+        let filter_pubkey = params.pubkey.map(Pubkey::try_from).transpose().rpc_err()?;
 
         // The two filter options are mutually exclusive: `only_pending` narrows to channels
         // that are still opening (or failed to open), while `include_closed` broadens to
@@ -310,7 +306,6 @@ where
         if only_pending && include_closed {
             return Err(rpc_error(
                 "only_pending and include_closed are mutually exclusive",
-                params,
             ));
         }
 
@@ -333,8 +328,8 @@ where
             if only_pending && !rpc_state.is_pending() {
                 continue;
             }
-            let offered_tlc_balance = state.get_offered_tlc_balance().rpc_err(&params)?;
-            let received_tlc_balance = state.get_received_tlc_balance().rpc_err(&params)?;
+            let offered_tlc_balance = state.get_offered_tlc_balance().rpc_err()?;
+            let received_tlc_balance = state.get_received_tlc_balance().rpc_err()?;
             // Enrich with failure_detail from ChannelOpenRecord when available
             let failure_detail = self
                 .store
@@ -516,7 +511,6 @@ where
         {
             return Err(rpc_error(
                 "close_script and fee_rate should not be set when force is true",
-                params,
             ));
         }
 
@@ -571,7 +565,7 @@ where
         &self,
         params: OpenChannelWithExternalFundingParams,
     ) -> Result<OpenChannelWithExternalFundingResult, ErrorObjectOwned> {
-        let pubkey = Pubkey::try_from(params.pubkey).rpc_err(&params)?;
+        let pubkey = Pubkey::try_from(params.pubkey).rpc_err()?;
         let funding_lock_script_cell_deps: Vec<packed::CellDep> = params
             .funding_lock_script_cell_deps
             .clone()

--- a/crates/fiber-lib/src/rpc/dev.rs
+++ b/crates/fiber-lib/src/rpc/dev.rs
@@ -263,7 +263,7 @@ impl DevRpcServerImpl {
             )
             .unwrap()
             {
-                Err(rpc_error(err.to_string(), params))
+                Err(rpc_error(err.to_string()))
             } else {
                 Ok(SubmitCommitmentTransactionResult {
                     tx_hash: JsonHash256(
@@ -272,10 +272,7 @@ impl DevRpcServerImpl {
                 })
             }
         } else {
-            Err(rpc_error(
-                "Commitment transaction not found".to_string(),
-                params,
-            ))
+            Err(rpc_error("Commitment transaction not found".to_string()))
         }
     }
 
@@ -316,18 +313,15 @@ impl DevRpcServerImpl {
             .strip_prefix("0x")
             .unwrap_or(&params.private_key);
         let private_key_bytes = hex::decode(private_key_hex)
-            .map_err(|e| rpc_error(format!("invalid private key hex: {}", e), &params))?;
+            .map_err(|e| rpc_error(format!("invalid private key hex: {}", e)))?;
         if private_key_bytes.len() != 32 {
-            return Err(rpc_error(
-                format!(
-                    "invalid private key length: expected 32 bytes, got {}",
-                    private_key_bytes.len()
-                ),
-                &params,
-            ));
+            return Err(rpc_error(format!(
+                "invalid private key length: expected 32 bytes, got {}",
+                private_key_bytes.len()
+            )));
         }
         let secret_key = SecretKey::from_slice(&private_key_bytes)
-            .map_err(|e| rpc_error(format!("invalid private key: {}", e), &params))?;
+            .map_err(|e| rpc_error(format!("invalid private key: {}", e)))?;
 
         // Convert the JSON transaction to a packed transaction
         let packed_tx: ckb_types::packed::Transaction = params.unsigned_funding_tx.clone().into();
@@ -337,7 +331,7 @@ impl DevRpcServerImpl {
         let signer = SecpCkbRawKeySigner::new_with_secret_keys(vec![std::str::FromStr::from_str(
             hex::encode(secret_key.as_ref()).as_ref(),
         )
-        .map_err(|e| rpc_error(format!("failed to create signer: {}", e), &params))?]);
+        .map_err(|e| rpc_error(format!("failed to create signer: {}", e)))?]);
 
         let pubkey_hash = blake160(
             secret_key
@@ -360,12 +354,7 @@ impl DevRpcServerImpl {
             let previous_tx = ckb_client
                 .get_transaction(tx_hash.clone())
                 .await
-                .map_err(|e| {
-                    rpc_error(
-                        format!("failed to fetch previous transaction: {}", e),
-                        &params,
-                    )
-                })?;
+                .map_err(|e| rpc_error(format!("failed to fetch previous transaction: {}", e)))?;
             let previous_tx = previous_tx.and_then(|response| {
                 response.transaction.map(|tx| match tx.inner {
                     ckb_jsonrpc_types::Either::Left(json) => {
@@ -378,22 +367,16 @@ impl DevRpcServerImpl {
                 })
             });
             let previous_tx = previous_tx.ok_or_else(|| {
-                rpc_error(
-                    format!(
-                        "previous transaction not found for input {}: {}",
-                        input_idx, tx_hash
-                    ),
-                    &params,
-                )
+                rpc_error(format!(
+                    "previous transaction not found for input {}: {}",
+                    input_idx, tx_hash
+                ))
             })?;
             let previous_output = previous_tx.outputs().get(output_index).ok_or_else(|| {
-                rpc_error(
-                    format!(
-                        "previous output index {} out of bounds for input {}",
-                        output_index, input_idx
-                    ),
-                    &params,
-                )
+                rpc_error(format!(
+                    "previous output index {} out of bounds for input {}",
+                    output_index, input_idx
+                ))
             })?;
             let lock_script = previous_output.lock();
             if lock_script.args().raw_data().as_ref() != pubkey_hash.as_bytes() {
@@ -418,7 +401,6 @@ impl DevRpcServerImpl {
         if signing_groups.is_empty() {
             return Err(rpc_error(
                 "no transaction inputs matched the provided private key".to_string(),
-                &params,
             ));
         }
 
@@ -429,16 +411,12 @@ impl DevRpcServerImpl {
                 .first()
                 .expect("script group should contain at least one input");
             let zero_lock = Bytes::from(vec![0u8; 65]);
-            let message = generate_message(&tx_view, &script_group, zero_lock).map_err(|e| {
-                rpc_error(
-                    format!("failed to generate sighash message: {}", e),
-                    &params,
-                )
-            })?;
+            let message = generate_message(&tx_view, &script_group, zero_lock)
+                .map_err(|e| rpc_error(format!("failed to generate sighash message: {}", e)))?;
 
             let signature = signer
                 .sign(pubkey_hash.as_bytes(), &message, true, &tx_view)
-                .map_err(|e| rpc_error(format!("failed to sign message: {}", e), &params))?;
+                .map_err(|e| rpc_error(format!("failed to sign message: {}", e)))?;
 
             while witnesses.len() <= input_idx {
                 witnesses.push(Default::default());

--- a/crates/fiber-lib/src/rpc/graph.rs
+++ b/crates/fiber-lib/src/rpc/graph.rs
@@ -138,7 +138,7 @@ where
             .map(|cursor| Cursor::from_bytes(cursor.as_bytes()))
             .transpose()
             .map_err(|e| {
-                ErrorObjectOwned::owned(INVALID_PARAMS_CODE, e.to_string(), Some(params))
+                ErrorObjectOwned::owned(INVALID_PARAMS_CODE, e.to_string(), Option::<()>::None)
             })?;
         let nodes = network_graph.get_nodes_with_params(limit, cursor);
         let last_cursor = nodes
@@ -163,7 +163,7 @@ where
             .map(|cursor| Cursor::from_bytes(cursor.as_bytes()))
             .transpose()
             .map_err(|e| {
-                ErrorObjectOwned::owned(INVALID_PARAMS_CODE, e.to_string(), Some(params))
+                ErrorObjectOwned::owned(INVALID_PARAMS_CODE, e.to_string(), Option::<()>::None)
             })?;
 
         let channels = network_graph.get_channels_with_params(limit, cursor);

--- a/crates/fiber-lib/src/rpc/info.rs
+++ b/crates/fiber-lib/src/rpc/info.rs
@@ -60,7 +60,7 @@ impl InfoRpcServerImpl {
         let message =
             |rpc_reply| NetworkActorMessage::Command(NetworkActorCommand::NodeInfo((), rpc_reply));
 
-        handle_actor_call!(self.actor, message, ()).map(|response| NodeInfoResult {
+        handle_actor_call!(self.actor, message).map(|response| NodeInfoResult {
             version,
             commit_hash,
             features: response.features.enabled_features_names(),

--- a/crates/fiber-lib/src/rpc/invoice.rs
+++ b/crates/fiber-lib/src/rpc/invoice.rs
@@ -9,7 +9,7 @@ use crate::fiber::{NetworkActorCommand, NetworkActorMessage};
 use crate::invoice::{
     CkbInvoice as InternalCkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder, InvoiceStore,
 };
-use crate::rpc::utils::{rpc_error, rpc_error_no_data, RpcResultExt};
+use crate::rpc::utils::{rpc_error, RpcResultExt};
 use crate::{gen_rand_sha256_hash, handle_actor_call, log_and_error, FiberConfig};
 use fiber_types::{FeatureVector, Privkey};
 
@@ -170,7 +170,7 @@ where
         &self,
         params: NewInvoiceParams,
     ) -> Result<InvoiceResult, ErrorObjectOwned> {
-        let error = |msg: &str| Err(rpc_error(msg.to_string(), params.clone()));
+        let error = |msg: &str| Err(rpc_error(msg.to_string()));
 
         let params_currency = params.currency.into();
 
@@ -295,7 +295,7 @@ where
             Ok(invoice) => Ok(ParseInvoiceResult {
                 invoice: invoice.into(),
             }),
-            Err(e) => Err(rpc_error(e.to_string(), params)),
+            Err(e) => Err(rpc_error(e.to_string())),
         }
     }
 
@@ -321,7 +321,7 @@ where
                     status: status.into(),
                 })
             }
-            None => Err(rpc_error("invoice not found", params)),
+            None => Err(rpc_error("invoice not found")),
         }
     }
 
@@ -343,16 +343,16 @@ where
 
                 let new_status = match status {
                     CkbInvoiceStatus::Paid | CkbInvoiceStatus::Cancelled => {
-                        return Err(rpc_error(
-                            format!("invoice can not be canceled, current status: {}", status),
-                            params,
-                        ));
+                        return Err(rpc_error(format!(
+                            "invoice can not be canceled, current status: {}",
+                            status
+                        )));
                     }
                     _ => CkbInvoiceStatus::Cancelled,
                 };
                 self.store
                     .update_invoice_status(&payment_hash, new_status)
-                    .rpc_err(&params)?;
+                    .rpc_err()?;
                 if let Some(network_actor) = &self.network_actor {
                     let _ = network_actor.send_message(NetworkActorMessage::new_command(
                         NetworkActorCommand::SettleHoldTlcSet(payment_hash),
@@ -364,7 +364,7 @@ where
                     status: new_status.into(),
                 })
             }
-            None => Err(rpc_error("invoice not found", params)),
+            None => Err(rpc_error("invoice not found")),
         }
     }
 
@@ -375,7 +375,7 @@ where
         let network_actor = self
             .network_actor
             .as_ref()
-            .ok_or_else(|| rpc_error_no_data("network actor not initialized"))?;
+            .ok_or_else(|| rpc_error("network actor not initialized"))?;
 
         let payment_hash = params.payment_hash.into();
         let payment_preimage = params.payment_preimage.into();

--- a/crates/fiber-lib/src/rpc/payment.rs
+++ b/crates/fiber-lib/src/rpc/payment.rs
@@ -174,7 +174,7 @@ where
             .target_pubkey
             .map(fiber_types::Pubkey::try_from)
             .transpose()
-            .rpc_err(&params)?;
+            .rpc_err()?;
         let payment_hash = params.payment_hash.map(fiber_types::Hash256::from);
         let trampoline_hops = params
             .trampoline_hops
@@ -186,7 +186,7 @@ where
                     .collect::<Result<Vec<_>, _>>()
             })
             .transpose()
-            .rpc_err(&params)?;
+            .rpc_err()?;
         let custom_records = params
             .custom_records
             .clone()
@@ -202,7 +202,7 @@ where
                     .collect::<Result<Vec<_>, _>>()
             })
             .transpose()
-            .rpc_err(&params)?;
+            .rpc_err()?;
 
         let message = |rpc_reply| -> NetworkActorMessage {
             NetworkActorMessage::Command(NetworkActorCommand::SendPayment(
@@ -254,7 +254,7 @@ where
             .cloned()
             .map(fiber_types::HopRequire::try_from)
             .collect::<Result<Vec<_>, _>>()
-            .rpc_err(&params)?;
+            .rpc_err()?;
 
         let message = |rpc_reply| -> NetworkActorMessage {
             NetworkActorMessage::Command(NetworkActorCommand::BuildPaymentRouter(
@@ -288,7 +288,7 @@ where
             .cloned()
             .map(fiber_types::RouterHop::try_from)
             .collect::<Result<Vec<_>, _>>()
-            .rpc_err(&params)?;
+            .rpc_err()?;
         let custom_records = params
             .custom_records
             .clone()

--- a/crates/fiber-lib/src/rpc/peer.rs
+++ b/crates/fiber-lib/src/rpc/peer.rs
@@ -75,10 +75,9 @@ impl PeerRpcServerImpl {
             if address_str.is_empty() {
                 return Err(rpc_error(
                     "address must not be empty, expected a multiaddr like /ip4/1.2.3.4/tcp/8080",
-                    &params,
                 ));
             }
-            let address = address_str.parse::<Multiaddr>().rpc_err(&params)?;
+            let address = address_str.parse::<Multiaddr>().rpc_err()?;
             let save = params.save.unwrap_or(true);
             let message = |rpc_reply| {
                 NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
@@ -92,7 +91,7 @@ impl PeerRpcServerImpl {
         }
 
         if let Some(pubkey_str) = params.pubkey {
-            let pubkey = Pubkey::try_from(pubkey_str).rpc_err(&params)?;
+            let pubkey = Pubkey::try_from(pubkey_str).rpc_err()?;
             let addr_transport = params.addr_type.map(to_transport_type);
             let message = |rpc_reply| {
                 NetworkActorMessage::Command(NetworkActorCommand::ConnectPeerWithPubkey(
@@ -105,17 +104,14 @@ impl PeerRpcServerImpl {
             return crate::handle_actor_call!(self.actor, message, params);
         }
 
-        Err(rpc_error(
-            "either `address` or `pubkey` is required",
-            params,
-        ))
+        Err(rpc_error("either `address` or `pubkey` is required"))
     }
 
     pub async fn disconnect_peer(
         &self,
         params: DisconnectPeerParams,
     ) -> Result<(), ErrorObjectOwned> {
-        let pubkey = Pubkey::try_from(params.pubkey).rpc_err(&params)?;
+        let pubkey = Pubkey::try_from(params.pubkey).rpc_err()?;
         let message = |rpc_reply| {
             NetworkActorMessage::Command(NetworkActorCommand::DisconnectPeer(
                 pubkey,
@@ -130,7 +126,7 @@ impl PeerRpcServerImpl {
         let message =
             |rpc_reply| NetworkActorMessage::Command(NetworkActorCommand::ListPeers((), rpc_reply));
 
-        crate::handle_actor_call!(self.actor, message, ()).map(|response| ListPeersResult {
+        crate::handle_actor_call!(self.actor, message).map(|response| ListPeersResult {
             peers: response
                 .into_iter()
                 .map(|peer| PeerInfo {

--- a/crates/fiber-lib/src/rpc/prof.rs
+++ b/crates/fiber-lib/src/rpc/prof.rs
@@ -37,7 +37,7 @@ impl ProfRpcServerImpl {
             Ok(path) => Ok(PprofResult {
                 path: path.to_string_lossy().into_owned(),
             }),
-            Err(err) => Err(rpc_error(err.to_string(), params)),
+            Err(err) => Err(rpc_error(err.to_string())),
         }
     }
 }

--- a/crates/fiber-lib/src/rpc/utils.rs
+++ b/crates/fiber-lib/src/rpc/utils.rs
@@ -1,32 +1,25 @@
 use jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE;
 use jsonrpsee::types::ErrorObjectOwned;
 use serde::Serialize;
+use serde_json::Value;
 use std::fmt::Display;
+
+pub const RPC_LOG_PARAMS_ENV: &str = "FIBER_RPC_LOG_PARAMS";
 
 /// ignore rpc-doc-gen
 ///
 /// Extension trait on `Result` for concise RPC error conversion.
 ///
-/// Replaces verbose `.map_err(|e| ErrorObjectOwned::owned(CALL_EXECUTION_FAILED_CODE, e, Some(&params)))`
-/// chains with a single `.rpc_err(&params)?` call.
+/// Replaces verbose `.map_err(|e| ErrorObjectOwned::owned(CALL_EXECUTION_FAILED_CODE, e, None))`
+/// chains with a single `.rpc_err()?` call.
 pub trait RpcResultExt<T> {
     /// Convert the error into an `ErrorObjectOwned` with `CALL_EXECUTION_FAILED_CODE`,
-    /// attaching `data` as the `Some(data)` payload.
-    fn rpc_err<D: Serialize>(self, data: &D) -> Result<T, ErrorObjectOwned>;
-
-    /// Convert the error into an `ErrorObjectOwned` with `CALL_EXECUTION_FAILED_CODE`,
-    /// without any data payload (`Option::<()>::None`).
-    fn rpc_err_no_data(self) -> Result<T, ErrorObjectOwned>;
+    /// without attaching request parameters to the error payload.
+    fn rpc_err(self) -> Result<T, ErrorObjectOwned>;
 }
 
 impl<T, E: Display> RpcResultExt<T> for Result<T, E> {
-    fn rpc_err<D: Serialize>(self, data: &D) -> Result<T, ErrorObjectOwned> {
-        self.map_err(|e| {
-            ErrorObjectOwned::owned(CALL_EXECUTION_FAILED_CODE, e.to_string(), Some(data))
-        })
-    }
-
-    fn rpc_err_no_data(self) -> Result<T, ErrorObjectOwned> {
+    fn rpc_err(self) -> Result<T, ErrorObjectOwned> {
         self.map_err(|e| {
             ErrorObjectOwned::owned(
                 CALL_EXECUTION_FAILED_CODE,
@@ -37,21 +30,81 @@ impl<T, E: Display> RpcResultExt<T> for Result<T, E> {
     }
 }
 
-/// Construct an `ErrorObjectOwned` with `CALL_EXECUTION_FAILED_CODE` and a data payload.
-pub fn rpc_error<D: Serialize>(msg: impl Into<String>, data: D) -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(CALL_EXECUTION_FAILED_CODE, msg, Some(data))
+/// Construct an `ErrorObjectOwned` with `CALL_EXECUTION_FAILED_CODE` and no data payload.
+pub fn rpc_error(msg: impl Into<String>) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(CALL_EXECUTION_FAILED_CODE, msg, Option::<()>::None)
 }
 
-/// Construct an `ErrorObjectOwned` with `CALL_EXECUTION_FAILED_CODE` and no data payload.
-pub fn rpc_error_no_data(msg: impl Into<String>) -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(CALL_EXECUTION_FAILED_CODE, msg, Option::<()>::None)
+#[doc(hidden)]
+pub fn should_log_rpc_params() -> bool {
+    cfg!(debug_assertions)
+        && std::env::var(RPC_LOG_PARAMS_ENV)
+            .map(|value| {
+                matches!(
+                    value.as_str(),
+                    "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+                )
+            })
+            .unwrap_or(false)
+}
+
+#[doc(hidden)]
+pub fn redacted_rpc_params<T: Serialize>(params: &T) -> Value {
+    let mut value =
+        serde_json::to_value(params).unwrap_or_else(|_| Value::String("<params>".into()));
+    redact_sensitive_fields(&mut value);
+    value
+}
+
+fn redact_sensitive_fields(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map {
+                if is_sensitive_rpc_param_key(key) {
+                    *value = Value::String("<redacted>".into());
+                } else {
+                    redact_sensitive_fields(value);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                redact_sensitive_fields(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_sensitive_rpc_param_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("private")
+        || key.contains("privkey")
+        || key.contains("preimage")
+        || key.contains("settlement_key")
+        || key == "local_key"
+        || key.ends_with("_secret")
 }
 
 #[macro_export]
 macro_rules! log_and_error {
+    ($err:expr) => {{
+        let err = $err;
+        tracing::error!(error = ?err, "rpc request failed");
+        Err($crate::rpc::utils::rpc_error(err))
+    }};
     ($params:expr, $err:expr) => {{
-        tracing::error!("channel request params {:?} => error: {:?}", $params, $err);
-        Err($crate::rpc::utils::rpc_error($err, $params))
+        let err = $err;
+        if $crate::rpc::utils::should_log_rpc_params() {
+            tracing::error!(
+                error = ?err,
+                params = ?$crate::rpc::utils::redacted_rpc_params(&$params),
+                "rpc request failed"
+            );
+        } else {
+            tracing::error!(error = ?err, "rpc request failed");
+        }
+        Err($crate::rpc::utils::rpc_error(err))
     }};
 }
 
@@ -70,15 +123,9 @@ macro_rules! handle_actor_call {
         match call!($actor, $message) {
             Ok(result) => match result {
                 Ok(res) => Ok(res),
-                Err(e) => {
-                    error!("Error: {:?}", e);
-                    Err(e)
-                }
+                Err(e) => log_and_error!(e.to_string()),
             },
-            Err(e) => {
-                error!("Error: {:?}", e);
-                Err(e)
-            }
+            Err(e) => log_and_error!(e.to_string()),
         }
     };
 }

--- a/crates/fiber-lib/src/rpc/watchtower.rs
+++ b/crates/fiber-lib/src/rpc/watchtower.rs
@@ -4,7 +4,7 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObjectOwned;
 
 #[cfg(feature = "watchtower")]
-use crate::rpc::utils::{rpc_error, rpc_error_no_data, RpcResultExt};
+use crate::rpc::utils::{rpc_error, RpcResultExt};
 #[cfg(feature = "watchtower")]
 use crate::watchtower::WatchtowerStore;
 #[cfg(feature = "watchtower")]
@@ -149,24 +149,19 @@ where
         ctx: RpcContext,
         params: CreateWatchChannelParams,
     ) -> Result<(), ErrorObjectOwned> {
-        let node_id = ctx.node_id.parse::<NodeId>().rpc_err_no_data()?;
+        let node_id = ctx.node_id.parse::<NodeId>().rpc_err()?;
         let channel_id = params.channel_id.into();
-        let local_settlement_key: fiber_types::Privkey = params
-            .local_settlement_key
-            .try_into()
-            .map_err(|e: String| rpc_error(e, &params))?;
-        let remote_settlement_key =
-            Pubkey::try_from(params.remote_settlement_key).rpc_err(&params)?;
-        let local_funding_pubkey =
-            Pubkey::try_from(params.local_funding_pubkey).rpc_err(&params)?;
-        let remote_funding_pubkey =
-            Pubkey::try_from(params.remote_funding_pubkey).rpc_err(&params)?;
+        let local_settlement_key: fiber_types::Privkey =
+            params.local_settlement_key.try_into().map_err(rpc_error)?;
+        let remote_settlement_key = Pubkey::try_from(params.remote_settlement_key).rpc_err()?;
+        let local_funding_pubkey = Pubkey::try_from(params.local_funding_pubkey).rpc_err()?;
+        let remote_funding_pubkey = Pubkey::try_from(params.remote_funding_pubkey).rpc_err()?;
         // Move fields out of params last, after all borrows of params are done.
         let funding_udt_type_script = params.funding_udt_type_script;
         let settlement_data: fiber_types::SettlementData = params
             .settlement_data
             .try_into()
-            .map_err(|e: String| rpc_error_no_data(e))?;
+            .map_err(|e: String| rpc_error(e))?;
         self.store.insert_watch_channel(
             node_id,
             channel_id,
@@ -185,7 +180,7 @@ where
         ctx: RpcContext,
         params: RemoveWatchChannelParams,
     ) -> Result<(), ErrorObjectOwned> {
-        let node_id = ctx.node_id.parse::<NodeId>().rpc_err_no_data()?;
+        let node_id = ctx.node_id.parse::<NodeId>().rpc_err()?;
         let channel_id = params.channel_id.into();
         self.store.remove_watch_channel(node_id, channel_id);
         Ok(())
@@ -196,16 +191,16 @@ where
         ctx: RpcContext,
         params: UpdateRevocationParams,
     ) -> Result<(), ErrorObjectOwned> {
-        let node_id = ctx.node_id.parse::<NodeId>().rpc_err_no_data()?;
+        let node_id = ctx.node_id.parse::<NodeId>().rpc_err()?;
         let channel_id = params.channel_id.into();
         let revocation_data: fiber_types::RevocationData = params
             .revocation_data
             .try_into()
-            .map_err(|e: String| rpc_error_no_data(e))?;
+            .map_err(|e: String| rpc_error(e))?;
         let settlement_data: fiber_types::SettlementData = params
             .settlement_data
             .try_into()
-            .map_err(|e: String| rpc_error_no_data(e))?;
+            .map_err(|e: String| rpc_error(e))?;
         self.store
             .update_revocation(node_id, channel_id, revocation_data, settlement_data);
         Ok(())
@@ -216,12 +211,12 @@ where
         ctx: RpcContext,
         params: UpdatePendingRemoteSettlementParams,
     ) -> Result<(), ErrorObjectOwned> {
-        let node_id = ctx.node_id.parse::<NodeId>().rpc_err_no_data()?;
+        let node_id = ctx.node_id.parse::<NodeId>().rpc_err()?;
         let channel_id = params.channel_id.into();
         let settlement_data: fiber_types::SettlementData = params
             .settlement_data
             .try_into()
-            .map_err(|e: String| rpc_error_no_data(e))?;
+            .map_err(|e: String| rpc_error(e))?;
         self.store
             .update_pending_remote_settlement(node_id, channel_id, settlement_data);
         Ok(())
@@ -232,12 +227,12 @@ where
         ctx: RpcContext,
         params: UpdateLocalSettlementParams,
     ) -> Result<(), ErrorObjectOwned> {
-        let node_id = ctx.node_id.parse::<NodeId>().rpc_err_no_data()?;
+        let node_id = ctx.node_id.parse::<NodeId>().rpc_err()?;
         let channel_id = params.channel_id.into();
         let settlement_data: fiber_types::SettlementData = params
             .settlement_data
             .try_into()
-            .map_err(|e: String| rpc_error_no_data(e))?;
+            .map_err(|e: String| rpc_error(e))?;
         self.store
             .update_local_settlement(node_id, channel_id, settlement_data);
         Ok(())
@@ -250,7 +245,7 @@ where
     ) -> Result<(), ErrorObjectOwned> {
         use fiber_types::HashAlgorithm;
 
-        let node_id = ctx.node_id.parse::<NodeId>().rpc_err_no_data()?;
+        let node_id = ctx.node_id.parse::<NodeId>().rpc_err()?;
         let payment_hash = params.payment_hash.into();
         let preimage = params.preimage.into();
 
@@ -258,7 +253,7 @@ where
             .iter()
             .all(|algorithm| payment_hash != algorithm.hash(preimage).into())
         {
-            return Err(rpc_error_no_data("Wrong preimage"));
+            return Err(rpc_error("Wrong preimage"));
         }
         self.store
             .insert_watch_preimage(node_id, payment_hash, preimage);
@@ -269,7 +264,7 @@ where
         ctx: RpcContext,
         params: RemovePreimageParams,
     ) -> Result<(), ErrorObjectOwned> {
-        let node_id = ctx.node_id.parse::<NodeId>().rpc_err_no_data()?;
+        let node_id = ctx.node_id.parse::<NodeId>().rpc_err()?;
         let payment_hash = params.payment_hash.into();
         self.store.remove_watch_preimage(node_id, payment_hash);
         Ok(())

--- a/crates/fiber-lib/src/tests/mod.rs
+++ b/crates/fiber-lib/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod gen_utils;
 pub use gen_utils::*;
+pub mod rpc_utils;
 pub mod test_utils;
 pub use test_utils::*;

--- a/crates/fiber-lib/src/tests/rpc_utils.rs
+++ b/crates/fiber-lib/src/tests/rpc_utils.rs
@@ -1,0 +1,53 @@
+#[cfg(test)]
+mod tests {
+    use jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE;
+    use serde_json::json;
+
+    use crate::rpc::utils::{redacted_rpc_params, rpc_error, RpcResultExt};
+
+    #[test]
+    fn rpc_error_omits_request_data() {
+        let err = rpc_error("invalid private key");
+
+        assert_eq!(err.code(), CALL_EXECUTION_FAILED_CODE);
+        assert_eq!(err.message(), "invalid private key");
+        assert!(err.data().is_none());
+    }
+
+    #[test]
+    fn rpc_err_omits_request_data() {
+        let err = Result::<(), &str>::Err("actor failed")
+            .rpc_err()
+            .unwrap_err();
+
+        assert_eq!(err.code(), CALL_EXECUTION_FAILED_CODE);
+        assert_eq!(err.message(), "actor failed");
+        assert!(err.data().is_none());
+    }
+
+    #[test]
+    fn rpc_param_debug_redacts_sensitive_fields() {
+        let private_key = "1111111111111111111111111111111111111111111111111111111111111111";
+        let payment_preimage = "2222222222222222222222222222222222222222222222222222222222222222";
+        let params = json!({
+            "private_key": private_key,
+            "nested": {
+                "payment_preimage": payment_preimage,
+                "public_field": "kept",
+            },
+            "items": [{
+                "local_settlement_key": "3333333333333333333333333333333333333333333333333333333333333333",
+            }],
+        });
+
+        let redacted = redacted_rpc_params(&params);
+        let rendered = redacted.to_string();
+
+        assert_eq!(redacted["private_key"], "<redacted>");
+        assert_eq!(redacted["nested"]["payment_preimage"], "<redacted>");
+        assert_eq!(redacted["nested"]["public_field"], "kept");
+        assert_eq!(redacted["items"][0]["local_settlement_key"], "<redacted>");
+        assert!(!rendered.contains(private_key));
+        assert!(!rendered.contains(payment_preimage));
+    }
+}


### PR DESCRIPTION
`params` may contains sensitive data, we should remove it from log files and response body.

Leave a opt-in way to print params in log file, `export RPC_LOG_PARAMS_ENV=1` in case developer may need it in develop phase.