### PR TITLE
fix(e2e): poll balance in watchtower force-close-preimage-multiple test

### DIFF
--- a/tests/bruno/e2e/watchtower/force-close-preimage-multiple/24-check-balance-node1.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-multiple/24-check-balance-node1.bru
@@ -35,6 +35,34 @@ script:pre-request {
   req.setBody(body);
 }
 
-assert {
-  Number(BigInt(bru.getVar("NODE1_BALANCE")) - BigInt(res.body.result.capacity)): lt 9005000
+script:post-response {
+  const initialCapacity = BigInt(bru.getVar("NODE1_BALANCE"));
+  const currentCapacity = BigInt(res.body.result.capacity);
+  const diff = initialCapacity - currentCapacity;
+  const threshold = BigInt(9005000);
+  const iteration = Number(bru.getVar("NODE1_BALANCE_POLL_ITERATION") || 0);
+  const maxIterations = Number(bru.getVar("NODE1_BALANCE_POLL_MAX_ITERATIONS") || 8);
+
+  console.log("node1 balance diff: ", {
+    diff: diff.toString(),
+    threshold: threshold.toString(),
+    iteration,
+    maxIterations,
+  });
+
+  if (diff < threshold) {
+    bru.setVar("NODE1_BALANCE_POLL_ITERATION", 0);
+    return;
+  }
+
+  if (iteration + 1 < maxIterations) {
+    bru.setVar("NODE1_BALANCE_POLL_ITERATION", iteration + 1);
+    bru.setNextRequest("generate a few blocks for final settlement tx committed");
+    return;
+  }
+
+  bru.setVar("NODE1_BALANCE_POLL_ITERATION", 0);
+  throw new Error(
+    `node1 balance diff too high after ${maxIterations} polling attempts, diff=${diff.toString()}, expected < ${threshold.toString()}`,
+  );
 }

--- a/tests/bruno/e2e/watchtower/force-close-preimage-multiple/25-check-balance-node2.bru
+++ b/tests/bruno/e2e/watchtower/force-close-preimage-multiple/25-check-balance-node2.bru
@@ -35,6 +35,34 @@ script:pre-request {
   req.setBody(body);
 }
 
-assert {
-  Number(BigInt(res.body.result.capacity) - BigInt(bru.getVar("NODE2_BALANCE"))): gt 8995000
+script:post-response {
+  const initialCapacity = BigInt(bru.getVar("NODE2_BALANCE"));
+  const currentCapacity = BigInt(res.body.result.capacity);
+  const diff = currentCapacity - initialCapacity;
+  const threshold = BigInt(8995000);
+  const iteration = Number(bru.getVar("NODE2_BALANCE_POLL_ITERATION") || 0);
+  const maxIterations = Number(bru.getVar("NODE2_BALANCE_POLL_MAX_ITERATIONS") || 8);
+
+  console.log("node2 balance diff: ", {
+    diff: diff.toString(),
+    threshold: threshold.toString(),
+    iteration,
+    maxIterations,
+  });
+
+  if (diff > threshold) {
+    bru.setVar("NODE2_BALANCE_POLL_ITERATION", 0);
+    return;
+  }
+
+  if (iteration + 1 < maxIterations) {
+    bru.setVar("NODE2_BALANCE_POLL_ITERATION", iteration + 1);
+    bru.setNextRequest("generate a few blocks for final settlement tx committed");
+    return;
+  }
+
+  bru.setVar("NODE2_BALANCE_POLL_ITERATION", 0);
+  throw new Error(
+    `node2 balance diff too low after ${maxIterations} polling attempts, diff=${diff.toString()}, expected > ${threshold.toString()}`,
+  );
 }


### PR DESCRIPTION
## Summary

Replace one-shot `assert` with a polling loop in node1/node2 balance-check steps of the watchtower `force-close-preimage-multiple` e2e test.

## Problem

The balance checks (steps 24/25) run immediately after generating blocks for the final settlement transaction. In CI, the settlement tx may not be committed by the time the check executes, causing false negatives.

## Fix

Each balance step now polls up to 8 times, calling `bru.setNextRequest("generate a few blocks for final settlement tx committed")` between retries. The check passes as soon as the balance diff crosses the expected threshold.