### PR TITLE
Fix: enhance TLC error packet decoding to reject spoofed nodes

### DIFF
--- a/crates/fiber-lib/src/fiber/tests/types.rs
+++ b/crates/fiber-lib/src/fiber/tests/types.rs
@@ -689,6 +689,27 @@ fn test_tlc_err_packet_encryption() {
             .expect("decrypted");
         assert_eq!(decrypted_tlc_fail_detail, tlc_fail_detail);
     }
+
+    {
+        // The error packet authenticates the second hop as reporter, so a payload that
+        // blames another node in the route must be rejected.
+        let reporter_node = hops_path[1];
+        let spoofed_node = hops_path[2];
+        let node_fail = TlcErr::new_node_fail(TlcErrorCode::PermanentNodeFailure, reporter_node);
+        let mut tlc_fail = TlcErrPacket::new(node_fail.clone(), &hops_ss[1]);
+        tlc_fail = tlc_fail.backward(&hops_ss[0]);
+        let decrypted_tlc_fail_detail = tlc_fail
+            .decode(session_key.as_ref(), hops_path.clone())
+            .expect("decrypted");
+        assert_eq!(decrypted_tlc_fail_detail, node_fail);
+
+        let spoofed_fail = TlcErr::new_node_fail(TlcErrorCode::PermanentNodeFailure, spoofed_node);
+        let mut tlc_fail = TlcErrPacket::new(spoofed_fail, &hops_ss[1]);
+        tlc_fail = tlc_fail.backward(&hops_ss[0]);
+        assert!(tlc_fail
+            .decode(session_key.as_ref(), hops_path.clone())
+            .is_none());
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/fiber-types/src/onion.rs
+++ b/crates/fiber-types/src/onion.rs
@@ -128,7 +128,7 @@ impl TlcErrPacket {
             }
         }
 
-        let hops_public_keys: Vec<PublicKey> = hops_public_keys
+        let secp_hops_public_keys: Vec<PublicKey> = hops_public_keys
             .iter()
             .map(|k| PublicKey::from_slice(&k.0).expect("valid pubkey"))
             .collect();
@@ -143,13 +143,20 @@ impl TlcErrPacket {
             })
             .ok()?;
         OnionErrorPacket::from_bytes(self.onion_packet.clone())
-            .parse(hops_public_keys, session_key, TlcErr::deserialize)
-            .map(|(error, hop_index)| {
+            .parse(secp_hops_public_keys, session_key, TlcErr::deserialize)
+            .and_then(|(error, hop_index)| {
                 for _ in hop_index..ERROR_DECODING_PASSES {
                     OnionErrorPacket::from_bytes(self.onion_packet.clone())
                         .xor_cipher_stream(&NO_SHARED_SECRET);
                 }
-                error
+                let reporter = hops_public_keys.get(hop_index)?;
+                if error
+                    .error_node_id()
+                    .is_some_and(|node_id| node_id != *reporter)
+                {
+                    return None;
+                }
+                Some(error)
             })
     }
 


### PR DESCRIPTION
Malicious node may use other node's pubkey as node_id in tlc error, we should check this.
