### PR TITLE
fix: validate ChannelAnnouncement outpoint index in on-chain info

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -2948,21 +2948,23 @@ async fn get_channel_on_chain_info(
     client: &impl CkbChainClient,
 ) -> Result<ChannelOnchainInfo, VerifyBroadcastMessageError> {
     let (tx, block_hash) = get_channel_tx(outpoint, chain, client).await?;
-    let first_output = match tx.outputs().get(0) {
+    let output_index: u32 = outpoint.index().unpack();
+    let output_index = output_index as usize;
+    let first_output = match tx.outputs().get(output_index) {
         None => {
             return Err(VerifyBroadcastMessageError::InvalidParameter(format!(
-                "On-chain transaction found but no output: {:?}",
-                &outpoint
+                "On-chain transaction found but output index {} out of range: {:?}",
+                output_index, &outpoint
             )));
         }
         Some(output) => output.clone().into(),
     };
 
-    let first_output_data = match tx.outputs_data().get(0) {
+    let first_output_data = match tx.outputs_data().get(output_index) {
         None => {
             return Err(VerifyBroadcastMessageError::InvalidParameter(format!(
-                "On-chain transaction found but no output data: {:?}",
-                &outpoint
+                "On-chain transaction found but output data at index {} missing: {:?}",
+                output_index, &outpoint
             )));
         }
         Some(data) => data,

--- a/crates/fiber-lib/src/fiber/tests/gossip.rs
+++ b/crates/fiber-lib/src/fiber/tests/gossip.rs
@@ -2,8 +2,8 @@ use std::{collections::HashSet, sync::Arc};
 
 use ckb_types::{
     core::{tx_pool::TxStatus, TransactionView},
-    packed::Bytes,
-    prelude::{Builder, Entity},
+    packed::{Bytes, OutPoint},
+    prelude::{Builder, Entity, Unpack},
 };
 use molecule::prelude::Byte;
 use ractor::{concurrency::Duration, Actor, ActorProcessingErr, ActorRef};
@@ -13,15 +13,19 @@ use crate::tests::test_utils::{
     establish_channel_between_nodes, ChannelParameters, NetworkNode, NetworkNodeConfigBuilder,
 };
 use crate::{
-    ckb::tests::test_utils::MockCkbChainClient,
-    fiber::{
-        gossip::{GossipActorMessage, GossipConfig, GossipService},
-        network::PeerChannelIndex,
-    },
-};
-use crate::{
     ckb::tests::test_utils::{MockChainActor, MockChainState},
     fiber::types::{ChannelUpdateChannelFlags, NodeAnnouncement},
+};
+use crate::{
+    ckb::{
+        contracts::{get_script_by_contract, Contract},
+        tests::test_utils::MockCkbChainClient,
+    },
+    fiber::{
+        gossip::{GossipActorMessage, GossipConfig, GossipService},
+        network::{get_chain_hash, PeerChannelIndex},
+        ChannelAnnouncement,
+    },
 };
 use crate::{
     ckb::{tests::test_utils::submit_tx, CkbChainMessage},
@@ -269,6 +273,64 @@ async fn test_saving_invalid_channel_announcement() {
         .get_store()
         .get_latest_channel_announcement(channel_context.channel_outpoint());
     assert_eq!(new_announcement, None);
+}
+
+#[tokio::test]
+async fn test_reject_channel_announcement_with_outpoint_index_not_zero() {
+    let context = GossipTestingContext::new().await;
+    let channel_context = ChannelTestContext::gen().await;
+
+    let real_output = channel_context
+        .funding_tx
+        .output(0)
+        .expect("get output")
+        .clone();
+    let dummy_lock = get_script_by_contract(Contract::Secp256k1Lock, b"dummy_placeholder");
+    let dummy_output = real_output.clone().as_builder().lock(dummy_lock).build();
+
+    let tx_with_output_at_index_1 = TransactionView::new_advanced_builder()
+        .output(dummy_output)
+        .output_data(Bytes::default())
+        .output(real_output)
+        .output_data(Bytes::default())
+        .build();
+
+    let outpoint_index_1 = OutPoint::new_builder()
+        .tx_hash(tx_with_output_at_index_1.hash())
+        .index(1u32)
+        .build();
+    let xonly = channel_context.funding_tx_sk.x_only_pub_key();
+    let capacity: u64 = channel_context
+        .funding_tx
+        .output(0)
+        .unwrap()
+        .capacity()
+        .unpack();
+    let mut announcement = ChannelAnnouncement::new_unsigned(
+        &channel_context.node1_sk.pubkey(),
+        &channel_context.node2_sk.pubkey(),
+        outpoint_index_1.clone(),
+        get_chain_hash(),
+        &xonly,
+        capacity as u128,
+        None,
+    );
+    let message = announcement.message_to_sign();
+    announcement.ckb_signature = Some(channel_context.funding_tx_sk.sign_schnorr(message));
+    announcement.node1_signature = Some(channel_context.node1_sk.sign(message));
+    announcement.node2_signature = Some(channel_context.node2_sk.sign(message));
+
+    context.save_message(BroadcastMessage::ChannelAnnouncement(announcement));
+    let status = context.submit_tx(tx_with_output_at_index_1).await;
+    assert!(matches!(status, TxStatus::Committed(..)));
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let saved = context
+        .get_store()
+        .get_latest_channel_announcement(&outpoint_index_1);
+    assert!(
+        saved.is_some(),
+        "should accept ChannelAnnouncement when funding output matches the announced outpoint index"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `get_channel_on_chain_info` was always reading transaction output index 0 regardless of the announced `channel_outpoint.index`
- An attacker controlling output 0 could sign multiple ChannelAnnouncements with different fake indices, inflating the graph with nonexistent channels

## Fix
- Read the actual announced outpoint index instead of hardcoded index 0
- Reject out-of-range output indices

## Test Plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings
- [x] cargo test -p fnn test_reject_channel_announcement_with_outpoint_index_not_zero --features rocksdb
- [x] cargo test -p fnn test_saving_confirmed_channel_announcement --features rocksdb
- [x] cargo test -p fnn test_saving_invalid_channel_announcement --features rocksdb
- [x] cargo test -p fnn test_deferred_channel_announcement --features rocksdb
