### PR TITLE
[codex] Fix synthetic rejected tx tracing

### DIFF
--- a/crates/fiber-lib/src/ckb/tx_tracing_actor.rs
+++ b/crates/fiber-lib/src/ckb/tx_tracing_actor.rs
@@ -147,12 +147,18 @@ impl Actor for CkbTxTracingActor {
         match message {
             CreateTracer(arguments) => state.create_tracer(myself, arguments).await,
             RemoveTracers(arguments) => state.remove_tracers(arguments),
-            ReportRejected(tx_hash) => state.report_rejected(myself, tx_hash).await,
+            ReportRejected(tx_hash) => state.report_tracing_result(
+                CkbTxTracingResult {
+                    tx_hash,
+                    tx_status: TxStatus::Rejected(
+                        "Transaction rejected when submitting".to_string(),
+                    ),
+                },
+                None,
+            ),
             Internal(InternalMessage::RunTracers) => state.run_tracers(myself, None).await,
             Internal(InternalMessage::ReportTracingResult(result, tip_block_number)) => {
-                state
-                    .report_tracing_result(myself, result, tip_block_number)
-                    .await
+                state.report_tracing_result(result, Some(tip_block_number))
             }
         }
     }
@@ -187,36 +193,6 @@ impl CkbTxTracingState {
         Ok(())
     }
 
-    async fn report_rejected(
-        &mut self,
-        myself: ActorRef<CkbTxTracingMessage>,
-        tx_hash: Hash256,
-    ) -> Result<(), ActorProcessingErr> {
-        // Get tip block number for reporting
-        let ckb_client = new_ckb_rpc_async_client(&self.rpc_url);
-        let tip_block_number = match ckb_client.get_tip_block_number().await {
-            Ok(n) => u64::from(n),
-            Err(err) => {
-                tracing::warn!(
-                    "Failed to get tip block number when reporting rejected tx {}: {:?}",
-                    tx_hash,
-                    err
-                );
-                return Ok(());
-            }
-        };
-
-        // Create a rejected result
-        let result = CkbTxTracingResult {
-            tx_hash,
-            tx_status: TxStatus::Rejected("Transaction rejected when submitting".to_string()),
-        };
-
-        // Report the result which will trigger callbacks for tracers with Rejected mask
-        self.report_tracing_result(myself, result, tip_block_number)
-            .await
-    }
-
     /// Run the tracers to check the txs statuses.
     ///
     /// When `tx_hashes` is None, all tracers are checked. Otherwise only the specified tx hashes are checked.
@@ -237,11 +213,10 @@ impl CkbTxTracingState {
         Ok(())
     }
 
-    async fn report_tracing_result(
+    fn report_tracing_result(
         &mut self,
-        _myself: ActorRef<CkbTxTracingMessage>,
         result: CkbTxTracingResult,
-        tip_block_number: u64,
+        tip_block_number: Option<u64>,
     ) -> Result<(), ActorProcessingErr> {
         let tx_tracers = if let Some(tx_tracers) = self.tracers.get_mut(&result.tx_hash) {
             tx_tracers
@@ -251,26 +226,34 @@ impl CkbTxTracingState {
 
         let tx_status = result.tx_status.clone();
 
-        match tx_status {
-            TxStatus::Committed(block_number, ..) => {
-                // Always use the latest committed block number
-                tx_tracers.last_block = block_number;
-            }
-            _ => {
-                // Otherwise, use tip block number when first entered this status
-                if tx_tracers.last_block == 0 || tx_status != tx_tracers.last_status {
-                    tx_tracers.last_block = tip_block_number
+        if let Some(tip_block_number) = tip_block_number {
+            match tx_status {
+                TxStatus::Committed(block_number, ..) => {
+                    // Always use the latest committed block number
+                    tx_tracers.last_block = block_number;
+                }
+                _ => {
+                    // Otherwise, use tip block number when first entered this status
+                    if tx_tracers.last_block == 0 || tx_status != tx_tracers.last_status {
+                        tx_tracers.last_block = tip_block_number
+                    }
                 }
             }
         }
         tx_tracers.last_status = tx_status.clone();
 
+        let last_block = tx_tracers.last_block;
+        let has_enough_confirmations = |tracer: &CkbTxTracer| match tip_block_number {
+            Some(tip_block_number) => {
+                tip_block_number.saturating_sub(last_block) >= tracer.confirmations
+            }
+            None => true,
+        };
+
         // Leave only tracers not fired
         for i in (0..tx_tracers.tracers.len()).rev() {
             let tracer = &tx_tracers.tracers[i];
-            if tracer.mask.contains((&tx_status).into())
-                && tip_block_number.saturating_sub(tx_tracers.last_block) >= tracer.confirmations
-            {
+            if tracer.mask.contains((&tx_status).into()) && has_enough_confirmations(tracer) {
                 let tracer = tx_tracers.tracers.swap_remove(i);
                 // ignore the error if the receiver is dropped
                 let _ = tracer.callback.send(result.clone());
@@ -324,5 +307,59 @@ impl TracingTask {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ckb_types::core::tx_pool::TxStatus;
+    use ractor::{Actor, RpcReplyPort};
+    use tokio::{
+        sync::oneshot,
+        time::{timeout, Duration as TokioDuration},
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn synthetic_rejected_callback_fires_before_next_unknown_poll() {
+        let (actor, _handle) = Actor::spawn(
+            None,
+            CkbTxTracingActor::new(),
+            CkbTxTracingArguments {
+                rpc_url: "http://127.0.0.1:0".to_string(),
+                polling_interval: Duration::from_secs(3600),
+            },
+        )
+        .await
+        .expect("spawn tx tracing actor");
+
+        let tx_hash = Hash256::from([42; 32]);
+        let (send, recv) = oneshot::channel();
+        actor
+            .send_message(CkbTxTracingMessage::CreateTracer(CkbTxTracer {
+                tx_hash,
+                confirmations: 4,
+                mask: CkbTxTracingMask::Rejected,
+                callback: RpcReplyPort::from(send),
+            }))
+            .expect("create tracer");
+        actor
+            .send_message(CkbTxTracingMessage::ReportRejected(tx_hash))
+            .expect("report rejected");
+        actor
+            .send_message(CkbTxTracingMessage::report_tracing_result(
+                CkbTxTracingResult::unknown(tx_hash),
+                101,
+            ))
+            .expect("report unknown");
+
+        let result = timeout(TokioDuration::from_millis(50), recv)
+            .await
+            .expect("synthetic rejected callback should fire before next unknown poll")
+            .expect("receive tracing result");
+        assert!(matches!(result.tx_status, TxStatus::Rejected(_)));
+
+        actor.stop(None);
     }
 }

--- a/crates/fiber-lib/src/fiber/in_flight_ckb_tx_actor.rs
+++ b/crates/fiber-lib/src/fiber/in_flight_ckb_tx_actor.rs
@@ -64,6 +64,7 @@ pub struct InFlightCkbTxActorArguments {
 pub struct InFlightCkbTxActorState {
     transaction: Option<TransactionView>,
     result: Option<CkbTxTracingResult>,
+    permanent_send_failure_reported: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -99,6 +100,7 @@ where
         Ok(InFlightCkbTxActorState {
             transaction: args.transaction,
             result: None,
+            permanent_send_failure_reported: false,
         })
     }
 
@@ -231,6 +233,10 @@ where
             return self.report_tracing_result(myself, result).await;
         }
 
+        if state.permanent_send_failure_reported {
+            return Ok(());
+        }
+
         let tx = match state.transaction.as_ref().cloned() {
             Some(tx) => tx,
             None => return Ok(()),
@@ -257,6 +263,7 @@ where
                 );
                 // Check if this is a permanent error that should stop retrying
                 if is_permanent_error(&err) {
+                    state.permanent_send_failure_reported = true;
                     let _ = self
                         .chain_actor
                         .send_message(CkbChainMessage::ReportRejected(self.tx_hash));


### PR DESCRIPTION
## Summary

- Treat synthetic `ReportRejected` results as immediate tracer deliveries by passing `None` into `report_tracing_result` instead of applying the normal confirmation delay.
- Stop retrying `send_tx` after a permanent send failure has already been reported.
- Add a regression covering `ReportRejected` followed by an `Unknown` poll while the tracer uses four confirmations.

## Root Cause

`InFlightCkbTxActor` reports permanent CKB send failures through `ReportRejected`, but the tx tracing actor previously stored that synthetic `Rejected` status at the current tip and required the normal confirmation delay. A later poll could then replace the status with `Unknown` before the callback fired, leaving funding/closing recovery stuck.

## Validation

- `cargo nextest run synthetic_rejected_callback_fires_before_next_unknown_poll -p fnn --features rocksdb`
- `cargo nextest run -p fnn --features rocksdb ckb::tx_tracing_actor`
- `cargo nextest run test_abort_funding_on_committing_funding_tx_on_chain -p fnn --features rocksdb`
- `cargo clippy --all-targets --features rocksdb -p fnn -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`