### PR TITLE
Fix explicit router overflow validation

### DIFF
--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -16,7 +16,8 @@ use crate::fiber::path::NodeHeapElement;
 use crate::fiber::types::{TrampolineHopPayload, TrampolineOnionPacket};
 use crate::now_timestamp_as_millis_u64;
 use crate::utils::arithmetic::{
-    checked_add_u128, checked_f64_to_u128, checked_mul_u128, checked_sum_u128, ArithmeticError,
+    checked_add_u128, checked_add_u64, checked_f64_to_u128, checked_mul_u128, checked_sum_u128,
+    ArithmeticError,
 };
 use ckb_types::packed::{OutPoint, Script};
 use fiber_types::protocol::AnnouncedNodeName;
@@ -1275,13 +1276,13 @@ where
             payment_data,
         )?;
 
-        Ok(self.build_router_from_path(
+        self.build_router_from_path(
             &path.hops,
             path.amount,
             payment_data,
             path.trampoline_onion,
             path.final_hop_expiry_delta_override,
-        ))
+        )
     }
 
     fn is_node_support_trampoline_routing(&self, node: &Pubkey) -> bool {
@@ -1301,7 +1302,7 @@ where
     ) -> Result<ResolvedRoute, PathFindError> {
         if !payment_data.router.is_empty() {
             // If a router is explicitly provided, use it.
-            // Assume it's valid for the requested `amount`.
+            self.validate_explicit_route(source, &payment_data.router, payment_data)?;
             return Ok(ResolvedRoute {
                 hops: payment_data.router.clone(),
                 amount,
@@ -1348,6 +1349,121 @@ where
             }
             Err(err) => Err(err),
         }
+    }
+
+    fn validate_explicit_route(
+        &self,
+        source: Pubkey,
+        route: &[RouterHop],
+        payment_data: &SendPaymentState,
+    ) -> Result<(), PathFindError> {
+        let mut from = source;
+        let mut previous_hop: Option<&RouterHop> = None;
+
+        for hop in route {
+            if hop.amount_received == 0 {
+                return Err(PathFindError::Amount(
+                    "route hop amount_received must be greater than 0".to_string(),
+                ));
+            }
+            if hop.incoming_tlc_expiry > payment_data.tlc_expiry_limit {
+                return Err(PathFindError::Overflow(format!(
+                    "route hop incoming_tlc_expiry {} exceeds tlc_expiry_limit {}",
+                    hop.incoming_tlc_expiry, payment_data.tlc_expiry_limit
+                )));
+            }
+
+            let (Some(channel_info), Some(channel_update)) =
+                self.get_outbound_channel_info_and_update(&hop.channel_outpoint, from)
+            else {
+                return Err(PathFindError::NoPathFound);
+            };
+
+            if !channel_update.enabled {
+                return Err(PathFindError::NoPathFound);
+            }
+
+            let expected_target = if channel_info.node1() == from {
+                channel_info.node2()
+            } else {
+                channel_info.node1()
+            };
+            if expected_target != hop.target {
+                return Err(PathFindError::NoPathFound);
+            }
+
+            if &payment_data.udt_type_script != channel_info.udt_type_script() {
+                return Err(PathFindError::NoPathFound);
+            }
+
+            if hop.amount_received > channel_info.capacity() {
+                return Err(PathFindError::InsufficientBalance(format!(
+                    "route hop amount {} exceeds channel capacity {}",
+                    hop.amount_received,
+                    channel_info.capacity()
+                )));
+            }
+
+            if let Some(balance) = channel_update.outbound_liquidity {
+                if hop.amount_received > balance {
+                    return Err(PathFindError::InsufficientBalance(format!(
+                        "route hop amount {} exceeds outbound liquidity {}",
+                        hop.amount_received, balance
+                    )));
+                }
+            }
+
+            if hop.amount_received < channel_update.tlc_minimum_value && !payment_data.allow_mpp() {
+                return Err(PathFindError::TlcMinValue(channel_update.tlc_minimum_value));
+            }
+
+            if let Some(previous_hop) = previous_hop {
+                let required_expiry = checked_add_u64(
+                    hop.incoming_tlc_expiry,
+                    channel_update.tlc_expiry_delta,
+                    "explicit route incoming_tlc_expiry",
+                )?;
+                if previous_hop.incoming_tlc_expiry < required_expiry {
+                    return Err(PathFindError::Other(
+                        "route hop incoming_tlc_expiry is too small".to_string(),
+                    ));
+                }
+
+                let fee =
+                    calculate_tlc_forward_fee(hop.amount_received, channel_update.fee_rate as u128)
+                        .map_err(|err| {
+                            PathFindError::Overflow(format!(
+                                "calculate_tlc_forward_fee error: {:?}",
+                                err
+                            ))
+                        })?;
+                let required_amount = hop.amount_received.checked_add(fee).ok_or_else(|| {
+                    PathFindError::Overflow(format!(
+                        "explicit route amount_received overflow: {} + {}",
+                        hop.amount_received, fee
+                    ))
+                })?;
+                if previous_hop.amount_received < required_amount {
+                    return Err(PathFindError::Amount(
+                        "route hop amount_received is too small for forwarding fee".to_string(),
+                    ));
+                }
+            }
+
+            previous_hop = Some(hop);
+            from = hop.target;
+        }
+
+        if route
+            .last()
+            .is_some_and(|hop| hop.incoming_tlc_expiry < payment_data.final_tlc_expiry_delta)
+        {
+            return Err(PathFindError::Other(
+                "final route hop incoming_tlc_expiry is too small".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 
     fn find_trampoline_route(
@@ -1817,7 +1933,7 @@ where
         payment_data: &SendPaymentState,
         trampoline_payload: Option<Vec<u8>>,
         final_hop_expiry_delta_override: Option<u64>,
-    ) -> Vec<PaymentHopData> {
+    ) -> Result<Vec<PaymentHopData>, PathFindError> {
         debug_assert!(!route.is_empty(), "Route hops should not be empty if Ok");
 
         let hash_algorithm = payment_data.hash_algorithm();
@@ -1827,11 +1943,17 @@ where
         let rand_tlc_expiry_delta = self.rand_tlc_expiry_delta(route);
 
         for r in route {
+            let expiry = checked_add_u64(now, r.incoming_tlc_expiry, "payment hop expiry")?;
+            let expiry = checked_add_u64(
+                expiry,
+                rand_tlc_expiry_delta,
+                "payment hop expiry random delta",
+            )?;
             hops_data.push(PaymentHopData {
                 amount: r.amount_received,
                 next_hop: Some(r.target),
                 hash_algorithm,
-                expiry: now + r.incoming_tlc_expiry + rand_tlc_expiry_delta,
+                expiry,
                 funding_tx_hash: r.channel_outpoint.tx_hash().into(),
                 ..Default::default()
             });
@@ -1850,11 +1972,17 @@ where
 
         let last_expiry_delta =
             final_hop_expiry_delta_override.unwrap_or(payment_data.final_tlc_expiry_delta);
+        let last_expiry = checked_add_u64(now, last_expiry_delta, "final payment hop expiry")?;
+        let last_expiry = checked_add_u64(
+            last_expiry,
+            rand_tlc_expiry_delta,
+            "final payment hop expiry random delta",
+        )?;
 
         let mut last_hop = PaymentHopData {
             amount: last_amount,
             hash_algorithm,
-            expiry: now + last_expiry_delta + rand_tlc_expiry_delta,
+            expiry: last_expiry,
             payment_preimage,
             custom_records,
             ..Default::default()
@@ -1863,15 +1991,17 @@ where
             last_hop.set_trampoline_onion(onion);
         }
         hops_data.push(last_hop);
-        // assert there is no duplicate node in the route
-        assert_eq!(
-            hops_data
-                .iter()
-                .filter_map(|x| x.next_hop)
-                .collect::<HashSet<_>>()
-                .len(),
-            route_len
-        );
+        if hops_data
+            .iter()
+            .filter_map(|x| x.next_hop)
+            .collect::<HashSet<_>>()
+            .len()
+            != route_len
+        {
+            return Err(PathFindError::Other(
+                "route contains duplicate nodes".to_string(),
+            ));
+        }
         // if is trampoline payment
         #[cfg(debug_assertions)]
         {
@@ -1882,7 +2012,7 @@ where
                 assert!(hops_data.last().unwrap().trampoline_onion().is_some());
             }
         }
-        hops_data
+        Ok(hops_data)
     }
 
     fn is_node_support_mpp(&self, node: &Pubkey) -> bool {
@@ -2733,20 +2863,21 @@ where
                     continue;
                 }
 
-                let mut amount_to_send = agg_amount;
                 let is_initial = from == source;
                 let fee = if is_initial {
                     0
                 } else {
-                    calculate_tlc_forward_fee(amount_to_send, channel_update.fee_rate as u128)
-                        .map_err(|err| {
+                    calculate_tlc_forward_fee(agg_amount, channel_update.fee_rate as u128).map_err(
+                        |err| {
                             PathFindError::Overflow(format!(
                                 "calculate_tlc_forward_fee error: {:?}",
                                 err
                             ))
-                        })?
+                        },
+                    )?
                 };
-                amount_to_send = checked_add_u128(amount_to_send, fee, "path amount to send")?;
+                let amount_to_send =
+                    checked_add_u128(agg_amount, fee, "build_router amount_to_send")?;
                 if amount_to_send > channel_info.capacity() {
                     continue;
                 }
@@ -2762,7 +2893,11 @@ where
                     channel_update.tlc_expiry_delta
                 };
 
-                let current_incoming_tlc_expiry = agg_tlc_expiry + expiry_delta;
+                let current_incoming_tlc_expiry = checked_add_u64(
+                    agg_tlc_expiry,
+                    expiry_delta,
+                    "build_router incoming_tlc_expiry",
+                )?;
                 let probability = if cur_hop.channel_outpoint.is_some() {
                     // If the channel outpoint is specified, we will assume that the channel is routable
                     // it's user's responsibility to ensure that the channel is routable.
@@ -2806,8 +2941,13 @@ where
                 ));
             }
             if let Some((_, fee, edge)) = found {
-                agg_tlc_expiry += edge.incoming_tlc_expiry;
-                agg_amount = edge.amount_received + fee;
+                agg_tlc_expiry = checked_add_u64(
+                    agg_tlc_expiry,
+                    edge.incoming_tlc_expiry,
+                    "build_router aggregate tlc_expiry",
+                )?;
+                agg_amount =
+                    checked_add_u128(edge.amount_received, fee, "build_router aggregate amount")?;
                 path.push(edge.clone());
             } else {
                 return Err(PathFindError::NoPathFound);

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -4,13 +4,14 @@ use crate::fiber::gossip::GossipMessageStore;
 use crate::fiber::graph::NetworkGraph;
 use crate::fiber::graph::PathFindError;
 use crate::fiber::graph::SendPaymentState;
-use crate::fiber::network::get_chain_hash;
+use crate::fiber::network::{get_chain_hash, BuildRouterCommand};
 use crate::fiber::payment::{SendPaymentCommand, SendPaymentDataBuilder, SendPaymentDataExt};
 use crate::fiber::types::new_channel_update_unsigned;
 use crate::fiber::types::TrampolineOnionPacket;
 use crate::fiber::{
     ChannelAnnouncement, ChannelUpdateChannelFlags, ChannelUpdateMessageFlags, FeatureVector,
-    Hash256, HopHint, NodeAnnouncement, Privkey, Pubkey, RouterHop, SendPaymentData, SessionRoute,
+    Hash256, HopHint, HopRequire, NodeAnnouncement, Privkey, Pubkey, RouterHop, SendPaymentData,
+    SessionRoute,
 };
 use crate::store::Store;
 use ckb_types::{
@@ -1825,6 +1826,109 @@ fn test_graph_session_router() {
         session_route_keys,
         vec![node0.into(), node2.into(), node3.into(), node4.into()]
     );
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_explicit_router_rejects_overflowing_expiry() {
+    let mut network = MockNetworkGraph::new(2);
+    network.add_edge(0, 1, Some(1000), Some(0));
+
+    let node1 = network.keys[1];
+    let payment_state: SendPaymentState =
+        SendPaymentDataBuilder::new(node1.into(), 100, Hash256::default())
+            .max_fee_amount(Some(0))
+            .router(vec![RouterHop {
+                target: node1.into(),
+                channel_outpoint: network.edges[0].2.clone(),
+                amount_received: 100,
+                incoming_tlc_expiry: u64::MAX,
+            }])
+            .build()
+            .expect("valid payment data")
+            .into();
+
+    let route = network
+        .graph
+        .build_route(payment_state.amount, None, None, &payment_state);
+    assert!(matches!(route, Err(PathFindError::Overflow(_))));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_explicit_router_validates_udt() {
+    let mut network = MockNetworkGraph::new(2);
+    network.add_edge_udt(0, 1, Some(1000), Some(0), Script::default());
+
+    let node1 = network.keys[1];
+    let payment_state: SendPaymentState =
+        SendPaymentDataBuilder::new(node1.into(), 100, Hash256::default())
+            .max_fee_amount(Some(0))
+            .router(vec![RouterHop {
+                target: node1.into(),
+                channel_outpoint: network.edges[0].2.clone(),
+                amount_received: 100,
+                incoming_tlc_expiry: FINAL_TLC_EXPIRY_DELTA_IN_TESTS,
+            }])
+            .build()
+            .expect("valid payment data")
+            .into();
+
+    let route = network
+        .graph
+        .build_route(payment_state.amount, None, None, &payment_state);
+    assert!(matches!(route, Err(PathFindError::NoPathFound)));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_build_path_rejects_amount_overflow() {
+    let mut network = MockNetworkGraph::new(3);
+    network.add_edge(0, 1, Some(u128::MAX), Some(0));
+    network.add_edge(1, 2, Some(u128::MAX), Some(1));
+
+    let result = network.graph.build_path(
+        network.keys[0].into(),
+        BuildRouterCommand {
+            amount: Some(u128::MAX),
+            udt_type_script: None,
+            hops_info: vec![
+                HopRequire {
+                    pubkey: network.keys[1].into(),
+                    channel_outpoint: Some(network.edges[0].2.clone()),
+                },
+                HopRequire {
+                    pubkey: network.keys[2].into(),
+                    channel_outpoint: Some(network.edges[1].2.clone()),
+                },
+            ],
+            final_tlc_expiry_delta: Some(FINAL_TLC_EXPIRY_DELTA_IN_TESTS),
+        },
+    );
+
+    assert!(matches!(result, Err(PathFindError::Overflow(_))));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_build_path_rejects_expiry_overflow() {
+    let mut network = MockNetworkGraph::new(2);
+    network.add_edge(0, 1, Some(1000), Some(0));
+
+    let result = network.graph.build_path(
+        network.keys[0].into(),
+        BuildRouterCommand {
+            amount: Some(100),
+            udt_type_script: None,
+            hops_info: vec![HopRequire {
+                pubkey: network.keys[1].into(),
+                channel_outpoint: Some(network.edges[0].2.clone()),
+            }],
+            final_tlc_expiry_delta: Some(u64::MAX),
+        },
+    );
+
+    assert!(matches!(result, Err(PathFindError::Overflow(_))));
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -1917,14 +1917,11 @@ async fn test_send_payment_with_route_with_invalid_parameters() {
         })
         .await;
 
-    assert!(res.is_ok());
-
-    let payment_hash = res.unwrap().payment_hash;
-    node_0.wait_until_failed(payment_hash).await;
-    let result = node_0
-        .get_payment_session(payment_hash)
-        .expect("get payment");
-    assert_eq!(result.retry_times(), 1);
+    let err = res.expect_err("invalid router amount should be rejected before sending TLC");
+    assert!(
+        err.contains("route hop amount_received is too small for forwarding fee"),
+        "unexpected error: {err}"
+    );
 
     // ================================================================
     // now we change the expiry delta in the middle hop
@@ -1939,15 +1936,11 @@ async fn test_send_payment_with_route_with_invalid_parameters() {
         })
         .await;
 
-    assert!(res.is_ok());
-
-    let payment_hash = res.unwrap().payment_hash;
-    node_0.wait_until_failed(payment_hash).await;
-    let result = node_0
-        .get_payment_session(payment_hash)
-        .expect("get payment");
-    eprintln!("result: {:?}", result.status);
-    assert_eq!(result.attempts_count(), 1);
+    let err = res.expect_err("invalid router expiry should be rejected before sending TLC");
+    assert!(
+        err.contains("route hop incoming_tlc_expiry is too small"),
+        "unexpected error: {err}"
+    );
     assert_eq!(node_0.get_inflight_payment_count().await, 0);
 }
 
@@ -1977,7 +1970,7 @@ async fn test_send_payment_with_router_rpc_rejects_overflowing_onion_expiry() {
         Some(gen_rpc_config()),
     )
     .await;
-    let [node_0, mut node_1, node_2] = nodes.try_into().expect("3 nodes");
+    let [node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
 
     node_0
         .with_network_graph_mut(|graph| graph.set_add_rand_expiry_delta(false))
@@ -2014,8 +2007,8 @@ async fn test_send_payment_with_router_rpc_rejects_overflowing_onion_expiry() {
         .incoming_tlc_expiry = overflowing_incoming_expiry;
     let router = router.into_iter().map(JsonRouterHop::from).collect();
 
-    let payment: GetPaymentCommandResult = node_0
-        .send_rpc_request(
+    let err = node_0
+        .send_rpc_request::<_, GetPaymentCommandResult>(
             "send_payment_with_router",
             SendPaymentWithRouterParams {
                 payment_hash: None,
@@ -2028,27 +2021,11 @@ async fn test_send_payment_with_router_rpc_rejects_overflowing_onion_expiry() {
             },
         )
         .await
-        .unwrap();
-
-    let payment_hash: Hash256 = payment.payment_hash.into();
-    let node_1_pubkey = node_1.pubkey;
-    node_1
-        .expect_event(|event| match event {
-            NetworkServiceEvent::DebugEvent(DebugEvent::AddTlcFailed(
-                pubkey,
-                failed_payment_hash,
-                err,
-            )) => {
-                assert_eq!(pubkey, &node_1_pubkey);
-                assert_eq!(failed_payment_hash, &payment_hash);
-                assert_eq!(err.error_code, TlcErrorCode::IncorrectTlcExpiry);
-                true
-            }
-            _ => false,
-        })
-        .await;
-
-    node_0.wait_until_failed(payment_hash).await;
+        .expect_err("overflowing explicit router expiry should be rejected before sending TLC");
+    assert!(
+        err.to_string().contains("route hop incoming_tlc_expiry"),
+        "unexpected error: {err:?}"
+    );
     assert_eq!(node_0.get_inflight_payment_count().await, 0);
 }
 
@@ -2539,7 +2516,7 @@ async fn test_send_payment_send_with_wrong_hop() {
     assert!(res
         .unwrap_err()
         .to_string()
-        .contains("Failed to send onion packet with error UnknownNextPeer"));
+        .contains("Failed to build route, PathFind error: no path found"));
     assert_eq!(node_1.get_inflight_payment_count().await, 0);
 }
 
@@ -3308,7 +3285,7 @@ async fn test_send_payment_with_router_to_offline_channel_fails_fast() {
         })
         .await
         .unwrap_err();
-    assert!(error.contains("UnknownNextPeer"));
+    assert!(error.contains("Failed to build route, PathFind error: no path found"));
     assert_eq!(node_0.get_inflight_payment_count().await, 0);
 }
 
@@ -5908,17 +5885,11 @@ async fn test_send_payment_with_mixed_channel_hops() {
         .await;
     eprintln!("res: {:?}", res);
 
-    let payment_hash = res.unwrap().payment_hash;
-    node0.wait_until_failed(payment_hash).await;
-    let payment_res = node0.get_payment_result(payment_hash).await;
-    eprintln!("payment_res: {:?}", payment_res);
-    assert_eq!(
-        payment_res.failed_error.unwrap(),
-        "IncorrectOrUnknownPaymentDetails"
+    let err = res.expect_err("mixed CKB/UDT explicit route should be rejected before sending TLC");
+    assert!(
+        err.contains("Failed to build route, PathFind error: no path found"),
+        "unexpected error: {err}"
     );
-    let payment_session = node0.get_payment_session(payment_hash).unwrap();
-    assert_eq!(payment_session.attempts_count(), 1);
-    assert_eq!(payment_session.retry_times(), 1);
 }
 
 #[tokio::test]
@@ -6148,6 +6119,7 @@ async fn test_ckb_with_udt_mixed_routes_fail() {
             .send_payment_with_router(SendPaymentWithRouterCommand {
                 router: udt1_router.router_hops.clone(),
                 keysend: Some(true),
+                udt_type_script: Some(udt1_script.clone()),
                 ..Default::default()
             })
             .await
@@ -6166,60 +6138,74 @@ async fn test_ckb_with_udt_mixed_routes_fail() {
         udt1_router.router_hops[1].clone(),
         udt2_router.router_hops[2].clone(),
     ];
-    let res = node_a
+    let err = node_a
         .send_payment_with_router(SendPaymentWithRouterCommand {
             router: mixed_router,
             keysend: Some(true),
             ..Default::default()
         })
         .await
-        .unwrap();
-    node_a.wait_until_failed(res.payment_hash).await;
+        .expect_err("mixed CKB/UDT explicit route should be rejected before sending TLC");
+    assert!(
+        err.contains("Failed to build route, PathFind error: no path found"),
+        "unexpected error: {err}"
+    );
 
     let mixed_router = vec![
         udt1_router.router_hops[0].clone(),
         udt1_router.router_hops[1].clone(),
         udt2_router.router_hops[2].clone(),
     ];
-    let res = node_a
+    let err = node_a
         .send_payment_with_router(SendPaymentWithRouterCommand {
             router: mixed_router,
             keysend: Some(true),
+            udt_type_script: Some(udt1_script.clone()),
             ..Default::default()
         })
         .await
-        .unwrap();
-    node_a.wait_until_failed(res.payment_hash).await;
+        .expect_err("mixed UDT explicit route should be rejected before sending TLC");
+    assert!(
+        err.contains("Failed to build route, PathFind error: no path found"),
+        "unexpected error: {err}"
+    );
 
     let mixed_router = vec![
         ckb_router.router_hops[0].clone(),
         udt1_router.router_hops[1].clone(),
         ckb_router.router_hops[2].clone(),
     ];
-    let res = node_a
+    let err = node_a
         .send_payment_with_router(SendPaymentWithRouterCommand {
             router: mixed_router,
             keysend: Some(true),
             ..Default::default()
         })
         .await
-        .unwrap();
-    node_a.wait_until_failed(res.payment_hash).await;
+        .expect_err("mixed CKB/UDT explicit route should be rejected before sending TLC");
+    assert!(
+        err.contains("Failed to build route, PathFind error: no path found"),
+        "unexpected error: {err}"
+    );
 
     let mixed_router = vec![
         udt1_router.router_hops[0].clone(),
         udt2_router.router_hops[1].clone(),
         udt1_router.router_hops[2].clone(),
     ];
-    let res = node_a
+    let err = node_a
         .send_payment_with_router(SendPaymentWithRouterCommand {
             router: mixed_router,
             keysend: Some(true),
+            udt_type_script: Some(udt1_script.clone()),
             ..Default::default()
         })
         .await
-        .unwrap();
-    node_a.wait_until_failed(res.payment_hash).await;
+        .expect_err("mixed UDT explicit route should be rejected before sending TLC");
+    assert!(
+        err.contains("Failed to build route, PathFind error: no path found"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Add more overflow check in build payment router with user's params, add `validate_explicit_route` so that we can report obivious error before sending the payment with inappropriate router.