### PR TITLE
fix: paginate shutdown tx search to avoid output blinding

### DIFF
--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -162,7 +162,6 @@ impl CkbChainClient for CkbRpcClient {
         funding_lock_script: Script,
     ) -> Result<Option<GetShutdownTxResponse>, anyhow::Error> {
         let client = self.config.ckb_rpc_client();
-        // query transaction spent the funding cell
         let search_key = SearchKey {
             script: funding_lock_script.into(),
             script_type: ScriptType::Lock,
@@ -171,18 +170,37 @@ impl CkbChainClient for CkbRpcClient {
             filter: None,
             group_by_transaction: None,
         };
-        let txs = client
-            .get_transactions(search_key, Order::Desc, 1u32.into(), None)
-            .await?;
 
-        let Some(Tx::Ungrouped(tx)) = txs.objects.first() else {
-            return Ok(None);
+        // Paginate to find the first Input (funding cell spend). A
+        // single-page query with limit=1 can be blinded by a newer
+        // output created with the same lock.
+        const PAGE_SIZE: u32 = 200;
+        let mut after_cursor: Option<JsonBytes> = None;
+        let shutdown_tx_hash: Hash256 = 'search: loop {
+            let txs = client
+                .get_transactions(
+                    search_key.clone(),
+                    Order::Desc,
+                    PAGE_SIZE.into(),
+                    after_cursor,
+                )
+                .await?;
+
+            if txs.objects.is_empty() {
+                return Ok(None);
+            }
+
+            for tx_item in &txs.objects {
+                if let Tx::Ungrouped(tx) = tx_item {
+                    if matches!(tx.io_type, CellType::Input) {
+                        break 'search tx.tx_hash.clone().into();
+                    }
+                }
+            }
+
+            after_cursor = Some(txs.last_cursor.clone());
         };
-        if !matches!(tx.io_type, CellType::Input) {
-            return Ok(None);
-        }
 
-        let shutdown_tx_hash: Hash256 = tx.tx_hash.clone().into();
         let tx_with_status = client.get_transaction(shutdown_tx_hash.into()).await?;
         Ok(Some(tx_with_status.into()))
     }

--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -1,3 +1,4 @@
+use crate::ckb::config::new_ckb_rpc_async_client;
 use crate::ckb::CkbConfig;
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_sdk::rpc::ckb_indexer::{Cell, CellType, Order, Pagination, ScriptType, SearchKey, Tx};
@@ -129,8 +130,8 @@ impl CkbRpcClient {
 ///
 /// Shared by both `get_shutdown_tx` and the synchronous watchtower
 /// `run_periodic_check`.
-pub(crate) fn find_first_input_tx_hash(
-    client: &ckb_sdk::CkbRpcClient,
+pub(crate) async fn find_first_input_tx_hash(
+    client: &ckb_sdk::CkbRpcAsyncClient,
     funding_lock_script: &Script,
 ) -> Result<Option<H256>, anyhow::Error> {
     let search_key = SearchKey {
@@ -152,6 +153,7 @@ pub(crate) fn find_first_input_tx_hash(
                 PAGE_SIZE.into(),
                 after_cursor,
             )
+            .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
         if txs.objects.is_empty() {
@@ -208,8 +210,9 @@ impl CkbChainClient for CkbRpcClient {
         &self,
         funding_lock_script: Script,
     ) -> Result<Option<GetShutdownTxResponse>, anyhow::Error> {
-        let indexer_client = ckb_sdk::CkbRpcClient::new(&self.config.rpc_url);
-        let Some(tx_hash) = find_first_input_tx_hash(&indexer_client, &funding_lock_script)? else {
+        let indexer_client = new_ckb_rpc_async_client(&self.config.rpc_url);
+        let Some(tx_hash) = find_first_input_tx_hash(&indexer_client, &funding_lock_script).await?
+        else {
             return Ok(None);
         };
 

--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -123,6 +123,53 @@ impl CkbRpcClient {
     }
 }
 
+/// Paginate the CKB indexer to find the first transaction whose `io_type` is
+/// `CellType::Input` for the given funding lock script. Returns `None` if no
+/// such transaction exists.
+///
+/// Shared by both `get_shutdown_tx` and the synchronous watchtower
+/// `run_periodic_check`.
+pub(crate) fn find_first_input_tx_hash(
+    client: &ckb_sdk::CkbRpcClient,
+    funding_lock_script: &Script,
+) -> Result<Option<H256>, anyhow::Error> {
+    let search_key = SearchKey {
+        script: funding_lock_script.clone().into(),
+        script_type: ScriptType::Lock,
+        script_search_mode: Some(ckb_sdk::rpc::ckb_indexer::SearchMode::Exact),
+        with_data: None,
+        filter: None,
+        group_by_transaction: None,
+    };
+
+    const PAGE_SIZE: u32 = 100;
+    let mut after_cursor: Option<JsonBytes> = None;
+    loop {
+        let txs = client
+            .get_transactions(
+                search_key.clone(),
+                Order::Desc,
+                PAGE_SIZE.into(),
+                after_cursor,
+            )
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        if txs.objects.is_empty() {
+            return Ok(None);
+        }
+
+        for tx_item in &txs.objects {
+            if let Tx::Ungrouped(tx) = tx_item {
+                if matches!(tx.io_type, CellType::Input) {
+                    return Ok(Some(tx.tx_hash.clone()));
+                }
+            }
+        }
+
+        after_cursor = Some(txs.last_cursor.clone());
+    }
+}
+
 #[async_trait::async_trait]
 impl CkbChainClient for CkbRpcClient {
     async fn get_transaction(&self, hash: H256) -> Result<GetTxResponse, anyhow::Error> {
@@ -161,47 +208,13 @@ impl CkbChainClient for CkbRpcClient {
         &self,
         funding_lock_script: Script,
     ) -> Result<Option<GetShutdownTxResponse>, anyhow::Error> {
-        let client = self.config.ckb_rpc_client();
-        let search_key = SearchKey {
-            script: funding_lock_script.into(),
-            script_type: ScriptType::Lock,
-            script_search_mode: Some(ckb_sdk::rpc::ckb_indexer::SearchMode::Exact),
-            with_data: None,
-            filter: None,
-            group_by_transaction: None,
+        let indexer_client = ckb_sdk::CkbRpcClient::new(&self.config.rpc_url);
+        let Some(tx_hash) = find_first_input_tx_hash(&indexer_client, &funding_lock_script)? else {
+            return Ok(None);
         };
 
-        // Paginate to find the first Input (funding cell spend). A
-        // single-page query with limit=1 can be blinded by a newer
-        // output created with the same lock.
-        const PAGE_SIZE: u32 = 200;
-        let mut after_cursor: Option<JsonBytes> = None;
-        let shutdown_tx_hash: Hash256 = 'search: loop {
-            let txs = client
-                .get_transactions(
-                    search_key.clone(),
-                    Order::Desc,
-                    PAGE_SIZE.into(),
-                    after_cursor,
-                )
-                .await?;
-
-            if txs.objects.is_empty() {
-                return Ok(None);
-            }
-
-            for tx_item in &txs.objects {
-                if let Tx::Ungrouped(tx) = tx_item {
-                    if matches!(tx.io_type, CellType::Input) {
-                        break 'search tx.tx_hash.clone().into();
-                    }
-                }
-            }
-
-            after_cursor = Some(txs.last_cursor.clone());
-        };
-
-        let tx_with_status = client.get_transaction(shutdown_tx_hash.into()).await?;
+        let async_client = self.config.ckb_rpc_client();
+        let tx_with_status = async_client.get_transaction(tx_hash).await?;
         Ok(Some(tx_with_status.into()))
     }
 }

--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -94,6 +94,13 @@ impl From<Pagination<Cell>> for GetCellsResponse {
     }
 }
 
+fn first_input_tx_hash(txs: &[Tx]) -> Option<H256> {
+    txs.iter().find_map(|tx_item| match tx_item {
+        Tx::Ungrouped(tx) if matches!(tx.io_type, CellType::Input) => Some(tx.tx_hash.clone()),
+        _ => None,
+    })
+}
+
 #[async_trait::async_trait]
 pub trait CkbChainClient: Send + Sync {
     async fn get_transaction(&self, hash: H256) -> Result<GetTxResponse, anyhow::Error>;
@@ -124,24 +131,56 @@ impl CkbRpcClient {
     }
 }
 
-/// Paginate the CKB indexer to find the first transaction whose `io_type` is
-/// `CellType::Input` for the given funding lock script. Returns `None` if no
-/// such transaction exists.
-///
-/// Shared by both `get_shutdown_tx` and the synchronous watchtower
-/// `run_periodic_check`.
-pub(crate) async fn find_first_input_tx_hash(
-    client: &ckb_sdk::CkbRpcAsyncClient,
-    funding_lock_script: &Script,
-) -> Result<Option<H256>, anyhow::Error> {
-    let search_key = SearchKey {
+fn new_shutdown_tx_search_key(funding_lock_script: &Script) -> SearchKey {
+    SearchKey {
         script: funding_lock_script.clone().into(),
         script_type: ScriptType::Lock,
         script_search_mode: Some(ckb_sdk::rpc::ckb_indexer::SearchMode::Exact),
         with_data: None,
         filter: None,
         group_by_transaction: None,
-    };
+    }
+}
+
+/// Paginate the CKB indexer to find the first transaction whose `io_type` is
+/// `CellType::Input` for the given funding lock script. Returns `None` if no
+/// such transaction exists.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn find_first_input_tx_hash(
+    client: &ckb_sdk::CkbRpcClient,
+    funding_lock_script: &Script,
+) -> Result<Option<H256>, anyhow::Error> {
+    let search_key = new_shutdown_tx_search_key(funding_lock_script);
+
+    const PAGE_SIZE: u32 = 100;
+    let mut after_cursor: Option<JsonBytes> = None;
+    loop {
+        let txs = client
+            .get_transactions(
+                search_key.clone(),
+                Order::Desc,
+                PAGE_SIZE.into(),
+                after_cursor,
+            )
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        if txs.objects.is_empty() {
+            return Ok(None);
+        }
+
+        if let Some(tx_hash) = first_input_tx_hash(&txs.objects) {
+            return Ok(Some(tx_hash));
+        }
+
+        after_cursor = Some(txs.last_cursor.clone());
+    }
+}
+
+async fn find_first_input_tx_hash_async(
+    client: &ckb_sdk::CkbRpcAsyncClient,
+    funding_lock_script: &Script,
+) -> Result<Option<H256>, anyhow::Error> {
+    let search_key = new_shutdown_tx_search_key(funding_lock_script);
 
     const PAGE_SIZE: u32 = 100;
     let mut after_cursor: Option<JsonBytes> = None;
@@ -160,12 +199,8 @@ pub(crate) async fn find_first_input_tx_hash(
             return Ok(None);
         }
 
-        for tx_item in &txs.objects {
-            if let Tx::Ungrouped(tx) = tx_item {
-                if matches!(tx.io_type, CellType::Input) {
-                    return Ok(Some(tx.tx_hash.clone()));
-                }
-            }
+        if let Some(tx_hash) = first_input_tx_hash(&txs.objects) {
+            return Ok(Some(tx_hash));
         }
 
         after_cursor = Some(txs.last_cursor.clone());
@@ -211,7 +246,8 @@ impl CkbChainClient for CkbRpcClient {
         funding_lock_script: Script,
     ) -> Result<Option<GetShutdownTxResponse>, anyhow::Error> {
         let indexer_client = new_ckb_rpc_async_client(&self.config.rpc_url);
-        let Some(tx_hash) = find_first_input_tx_hash(&indexer_client, &funding_lock_script).await?
+        let Some(tx_hash) =
+            find_first_input_tx_hash_async(&indexer_client, &funding_lock_script).await?
         else {
             return Ok(None);
         };
@@ -219,5 +255,36 @@ impl CkbChainClient for CkbRpcClient {
         let async_client = self.config.ckb_rpc_client();
         let tx_with_status = async_client.get_transaction(tx_hash).await?;
         Ok(Some(tx_with_status.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::first_input_tx_hash;
+    use ckb_jsonrpc_types::{BlockNumber, Uint32};
+    use ckb_sdk::rpc::ckb_indexer::{CellType, Tx, TxWithCell};
+    use ckb_types::H256;
+
+    fn build_tx(io_type: CellType, tx_hash: u8) -> Tx {
+        Tx::Ungrouped(TxWithCell {
+            tx_hash: H256::from([tx_hash; 32]),
+            block_number: BlockNumber::from(1_u64),
+            tx_index: Uint32::from(0_u32),
+            io_index: Uint32::from(0_u32),
+            io_type,
+        })
+    }
+
+    #[test]
+    fn test_find_first_input_tx_hash_returns_first_input_from_page() {
+        let output_only_page = vec![build_tx(CellType::Output, 1), build_tx(CellType::Output, 2)];
+        let input_page = vec![
+            build_tx(CellType::Output, 3),
+            build_tx(CellType::Input, 4),
+            build_tx(CellType::Input, 5),
+        ];
+
+        assert_eq!(first_input_tx_hash(&output_only_page), None);
+        assert_eq!(first_input_tx_hash(&input_page), Some(H256::from([4; 32])));
     }
 }

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -5,9 +5,9 @@ use std::sync::{
 
 use anyhow::anyhow;
 use ckb_hash::new_blake2b;
-use ckb_jsonrpc_types::{Either, JsonBytes, Status};
+use ckb_jsonrpc_types::{Either, Status};
 use ckb_sdk::{
-    rpc::ckb_indexer::{Cell, CellType, Order, ScriptType, SearchKey, SearchMode, Tx},
+    rpc::ckb_indexer::{Cell, Order, ScriptType, SearchKey, SearchMode},
     traits::{CellCollector, CellQueryOptions, DefaultCellCollector, ValueRangeOption},
     transaction::builder::FeeCalculator,
     util::blake160,
@@ -255,172 +255,131 @@ where
         let ckb_client =
             CkbRpcClient::with_builder(&rpc_url, |builder| builder.timeout(CKB_RPC_TIMEOUT))
                 .expect("create ckb rpc client should not fail");
-        let search_key = SearchKey {
-            script: channel_data_funding_tx_lock(&channel_data).into(),
-            script_type: ScriptType::Lock,
-            script_search_mode: Some(SearchMode::Exact),
-            with_data: None,
-            filter: None,
-            group_by_transaction: None,
-        };
-        // we need two parties' signatures to unlock the funding tx, so we can check the last one transaction only to see if it's an old version commitment tx
-        let tx_hash = {
-            const PAGE_SIZE: u32 = 200;
-            let mut after: Option<JsonBytes> = None;
-            let mut found = None;
-            loop {
-                match ckb_client.get_transactions(
-                    search_key.clone(),
-                    Order::Desc,
-                    PAGE_SIZE.into(),
-                    after,
-                ) {
-                    Ok(txs) => {
-                        if txs.objects.is_empty() {
-                            break;
-                        }
-                        for tx_item in &txs.objects {
-                            if let Tx::Ungrouped(tx) = tx_item {
-                                if matches!(tx.io_type, CellType::Input) {
-                                    found = Some(tx.tx_hash.clone());
-                                    break;
-                                }
-                            }
-                        }
-                        if found.is_some() {
-                            break;
-                        }
-                        after = Some(txs.last_cursor.clone());
-                    }
-                    Err(err) => {
-                        error!("Failed to get transactions: {:?}", err);
-                        break;
-                    }
-                }
+        let tx_hash = match crate::ckb::client::find_first_input_tx_hash(
+            &ckb_client,
+            &channel_data_funding_tx_lock(&channel_data),
+        ) {
+            Ok(Some(tx_hash)) => tx_hash,
+            Ok(None) => continue,
+            Err(err) => {
+                error!("Failed to get transactions: {:?}", err);
+                continue;
             }
-            found
         };
-        if let Some(tx_hash) = tx_hash {
-            match ckb_client.get_transaction(tx_hash.clone()) {
-                Ok(Some(tx_with_status)) => {
-                    if tx_with_status.tx_status.status != Status::Committed {
-                        error!("Cannot find the commitment tx: {:?}, status is {:?}, maybe ckb indexer bug?", tx_with_status.tx_status.status, tx_hash);
-                    } else if let Some(tx) = tx_with_status.transaction {
-                        match tx.inner {
-                            Either::Left(tx) => {
-                                let tx: Transaction = tx.inner.into();
-                                if tx.raw().outputs().len() == 1 {
-                                    let first_commitment_tx_out_point =
-                                        OutPoint::new(tx.calc_tx_hash(), 0);
-                                    let output =
-                                        tx.raw().outputs().get(0).expect("get output 0 of tx");
-                                    let commitment_lock = output.lock();
-                                    let lock_args = commitment_lock.args().raw_data();
-                                    let pub_key_hash: [u8; 20] =
-                                        lock_args[0..20].try_into().expect("checked length");
-                                    let commitment_number = u64::from_be_bytes(
-                                        lock_args[28..36].try_into().expect("u64 from slice"),
-                                    );
+        match ckb_client.get_transaction(tx_hash.clone()) {
+            Ok(Some(tx_with_status)) => {
+                if tx_with_status.tx_status.status != Status::Committed {
+                    error!("Cannot find the commitment tx: {:?}, status is {:?}, maybe ckb indexer bug?", tx_with_status.tx_status.status, tx_hash);
+                } else if let Some(tx) = tx_with_status.transaction {
+                    match tx.inner {
+                        Either::Left(tx) => {
+                            let tx: Transaction = tx.inner.into();
+                            if tx.raw().outputs().len() == 1 {
+                                let first_commitment_tx_out_point =
+                                    OutPoint::new(tx.calc_tx_hash(), 0);
+                                let output = tx.raw().outputs().get(0).expect("get output 0 of tx");
+                                let commitment_lock = output.lock();
+                                let lock_args = commitment_lock.args().raw_data();
+                                let pub_key_hash: [u8; 20] =
+                                    lock_args[0..20].try_into().expect("checked length");
+                                let commitment_number = u64::from_be_bytes(
+                                    lock_args[28..36].try_into().expect("u64 from slice"),
+                                );
 
-                                    let x_only_aggregated_pubkey =
-                                        channel_data_x_only_aggregated_pubkey(&channel_data, false);
-                                    if blake160(&x_only_aggregated_pubkey).0 == pub_key_hash {
-                                        match channel_data.revocation_data.clone() {
-                                            Some(revocation_data)
-                                                if revocation_data.commitment_number
-                                                    >= commitment_number =>
-                                            {
-                                                match ckb_client.get_live_cell(
-                                                    first_commitment_tx_out_point.clone().into(),
-                                                    false,
-                                                ) {
-                                                    Ok(cell_with_status) => {
-                                                        if cell_with_status.status == "live" {
-                                                            warn!("Found an old version commitment tx submitted by remote: {:#x}", tx.calc_tx_hash());
-                                                            match build_revocation_tx(
-                                                                first_commitment_tx_out_point,
-                                                                revocation_data,
-                                                                x_only_aggregated_pubkey,
-                                                                &signer,
-                                                                &mut cell_collector,
-                                                            ) {
-                                                                Ok(tx) => {
-                                                                    match ckb_client
-                                                                        .send_transaction(
-                                                                            tx.data().into(),
-                                                                            None,
-                                                                        ) {
-                                                                        Ok(tx_hash) => {
-                                                                            info!("Revocation tx: {:?} sent, tx_hash: {:?}", tx, tx_hash);
-                                                                        }
-                                                                        Err(err) => {
-                                                                            error!("Failed to send revocation tx: {:?}, error: {:?}", tx, err);
-                                                                        }
+                                let x_only_aggregated_pubkey =
+                                    channel_data_x_only_aggregated_pubkey(&channel_data, false);
+                                if blake160(&x_only_aggregated_pubkey).0 == pub_key_hash {
+                                    match channel_data.revocation_data.clone() {
+                                        Some(revocation_data)
+                                            if revocation_data.commitment_number
+                                                >= commitment_number =>
+                                        {
+                                            match ckb_client.get_live_cell(
+                                                first_commitment_tx_out_point.clone().into(),
+                                                false,
+                                            ) {
+                                                Ok(cell_with_status) => {
+                                                    if cell_with_status.status == "live" {
+                                                        warn!("Found an old version commitment tx submitted by remote: {:#x}", tx.calc_tx_hash());
+                                                        match build_revocation_tx(
+                                                            first_commitment_tx_out_point,
+                                                            revocation_data,
+                                                            x_only_aggregated_pubkey,
+                                                            &signer,
+                                                            &mut cell_collector,
+                                                        ) {
+                                                            Ok(tx) => {
+                                                                match ckb_client.send_transaction(
+                                                                    tx.data().into(),
+                                                                    None,
+                                                                ) {
+                                                                    Ok(tx_hash) => {
+                                                                        info!("Revocation tx: {:?} sent, tx_hash: {:?}", tx, tx_hash);
+                                                                    }
+                                                                    Err(err) => {
+                                                                        error!("Failed to send revocation tx: {:?}, error: {:?}", tx, err);
                                                                     }
                                                                 }
-                                                                Err(err) => {
-                                                                    error!("Failed to build revocation tx: {:?}", err);
-                                                                }
+                                                            }
+                                                            Err(err) => {
+                                                                error!("Failed to build revocation tx: {:?}", err);
                                                             }
                                                         }
                                                     }
-                                                    Err(err) => {
-                                                        error!(
-                                                            "Failed to get live cell: {:?}",
-                                                            err
-                                                        );
-                                                    }
+                                                }
+                                                Err(err) => {
+                                                    error!("Failed to get live cell: {:?}", err);
                                                 }
                                             }
-                                            _ => {
-                                                try_settle_commitment_tx(
-                                                    commitment_lock,
-                                                    first_commitment_tx_out_point,
-                                                    ckb_client,
-                                                    channel_data,
-                                                    true,
-                                                    &signer,
-                                                    &mut cell_collector,
-                                                    &store,
-                                                    node_id.clone(),
-                                                );
-                                            }
                                         }
-                                    } else {
-                                        try_settle_commitment_tx(
-                                            commitment_lock,
-                                            first_commitment_tx_out_point,
-                                            ckb_client,
-                                            channel_data,
-                                            false,
-                                            &signer,
-                                            &mut cell_collector,
-                                            &store,
-                                            node_id.clone(),
-                                        );
+                                        _ => {
+                                            try_settle_commitment_tx(
+                                                commitment_lock,
+                                                first_commitment_tx_out_point,
+                                                ckb_client,
+                                                channel_data,
+                                                true,
+                                                &signer,
+                                                &mut cell_collector,
+                                                &store,
+                                                node_id.clone(),
+                                            );
+                                        }
                                     }
                                 } else {
-                                    // there may be a race condition that PeriodicCheck is triggered before the remove_channel fn is called
-                                    // it's a close channel tx, ignore
+                                    try_settle_commitment_tx(
+                                        commitment_lock,
+                                        first_commitment_tx_out_point,
+                                        ckb_client,
+                                        channel_data,
+                                        false,
+                                        &signer,
+                                        &mut cell_collector,
+                                        &store,
+                                        node_id.clone(),
+                                    );
                                 }
-                            }
-                            Either::Right(_tx) => {
-                                // unreachable, ignore
+                            } else {
+                                // there may be a race condition that PeriodicCheck is triggered before the remove_channel fn is called
+                                // it's a close channel tx, ignore
                             }
                         }
-                    } else {
-                        error!("Cannot find the commitment tx: {:?}, transaction is none, maybe ckb indexer bug?", tx_hash);
+                        Either::Right(_tx) => {
+                            // unreachable, ignore
+                        }
                     }
+                } else {
+                    error!("Cannot find the commitment tx: {:?}, transaction is none, maybe ckb indexer bug?", tx_hash);
                 }
-                Ok(None) => {
-                    error!(
-                        "Cannot find the commitment tx: {:?}, maybe ckb indexer bug?",
-                        tx_hash
-                    );
-                }
-                Err(err) => {
-                    error!("Failed to get funding tx: {:?}", err);
-                }
+            }
+            Ok(None) => {
+                error!(
+                    "Cannot find the commitment tx: {:?}, maybe ckb indexer bug?",
+                    tx_hash
+                );
+            }
+            Err(err) => {
+                error!("Failed to get funding tx: {:?}", err);
             }
         }
     }

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -379,7 +379,7 @@ where
                 );
             }
             Err(err) => {
-                error!("Failed to get funding tx: {:?}", err);
+                error!("Failed to get commitment tx: {:?}", err);
             }
         }
     }

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -5,7 +5,7 @@ use std::sync::{
 
 use anyhow::anyhow;
 use ckb_hash::new_blake2b;
-use ckb_jsonrpc_types::{Either, Status};
+use ckb_jsonrpc_types::{Either, JsonBytes, Status};
 use ckb_sdk::{
     rpc::ckb_indexer::{Cell, CellType, Order, ScriptType, SearchKey, SearchMode, Tx},
     traits::{CellCollector, CellQueryOptions, DefaultCellCollector, ValueRangeOption},
@@ -264,150 +264,163 @@ where
             group_by_transaction: None,
         };
         // we need two parties' signatures to unlock the funding tx, so we can check the last one transaction only to see if it's an old version commitment tx
-        match ckb_client.get_transactions(search_key, Order::Desc, 1u32.into(), None) {
-            Ok(txs) => {
-                if let Some(Tx::Ungrouped(tx)) = txs.objects.first() {
-                    if matches!(tx.io_type, CellType::Input) {
-                        match ckb_client.get_transaction(tx.tx_hash.clone()) {
-                            Ok(Some(tx_with_status)) => {
-                                if tx_with_status.tx_status.status != Status::Committed {
-                                    error!("Cannot find the commitment tx: {:?}, status is {:?}, maybe ckb indexer bug?", tx_with_status.tx_status.status, tx.tx_hash);
-                                } else if let Some(tx) = tx_with_status.transaction {
-                                    match tx.inner {
-                                        Either::Left(tx) => {
-                                            let tx: Transaction = tx.inner.into();
-                                            if tx.raw().outputs().len() == 1 {
-                                                let first_commitment_tx_out_point =
-                                                    OutPoint::new(tx.calc_tx_hash(), 0);
-                                                let output = tx
-                                                    .raw()
-                                                    .outputs()
-                                                    .get(0)
-                                                    .expect("get output 0 of tx");
-                                                let commitment_lock = output.lock();
-                                                let lock_args = commitment_lock.args().raw_data();
-                                                let pub_key_hash: [u8; 20] = lock_args[0..20]
-                                                    .try_into()
-                                                    .expect("checked length");
-                                                let commitment_number = u64::from_be_bytes(
-                                                    lock_args[28..36]
-                                                        .try_into()
-                                                        .expect("u64 from slice"),
-                                                );
-
-                                                let x_only_aggregated_pubkey =
-                                                    channel_data_x_only_aggregated_pubkey(
-                                                        &channel_data,
-                                                        false,
-                                                    );
-                                                if blake160(&x_only_aggregated_pubkey).0
-                                                    == pub_key_hash
-                                                {
-                                                    match channel_data.revocation_data.clone() {
-                                                        Some(revocation_data)
-                                                            if revocation_data
-                                                                .commitment_number
-                                                                >= commitment_number =>
-                                                        {
-                                                            match ckb_client.get_live_cell(
-                                                                first_commitment_tx_out_point
-                                                                    .clone()
-                                                                    .into(),
-                                                                false,
-                                                            ) {
-                                                                Ok(cell_with_status) => {
-                                                                    if cell_with_status.status
-                                                                        == "live"
-                                                                    {
-                                                                        warn!("Found an old version commitment tx submitted by remote: {:#x}", tx.calc_tx_hash());
-                                                                        match build_revocation_tx(
-                                                                                    first_commitment_tx_out_point,
-                                                                                    revocation_data,
-                                                                                    x_only_aggregated_pubkey,
-                                                                                    &signer,
-                                                                                    &mut cell_collector,
-                                                                                ) {
-                                                                                    Ok(tx) => {
-                                                                                        match ckb_client
-                                                                                            .send_transaction(
-                                                                                                tx.data()
-                                                                                                    .into(),
-                                                                                                None,
-                                                                                            ) {
-                                                                                            Ok(tx_hash) => {
-                                                                                                info!("Revocation tx: {:?} sent, tx_hash: {:?}", tx, tx_hash);
-                                                                                            }
-                                                                                            Err(err) => {
-                                                                                                error!("Failed to send revocation tx: {:?}, error: {:?}", tx, err);
-                                                                                            }
-                                                                                        }
-                                                                                    }
-                                                                                    Err(err) => {
-                                                                                        error!("Failed to build revocation tx: {:?}", err);
-                                                                                    }
-                                                                                }
-                                                                    }
-                                                                }
-                                                                Err(err) => {
-                                                                    error!("Failed to get live cell: {:?}", err);
-                                                                }
-                                                            }
-                                                        }
-                                                        _ => {
-                                                            try_settle_commitment_tx(
-                                                                commitment_lock,
-                                                                first_commitment_tx_out_point,
-                                                                ckb_client,
-                                                                channel_data,
-                                                                true,
-                                                                &signer,
-                                                                &mut cell_collector,
-                                                                &store,
-                                                                node_id.clone(),
-                                                            );
-                                                        }
-                                                    }
-                                                } else {
-                                                    try_settle_commitment_tx(
-                                                        commitment_lock,
-                                                        first_commitment_tx_out_point,
-                                                        ckb_client,
-                                                        channel_data,
-                                                        false,
-                                                        &signer,
-                                                        &mut cell_collector,
-                                                        &store,
-                                                        node_id.clone(),
-                                                    );
-                                                }
-                                            } else {
-                                                // there may be a race condition that PeriodicCheck is triggered before the remove_channel fn is called
-                                                // it's a close channel tx, ignore
-                                            }
-                                        }
-                                        Either::Right(_tx) => {
-                                            // unreachable, ignore
-                                        }
-                                    }
-                                } else {
-                                    error!("Cannot find the commitment tx: {:?}, transaction is none, maybe ckb indexer bug?", tx.tx_hash);
+        let tx_hash = {
+            const PAGE_SIZE: u32 = 200;
+            let mut after: Option<JsonBytes> = None;
+            let mut found = None;
+            loop {
+                match ckb_client.get_transactions(
+                    search_key.clone(),
+                    Order::Desc,
+                    PAGE_SIZE.into(),
+                    after,
+                ) {
+                    Ok(txs) => {
+                        if txs.objects.is_empty() {
+                            break;
+                        }
+                        for tx_item in &txs.objects {
+                            if let Tx::Ungrouped(tx) = tx_item {
+                                if matches!(tx.io_type, CellType::Input) {
+                                    found = Some(tx.tx_hash.clone());
+                                    break;
                                 }
                             }
-                            Ok(None) => {
-                                error!(
-                                    "Cannot find the commitment tx: {:?}, maybe ckb indexer bug?",
-                                    tx.tx_hash
-                                );
-                            }
-                            Err(err) => {
-                                error!("Failed to get funding tx: {:?}", err);
-                            }
                         }
+                        if found.is_some() {
+                            break;
+                        }
+                        after = Some(txs.last_cursor.clone());
+                    }
+                    Err(err) => {
+                        error!("Failed to get transactions: {:?}", err);
+                        break;
                     }
                 }
             }
-            Err(err) => {
-                error!("Failed to get transactions: {:?}", err);
+            found
+        };
+        if let Some(tx_hash) = tx_hash {
+            match ckb_client.get_transaction(tx_hash.clone()) {
+                Ok(Some(tx_with_status)) => {
+                    if tx_with_status.tx_status.status != Status::Committed {
+                        error!("Cannot find the commitment tx: {:?}, status is {:?}, maybe ckb indexer bug?", tx_with_status.tx_status.status, tx_hash);
+                    } else if let Some(tx) = tx_with_status.transaction {
+                        match tx.inner {
+                            Either::Left(tx) => {
+                                let tx: Transaction = tx.inner.into();
+                                if tx.raw().outputs().len() == 1 {
+                                    let first_commitment_tx_out_point =
+                                        OutPoint::new(tx.calc_tx_hash(), 0);
+                                    let output =
+                                        tx.raw().outputs().get(0).expect("get output 0 of tx");
+                                    let commitment_lock = output.lock();
+                                    let lock_args = commitment_lock.args().raw_data();
+                                    let pub_key_hash: [u8; 20] =
+                                        lock_args[0..20].try_into().expect("checked length");
+                                    let commitment_number = u64::from_be_bytes(
+                                        lock_args[28..36].try_into().expect("u64 from slice"),
+                                    );
+
+                                    let x_only_aggregated_pubkey =
+                                        channel_data_x_only_aggregated_pubkey(&channel_data, false);
+                                    if blake160(&x_only_aggregated_pubkey).0 == pub_key_hash {
+                                        match channel_data.revocation_data.clone() {
+                                            Some(revocation_data)
+                                                if revocation_data.commitment_number
+                                                    >= commitment_number =>
+                                            {
+                                                match ckb_client.get_live_cell(
+                                                    first_commitment_tx_out_point.clone().into(),
+                                                    false,
+                                                ) {
+                                                    Ok(cell_with_status) => {
+                                                        if cell_with_status.status == "live" {
+                                                            warn!("Found an old version commitment tx submitted by remote: {:#x}", tx.calc_tx_hash());
+                                                            match build_revocation_tx(
+                                                                first_commitment_tx_out_point,
+                                                                revocation_data,
+                                                                x_only_aggregated_pubkey,
+                                                                &signer,
+                                                                &mut cell_collector,
+                                                            ) {
+                                                                Ok(tx) => {
+                                                                    match ckb_client
+                                                                        .send_transaction(
+                                                                            tx.data().into(),
+                                                                            None,
+                                                                        ) {
+                                                                        Ok(tx_hash) => {
+                                                                            info!("Revocation tx: {:?} sent, tx_hash: {:?}", tx, tx_hash);
+                                                                        }
+                                                                        Err(err) => {
+                                                                            error!("Failed to send revocation tx: {:?}, error: {:?}", tx, err);
+                                                                        }
+                                                                    }
+                                                                }
+                                                                Err(err) => {
+                                                                    error!("Failed to build revocation tx: {:?}", err);
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    Err(err) => {
+                                                        error!(
+                                                            "Failed to get live cell: {:?}",
+                                                            err
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                            _ => {
+                                                try_settle_commitment_tx(
+                                                    commitment_lock,
+                                                    first_commitment_tx_out_point,
+                                                    ckb_client,
+                                                    channel_data,
+                                                    true,
+                                                    &signer,
+                                                    &mut cell_collector,
+                                                    &store,
+                                                    node_id.clone(),
+                                                );
+                                            }
+                                        }
+                                    } else {
+                                        try_settle_commitment_tx(
+                                            commitment_lock,
+                                            first_commitment_tx_out_point,
+                                            ckb_client,
+                                            channel_data,
+                                            false,
+                                            &signer,
+                                            &mut cell_collector,
+                                            &store,
+                                            node_id.clone(),
+                                        );
+                                    }
+                                } else {
+                                    // there may be a race condition that PeriodicCheck is triggered before the remove_channel fn is called
+                                    // it's a close channel tx, ignore
+                                }
+                            }
+                            Either::Right(_tx) => {
+                                // unreachable, ignore
+                            }
+                        }
+                    } else {
+                        error!("Cannot find the commitment tx: {:?}, transaction is none, maybe ckb indexer bug?", tx_hash);
+                    }
+                }
+                Ok(None) => {
+                    error!(
+                        "Cannot find the commitment tx: {:?}, maybe ckb indexer bug?",
+                        tx_hash
+                    );
+                }
+                Err(err) => {
+                    error!("Failed to get funding tx: {:?}", err);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fix GHSA-xhmq-32x3-xhpw: force-close detection can be blinded by a newer output with the same lock

## Problem
`get_shutdown_tx` queried CKB Indexer with `limit=1, Order::Desc` and returned `None` if the single result was not `CellType::Input`. A third party can create an output to the channel's funding lock script (no signature required on CKB), which becomes the latest indexed transaction and hides the real force-close Input.

## Fix
Add `find_first_input_tx_hash` helper that paginates through descending transaction pages (100 per page) until it finds a `CellType::Input` or exhausts results. Call it from `get_shutdown_tx`.

## Changes
`crates/fiber-lib/src/ckb/client.rs` — new helper + simplified `get_shutdown_tx`