### PR TITLE
[codex] Require dev scope for dev RPC

### DIFF
--- a/crates/fiber-lib/src/rpc/biscuit.rs
+++ b/crates/fiber-lib/src/rpc/biscuit.rs
@@ -96,15 +96,12 @@ fn build_rules() -> HashMap<&'static str, AuthRule> {
     );
     b.rule("submit_signed_funding_tx", r#"allow if write("channels");"#);
     // dev
-    b.rule("commitment_signed", r#"allow if write("messages");"#);
-    b.rule("add_tlc", r#"allow if write("channels");"#);
-    b.rule("remove_tlc", r#"allow if write("channels");"#);
-    b.rule("check_channel_shutdown", r#"allow if write("channels");"#);
-    b.rule("sign_external_funding_tx", r#"allow if write("channels");"#);
-    b.rule(
-        "submit_commitment_transaction",
-        r#"allow if write("chain");"#,
-    );
+    b.rule("commitment_signed", r#"allow if write("dev");"#);
+    b.rule("add_tlc", r#"allow if write("dev");"#);
+    b.rule("remove_tlc", r#"allow if write("dev");"#);
+    b.rule("check_channel_shutdown", r#"allow if write("dev");"#);
+    b.rule("sign_external_funding_tx", r#"allow if write("dev");"#);
+    b.rule("submit_commitment_transaction", r#"allow if write("dev");"#);
     // prof
     b.rule("pprof", r#"allow if write("pprof");"#);
     // graph
@@ -355,6 +352,57 @@ mod tests {
         assert!(auth
             .check_permission("subscribe_store_changes", &internal_token)
             .is_ok());
+    }
+
+    #[test]
+    fn test_biscuit_auth_dev_methods_require_write_dev() {
+        let root = KeyPair::new();
+        let auth = BiscuitAuth::from_pubkey(root.public().to_string()).unwrap();
+
+        let production_write_token = biscuit!(
+            r#"
+          write("channels");
+          write("messages");
+          write("chain");
+    "#
+        )
+        .build(&root)
+        .unwrap()
+        .to_base64()
+        .unwrap();
+
+        let dev_write_token = biscuit!(
+            r#"
+          write("dev");
+    "#
+        )
+        .build(&root)
+        .unwrap()
+        .to_base64()
+        .unwrap();
+
+        let dev_methods = [
+            "commitment_signed",
+            "add_tlc",
+            "remove_tlc",
+            "check_channel_shutdown",
+            "sign_external_funding_tx",
+            "submit_commitment_transaction",
+        ];
+
+        for method in dev_methods {
+            assert!(auth
+                .check_permission(method, &production_write_token)
+                .is_err());
+            assert!(auth.check_permission(method, &dev_write_token).is_ok());
+        }
+
+        assert!(auth
+            .check_permission("open_channel", &production_write_token)
+            .is_ok());
+        assert!(auth
+            .check_permission("submit_signed_funding_tx", &dev_write_token)
+            .is_err());
     }
 
     #[test]

--- a/docs/biscuit-auth.md
+++ b/docs/biscuit-auth.md
@@ -46,17 +46,12 @@ rule("list_channels", r#"allow if read("channels");"#);
 rule("shutdown_channel", r#"allow if write("channels");"#); 
 rule("update_channel", r#"allow if write("channels");"#); 
 // dev 
-rule("commitment_signed", r#"allow if write("messages");"#); 
-rule("add_tlc", r#"allow if write("channels");"#); 
-rule("remove_tlc", r#"allow if write("channels");"#); 
-rule(
-    "check_channel_shutdown",
-    r#"allow if write("channels");"#,
-);
-rule( 
-    "submit_commitment_transaction", 
-    r#"allow if write("chain");"#, 
-); 
+rule("commitment_signed", r#"allow if write("dev");"#);
+rule("add_tlc", r#"allow if write("dev");"#);
+rule("remove_tlc", r#"allow if write("dev");"#);
+rule("check_channel_shutdown", r#"allow if write("dev");"#);
+rule("sign_external_funding_tx", r#"allow if write("dev");"#);
+rule("submit_commitment_transaction", r#"allow if write("dev");"#);
 // graph 
 rule("graph_nodes", r#"allow if read("graph");"#); 
 rule("graph_channels", r#"allow if read("graph");"#); 


### PR DESCRIPTION
## Summary

Require all development RPC methods to use the dedicated Biscuit `write("dev")` scope instead of ordinary production write scopes.

## Details

- Updates `commitment_signed`, `add_tlc`, `remove_tlc`, `check_channel_shutdown`, `sign_external_funding_tx`, and `submit_commitment_transaction` authorization rules to require `write("dev")`.
- Adds Biscuit auth coverage proving `write("channels")`, `write("messages")`, and `write("chain")` no longer grant dev RPC access, while `write("dev")` does.
- Updates `docs/biscuit-auth.md` to document the distinct dev scope.

This keeps the existing behavior where local/private RPC can run without a configured Biscuit token when auth is disabled.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo nextest run -p fnn --features rocksdb rpc::biscuit`

Note: `cargo nextest run -p fnn test_biscuit_auth_dev_methods_require_write_dev` without a store backend feature failed to compile because `fiber_store` backend modules are feature-gated. Re-running with `--features rocksdb` passed.