### PR TITLE
Fix deprecated rand API calls in udt-init

### DIFF
--- a/tests/deploy/udt-init/src/main.rs
+++ b/tests/deploy/udt-init/src/main.rs
@@ -215,11 +215,11 @@ fn is_port_available(port: u16) -> bool {
 
 fn generate_ports(num_ports: usize) -> Vec<u16> {
     let mut ports = HashSet::new();
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     while ports.len() < num_ports {
         // avoid https://en.wikipedia.org/wiki/Ephemeral_port
-        let port: u16 = rng.gen_range(1024..32768);
+        let port: u16 = rng.random_range(1024..32768);
         if is_port_available(port) {
             ports.insert(port);
         }


### PR DESCRIPTION
## Summary

Fixes deprecated `rand` API calls in `tests/deploy/udt-init`.

The `rand` crate deprecated several functions in its newer releases. This updates `generate_ports` to use the current API:

- `rand::thread_rng()` → `rand::rng()`
- `Rng::gen_range(..)` → `Rng::random_range(..)`

No behavioral change; this only removes deprecation warnings.

## Test plan

- `cargo build` / `cargo clippy` for the `udt-init` test helper no longer emit `rand` deprecation warnings.

---

🤖 This pull request description was generated with AI assistance.
