### PR TITLE
fix: bound peer-added funding tx complexity before chain lookups

### DIFF
--- a/crates/fiber-lib/src/ckb/error.rs
+++ b/crates/fiber-lib/src/ckb/error.rs
@@ -24,6 +24,9 @@ pub enum FundingError {
     #[error("Peer sent us an invalid funding tx")]
     InvalidPeerFundingTx,
 
+    #[error("Funding tx rejected: peer-added complexity exceeds allowed limit ({0})")]
+    PeerFundingTxExceedsLimit(String),
+
     #[error(
         "Funding tx rejected: peer-added input #{input_index} has the local funding source lock args"
     )]
@@ -105,6 +108,7 @@ impl FundingError {
             CkbTxBuilderError(e) => error_chain_has_transient(e),
             CkbTxUnlockError(e) => error_chain_has_transient(e),
             PeerInputUsesOurFundingLock { .. } => false,
+            PeerFundingTxExceedsLimit(_) => false,
             _ => false,
         }
     }

--- a/crates/fiber-lib/src/ckb/funding/funding_tx.rs
+++ b/crates/fiber-lib/src/ckb/funding/funding_tx.rs
@@ -1,4 +1,5 @@
 use super::super::FundingError;
+use super::limits::validate_peer_funding_tx_complexity;
 use crate::ckb::{
     config::{new_ckb_rpc_async_client, new_default_cell_collector},
     contracts::get_udt_cell_deps,
@@ -819,6 +820,10 @@ impl FundingTx {
             remote_tx.outputs().len(),
         );
 
+        // Bound the peer-added complexity before any chain lookup, so a single
+        // TxUpdate cannot amplify into an unbounded number of CKB RPC requests.
+        validate_peer_funding_tx_complexity(&local_tx, &remote_tx)?;
+
         // Version MUST be the same
         if remote_tx.version() != local_tx.version() {
             debug!(
@@ -886,30 +891,6 @@ impl FundingTx {
         {
             debug!("invalid funding tx (inputs)");
             return Err(FundingError::InvalidPeerFundingTx);
-        }
-        // Peer SHOULD NOT add inputs locked by our lock scripts
-        let ckb_client = new_ckb_rpc_async_client(&context.rpc_url);
-        for (input_index, input) in remote_tx
-            .input_pts_iter()
-            .enumerate()
-            .skip(local_tx.inputs().len())
-        {
-            match ckb_client.get_live_cell(input.into(), false).await?.cell {
-                Some(cell) => {
-                    let cell_output_lock: packed::Script = cell.output.lock.into();
-                    if cell_output_lock == context.funding_source_lock_script {
-                        debug!(
-                            "invalid funding tx (inputs): peer uses input #{} with our lock script",
-                            input_index
-                        );
-                        return Err(FundingError::PeerInputUsesOurFundingLock { input_index });
-                    }
-                }
-                None => {
-                    debug!("invalid funding tx (inputs): dead input");
-                    return Err(FundingError::InvalidPeerFundingTx);
-                }
-            };
         }
 
         // Peer SHOULD NOT remove outputs
@@ -991,6 +972,34 @@ impl FundingTx {
         }
 
         // Ignore witnesses
+
+        // Peer SHOULD NOT add inputs locked by our lock scripts. This requires one
+        // get_live_cell RPC per peer-added input, so it runs last, after all the
+        // cheap structural checks above (including the complexity budget) have
+        // passed.
+        let ckb_client = new_ckb_rpc_async_client(&context.rpc_url);
+        for (input_index, input) in remote_tx
+            .input_pts_iter()
+            .enumerate()
+            .skip(local_tx.inputs().len())
+        {
+            match ckb_client.get_live_cell(input.into(), false).await?.cell {
+                Some(cell) => {
+                    let cell_output_lock: packed::Script = cell.output.lock.into();
+                    if cell_output_lock == context.funding_source_lock_script {
+                        debug!(
+                            "invalid funding tx (inputs): peer uses input #{} with our lock script",
+                            input_index
+                        );
+                        return Err(FundingError::PeerInputUsesOurFundingLock { input_index });
+                    }
+                }
+                None => {
+                    debug!("invalid funding tx (inputs): dead input");
+                    return Err(FundingError::InvalidPeerFundingTx);
+                }
+            };
+        }
 
         self.tx = Some(remote_tx);
         Ok(())

--- a/crates/fiber-lib/src/ckb/funding/limits.rs
+++ b/crates/fiber-lib/src/ckb/funding/limits.rs
@@ -1,0 +1,129 @@
+//! Complexity budgets for peer-supplied funding transactions.
+//!
+//! During funding collaboration a remote peer sends a `TxUpdate` carrying a full
+//! CKB transaction. Verifying that transaction requires one `get_live_cell` RPC
+//! per peer-added input, so an unbounded `TxUpdate` lets a single P2P message
+//! amplify into many serialized CKB RPC lookups while the channel actor blocks.
+//! The constants below bound how much a peer may add relative to the local
+//! funding transaction, and [`validate_peer_funding_tx_complexity`] enforces them
+//! using only cheap structural checks, before any chain lookup is performed.
+//!
+//! # Future work
+//!
+//! 1. Make these limits user-configurable. Promote the constants to fields on a
+//!    `PeerFundingLimits` struct with a `Default` matching today's values, surface
+//!    them through the node config (mirroring the `gossip_policy` rate-limit
+//!    configs), and thread the resolved config into `FundingContext` so the
+//!    validator reads operator-tuned values. Operators with heavy UDT
+//!    consolidation could then raise the input cap deliberately.
+//! 2. Advertise/negotiate the limits with peers. Today they are unilateral and a
+//!    violating peer only learns about them via `TxAbort` after the fact. Future
+//!    protocol work could publish the accepted maxima in node announcements or as
+//!    channel negotiation parameters exchanged in `OpenChannel`/`AcceptChannel`,
+//!    so the funding initiator can build a compliant `TxUpdate` up front. This
+//!    requires a spec change and backward-compatible defaults for peers that do
+//!    not advertise the field.
+
+use ckb_types::core::TransactionView;
+
+use crate::ckb::error::FundingError;
+
+/// Maximum serialized size (in block) accepted for a peer funding transaction.
+///
+/// This mirrors the P2P frame cap `MAX_SERVICE_PROTOCOAL_DATA_SIZE`
+/// (`1024 * (128 + 2)`) in `fiber::network`; a transaction cannot exceed the
+/// frame that carried it. It is duplicated here to keep the `ckb` layer
+/// independent of `fiber::network`.
+pub(crate) const MAX_PEER_FUNDING_TX_SERIALIZED_SIZE: usize = 1024 * (128 + 2);
+
+/// Maximum number of inputs a peer may add beyond the local funding tx.
+///
+/// Each peer-added input triggers one `get_live_cell` RPC, so this directly
+/// bounds the RPC fan-out per `TxUpdate`. The value comfortably covers UDT
+/// consolidation and multi-cell peer funding while keeping the work bounded.
+pub(crate) const MAX_PEER_ADDED_FUNDING_INPUTS: usize = 64;
+
+/// Maximum number of outputs a peer may add beyond the local funding tx.
+///
+/// When the local node still has the default empty funding tx, a peer who funds
+/// first may add up to three outputs:
+///
+/// 1. The funding cell.
+/// 2. A UDT change output, when the peer spends a UDT cell that holds more
+///    tokens than the channel requires.
+/// 3. A CKB change output, when the peer adds CKB inputs to pay transaction
+///    fees.
+///
+/// CKB-only channels use (1) and (3) only. UDT channels may use all three.
+/// Peers are recommended to merge the UDT and CKB change into a single cell
+/// when possible, but the current funding builder emits them separately.
+pub(crate) const MAX_PEER_ADDED_FUNDING_OUTPUTS: usize = 3;
+
+/// Maximum number of cell deps a peer may add beyond the local funding tx.
+///
+/// Covers UDT and external-funding lock cell deps, far above what legitimate
+/// dual funding requires.
+pub(crate) const MAX_PEER_ADDED_CELL_DEPS: usize = 8;
+
+/// Validate that the peer's funding transaction does not exceed the allowed
+/// complexity relative to the local funding transaction.
+///
+/// All checks here are cheap and structural; they must run before any
+/// `get_live_cell` RPC so a malicious `TxUpdate` cannot amplify into many chain
+/// lookups. Every violation returns [`FundingError::PeerFundingTxExceedsLimit`]
+/// with a message naming the breached budget, which is relayed to the peer via
+/// `TxAbort`.
+///
+/// Limits are expressed as peer-added deltas against the local funding tx. When
+/// the local node still has the default empty funding tx, those deltas equal the
+/// remote transaction totals.
+pub(crate) fn validate_peer_funding_tx_complexity(
+    local_tx: &TransactionView,
+    remote_tx: &TransactionView,
+) -> Result<(), FundingError> {
+    let serialized_size = remote_tx.data().serialized_size_in_block();
+    if serialized_size > MAX_PEER_FUNDING_TX_SERIALIZED_SIZE {
+        return Err(FundingError::PeerFundingTxExceedsLimit(format!(
+            "serialized size {} > {}",
+            serialized_size, MAX_PEER_FUNDING_TX_SERIALIZED_SIZE
+        )));
+    }
+
+    let added_inputs = remote_tx
+        .inputs()
+        .len()
+        .saturating_sub(local_tx.inputs().len());
+    if added_inputs > MAX_PEER_ADDED_FUNDING_INPUTS {
+        return Err(FundingError::PeerFundingTxExceedsLimit(format!(
+            "peer-added inputs {} > {}",
+            added_inputs, MAX_PEER_ADDED_FUNDING_INPUTS
+        )));
+    }
+
+    let added_outputs = remote_tx
+        .outputs()
+        .len()
+        .saturating_sub(local_tx.outputs().len());
+    if added_outputs > MAX_PEER_ADDED_FUNDING_OUTPUTS {
+        return Err(FundingError::PeerFundingTxExceedsLimit(format!(
+            "peer-added outputs {} > {}",
+            added_outputs, MAX_PEER_ADDED_FUNDING_OUTPUTS
+        )));
+    }
+
+    let added_cell_deps = remote_tx
+        .cell_deps()
+        .len()
+        .saturating_sub(local_tx.cell_deps().len());
+    if added_cell_deps > MAX_PEER_ADDED_CELL_DEPS {
+        return Err(FundingError::PeerFundingTxExceedsLimit(format!(
+            "peer-added cell deps {} > {}",
+            added_cell_deps, MAX_PEER_ADDED_CELL_DEPS
+        )));
+    }
+
+    // Witnesses are intentionally not capped here: their total cost is already
+    // bounded by the serialized transaction size limit above.
+
+    Ok(())
+}

--- a/crates/fiber-lib/src/ckb/funding/mod.rs
+++ b/crates/fiber-lib/src/ckb/funding/mod.rs
@@ -1,4 +1,13 @@
 mod funding_tx;
+mod limits;
+
+pub(crate) use limits::validate_peer_funding_tx_complexity;
+
+#[cfg(test)]
+pub(crate) use limits::{
+    MAX_PEER_ADDED_CELL_DEPS, MAX_PEER_ADDED_FUNDING_INPUTS, MAX_PEER_ADDED_FUNDING_OUTPUTS,
+    MAX_PEER_FUNDING_TX_SERIALIZED_SIZE,
+};
 
 #[cfg(test)]
 pub(crate) use funding_tx::map_tx_builder_error;

--- a/crates/fiber-lib/src/ckb/mod.rs
+++ b/crates/fiber-lib/src/ckb/mod.rs
@@ -12,6 +12,7 @@ pub use config::{CkbConfig, UdtCfgInfosExt, DEFAULT_CKB_BASE_DIR_NAME};
 pub use error::{CkbChainError, FundingError};
 pub use fiber_types::{UdtArgInfo, UdtCellDep, UdtCfgInfos, UdtDep, UdtScript};
 pub(crate) use funding::is_secp_sighash_placeholder_witness;
+pub(crate) use funding::validate_peer_funding_tx_complexity;
 pub use funding::{FundingRequest, FundingTx};
 pub use signer::LocalSigner;
 pub use tx_tracing_actor::{CkbTxTracer, CkbTxTracingMask, CkbTxTracingResult};

--- a/crates/fiber-lib/src/ckb/tests/error.rs
+++ b/crates/fiber-lib/src/ckb/tests/error.rs
@@ -68,6 +68,21 @@ fn never_temporary_variants() {
     assert!(!FundingError::DeadCell.is_temporary());
     assert!(!FundingError::OverflowError.is_temporary());
     assert!(!FundingError::InvalidPeerFundingTx.is_temporary());
+    assert!(
+        !FundingError::PeerFundingTxExceedsLimit("peer-added inputs 65 > 64".to_string())
+            .is_temporary()
+    );
+}
+
+#[test]
+fn peer_funding_tx_exceeds_limit_display_includes_detail() {
+    let detail = "peer-added inputs 65 > 64";
+    let err = FundingError::PeerFundingTxExceedsLimit(detail.to_string());
+    let msg = err.to_string();
+    assert!(
+        msg.contains(detail),
+        "expected display to contain the violated budget, got: {msg}"
+    );
 }
 
 #[test]

--- a/crates/fiber-lib/src/ckb/tests/funding_limits_tests.rs
+++ b/crates/fiber-lib/src/ckb/tests/funding_limits_tests.rs
@@ -1,0 +1,177 @@
+use crate::ckb::funding::{
+    validate_peer_funding_tx_complexity, MAX_PEER_ADDED_CELL_DEPS, MAX_PEER_ADDED_FUNDING_INPUTS,
+    MAX_PEER_ADDED_FUNDING_OUTPUTS, MAX_PEER_FUNDING_TX_SERIALIZED_SIZE,
+};
+use crate::ckb::FundingError;
+use ckb_types::{
+    core::TransactionView,
+    packed::{self, Byte32, CellDep, CellInput, CellOutput, OutPoint},
+    prelude::*,
+};
+
+#[derive(Default)]
+struct TxSpec {
+    inputs: usize,
+    outputs: usize,
+    cell_deps: usize,
+}
+
+fn build_tx(spec: TxSpec) -> TransactionView {
+    let inputs: Vec<CellInput> = (0..spec.inputs)
+        .map(|i| CellInput::new(OutPoint::new(Byte32::default(), i as u32), 0))
+        .collect();
+    let outputs: Vec<CellOutput> = (0..spec.outputs)
+        .map(|_| CellOutput::new_builder().build())
+        .collect();
+    let outputs_data: Vec<packed::Bytes> = (0..spec.outputs)
+        .map(|_| packed::Bytes::default())
+        .collect();
+    let cell_deps: Vec<CellDep> = (0..spec.cell_deps)
+        .map(|_| CellDep::new_builder().build())
+        .collect();
+
+    packed::Transaction::default()
+        .as_advanced_builder()
+        .set_inputs(inputs)
+        .set_outputs(outputs)
+        .set_outputs_data(outputs_data)
+        .set_cell_deps(cell_deps)
+        .build()
+}
+
+fn assert_limit_err(result: Result<(), FundingError>, needle: &str) {
+    match result {
+        Err(FundingError::PeerFundingTxExceedsLimit(msg)) => assert!(
+            msg.contains(needle),
+            "expected limit message to contain {needle:?}, got: {msg}"
+        ),
+        other => panic!("expected PeerFundingTxExceedsLimit, got: {other:?}"),
+    }
+}
+
+#[test]
+fn small_peer_delta_passes() {
+    let local = build_tx(TxSpec {
+        inputs: 1,
+        outputs: 1,
+        cell_deps: 1,
+    });
+    let remote = build_tx(TxSpec {
+        inputs: 1 + MAX_PEER_ADDED_FUNDING_INPUTS,
+        outputs: 1 + MAX_PEER_ADDED_FUNDING_OUTPUTS,
+        cell_deps: 1 + MAX_PEER_ADDED_CELL_DEPS,
+    });
+    assert!(
+        validate_peer_funding_tx_complexity(&local, &remote).is_ok(),
+        "deltas exactly at the limits should be accepted"
+    );
+}
+
+#[test]
+fn peer_adds_funding_cell_and_change_passes() {
+    let local = build_tx(TxSpec {
+        outputs: 1,
+        ..Default::default()
+    });
+    let remote = build_tx(TxSpec {
+        outputs: 1 + MAX_PEER_ADDED_FUNDING_OUTPUTS,
+        ..Default::default()
+    });
+    assert!(
+        validate_peer_funding_tx_complexity(&local, &remote).is_ok(),
+        "peer may add funding cell plus UDT and CKB change outputs beyond the local shell"
+    );
+}
+
+#[test]
+fn initiator_first_tx_update_ckb_only_passes() {
+    let local = build_tx(TxSpec::default());
+    let remote = build_tx(TxSpec {
+        inputs: 2,
+        outputs: 2,
+        cell_deps: 2,
+    });
+    assert!(
+        validate_peer_funding_tx_complexity(&local, &remote).is_ok(),
+        "acceptor with no local tx yet should accept funding cell plus CKB change"
+    );
+}
+
+#[test]
+fn initiator_first_tx_update_udt_with_separate_change_outputs_passes() {
+    let local = build_tx(TxSpec::default());
+    let remote = build_tx(TxSpec {
+        inputs: 2,
+        outputs: 3,
+        cell_deps: 2,
+    });
+    assert!(
+        validate_peer_funding_tx_complexity(&local, &remote).is_ok(),
+        "acceptor with no local tx yet should accept funding cell plus UDT and CKB change"
+    );
+}
+
+#[test]
+fn too_many_peer_inputs_rejected_without_rpc() {
+    let local = build_tx(TxSpec {
+        inputs: 1,
+        ..Default::default()
+    });
+    let remote = build_tx(TxSpec {
+        inputs: 1 + MAX_PEER_ADDED_FUNDING_INPUTS + 1,
+        ..Default::default()
+    });
+    assert_limit_err(
+        validate_peer_funding_tx_complexity(&local, &remote),
+        "peer-added inputs",
+    );
+}
+
+#[test]
+fn too_many_peer_outputs_rejected() {
+    let local = build_tx(TxSpec {
+        outputs: 1,
+        ..Default::default()
+    });
+    let remote = build_tx(TxSpec {
+        outputs: 1 + MAX_PEER_ADDED_FUNDING_OUTPUTS + 1,
+        ..Default::default()
+    });
+    assert_limit_err(
+        validate_peer_funding_tx_complexity(&local, &remote),
+        "peer-added outputs",
+    );
+}
+
+#[test]
+fn too_many_peer_cell_deps_rejected() {
+    let local = build_tx(TxSpec {
+        cell_deps: 1,
+        ..Default::default()
+    });
+    let remote = build_tx(TxSpec {
+        cell_deps: 1 + MAX_PEER_ADDED_CELL_DEPS + 1,
+        ..Default::default()
+    });
+    assert_limit_err(
+        validate_peer_funding_tx_complexity(&local, &remote),
+        "peer-added cell deps",
+    );
+}
+
+#[test]
+fn oversized_serialized_tx_rejected() {
+    let local = build_tx(TxSpec::default());
+    // A single output carrying data larger than the serialized-size cap keeps
+    // every per-element delta within bounds while exceeding the size budget.
+    let big_data: packed::Bytes = vec![0u8; MAX_PEER_FUNDING_TX_SERIALIZED_SIZE + 1].pack();
+    let remote = packed::Transaction::default()
+        .as_advanced_builder()
+        .set_outputs(vec![CellOutput::new_builder().build()])
+        .set_outputs_data(vec![big_data])
+        .build();
+    assert_limit_err(
+        validate_peer_funding_tx_complexity(&local, &remote),
+        "serialized size",
+    );
+}

--- a/crates/fiber-lib/src/ckb/tests/mod.rs
+++ b/crates/fiber-lib/src/ckb/tests/mod.rs
@@ -5,6 +5,8 @@ mod config;
 #[cfg(test)]
 mod error;
 #[cfg(test)]
+mod funding_limits_tests;
+#[cfg(test)]
 mod funding_tx_tests;
 
 pub mod test_utils;

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -24,7 +24,7 @@ use crate::utils::payment::is_invoice_fulfilled;
 use crate::{
     ckb::{
         contracts::{get_cell_deps, get_script_by_contract, Contract},
-        is_secp_sighash_placeholder_witness, FundingRequest,
+        is_secp_sighash_placeholder_witness, validate_peer_funding_tx_complexity, FundingRequest,
     },
     fiber::{
         config::{DEFAULT_MIN_SHUTDOWN_FEE, MAX_PAYMENT_TLC_EXPIRY_LIMIT, MIN_TLC_EXPIRY_DELTA},
@@ -7392,6 +7392,24 @@ impl ChannelActorState {
                         }
                     }
                 }
+                // Defense in depth: reject overly complex peer funding txs before
+                // queueing work on the shared CKB chain actor. The same budget is
+                // re-checked inside VerifyFundingTx prior to any chain lookup.
+                let local_tx_view = self.funding_tx.clone().unwrap_or_default().into_view();
+                let remote_tx_view = msg.tx.clone().into_view();
+                if let Err(err) =
+                    validate_peer_funding_tx_complexity(&local_tx_view, &remote_tx_view)
+                {
+                    error!("rejecting TxUpdate from peer before verification: {}", err);
+                    let abort_reason = err.to_string();
+                    myself
+                        .send_message(ChannelActorMessage::Event(ChannelEvent::Stop(
+                            StopReason::AbortFundingWithDetail(abort_reason),
+                        )))
+                        .expect("myself alive");
+                    return Ok(());
+                }
+
                 if let Err(err) = call!(network, |tx| NetworkActorMessage::Command(
                     NetworkActorCommand::VerifyFundingTx {
                         local_tx: self.funding_tx.clone().unwrap_or_default(),

--- a/docs/specs/p2p-message.md
+++ b/docs/specs/p2p-message.md
@@ -189,6 +189,19 @@ table TxUpdate {
 
 Both parties must save the funding tx field of the previous message to compare it with the latest message field. They must also mark which inputs/outputs belong to their side. If a TxUpdate message from the other party removes or modifies inputs/outputs from their side, it is considered an illegal operation, and the entire process should be terminated.
 
+#### Peer-added complexity limits
+
+Verifying a peer's `tx` requires one chain lookup per peer-added input, so an unbounded `TxUpdate` lets a single message amplify into many chain RPC requests. To bound this, a node MUST reject a `TxUpdate` whose `tx` exceeds any of the following peer-added limits relative to its own previous version of the funding transaction, before performing any chain lookup. When the local node still has the default empty funding transaction, these deltas equal the remote transaction totals. The rejection is signalled with a `TxAbort` describing the violated budget.
+
+| Limit | Maximum |
+| --- | --- |
+| Serialized transaction size (in block) | `133120` bytes (the P2P frame cap, `1024 * (128 + 2)`) |
+| Peer-added inputs (beyond the local version) | `64` |
+| Peer-added outputs (beyond the local version) | `3` (funding cell plus UDT and CKB change when the peer funds first; CKB-only channels use two) |
+| Peer-added cell deps (beyond the local version) | `8` |
+
+These values are the implementation defaults; future versions may make them configurable and advertise them during connection or channel negotiation so the initiator can build a compliant transaction up front.
+
 ### TxComplete
 
 After successfully exchanging TxComplete messages, both parties should have constructed the transaction and move to the next part of the protocol to exchange signatures for the commitment transaction.


### PR DESCRIPTION
## Summary

During funding collaboration, a remote peer's `TxUpdate` could include an arbitrary number of non-local inputs. Each peer-added input was verified with a separate `get_live_cell` CKB RPC inside `VerifyFundingTx`, so a single near-frame-size P2P message could amplify into many serialized chain lookups while the channel actor blocked, enabling a remote availability attack across channels or auto-accepted openings.

This change bounds peer-added funding transaction complexity using cheap structural checks performed **before** any chain lookup.

- Add `validate_peer_funding_tx_complexity` in [`ckb/funding/limits.rs`](crates/fiber-lib/src/ckb/funding/limits.rs) enforcing budgets relative to the local funding tx: serialized size (P2P frame cap, 133120 bytes), peer-added inputs (64), outputs (3), and cell deps (8). Witnesses are not capped separately; their cost is bounded by the serialized size limit.
- Call the budget check first in `FundingTx::update_for_peer` and move the per-input `get_live_cell` loop to the end, after all cheap checks.
- Re-check complexity in `handle_tx_collaboration_msg` before the blocking `VerifyFundingTx` call (defense in depth).
- New `FundingError::PeerFundingTxExceedsLimit(String)` (non-temporary) names the violated budget; the channel actor relays it to the peer via `TxAbort`.
- Unit tests in [`ckb/tests/funding_limits_tests.rs`](crates/fiber-lib/src/ckb/tests/funding_limits_tests.rs); limits documented in [`docs/specs/p2p-message.md`](docs/specs/p2p-message.md).

## Breaking

The external funding script may fail when the built tx exceed the complexity upper bound.

## Test plan

- [x] `cargo nextest run -p fnn -p fiber-bin funding_limits_tests ckb::tests::error`
- [x] `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- [x] `cargo fmt --all -- --check`