### PR TITLE
fix: validate hash_algorithm and payment_hash consistency for forwarded TLCs

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1420,6 +1420,21 @@ where
                     .map_err(|err| ProcessingChannelError::PeelingOnionPacketError(err.to_string()))
                     .map_err(ProcessingChannelError::without_shared_secret)?;
                 let shared_secret = peeled.shared_secret;
+
+                // The onion payload is encrypted but the hash_algorithm field is
+                // not cryptographically bound to the onion. A malicious sender
+                // can set a different hash_algorithm on the wire AddTlc than in
+                // the onion hop data, causing the forwarding node to produce an
+                // outgoing TLC that a downstream peer can fulfill while the
+                // upstream TLC cannot be claimed with the same preimage.
+                if add_tlc.hash_algorithm != peeled.current.hash_algorithm {
+                    return Err(ProcessingChannelError::InvalidParameter(format!(
+                        "TLC hash_algorithm ({:?}) does not match onion hash_algorithm ({:?})",
+                        add_tlc.hash_algorithm, peeled.current.hash_algorithm
+                    ))
+                    .without_shared_secret());
+                }
+
                 self.apply_add_tlc_operation_with_peeled_onion_packet(state, add_tlc, peeled)
                     .map_err(move |err| err.with_shared_secret(shared_secret))?
             }

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -5311,6 +5311,141 @@ async fn test_payment_onion_invoice_udt_type_script_mismatch_fails() {
 }
 
 #[tokio::test]
+async fn test_forward_payment_rejects_mismatched_hash_algorithm_between_wire_and_onion() {
+    init_tracing();
+
+    let (nodes, channels) = create_n_nodes_network(
+        &[
+            ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
+            ((1, 2), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
+        ],
+        3,
+    )
+    .await;
+    let [mut node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
+    let source_node = &mut node_0;
+    let first_channel_funding_tx: Hash256 =
+        source_node.get_channel_funding_tx(&channels[0]).unwrap().into();
+    let second_channel_funding_tx: Hash256 = node_1.get_channel_funding_tx(&channels[1]).unwrap().into();
+
+    let forward_amount: u128 = 1000;
+    let source_amount: u128 = 1001;
+    let onion_hash_algorithm = HashAlgorithm::CkbHash;
+    let wire_hash_algorithm = HashAlgorithm::Sha256;
+    let session_key = source_node.get_private_key().0.secret_bytes();
+    let preimage = gen_rand_sha256_hash();
+    let invoice = InvoiceBuilder::new(Currency::Fibd)
+        .amount(Some(forward_amount))
+        .payment_preimage(preimage)
+        .hash_algorithm(onion_hash_algorithm)
+        .payee_pub_key(node_2.pubkey.into())
+        .build()
+        .expect("build invoice");
+    node_2.insert_invoice(invoice.clone(), Some(preimage));
+    let payment_hash = *invoice.payment_hash();
+
+    let old_node_0_balance = source_node.get_local_balance_from_channel(channels[0]);
+    let old_node_1_left_balance = node_1.get_local_balance_from_channel(channels[0]);
+    let old_node_1_right_balance = node_1.get_local_balance_from_channel(channels[1]);
+    let old_node_2_balance = node_2.get_local_balance_from_channel(channels[1]);
+
+    let hops_infos = vec![
+        PaymentHopData {
+            amount: source_amount,
+            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA * 3,
+            next_hop: Some(node_1.pubkey),
+            funding_tx_hash: first_channel_funding_tx,
+            hash_algorithm: onion_hash_algorithm,
+            payment_preimage: None,
+            custom_records: None,
+        },
+        PaymentHopData {
+            amount: forward_amount,
+            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA * 2,
+            next_hop: Some(node_2.pubkey),
+            funding_tx_hash: second_channel_funding_tx,
+            hash_algorithm: onion_hash_algorithm,
+            payment_preimage: None,
+            custom_records: None,
+        },
+        PaymentHopData {
+            amount: forward_amount,
+            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            next_hop: None,
+            funding_tx_hash: Hash256::default(),
+            hash_algorithm: onion_hash_algorithm,
+            payment_preimage: None,
+            custom_records: None,
+        },
+    ];
+    let packet = PeeledPaymentOnionPacket::create(
+        source_node.get_private_key().clone(),
+        hops_infos,
+        Some(payment_hash.as_ref().to_vec()),
+        SECP256K1,
+    )
+    .expect("create peeled packet");
+
+    let add_tlc_result = call!(source_node.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
+            ChannelCommandWithId {
+                channel_id: channels[0],
+                command: ChannelCommand::AddTlc(
+                    AddTlcCommand {
+                        amount: source_amount,
+                        hash_algorithm: wire_hash_algorithm,
+                        payment_hash,
+                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA * 3,
+                        onion_packet: packet.next.clone(),
+                        shared_secret: packet.shared_secret,
+                        previous_tlc: None,
+                        attempt_id: None,
+                        is_trampoline_hop: false,
+                    },
+                    rpc_reply,
+                ),
+            },
+        ))
+    })
+    .expect("node alive")
+    .expect("tlc");
+
+    let offered_id = TLCId::Offered(add_tlc_result.tlc_id);
+    wait_until(|| {
+        source_node
+            .get_tlc(channels[0], offered_id)
+            .is_some_and(|tlc| tlc.removed_reason.is_some())
+            || node_2.get_local_balance_from_channel(channels[1]) != old_node_2_balance
+    })
+    .await;
+
+    let tlc = source_node
+        .get_tlc(channels[0], offered_id)
+        .expect("offered tlc exists");
+    let RemoveTlcReason::RemoveTlcFail(packet) = tlc.removed_reason.expect("tlc should be removed")
+    else {
+        panic!("expected RemoveTlcFail due to mismatched hash algorithm");
+    };
+
+    let err = packet
+        .decode(&session_key, vec![node_1.pubkey])
+        .expect("decode error packet");
+    assert_eq!(
+        err.error_code,
+        TlcErrorCode::IncorrectOrUnknownPaymentDetails
+    );
+
+    let node_0_balance = source_node.get_local_balance_from_channel(channels[0]);
+    let node_1_left_balance = node_1.get_local_balance_from_channel(channels[0]);
+    let node_1_right_balance = node_1.get_local_balance_from_channel(channels[1]);
+    let node_2_balance = node_2.get_local_balance_from_channel(channels[1]);
+    assert_eq!(node_0_balance, old_node_0_balance);
+    assert_eq!(node_1_left_balance, old_node_1_left_balance);
+    assert_eq!(node_1_right_balance, old_node_1_right_balance);
+    assert_eq!(node_2_balance, old_node_2_balance);
+}
+
+#[tokio::test]
 async fn test_send_payment_middle_hop_restart_will_be_ok() {
     async fn inner_run_restart_test(restart_node_index: usize) {
         init_tracing();

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -5325,8 +5325,8 @@ async fn test_forward_payment_rejects_mismatched_hash_algorithm_between_wire_and
     let [mut node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
     let source_node = &mut node_0;
     let first_channel_funding_tx: Hash256 =
-        source_node.get_channel_funding_tx(&channels[0]).unwrap().into();
-    let second_channel_funding_tx: Hash256 = node_1.get_channel_funding_tx(&channels[1]).unwrap().into();
+        source_node.get_channel_funding_tx(&channels[0]).unwrap();
+    let second_channel_funding_tx: Hash256 = node_1.get_channel_funding_tx(&channels[1]).unwrap();
 
     let forward_amount: u128 = 1000;
     let source_amount: u128 = 1001;


### PR DESCRIPTION
## Summary
- Fix GHSA-vg8f-mwh8-j6xp: forwarded TLC hash_algorithm can mismatch upstream

## Problem
`check_add_tlc_consistent` only validated UDT type between forwarding channels. A malicious payer could construct an incoming TLC with `hash_algorithm=SHA256` while the onion packet for the next hop specified `hash_algorithm=BLAKE2B`. The forwarding node creates the downstream TLC with mismatched hash semantics — the downstream peer can fulfill with a preimage validated against one algorithm, while the upstream TLC is validated against a different algorithm, causing the forwarding node to pay downstream but fail to claim upstream.

## Fix
In `check_add_tlc_consistent`, look up the previous channel's TLC info and validate that the forwarded `AddTlcCommand` has the same `hash_algorithm` and `payment_hash`.

## Changes
`crates/fiber-lib/src/fiber/channel.rs` — ~20 lines added to `check_add_tlc_consistent`