### PR TITLE
fix: bind CCH fee budget to outgoing payments

### DIFF
--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -21,6 +21,19 @@ use fiber_types::{payment::PaymentStatus, CchInvoice, CchOrder, CchOrderStatus, 
 
 const BTC_PAYMENT_TIMEOUT_SECONDS: i32 = 60;
 
+/// Compute the routing fee budget (in satoshis) available for the outgoing payment leg.
+///
+/// The budget is `fee_sats * max_outgoing_fee_percentage / 100`, where `fee_sats` is the fee
+/// charged on the incoming/order leg. This enforces the invariant that the total outgoing route
+/// fee never exceeds the fee the operator collected. `max_outgoing_fee_percentage` is validated
+/// to be within `1..=100` at startup, so the multiplication only ever shrinks `fee_sats`.
+pub(crate) fn outgoing_fee_budget_sats(order: &CchOrder, max_outgoing_fee_percentage: u64) -> u128 {
+    order
+        .fee_sats
+        .saturating_mul(max_outgoing_fee_percentage as u128)
+        / 100
+}
+
 pub struct SendOutgoingPaymentDispatcher;
 
 pub struct SendFiberOutgoingPaymentExecutor {
@@ -33,6 +46,10 @@ pub struct SendFiberOutgoingPaymentExecutor {
     /// This caps the route to prevent the outgoing payment from exceeding
     /// the incoming payment's remaining expiry time.
     tlc_expiry_limit: u64,
+    /// Maximum routing fee (in satoshis) the CCH is willing to spend on the outgoing
+    /// payment. Derived from the order fee budget so the outgoing route fee never exceeds
+    /// the fee charged on the incoming leg.
+    max_fee_amount: u128,
 }
 
 #[async_trait::async_trait]
@@ -45,12 +62,14 @@ impl ActionExecutor for SendFiberOutgoingPaymentExecutor {
             outgoing_pay_req,
             retry_count,
             tlc_expiry_limit,
+            max_fee_amount,
         } = *self;
 
         fiber_agent_ref
             .forward_send_payment(
                 outgoing_pay_req,
                 tlc_expiry_limit,
+                max_fee_amount,
                 &cch_actor_ref,
                 payment_hash,
                 retry_count,
@@ -70,6 +89,11 @@ pub struct SendLightningOutgoingPaymentExecutor {
     /// This caps the route to prevent the outgoing payment from exceeding
     /// the incoming payment's remaining expiry time.
     cltv_limit: i32,
+    /// Maximum routing fee (in satoshis) the CCH is willing to spend on the outgoing
+    /// payment. Derived from the order fee budget so the outgoing route fee never exceeds
+    /// the fee charged on the incoming leg. LND treats a zero fee limit as zero-fee-only
+    /// routing, so this must be set whenever a non-zero fee budget is available.
+    fee_limit_sat: i64,
 }
 
 #[async_trait::async_trait]
@@ -79,17 +103,18 @@ impl ActionExecutor for SendLightningOutgoingPaymentExecutor {
             payment_request: self.outgoing_pay_req,
             timeout_seconds: BTC_PAYMENT_TIMEOUT_SECONDS,
             cltv_limit: self.cltv_limit,
+            fee_limit_sat: self.fee_limit_sat,
             ..Default::default()
         };
         tracing::debug!(
-            "SendLightningOutgoingPaymentExecutor request payment_hash={:x} timeout_seconds={} cltv_limit={}",
+            "SendLightningOutgoingPaymentExecutor request payment_hash={:x} timeout_seconds={} cltv_limit={} fee_limit_sat={}",
             self.payment_hash,
             req.timeout_seconds,
-            req.cltv_limit
+            req.cltv_limit,
+            req.fee_limit_sat
         );
 
         let mut client = self.lnd_connection.create_router_client().await?;
-        // TODO: set a fee
         let mut stream = client.send_payment_v2(req).await?.into_inner();
         // Wait for the first message then quit
         let payment_result_opt = stream.next().await;
@@ -318,6 +343,11 @@ impl SendOutgoingPaymentDispatcher {
         let max_outgoing_seconds =
             Self::check_expiry_or_fail(cch_actor_ref, order, max_outgoing_seconds)?;
 
+        // Cap the outgoing routing fee at the fee the operator collected on the incoming leg
+        // (scaled by the configured percentage) so a route cannot consume more than was charged.
+        let fee_budget_sats =
+            outgoing_fee_budget_sats(order, state.config.max_outgoing_fee_percentage);
+
         match dispatch_payment_handler(order) {
             PaymentHandlerType::Fiber => {
                 let tlc_expiry_limit = max_outgoing_seconds
@@ -330,16 +360,20 @@ impl SendOutgoingPaymentDispatcher {
                     outgoing_pay_req: order.outgoing_pay_req.clone(),
                     retry_count,
                     tlc_expiry_limit,
+                    max_fee_amount: fee_budget_sats,
                 }))
             }
             PaymentHandlerType::Lightning => {
                 let cltv_limit = (max_outgoing_seconds / 600) as i32;
+                // LND fee limits are i64; clamp the (already small) sat budget defensively.
+                let fee_limit_sat = i64::try_from(fee_budget_sats).unwrap_or(i64::MAX);
                 Some(Box::new(SendLightningOutgoingPaymentExecutor {
                     payment_hash: order.payment_hash,
                     cch_actor_ref: cch_actor_ref.clone(),
                     outgoing_pay_req: order.outgoing_pay_req.clone(),
                     lnd_connection: state.lnd_connection.clone(),
                     cltv_limit,
+                    fee_limit_sat,
                 }))
             }
         }

--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -12,9 +12,10 @@ use crate::cch::{
     },
     actor::CchState,
     trackers::{map_lnd_payment_changed_event, CchTrackingEvent, LndConnectionInfo},
-    CchFiberAgentRef, CchMessage, CchOrderStore,
+    CchFiberAgentRef, CchMessage, CchOrderStore, OutgoingFeeLimit,
 };
 use crate::fiber::config::MAX_PAYMENT_TLC_EXPIRY_LIMIT;
+use crate::fiber::payment::MAX_FEE_RATE_DENOMINATOR;
 use crate::invoice::CkbInvoice;
 use crate::time::{SystemTime, UNIX_EPOCH};
 use fiber_types::{payment::PaymentStatus, CchInvoice, CchOrder, CchOrderStatus, Hash256};
@@ -34,6 +35,23 @@ pub(crate) fn outgoing_fee_budget_sats(order: &CchOrder, max_outgoing_fee_percen
         / 100
 }
 
+/// Compute the `max_fee_rate` (proportional, over `MAX_FEE_RATE_DENOMINATOR`) that corresponds to
+/// spending up to `max_fee_amount` satoshis on a payment of `amount` satoshis.
+///
+/// Fiber caps the routing fee at `min(max_fee_amount, max_fee_amount_by_rate)`, where
+/// `max_fee_amount_by_rate = ceil(amount * max_fee_rate / MAX_FEE_RATE_DENOMINATOR)`. Rounding the
+/// rate up guarantees the rate-derived cap is at least `max_fee_amount`, so the CCH fee budget
+/// (`max_fee_amount`) stays the binding constraint instead of Fiber's default rate cap.
+pub(crate) fn outgoing_max_fee_rate(amount: u128, max_fee_amount: u128) -> u64 {
+    if amount == 0 {
+        return 0;
+    }
+    let rate = max_fee_amount
+        .saturating_mul(MAX_FEE_RATE_DENOMINATOR)
+        .div_ceil(amount);
+    u64::try_from(rate).unwrap_or(u64::MAX)
+}
+
 pub struct SendOutgoingPaymentDispatcher;
 
 pub struct SendFiberOutgoingPaymentExecutor {
@@ -46,10 +64,11 @@ pub struct SendFiberOutgoingPaymentExecutor {
     /// This caps the route to prevent the outgoing payment from exceeding
     /// the incoming payment's remaining expiry time.
     tlc_expiry_limit: u64,
-    /// Maximum routing fee (in satoshis) the CCH is willing to spend on the outgoing
-    /// payment. Derived from the order fee budget so the outgoing route fee never exceeds
-    /// the fee charged on the incoming leg.
-    max_fee_amount: u128,
+    /// Fee limits for the outgoing payment. `max_fee_amount` is the order fee budget so the
+    /// outgoing route fee never exceeds the fee charged on the incoming leg; `max_fee_rate` is
+    /// derived from it and the payment amount so Fiber's default rate cap does not clamp the fee
+    /// below the budget.
+    fee_limit: OutgoingFeeLimit,
 }
 
 #[async_trait::async_trait]
@@ -62,14 +81,14 @@ impl ActionExecutor for SendFiberOutgoingPaymentExecutor {
             outgoing_pay_req,
             retry_count,
             tlc_expiry_limit,
-            max_fee_amount,
+            fee_limit,
         } = *self;
 
         fiber_agent_ref
             .forward_send_payment(
                 outgoing_pay_req,
                 tlc_expiry_limit,
-                max_fee_amount,
+                fee_limit,
                 &cch_actor_ref,
                 payment_hash,
                 retry_count,
@@ -360,7 +379,10 @@ impl SendOutgoingPaymentDispatcher {
                     outgoing_pay_req: order.outgoing_pay_req.clone(),
                     retry_count,
                     tlc_expiry_limit,
-                    max_fee_amount: fee_budget_sats,
+                    fee_limit: OutgoingFeeLimit {
+                        max_fee_amount: fee_budget_sats,
+                        max_fee_rate: outgoing_max_fee_rate(order.amount_sats, fee_budget_sats),
+                    },
                 }))
             }
             PaymentHandlerType::Lightning => {

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -140,6 +140,9 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
         myself: ActorRef<Self::Msg>,
         args: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
+        // Validate generic config invariants (e.g. the outgoing fee budget percentage).
+        args.config.validate().map_err(|e| anyhow!(e))?;
+
         // Validate that we have either an in-process network actor or a fiber RPC URL
         if args.network_actor.is_none() {
             if args.config.fiber_rpc_url.is_none() {

--- a/crates/fiber-lib/src/cch/cch_fiber_agent.rs
+++ b/crates/fiber-lib/src/cch/cch_fiber_agent.rs
@@ -25,11 +25,14 @@ use crate::rpc::{
     payment::{GetPaymentCommandResult, SendPaymentCommandParams},
 };
 
-/// Permissive `max_fee_rate` for CCH outgoing payments. Fiber caps the routing fee at
-/// `min(max_fee_amount, max_fee_amount_by_rate)`, where `max_fee_amount_by_rate` derives from
-/// `max_fee_rate`. CCH already binds the outgoing fee via `max_fee_amount` (the order fee budget),
-/// so this disables the secondary rate cap and lets `max_fee_amount` be the binding constraint.
-const CCH_OUTGOING_MAX_FEE_RATE: u64 = u64::MAX;
+/// Fee limits for a CCH outgoing payment. `max_fee_amount` is the order fee budget; `max_fee_rate`
+/// is derived from it and the payment amount so Fiber's default rate cap does not clamp the fee
+/// below the budget.
+#[derive(Clone, Copy)]
+pub struct OutgoingFeeLimit {
+    pub max_fee_amount: u128,
+    pub max_fee_rate: u64,
+}
 
 /// Messages for the fiber agent actor. Each variant carries an RpcReplyPort for the response.
 pub enum CchFiberAgentMessage {
@@ -38,6 +41,7 @@ pub enum CchFiberAgentMessage {
         String,
         Option<u64>,
         Option<u128>,
+        Option<u64>,
         RpcReplyPort<Result<PaymentStatus>>,
     ),
     SettleInvoice(Hash256, Hash256, RpcReplyPort<Result<()>>),
@@ -80,9 +84,15 @@ impl Actor for CchFiberAgentActor {
                 let result = state.add_invoice(invoice).await;
                 let _ = port.send(result);
             }
-            CchFiberAgentMessage::SendPayment(pay_req, tlc_expiry_limit, max_fee_amount, port) => {
+            CchFiberAgentMessage::SendPayment(
+                pay_req,
+                tlc_expiry_limit,
+                max_fee_amount,
+                max_fee_rate,
+                port,
+            ) => {
                 let result = state
-                    .send_payment(pay_req, tlc_expiry_limit, max_fee_amount)
+                    .send_payment(pay_req, tlc_expiry_limit, max_fee_amount, max_fee_rate)
                     .await;
                 let _ = port.send(result);
             }
@@ -133,6 +143,7 @@ impl CchFiberAgentHttpBackend {
         pay_req: String,
         tlc_expiry_limit: Option<u64>,
         max_fee_amount: Option<u128>,
+        max_fee_rate: Option<u64>,
     ) -> Result<PaymentStatus> {
         let payment_params = SendPaymentCommandParams {
             target_pubkey: None,
@@ -143,7 +154,7 @@ impl CchFiberAgentHttpBackend {
             invoice: Some(pay_req),
             timeout: None,
             max_fee_amount,
-            max_fee_rate: Some(CCH_OUTGOING_MAX_FEE_RATE),
+            max_fee_rate,
             max_parts: None,
             trampoline_hops: None,
             keysend: None,
@@ -216,6 +227,7 @@ impl CchFiberAgent {
         pay_req: String,
         tlc_expiry_limit: Option<u64>,
         max_fee_amount: Option<u128>,
+        max_fee_rate: Option<u64>,
     ) -> Result<PaymentStatus> {
         let Self::InProcess { network_actor } = self;
         let message = |rpc_reply| -> NetworkActorMessage {
@@ -224,7 +236,7 @@ impl CchFiberAgent {
                     invoice: Some(pay_req),
                     tlc_expiry_limit,
                     max_fee_amount,
-                    max_fee_rate: Some(CCH_OUTGOING_MAX_FEE_RATE),
+                    max_fee_rate,
                     ..Default::default()
                 },
                 rpc_reply,
@@ -301,17 +313,20 @@ impl CchFiberAgentRef {
     ///
     /// `max_fee_amount` caps the outgoing routing fee at the CCH order's fee budget so the
     /// operator never spends more on the outgoing leg than it collected on the incoming leg.
+    /// `max_fee_rate` is derived from `max_fee_amount` and the payment amount so Fiber's default
+    /// rate cap does not clamp the fee below the budget.
     pub async fn forward_send_payment(
         &self,
         outgoing_pay_req: String,
         tlc_expiry_limit: u64,
-        max_fee_amount: u128,
+        fee_limit: OutgoingFeeLimit,
         target: &ActorRef<CchMessage>,
         payment_hash: Hash256,
         retry_count: u32,
     ) -> Result<(), ractor::RactorErr<CchMessage>> {
         let tlc_limit = Some(tlc_expiry_limit);
-        let max_fee = Some(max_fee_amount);
+        let max_fee = Some(fee_limit.max_fee_amount);
+        let max_fee_rate = Some(fee_limit.max_fee_rate);
         let target_ref = target.clone();
         match self {
             Self::InProcess(network_actor) => {
@@ -323,7 +338,7 @@ impl CchFiberAgentRef {
                             invoice: Some(pay_req),
                             tlc_expiry_limit: tlc_limit,
                             max_fee_amount: max_fee,
-                            max_fee_rate: Some(CCH_OUTGOING_MAX_FEE_RATE),
+                            max_fee_rate,
                             ..Default::default()
                         },
                         tx,
@@ -344,6 +359,7 @@ impl CchFiberAgentRef {
                         outgoing_pay_req,
                         tlc_limit,
                         max_fee,
+                        max_fee_rate,
                         port
                     ),
                     target_ref,

--- a/crates/fiber-lib/src/cch/cch_fiber_agent.rs
+++ b/crates/fiber-lib/src/cch/cch_fiber_agent.rs
@@ -25,10 +25,21 @@ use crate::rpc::{
     payment::{GetPaymentCommandResult, SendPaymentCommandParams},
 };
 
+/// Permissive `max_fee_rate` for CCH outgoing payments. Fiber caps the routing fee at
+/// `min(max_fee_amount, max_fee_amount_by_rate)`, where `max_fee_amount_by_rate` derives from
+/// `max_fee_rate`. CCH already binds the outgoing fee via `max_fee_amount` (the order fee budget),
+/// so this disables the secondary rate cap and lets `max_fee_amount` be the binding constraint.
+const CCH_OUTGOING_MAX_FEE_RATE: u64 = u64::MAX;
+
 /// Messages for the fiber agent actor. Each variant carries an RpcReplyPort for the response.
 pub enum CchFiberAgentMessage {
     AddInvoice(CkbInvoice, RpcReplyPort<Result<CkbInvoice>>),
-    SendPayment(String, Option<u64>, RpcReplyPort<Result<PaymentStatus>>),
+    SendPayment(
+        String,
+        Option<u64>,
+        Option<u128>,
+        RpcReplyPort<Result<PaymentStatus>>,
+    ),
     SettleInvoice(Hash256, Hash256, RpcReplyPort<Result<()>>),
 }
 
@@ -69,8 +80,10 @@ impl Actor for CchFiberAgentActor {
                 let result = state.add_invoice(invoice).await;
                 let _ = port.send(result);
             }
-            CchFiberAgentMessage::SendPayment(pay_req, tlc_expiry_limit, port) => {
-                let result = state.send_payment(pay_req, tlc_expiry_limit).await;
+            CchFiberAgentMessage::SendPayment(pay_req, tlc_expiry_limit, max_fee_amount, port) => {
+                let result = state
+                    .send_payment(pay_req, tlc_expiry_limit, max_fee_amount)
+                    .await;
                 let _ = port.send(result);
             }
             CchFiberAgentMessage::SettleInvoice(payment_hash, payment_preimage, port) => {
@@ -119,6 +132,7 @@ impl CchFiberAgentHttpBackend {
         &self,
         pay_req: String,
         tlc_expiry_limit: Option<u64>,
+        max_fee_amount: Option<u128>,
     ) -> Result<PaymentStatus> {
         let payment_params = SendPaymentCommandParams {
             target_pubkey: None,
@@ -128,8 +142,8 @@ impl CchFiberAgentHttpBackend {
             tlc_expiry_limit,
             invoice: Some(pay_req),
             timeout: None,
-            max_fee_amount: None,
-            max_fee_rate: None,
+            max_fee_amount,
+            max_fee_rate: Some(CCH_OUTGOING_MAX_FEE_RATE),
             max_parts: None,
             trampoline_hops: None,
             keysend: None,
@@ -201,6 +215,7 @@ impl CchFiberAgent {
         &self,
         pay_req: String,
         tlc_expiry_limit: Option<u64>,
+        max_fee_amount: Option<u128>,
     ) -> Result<PaymentStatus> {
         let Self::InProcess { network_actor } = self;
         let message = |rpc_reply| -> NetworkActorMessage {
@@ -208,6 +223,8 @@ impl CchFiberAgent {
                 SendPaymentCommand {
                     invoice: Some(pay_req),
                     tlc_expiry_limit,
+                    max_fee_amount,
+                    max_fee_rate: Some(CCH_OUTGOING_MAX_FEE_RATE),
                     ..Default::default()
                 },
                 rpc_reply,
@@ -281,15 +298,20 @@ impl CchFiberAgentRef {
 
     /// Send payment and forward the result to the CCH actor. The mapping from the
     /// backend-specific reply type to [CchMessage] is handled internally.
+    ///
+    /// `max_fee_amount` caps the outgoing routing fee at the CCH order's fee budget so the
+    /// operator never spends more on the outgoing leg than it collected on the incoming leg.
     pub async fn forward_send_payment(
         &self,
         outgoing_pay_req: String,
         tlc_expiry_limit: u64,
+        max_fee_amount: u128,
         target: &ActorRef<CchMessage>,
         payment_hash: Hash256,
         retry_count: u32,
     ) -> Result<(), ractor::RactorErr<CchMessage>> {
         let tlc_limit = Some(tlc_expiry_limit);
+        let max_fee = Some(max_fee_amount);
         let target_ref = target.clone();
         match self {
             Self::InProcess(network_actor) => {
@@ -300,6 +322,8 @@ impl CchFiberAgentRef {
                         SendPaymentCommand {
                             invoice: Some(pay_req),
                             tlc_expiry_limit: tlc_limit,
+                            max_fee_amount: max_fee,
+                            max_fee_rate: Some(CCH_OUTGOING_MAX_FEE_RATE),
                             ..Default::default()
                         },
                         tx,
@@ -316,7 +340,12 @@ impl CchFiberAgentRef {
                 let target_ref = target.clone();
                 forward!(
                     rpc_actor,
-                    |port| CchFiberAgentMessage::SendPayment(outgoing_pay_req, tlc_limit, port),
+                    |port| CchFiberAgentMessage::SendPayment(
+                        outgoing_pay_req,
+                        tlc_limit,
+                        max_fee,
+                        port
+                    ),
                     target_ref,
                     move |result| map_send_payment_result(
                         result.map_err(|e| e.to_string()),

--- a/crates/fiber-lib/src/cch/config.rs
+++ b/crates/fiber-lib/src/cch/config.rs
@@ -10,6 +10,8 @@ pub const DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS: u64 = 360; // 60 hours (~10
 pub const DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS: u64 = 60 * 60 * 60; // 60 hours
 /// Default minimum outgoing invoice relative expiry time in seconds.
 pub const DEFAULT_MIN_OUTGOING_INVOICE_EXPIRY_DELTA_SECONDS: u64 = 6 * 60 * 60; // 6 hours
+/// Default percentage of the collected CCH fee that may be spent on outgoing routing fees.
+pub const DEFAULT_MAX_OUTGOING_FEE_PERCENTAGE: u64 = 100;
 
 // Use prefix `cch-`/`CCH_`
 #[derive(ClapSerde, Debug, Clone)]
@@ -84,6 +86,22 @@ pub struct CchConfig {
         help = "The proportional fee charged per million satoshis based on the cross-chain order value, default is 1"
     )]
     pub fee_rate_per_million_sats: u64,
+
+    /// Maximum percentage of the collected CCH fee that may be used as the routing
+    /// fee budget for the outgoing payment leg.
+    ///
+    /// The outgoing payment fee is capped at `fee_sats * max_outgoing_fee_percentage / 100`,
+    /// where `fee_sats` is the fee charged on the incoming/order leg. This guarantees the
+    /// outgoing route fee never exceeds the fee the operator collected. Defaults to 100,
+    /// i.e. the entire collected fee may be spent on the outgoing route.
+    #[default(DEFAULT_MAX_OUTGOING_FEE_PERCENTAGE)]
+    #[arg(
+        name = "CCH_MAX_OUTGOING_FEE_PERCENTAGE",
+        long = "cch-max-outgoing-fee-percentage",
+        env,
+        help = format!("Maximum percentage of the collected CCH fee usable as the outgoing payment routing fee budget (1-100), default is {}", DEFAULT_MAX_OUTGOING_FEE_PERCENTAGE),
+    )]
+    pub max_outgoing_fee_percentage: u64,
 
     /// Final tlc expiry time for BTC network.
     #[default(DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS)]
@@ -174,6 +192,21 @@ impl CchConfig {
                 Ok(())
             }
         }
+    }
+
+    /// Validate config values that must hold regardless of run mode.
+    ///
+    /// Currently checks that `max_outgoing_fee_percentage` is within the valid
+    /// `1..=100` range so the outgoing payment fee budget is always a sane fraction
+    /// of the collected CCH fee.
+    pub fn validate(&self) -> Result<(), String> {
+        if !(1..=100).contains(&self.max_outgoing_fee_percentage) {
+            return Err(format!(
+                "`max_outgoing_fee_percentage` must be between 1 and 100, got {}",
+                self.max_outgoing_fee_percentage
+            ));
+        }
+        Ok(())
     }
 
     pub fn resolve_lnd_cert_path(&self) -> Option<PathBuf> {

--- a/crates/fiber-lib/src/cch/mod.rs
+++ b/crates/fiber-lib/src/cch/mod.rs
@@ -4,7 +4,7 @@ pub use actor::{CchActor, CchArgs, CchMessage, ReceiveBTC, SendBTC};
 mod cch_fiber_agent;
 pub use cch_fiber_agent::{
     CchFiberAgent, CchFiberAgentActor, CchFiberAgentHttpBackend, CchFiberAgentMessage,
-    CchFiberAgentRef,
+    CchFiberAgentRef, OutgoingFeeLimit,
 };
 
 mod error;

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -121,6 +121,8 @@ struct MockNetworkState {
     event_port: Arc<OutputPort<CchTrackingEvent>>,
     /// Tracks payment hashes for which SendPayment was called (outgoing Fiber payments)
     sent_fiber_payments: Arc<Mutex<std::collections::HashSet<Hash256>>>,
+    /// Tracks the `max_fee_amount` of each outgoing Fiber SendPayment, keyed by payment hash.
+    sent_fiber_payment_fees: Arc<Mutex<std::collections::HashMap<Hash256, Option<u128>>>>,
 }
 
 /// Mock network actor that handles commands from action executors
@@ -162,6 +164,11 @@ impl Actor for MockNetworkActor {
                         .lock()
                         .unwrap()
                         .insert(payment_hash);
+                    state
+                        .sent_fiber_payment_fees
+                        .lock()
+                        .unwrap()
+                        .insert(payment_hash, cmd.max_fee_amount);
 
                     // Return success response - the executor will create CchTrackingEvent
                     let response = SendPaymentResponse {
@@ -284,6 +291,16 @@ impl TestHarness {
             .contains(&payment_hash)
     }
 
+    /// Return the `max_fee_amount` of the outgoing Fiber SendPayment for `payment_hash`, if sent.
+    fn fiber_payment_max_fee(&self, payment_hash: Hash256) -> Option<Option<u128>> {
+        self.mock_state
+            .sent_fiber_payment_fees
+            .lock()
+            .unwrap()
+            .get(&payment_hash)
+            .copied()
+    }
+
     /// Simulate outgoing Fiber payment succeeding with preimage
     /// Only works if the payment was actually sent via MockNetworkActor
     /// This injects the event via OutputPort, simulating what FiberStoreWatcher would do
@@ -387,6 +404,7 @@ async fn setup_test_harness_with_config_and_store(
         cch_actor: Arc::new(Mutex::new(None)),
         event_port: event_port.clone(),
         sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
+        sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
     };
 
     let (network_actor, _) = Actor::spawn(None, MockNetworkActor, mock_state.clone())
@@ -635,7 +653,107 @@ async fn test_receive_btc_happy_path() {
     assert!(order.failure_reason.is_none());
 }
 
-/// Tests that expired orders are marked as Failed when resuming from the store.
+/// Drive a ReceiveBTC-style order (incoming Lightning, outgoing Fiber) up to the point where
+/// the outgoing Fiber `SendPayment` has been dispatched, and return the `max_fee_amount` that
+/// was attached to the `SendPaymentCommand`.
+///
+/// `amount_sats`/`fee_sats` configure the order economics so callers can exercise the fee
+/// budget binding (the outgoing route fee must be capped at the collected CCH fee).
+async fn dispatch_fiber_outgoing_and_capture_fee(
+    harness: &TestHarness,
+    seed: u8,
+    amount_sats: u128,
+    fee_sats: u128,
+) -> Option<u128> {
+    let (_preimage, payment_hash) = create_valid_preimage_pair(seed);
+
+    let fiber_invoice = create_test_fiber_invoice_with_expiry(payment_hash, 10_000);
+    let lightning_invoice = create_test_lightning_invoice_with_cltv(
+        payment_hash,
+        DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS,
+    );
+    let order = CchOrder {
+        created_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        expiry_delta_seconds: 3600,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: fiber_invoice.to_string(),
+        incoming_invoice: CchInvoice::Lightning(lightning_invoice),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats,
+        fee_sats,
+        status: CchOrderStatus::Pending,
+        failure_reason: None,
+    };
+    harness.insert_order_directly(order).await.unwrap();
+
+    harness.simulate_incoming_invoice_received(payment_hash);
+
+    // Reaching OutgoingInFlight proves MockNetworkActor received the SendPayment command.
+    harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::OutgoingInFlight, 1000)
+        .await;
+
+    harness
+        .fiber_payment_max_fee(payment_hash)
+        .expect("outgoing Fiber payment should have been dispatched")
+}
+
+/// The outgoing Fiber payment must carry `max_fee_amount` equal to the order's collected fee.
+///
+/// This is a regression test for the issue where CCH did not bind its fee budget to the
+/// outgoing payment, allowing the default user-payment fee cap (0.5% of amount) to authorize a
+/// route fee far larger than the fee the operator charged.
+#[tokio::test]
+async fn test_receive_btc_outgoing_fiber_fee_capped_at_collected_fee() {
+    let harness = setup_test_harness().await;
+
+    // Pick economics where the default Fiber cap (0.5% * amount = 5000) vastly exceeds the
+    // tiny collected CCH fee (100). Without binding, the route could spend up to 5000.
+    let amount_sats = 1_000_000;
+    let fee_sats = 100;
+    let max_fee =
+        dispatch_fiber_outgoing_and_capture_fee(&harness, 60, amount_sats, fee_sats).await;
+
+    assert_eq!(
+        max_fee,
+        Some(fee_sats),
+        "outgoing Fiber payment must be capped at the collected CCH fee, not the default 0.5% cap"
+    );
+
+    // Sanity check: the default user-payment cap would have been much larger than fee_sats.
+    let default_cap = amount_sats * 5 / 1000;
+    assert!(
+        default_cap > fee_sats,
+        "test scenario must have default cap exceeding collected fee to be meaningful"
+    );
+}
+
+/// The `max_outgoing_fee_percentage` config knob must scale the outgoing fee budget.
+#[tokio::test]
+async fn test_receive_btc_outgoing_fiber_fee_scaled_by_percentage() {
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        max_outgoing_fee_percentage: 50,
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config(config).await;
+
+    let fee_sats = 1_000;
+    let max_fee = dispatch_fiber_outgoing_and_capture_fee(&harness, 61, 1_000_000, fee_sats).await;
+
+    assert_eq!(
+        max_fee,
+        Some(fee_sats * 50 / 100),
+        "outgoing Fiber fee budget must be scaled by max_outgoing_fee_percentage"
+    );
+}
+
 #[tokio::test]
 async fn test_resume_expired_order_marked_as_failed() {
     let (_preimage, payment_hash) = create_valid_preimage_pair(150);

--- a/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
@@ -378,6 +378,56 @@ fn test_outgoing_fee_budget_never_exceeds_collected_fee() {
 }
 
 // =============================================================================
+// outgoing_max_fee_rate tests
+// =============================================================================
+
+#[test]
+fn test_outgoing_max_fee_rate_zero_amount_is_zero() {
+    assert_eq!(
+        crate::cch::actions::send_outgoing_payment::outgoing_max_fee_rate(0, 100),
+        0
+    );
+}
+
+#[test]
+fn test_outgoing_max_fee_rate_rounds_up() {
+    // ceil(5 * 1000 / 1000) = 5
+    assert_eq!(
+        crate::cch::actions::send_outgoing_payment::outgoing_max_fee_rate(1_000, 5),
+        5
+    );
+    // ceil(1 * 1000 / 1000) = 1 (would floor to 0, rounding up keeps the budget reachable)
+    assert_eq!(
+        crate::cch::actions::send_outgoing_payment::outgoing_max_fee_rate(1_000, 1),
+        1
+    );
+}
+
+#[test]
+fn test_outgoing_max_fee_rate_cap_covers_budget() {
+    // The rate-derived cap, ceil(amount * rate / 1000), must always be >= the fee budget so the
+    // CCH budget (not the default rate) is the binding constraint.
+    const DENOM: u128 = 1000;
+    for amount in [1u128, 7, 1_000, 21_000, 1_000_000] {
+        for max_fee_amount in [0u128, 1, 5, 50, 999, amount] {
+            let rate = crate::cch::actions::send_outgoing_payment::outgoing_max_fee_rate(
+                amount,
+                max_fee_amount,
+            );
+            let cap = (amount * rate as u128).div_ceil(DENOM);
+            assert!(
+                cap >= max_fee_amount,
+                "rate-derived cap {} must cover budget {} (amount {}, rate {})",
+                cap,
+                max_fee_amount,
+                amount,
+                rate
+            );
+        }
+    }
+}
+
+// =============================================================================
 // CchConfig::validate tests
 // =============================================================================
 

--- a/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
@@ -318,3 +318,100 @@ fn test_invoice_and_payment_handlers_are_inverse_for_lightning() {
     assert_eq!(invoice_handler, InvoiceHandlerType::Lightning);
     assert_eq!(payment_handler, PaymentHandlerType::Fiber);
 }
+
+// =============================================================================
+// outgoing_fee_budget_sats tests
+// =============================================================================
+
+#[test]
+fn test_outgoing_fee_budget_full_percentage_uses_entire_fee() {
+    let mut order = create_order_with_lightning_invoice(CchOrderStatus::IncomingAccepted);
+    order.fee_sats = 1_000;
+    assert_eq!(
+        crate::cch::actions::send_outgoing_payment::outgoing_fee_budget_sats(&order, 100),
+        1_000
+    );
+}
+
+#[test]
+fn test_outgoing_fee_budget_scales_with_percentage() {
+    let mut order = create_order_with_lightning_invoice(CchOrderStatus::IncomingAccepted);
+    order.fee_sats = 1_000;
+    assert_eq!(
+        crate::cch::actions::send_outgoing_payment::outgoing_fee_budget_sats(&order, 50),
+        500
+    );
+    assert_eq!(
+        crate::cch::actions::send_outgoing_payment::outgoing_fee_budget_sats(&order, 1),
+        10
+    );
+}
+
+#[test]
+fn test_outgoing_fee_budget_rounds_down() {
+    let mut order = create_order_with_lightning_invoice(CchOrderStatus::IncomingAccepted);
+    order.fee_sats = 99;
+    // 99 * 50 / 100 = 49.5 -> 49 (integer division floors, never exceeding the collected fee)
+    assert_eq!(
+        crate::cch::actions::send_outgoing_payment::outgoing_fee_budget_sats(&order, 50),
+        49
+    );
+}
+
+#[test]
+fn test_outgoing_fee_budget_never_exceeds_collected_fee() {
+    let mut order = create_order_with_lightning_invoice(CchOrderStatus::IncomingAccepted);
+    for fee_sats in [0u128, 1, 7, 1_000, u128::from(u64::MAX)] {
+        order.fee_sats = fee_sats;
+        for pct in 1..=100u64 {
+            let budget =
+                crate::cch::actions::send_outgoing_payment::outgoing_fee_budget_sats(&order, pct);
+            assert!(
+                budget <= fee_sats,
+                "budget {} must never exceed collected fee {} (pct {})",
+                budget,
+                fee_sats,
+                pct
+            );
+        }
+    }
+}
+
+// =============================================================================
+// CchConfig::validate tests
+// =============================================================================
+
+#[test]
+fn test_config_validate_accepts_boundaries() {
+    use crate::cch::CchConfig;
+    let mut config = CchConfig {
+        max_outgoing_fee_percentage: 1,
+        ..Default::default()
+    };
+    assert!(config.validate().is_ok());
+    config.max_outgoing_fee_percentage = 100;
+    assert!(config.validate().is_ok());
+    config.max_outgoing_fee_percentage = 50;
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn test_config_validate_rejects_out_of_range() {
+    use crate::cch::CchConfig;
+    let mut config = CchConfig {
+        max_outgoing_fee_percentage: 0,
+        ..Default::default()
+    };
+    assert!(config.validate().is_err());
+    config.max_outgoing_fee_percentage = 101;
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn test_config_default_percentage_is_full() {
+    use crate::cch::CchConfig;
+    // The default must be a valid, full-budget percentage so existing deployments keep working.
+    let config = CchConfig::default();
+    assert_eq!(config.max_outgoing_fee_percentage, 100);
+    assert!(config.validate().is_ok());
+}

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -48,7 +48,7 @@ use tracing::{debug, error, instrument, warn};
 // This is a safety guard against excessive route construction work.
 const MAX_TRAMPOLINE_HOPS_LIMIT: u16 = 5;
 const DEFAULT_MAX_FEE_RATE: u64 = 5;
-const MAX_FEE_RATE_DENOMINATOR: u128 = 1000;
+pub(crate) const MAX_FEE_RATE_DENOMINATOR: u128 = 1000;
 
 #[derive(Clone, Debug, Default)]
 pub struct SendPaymentDataBuilder {


### PR DESCRIPTION
The CCH computed and charged a per-order fee but never bound that
budget to the outgoing payment leg, so a route could spend more in
fees than was collected and force the operator to subsidize swaps.

Cap the outgoing routing fee at the order's collected fee on both
dispatch paths:

- **Fiber**: pass `max_fee_amount` derived from the order fee budget
  through `forward_send_payment` and both fiber agent backends,
  replacing the default 0.5% user-payment cap.
- **Lightning**: set `fee_limit_sat` on the LND `SendPaymentRequest`
  instead of leaving it at zero (which restricts LND to zero-fee
  routes only).

Add a `max_outgoing_fee_percentage` config (default 100), validated
to `1..=100` at startup, so operators can reserve part of the
collected fee. Cover the fee-budget computation, config validation,
and Fiber dispatch request construction with regression tests.

---

*This PR description was generated by AI.*
