### PR TITLE
fix: prevent funding abort when tx is committed on chain after restart

### DIFF
--- a/crates/fiber-lib/src/fiber/in_flight_ckb_tx_actor.rs
+++ b/crates/fiber-lib/src/fiber/in_flight_ckb_tx_actor.rs
@@ -1,4 +1,3 @@
-use ckb_sdk::RpcError;
 use ckb_types::{
     core::{tx_pool::TxStatus, TransactionView},
     packed::OutPoint,
@@ -16,22 +15,6 @@ use crate::{
 
 use super::{NetworkActorMessage, ASSUME_NETWORK_ACTOR_ALIVE};
 use fiber_types::Hash256;
-
-/// Check if an RPC error is a permanent error that should not be retried.
-/// Currently checks for TransactionFailedToResolve errors.
-fn is_permanent_error(err: &RpcError) -> bool {
-    match err {
-        RpcError::Rpc(e) => {
-            // Check error code -301 (TransactionFailedToResolve)
-            if e.code.code() == -301 {
-                return true;
-            }
-            // Also check message content as fallback
-            e.message.contains("TransactionFailedToResolve")
-        }
-        _ => false,
-    }
-}
 
 // tx index is not returned on older ckb version, using dummy tx index instead.
 // Waiting for https://github.com/nervosnetwork/ckb/pull/4583/ to be released.
@@ -64,7 +47,6 @@ pub struct InFlightCkbTxActorArguments {
 pub struct InFlightCkbTxActorState {
     transaction: Option<TransactionView>,
     result: Option<CkbTxTracingResult>,
-    permanent_send_failure_reported: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -100,7 +82,6 @@ where
         Ok(InFlightCkbTxActorState {
             transaction: args.transaction,
             result: None,
-            permanent_send_failure_reported: false,
         })
     }
 
@@ -233,10 +214,6 @@ where
             return self.report_tracing_result(myself, result).await;
         }
 
-        if state.permanent_send_failure_reported {
-            return Ok(());
-        }
-
         let tx = match state.transaction.as_ref().cloned() {
             Some(tx) => tx,
             None => return Ok(()),
@@ -246,6 +223,37 @@ where
             self.tx_hash,
             self.tx_kind
         );
+
+        // Check the current tx status before broadcasting. The tx may already
+        // be committed on chain (e.g. after a restart of the node that
+        // originally broadcast the funding transaction). Re-broadcasting an
+        // already committed tx returns `-301 TransactionFailedToResolve` from
+        // CKB because the inputs are already spent. Defer to the tracer for
+        // status rather than re-broadcasting.
+        match self.chain_client.get_transaction(self.tx_hash.into()).await {
+            Ok(response) => match response.tx_status {
+                TxStatus::Committed(..) | TxStatus::Rejected(_) => {
+                    tracing::debug!(
+                        "Skipping broadcast for tx {} ({:?}): already {:?}",
+                        self.tx_hash,
+                        self.tx_kind,
+                        response.tx_status,
+                    );
+                    return Ok(());
+                }
+                TxStatus::Pending | TxStatus::Proposed | TxStatus::Unknown => {
+                    // proceed with broadcast
+                }
+            },
+            Err(err) => {
+                tracing::warn!(
+                    "failed to query tx status for {} before broadcasting: {}; will attempt broadcast anyway",
+                    self.tx_hash,
+                    err
+                );
+            }
+        }
+
         match ractor::call_t!(
             self.chain_actor,
             CkbChainMessage::SendTx,
@@ -261,13 +269,6 @@ where
                     self.tx_hash,
                     err
                 );
-                // Check if this is a permanent error that should stop retrying
-                if is_permanent_error(&err) {
-                    state.permanent_send_failure_reported = true;
-                    let _ = self
-                        .chain_actor
-                        .send_message(CkbChainMessage::ReportRejected(self.tx_hash));
-                }
             }
             Err(err) => {
                 tracing::error!(


### PR DESCRIPTION
Fix the funding transaction abort after restart issue described in #1433.

When a node restarts while a funding transaction is being confirmed (the
tx was accepted into the pool before restart, then committed to a block
during the restart), re-broadcasting the already committed transaction
after restart returns `-301 TransactionFailedToResolve: Unknown(OutPoint)`
because the inputs are already spent on chain. Previously,
`InFlightCkbTxActor` treated this as a permanent broadcast error and
immediately reported the transaction as rejected via `ReportRejected`,
which caused `abort_funding` to be called even though the transaction
was already confirmed on chain.

Note: when the tx is still in the pool (not yet committed), the
CkbChainActor handles the duplicate gracefully (error codes -1107/-1111
are swallowed and Ok(()) is returned). The -301 error only surfaces
when the tx has been committed to a block.

## Changes

- Removed the `is_permanent_error` / `ReportRejected` path that classified
  `-301` as a fatal rejection.
- Removed the `permanent_send_failure_reported` guard flag.
- `send_tx` now queries `get_transaction` before broadcasting:
  - If **Committed** or **Rejected**: skip the broadcast entirely and let the
    existing tx tracer handle the terminal status.
  - If **Pending**, **Proposed**, or **Unknown**: proceed with broadcast.
  - If the query fails: log a warning and attempt the broadcast anyway.

_Note: This PR description was generated by AI (opencode:deepseek-v4-flash)._
