### PR TITLE
fix: scope watchtower preimage lookups by node

### DIFF
--- a/crates/fiber-lib/src/fiber/tests/invoice_settlement.rs
+++ b/crates/fiber-lib/src/fiber/tests/invoice_settlement.rs
@@ -767,7 +767,10 @@ async fn test_mpp_payer_force_close_keeps_watchtower_preimage_for_onchain_split(
     insert_watch_channel_with_pending_tlc(&node_1, channels[0], payment_hash);
     replay_watchtower_preimage_events(&node_1, payment_hash, &preimage_events);
     assert!(
-        node_1.store.get_watch_preimage(&payment_hash).is_some(),
+        node_1
+            .store
+            .get_watch_preimage(&NodeId::local(), &payment_hash)
+            .is_some(),
         "watchtower must keep the preimage after the payer force-closes one same-hash MPP split; preimage events: {preimage_events:?}"
     );
 }
@@ -945,7 +948,10 @@ async fn test_mpp_force_close_pending_confirmation_removes_watchtower_preimage_r
     insert_watch_channel_with_pending_tlc(&node_1, channels[0], payment_hash);
     replay_watchtower_preimage_events(&node_1, payment_hash, &preimage_events);
     assert!(
-        node_1.store.get_watch_preimage(&payment_hash).is_some(),
+        node_1
+            .store
+            .get_watch_preimage(&NodeId::local(), &payment_hash)
+            .is_some(),
         "watchtower must keep the preimage while another same-hash split is still waiting for on-chain settlement; preimage events: {preimage_events:?}"
     );
 }

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -1043,15 +1043,6 @@ impl PreimageStore for Store {
         let key = [&[PREIMAGE_PREFIX], payment_hash.as_ref()].concat();
         self.get(key)
             .map(|v| deserialize_from(v.as_ref(), "Preimage"))
-            // Try to get the preimage from watchtower store
-            .or_else(|| {
-                let prefix = [&[WATCHTOWER_PREIMAGE_PREFIX], payment_hash.as_ref()].concat();
-                let iter = self
-                    .collect_by_prefix_with(prefix.as_slice(), PrefixIterOptions::new().limit(1));
-                iter.into_iter()
-                    .next()
-                    .map(|kv| deserialize_from(kv.value.as_ref(), "Watchtower Preimage"))
-            })
     }
 
     #[cfg(not(feature = "watchtower"))]
@@ -1327,11 +1318,15 @@ impl NetworkGraphStateStore for Store {
 
 #[cfg(feature = "watchtower")]
 impl WatchtowerStore for Store {
-    fn get_watch_channels(&self) -> Vec<ChannelData> {
+    fn get_watch_channels_with_nodes(&self) -> Vec<(NodeId, ChannelData)> {
         let prefix = vec![WATCHTOWER_CHANNEL_PREFIX];
         self.collect_by_prefix(&prefix)
             .into_iter()
-            .map(|kv| deserialize_from(kv.value.as_ref(), "ChannelData"))
+            .filter_map(|kv| {
+                let (node_id, _) = Self::parse_watchtower_channel_key(&kv.key)?;
+                let channel_data = deserialize_from(kv.value.as_ref(), "ChannelData");
+                Some((node_id, channel_data))
+            })
             .collect()
     }
 
@@ -1481,20 +1476,20 @@ impl WatchtowerStore for Store {
         );
     }
 
-    fn get_watch_preimage(&self, payment_hash: &Hash256) -> Option<Hash256> {
-        // The preimage is verified before insert_watch_preimage, so we can just pick one.
-        let prefix = [&[WATCHTOWER_PREIMAGE_PREFIX], payment_hash.as_ref()].concat();
-        self.collect_by_prefix_with(prefix.as_slice(), PrefixIterOptions::new().limit(1))
-            .into_iter()
-            .next()
-            .map(|kv| deserialize_from(kv.value.as_ref(), "Preimage"))
+    fn get_watch_preimage(&self, node_id: &NodeId, payment_hash: &Hash256) -> Option<Hash256> {
+        self.get(Self::watchtower_preimage_key(node_id, payment_hash))
+            .map(|v| deserialize_from(v.as_ref(), "Preimage"))
     }
 
-    fn search_preimage(&self, payment_hash_prefix: &[u8]) -> Option<Hash256> {
+    fn search_preimage(&self, node_id: &NodeId, payment_hash_prefix: &[u8]) -> Option<Hash256> {
         let prefix = [&[WATCHTOWER_PREIMAGE_PREFIX], payment_hash_prefix].concat();
-        self.collect_by_prefix_with(prefix.as_slice(), PrefixIterOptions::new().limit(1))
+        self.collect_by_prefix(prefix.as_slice())
             .into_iter()
-            .next()
+            .find(|kv| {
+                let key = &kv.key;
+                let node_offset = 1 + 32;
+                key.len() >= node_offset && key[node_offset..] == node_id.as_ref()[..]
+            })
             .map(|kv| deserialize_from(kv.value.as_ref(), "Preimage"))
     }
 

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -1043,6 +1043,7 @@ impl PreimageStore for Store {
         let key = [&[PREIMAGE_PREFIX], payment_hash.as_ref()].concat();
         self.get(key)
             .map(|v| deserialize_from(v.as_ref(), "Preimage"))
+            .or_else(|| self.get_watch_preimage(&NodeId::local(), payment_hash))
     }
 
     #[cfg(not(feature = "watchtower"))]

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -441,11 +441,11 @@ fn test_store_watchtower_preimage() {
     let path = TempDir::new("test-watchtower-store");
     let store = open_store(path).expect("created store failed");
 
-    let node_id_a = NodeId::from_bytes(PeerId::random().into_bytes());
+    let node_id_a = NodeId::local();
     let preimage_a = gen_rand_sha256_hash();
     let payment_hash_a = blake2b_256(preimage_a).into();
 
-    let node_id_b = NodeId::local();
+    let node_id_b = NodeId::from_bytes(PeerId::random().into_bytes());
     let preimage_b = gen_rand_sha256_hash();
     let payment_hash_b = blake2b_256(preimage_b).into();
 
@@ -469,8 +469,12 @@ fn test_store_watchtower_preimage() {
         "watch preimage should be scoped by node"
     );
     assert!(
-        store.get_preimage(&payment_hash_a).is_none(),
-        "normal preimage lookup must not read watchtower-scoped preimages"
+        store.get_preimage(&payment_hash_a).is_some(),
+        "normal preimage lookup should still read local watchtower preimages"
+    );
+    assert!(
+        store.get_preimage(&payment_hash_b).is_none(),
+        "normal preimage lookup must not read another node's watchtower preimage"
     );
 
     // watch preimage should not return a node preimage

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -455,46 +455,106 @@ fn test_store_watchtower_preimage() {
     store.insert_watch_preimage(node_id_a.clone(), payment_hash_a, preimage_a);
     store.insert_watch_preimage(node_id_b.clone(), payment_hash_b, preimage_b);
 
-    assert!(
-        store.get_preimage(&payment_hash_a).is_some(),
-        "should return a watch preimage also"
-    );
     assert_eq!(
-        store.get_watch_preimage(&payment_hash_a).unwrap(),
+        store
+            .get_watch_preimage(&node_id_a, &payment_hash_a)
+            .unwrap(),
         preimage_a,
         "query watch preimage"
+    );
+    assert!(
+        store
+            .get_watch_preimage(&node_id_b, &payment_hash_a)
+            .is_none(),
+        "watch preimage should be scoped by node"
+    );
+    assert!(
+        store.get_preimage(&payment_hash_a).is_none(),
+        "normal preimage lookup must not read watchtower-scoped preimages"
     );
 
     // watch preimage should not return a node preimage
     store.insert_preimage(payment_hash_c, preimage_c);
     assert!(
-        store.get_watch_preimage(&payment_hash_c).is_none(),
+        store
+            .get_watch_preimage(&node_id_a, &payment_hash_c)
+            .is_none(),
         "query non exist watch preimage"
     );
 
     assert!(
         store
-            .search_preimage(&payment_hash_c.as_ref()[..20])
+            .search_preimage(&node_id_a, &payment_hash_c.as_ref()[..20])
             .is_none(),
         "search a non exist watch preimage"
     );
     // search preimage only returns watch preimage
     assert_eq!(
         store
-            .search_preimage(&payment_hash_a.as_ref()[..20])
+            .search_preimage(&node_id_a, &payment_hash_a.as_ref()[..20])
             .unwrap(),
         preimage_a,
         "search"
     );
+    assert!(
+        store
+            .search_preimage(&node_id_b, &payment_hash_a.as_ref()[..20])
+            .is_none(),
+        "search should not cross node scope"
+    );
 
     // delete preimage with wrong node
     store.remove_watch_preimage(node_id_a, payment_hash_b);
-    assert!(store.get_watch_preimage(&payment_hash_b).is_some(), "exist");
-
-    store.remove_watch_preimage(node_id_b, payment_hash_b);
     assert!(
-        store.get_watch_preimage(&payment_hash_b).is_none(),
+        store
+            .get_watch_preimage(&node_id_b, &payment_hash_b)
+            .is_some(),
+        "exist"
+    );
+
+    store.remove_watch_preimage(node_id_b.clone(), payment_hash_b);
+    assert!(
+        store
+            .get_watch_preimage(&node_id_b, &payment_hash_b)
+            .is_none(),
         "removed"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_store_watchtower_preimage_search_is_node_scoped_with_same_prefix() {
+    let path = TempDir::new("test-watchtower-store-same-prefix");
+    let store = open_store(path).expect("created store failed");
+
+    let node_id_a = NodeId::from_bytes(PeerId::random().into_bytes());
+    let node_id_b = NodeId::from_bytes(PeerId::random().into_bytes());
+
+    let preimage_a = gen_rand_sha256_hash();
+    let preimage_b = gen_rand_sha256_hash();
+
+    let mut payment_hash_bytes = [7u8; 32];
+    payment_hash_bytes[31] = 1;
+    let payment_hash_a: Hash256 = payment_hash_bytes.into();
+
+    payment_hash_bytes[31] = 2;
+    let payment_hash_b: Hash256 = payment_hash_bytes.into();
+
+    let payment_hash_prefix = &payment_hash_a.as_ref()[..20];
+
+    store.insert_watch_preimage(node_id_b.clone(), payment_hash_b, preimage_b);
+    store.insert_watch_preimage(node_id_a.clone(), payment_hash_a, preimage_a);
+
+    assert_eq!(
+        store.search_preimage(&node_id_a, payment_hash_prefix),
+        Some(preimage_a),
+        "search should skip another node's preimage with the same prefix"
+    );
+    assert_eq!(
+        store.search_preimage(&node_id_b, payment_hash_prefix),
+        Some(preimage_b),
+        "search should still find the matching node's preimage"
     );
 }
 
@@ -541,7 +601,7 @@ fn test_store_watchtower_preimage_gc_waits_for_watched_tlc() {
 
     store.remove_watch_preimage(node_id.clone(), payment_hash);
     assert_eq!(
-        store.get_watch_preimage(&payment_hash),
+        store.get_watch_preimage(&node_id, &payment_hash),
         Some(preimage),
         "preimage is retained while a watched TLC still references it"
     );
@@ -549,7 +609,7 @@ fn test_store_watchtower_preimage_gc_waits_for_watched_tlc() {
     let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[..20].try_into().unwrap();
     store.update_tlc_settled(&channel_id, payment_hash_prefix);
     assert!(
-        store.get_watch_preimage(&payment_hash).is_none(),
+        store.get_watch_preimage(&node_id, &payment_hash).is_none(),
         "watchtower GC removes the preimage after the watched TLC is settled"
     );
 }

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -245,13 +245,13 @@ impl Drop for PeriodicCheckGuard {
     }
 }
 
-fn run_periodic_check<S>(store: S, node_id: NodeId, signer: LocalSigner, rpc_url: String)
+fn run_periodic_check<S>(store: S, _node_id: NodeId, signer: LocalSigner, rpc_url: String)
 where
     S: WatchtowerStore + Send + Sync + 'static,
 {
     let mut cell_collector = new_default_cell_collector(&rpc_url);
 
-    for channel_data in store.get_watch_channels() {
+    for (channel_node_id, channel_data) in store.get_watch_channels_with_nodes() {
         let ckb_client =
             CkbRpcClient::with_builder(&rpc_url, |builder| builder.timeout(CKB_RPC_TIMEOUT))
                 .expect("create ckb rpc client should not fail");
@@ -342,7 +342,7 @@ where
                                                 &signer,
                                                 &mut cell_collector,
                                                 &store,
-                                                node_id.clone(),
+                                                channel_node_id.clone(),
                                             );
                                         }
                                     }
@@ -356,7 +356,7 @@ where
                                         &signer,
                                         &mut cell_collector,
                                         &store,
-                                        node_id.clone(),
+                                        channel_node_id.clone(),
                                     );
                                 }
                             } else {
@@ -523,7 +523,7 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
         &channel_data.channel_id,
         &ckb_client,
         store,
-        self_node_id,
+        &self_node_id,
     );
 
     let (current_epoch, current_time) = match ckb_client.get_tip_header() {
@@ -645,6 +645,7 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
                         cell_header_epoch,
                         current_epoch,
                         current_time,
+                        &self_node_id,
                         for_remote,
                         channel_data.clone(),
                         settlement_witness,
@@ -682,7 +683,7 @@ fn find_preimages<S: WatchtowerStore>(
     channel_id: &Hash256,
     ckb_client: &CkbRpcClient,
     store: &S,
-    self_node_id: NodeId,
+    self_node_id: &NodeId,
 ) {
     let mut after = None;
     loop {
@@ -807,6 +808,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
     cell_header_epoch: EpochNumberWithFraction,
     current_epoch: EpochNumberWithFraction,
     current_time: u64,
+    self_node_id: &NodeId,
     for_remote: bool,
     channel_data: ChannelData,
     settlement_witness: Option<SettlementWitness>,
@@ -921,7 +923,8 @@ fn build_settlement_tx<S: WatchtowerStore>(
                                 } else if let Some(private_key) =
                                     tlc.find_matched_private_key(&settlement_data, true)
                                 {
-                                    if let Some(preimage) = store.search_preimage(&tlc.payment_hash)
+                                    if let Some(preimage) =
+                                        store.search_preimage(self_node_id, &tlc.payment_hash)
                                     {
                                         unlock_option = Some((
                                             Unlock {
@@ -1017,7 +1020,9 @@ fn build_settlement_tx<S: WatchtowerStore>(
                             } else if let Some(private_key) =
                                 tlc.find_matched_private_key(&settlement_data, true)
                             {
-                                if let Some(preimage) = store.search_preimage(&tlc.payment_hash) {
+                                if let Some(preimage) =
+                                    store.search_preimage(self_node_id, &tlc.payment_hash)
+                                {
                                     unlock_option = Some((
                                         Unlock {
                                             unlock_type: i as u8,
@@ -1109,7 +1114,9 @@ fn build_settlement_tx<S: WatchtowerStore>(
                         if cell_header_epoch.to_rational() + delay.to_rational()
                             <= current_epoch.to_rational()
                         {
-                            if let Some(preimage) = store.get_watch_preimage(&tlc.payment_hash) {
+                            if let Some(preimage) =
+                                store.get_watch_preimage(self_node_id, &tlc.payment_hash)
+                            {
                                 unlock_option = Some((
                                     Unlock {
                                         unlock_type: i as u8,

--- a/crates/fiber-lib/src/watchtower/store.rs
+++ b/crates/fiber-lib/src/watchtower/store.rs
@@ -6,8 +6,16 @@ use crate::ckb::contracts::{get_script_by_contract, Contract};
 use fiber_types::{ChannelData, Hash256, NodeId, Privkey, Pubkey, RevocationData, SettlementData};
 
 pub trait WatchtowerStore {
+    /// Get the channels currently being watched together with their owning node.
+    fn get_watch_channels_with_nodes(&self) -> Vec<(NodeId, ChannelData)>;
+
     /// Get the channels that are currently being watched by the watchtower
-    fn get_watch_channels(&self) -> Vec<ChannelData>;
+    fn get_watch_channels(&self) -> Vec<ChannelData> {
+        self.get_watch_channels_with_nodes()
+            .into_iter()
+            .map(|(_, channel_data)| channel_data)
+            .collect()
+    }
     /// Insert a channel's funding tx lock script into the store, it will be used to monitor the channel,
     /// please note that the lock script should be globally unique, so that the watchtower can identify the channel.
     #[allow(clippy::too_many_arguments)]
@@ -55,11 +63,11 @@ pub trait WatchtowerStore {
     /// Remove a watch preimage from the store.
     fn remove_watch_preimage(&self, node_id: NodeId, payment_hash: Hash256);
 
-    /// Insert a watch preimage into the store, the payment hash should be a 32 bytes hash result of the preimage after `HashAlgorithm` is applied.
-    fn get_watch_preimage(&self, payment_hash: &Hash256) -> Option<Hash256>;
+    /// Get a watch preimage owned by the given node.
+    fn get_watch_preimage(&self, node_id: &NodeId, payment_hash: &Hash256) -> Option<Hash256>;
 
     /// Search for the stored preimage with the given payment hash prefix, should be the first 20 bytes of the payment hash.
-    fn search_preimage(&self, payment_hash_prefix: &[u8]) -> Option<Hash256>;
+    fn search_preimage(&self, node_id: &NodeId, payment_hash_prefix: &[u8]) -> Option<Hash256>;
 
     /// Mark a tlc as settled on chain
     fn update_tlc_settled(&self, channel_id: &Hash256, payment_hash: [u8; 20]);


### PR DESCRIPTION
## Summary
- scope watchtower preimage reads to the owning node instead of scanning globally
- stop falling back from normal preimage lookups into watchtower-scoped preimages
- preserve watched channel owner node IDs in the watchtower settlement path and add regression tests

## Test Plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings
- [x] cargo test -p fnn test_store_watchtower_preimage --features rocksdb
- [x] cargo test -p fnn test_store_watchtower_preimage_gc_waits_for_watched_tlc --features rocksdb
