### PR TITLE
[codex] Fix active gossip sync accounting

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -430,7 +430,12 @@ pub(crate) enum GossipActorMessage {
     PruneStaleGossipMessages(u64),
 
     // The active syncing process is finished for a peer.
-    ActiveSyncingFinished(Pubkey, Cursor),
+    ActiveSyncingFinished {
+        peer: Pubkey,
+        session_id: SessionId,
+        sync_id: u64,
+        cursor: Cursor,
+    },
 
     // A malicious peer is found during gossip validation or policy checks.
     MaliciousPeerFound {
@@ -617,7 +622,7 @@ where
 
     async fn update_peer_filter(
         &self,
-        state: &mut GossipActorState<S, C>,
+        state: &mut GossipActorState<S>,
         pubkey: &Pubkey,
         after_cursor: &Cursor,
         myself: ActorRef<GossipActorMessage>,
@@ -756,11 +761,11 @@ impl DelayedGossipMessageQueue {
     }
 }
 
-pub struct GossipSyncingActorState<S, C> {
+pub struct GossipSyncingActorState<S> {
     peer_pubkey: Pubkey,
+    session_id: SessionId,
+    sync_id: u64,
     gossip_actor: ActorRef<GossipActorMessage>,
-    chain_actor: ActorRef<CkbChainMessage>,
-    chain_client: C,
     store: ExtendedGossipMessageStore<S>,
     // The problem of using the cursor from the store is that a malicious peer may only
     // send large cursor to us, which may cause us to miss some messages.
@@ -774,20 +779,20 @@ pub struct GossipSyncingActorState<S, C> {
         HashMap<u64, JoinHandle<Result<(), MessagingErr<GossipSyncingActorMessage>>>>,
 }
 
-impl<S, C> GossipSyncingActorState<S, C> {
+impl<S> GossipSyncingActorState<S> {
     fn new(
         peer_pubkey: Pubkey,
+        session_id: SessionId,
+        sync_id: u64,
         gossip_actor: ActorRef<GossipActorMessage>,
-        chain_actor: ActorRef<CkbChainMessage>,
-        chain_client: C,
         store: ExtendedGossipMessageStore<S>,
         cursor: Cursor,
     ) -> Self {
         Self {
             peer_pubkey,
+            session_id,
+            sync_id,
             gossip_actor,
-            chain_actor,
-            chain_client,
             store,
             cursor,
             peer_state: Default::default(),
@@ -807,11 +812,11 @@ impl<S, C> GossipSyncingActorState<S, C> {
     }
 }
 
-pub(crate) struct GossipSyncingActor<S, C> {
-    _phantom: std::marker::PhantomData<(S, C)>,
+pub(crate) struct GossipSyncingActor<S> {
+    _phantom: std::marker::PhantomData<S>,
 }
 
-impl<S, C> GossipSyncingActor<S, C> {
+impl<S> GossipSyncingActor<S> {
     fn new() -> Self {
         Self {
             _phantom: Default::default(),
@@ -831,18 +836,17 @@ pub(crate) enum GossipSyncingActorMessage {
 }
 
 #[async_trait::async_trait]
-impl<S, C> Actor for GossipSyncingActor<S, C>
+impl<S> Actor for GossipSyncingActor<S>
 where
     S: GossipMessageStore + Clone + Send + Sync + 'static,
-    C: CkbChainClient + Clone + Send + Sync + 'static,
 {
     type Msg = GossipSyncingActorMessage;
-    type State = GossipSyncingActorState<S, C>;
+    type State = GossipSyncingActorState<S>;
     type Arguments = (
         Pubkey,
+        SessionId,
+        u64,
         ActorRef<GossipActorMessage>,
-        ActorRef<CkbChainMessage>,
-        C,
         ExtendedGossipMessageStore<S>,
         Cursor,
     );
@@ -850,16 +854,16 @@ where
     async fn pre_start(
         &self,
         myself: ActorRef<Self::Msg>,
-        (peer_pubkey, gossip_actor, chain_actor, chain_client, store, cursor): Self::Arguments,
+        (peer_pubkey, session_id, sync_id, gossip_actor, store, cursor): Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
         myself
             .send_message(GossipSyncingActorMessage::NewGetRequest())
             .expect("gossip syncing actor alive");
         Ok(GossipSyncingActorState::new(
             peer_pubkey,
+            session_id,
+            sync_id,
             gossip_actor,
-            chain_actor,
-            chain_client,
             store,
             cursor,
         ))
@@ -897,88 +901,73 @@ where
                     // Stop the timeout notification.
                     handle.abort();
                     let messages = result.messages;
-                    let mut retry_cursor_later = false;
                     // If we are receiving an empty response, then the syncing process is finished.
-                    match messages.last() {
-                        Some(last_message) => {
-                            // We need the message timestamp to construct a valid cursor.
-                            match get_message_cursor(
-                                last_message,
-                                &state.store.store,
-                                &state.chain_actor,
-                                &state.chain_client,
-                            )
-                            .await
-                            {
-                                Ok(cursor) => {
-                                    state.cursor = cursor;
-                                }
-                                Err(Error::DeferredChannelAnnouncementVerification(
-                                    outpoint,
-                                    reason,
-                                )) => {
-                                    warn!(
-                                        peer = format!("{:?}", &state.peer_pubkey),
-                                        outpoint = format!("{:?}", outpoint),
-                                        reason,
-                                        "Deferring active sync cursor advancement until channel announcement can be verified locally"
-                                    );
-                                    retry_cursor_later = true;
-                                }
-                                Err(error) => {
-                                    warn!(
-                                        "Failed to verify the last message in the response: message {:?}, peer {:?}",
-                                        error, &state.peer_pubkey
-                                    );
-                                    myself.stop(Some(
-                                        "Failed to verify the last message in the response"
-                                            .to_string(),
-                                    ));
-                                    state
-                                        .gossip_actor
-                                        .send_message(GossipActorMessage::MaliciousPeerFound {
-                                            peer: state.peer_pubkey,
-                                            violation: GossipViolation::InvalidSyncResponse,
-                                        })
-                                        .expect("gossip actor alive");
-                                    return Ok(());
-                                }
-                            }
+                    if messages.is_empty() {
+                        state
+                            .gossip_actor
+                            .send_message(GossipActorMessage::ActiveSyncingFinished {
+                                peer: state.peer_pubkey,
+                                session_id: state.session_id,
+                                sync_id: state.sync_id,
+                                cursor: state.cursor.clone(),
+                            })
+                            .expect("gossip actor alive");
+                        myself.stop(Some("Active syncing finished".to_string()));
+                        return Ok(());
+                    }
+
+                    match call!(
+                        &state.store.actor,
+                        ExtendedGossipMessageStoreMessage::SaveActiveSyncMessages,
+                        state.peer_pubkey,
+                        messages
+                    ) {
+                        Ok(ActiveSyncSaveMessagesResult::Validated(cursor)) => {
+                            state.cursor = cursor;
                         }
-                        None => {
+                        Ok(ActiveSyncSaveMessagesResult::Pending) => {
+                            trace!(
+                                "Deferring active sync cursor advancement for peer {:?}",
+                                &state.peer_pubkey
+                            );
+                            std::mem::drop(
+                                myself.send_after(DEFERRED_SYNC_CURSOR_RETRY_DELAY, || {
+                                    GossipSyncingActorMessage::NewGetRequest()
+                                }),
+                            );
+                            return Ok(());
+                        }
+                        Ok(ActiveSyncSaveMessagesResult::Rejected(violation)) => {
+                            warn!(
+                                "Active sync response from peer {:?} rejected: {:?}",
+                                &state.peer_pubkey, violation
+                            );
+                            myself.stop(Some("Rejected active sync response".to_string()));
+                            return Ok(());
+                        }
+                        Err(error) => {
+                            warn!(
+                                "Failed to save active sync messages from peer {:?}: {:?}",
+                                &state.peer_pubkey, error
+                            );
                             state
                                 .gossip_actor
-                                .send_message(GossipActorMessage::ActiveSyncingFinished(
-                                    state.peer_pubkey,
-                                    state.cursor.clone(),
-                                ))
+                                .send_message(GossipActorMessage::MaliciousPeerFound {
+                                    peer: state.peer_pubkey,
+                                    violation: GossipViolation::InvalidSyncResponse,
+                                })
                                 .expect("gossip actor alive");
-                            myself.stop(Some("Active syncing finished".to_string()));
+                            myself.stop(Some("Failed to save active sync messages".to_string()));
                             return Ok(());
                         }
                     }
-
-                    state
-                        .store
-                        .actor
-                        .send_message(ExtendedGossipMessageStoreMessage::SaveMessages(
-                            state.peer_pubkey,
-                            messages,
-                        ))
-                        .expect("store actor alive");
                     trace!(
                         "Sending new GetBroadcastMessages request after receiving response: pubkey {:?}",
                         &state.peer_pubkey
                     );
-                    if retry_cursor_later {
-                        std::mem::drop(myself.send_after(DEFERRED_SYNC_CURSOR_RETRY_DELAY, || {
-                            GossipSyncingActorMessage::NewGetRequest()
-                        }));
-                    } else {
-                        myself
-                            .send_message(GossipSyncingActorMessage::NewGetRequest())
-                            .expect("gossip syncing actor alive");
-                    }
+                    myself
+                        .send_message(GossipSyncingActorMessage::NewGetRequest())
+                        .expect("gossip syncing actor alive");
                 } else {
                     warn!(
                         "Received GetBroadcastMessages response from peer {:?} with unknown request id: {:?}",
@@ -1157,20 +1146,37 @@ where
 // BroadcastMessageFilter to enough number of peers to passively receive
 // updates.
 #[derive(Debug)]
+struct ActiveSyncSession {
+    session_id: SessionId,
+    sync_id: u64,
+    actor: ActorRef<GossipSyncingActorMessage>,
+    started_at_ms: u64,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct FinishedActiveSyncSession {
+    session_id: SessionId,
+    sync_id: u64,
+    finished_at_ms: u64,
+    cursor: Cursor,
+}
+
+#[derive(Debug)]
 #[allow(dead_code)]
 enum PeerSyncStatus {
     // We are not syncing with the peer.
     NotSyncing(),
     // We are actively sending GetBroadcastMessages to the peer.
     // The actor here is responsible to get syncing process running.
-    ActiveGet(ActorRef<GossipSyncingActorMessage>),
+    ActiveGet(ActiveSyncSession),
     // We are only passively receiving messages from the peer.
     // The cursor here is the filter that we sent to the peer.
     PassiveFilter(Cursor),
     // We have finished syncing with the peer. The cursor here is the latest cursor
     // that we have received from the peer. The u64 here is the timestamp
     // of the finishing syncing time.
-    FinishedActiveSyncing(u64, Cursor),
+    FinishedActiveSyncing(FinishedActiveSyncSession),
 }
 
 impl PeerSyncStatus {
@@ -1183,7 +1189,7 @@ impl PeerSyncStatus {
     }
 
     fn is_finished_active_syncing(&self) -> bool {
-        matches!(self, PeerSyncStatus::FinishedActiveSyncing(_, _))
+        matches!(self, PeerSyncStatus::FinishedActiveSyncing(_))
     }
 
     fn can_start_active_syncing(&self) -> bool {
@@ -1223,8 +1229,8 @@ impl Drop for PeerState {
                 .actor
                 .stop(Some("peer state dropped".to_string()));
         }
-        if let PeerSyncStatus::ActiveGet(actor) = &self.sync_status {
-            actor.stop(Some("peer state dropped".to_string()));
+        if let PeerSyncStatus::ActiveGet(session) = &self.sync_status {
+            session.actor.stop(Some("peer state dropped".to_string()));
         }
     }
 }
@@ -1469,6 +1475,13 @@ enum InsertMessageStatus {
     Inserted,
     InsertedDuplicate,
     Duplicate,
+}
+
+#[derive(Debug)]
+pub(crate) enum ActiveSyncSaveMessagesResult {
+    Validated(Cursor),
+    Pending,
+    Rejected(GossipViolation),
 }
 
 pub struct ExtendedGossipMessageStoreState<S, C> {
@@ -1815,16 +1828,6 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
             .iter()
             .any(|(peer, messages)| peer != pubkey && messages.contains(message));
 
-        if let Some(existing_message) = get_existing_newer_broadcast_message(message, &self.store) {
-            if &BroadcastMessage::from(existing_message.clone()) != message {
-                return Err(GossipMessageProcessingError::NewerMessageSaved(
-                    existing_message,
-                ));
-            } else {
-                return Ok(InsertMessageStatus::Duplicate);
-            }
-        }
-
         if let Some(timestamp) = message.timestamp() {
             let max_acceptable_gossip_message_timestamp = max_acceptable_gossip_message_timestamp();
             if timestamp > max_acceptable_gossip_message_timestamp {
@@ -1832,6 +1835,16 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
                     timestamp,
                     max_acceptable_gossip_message_timestamp,
                 ));
+            }
+        }
+
+        if let Some(existing_message) = get_existing_newer_broadcast_message(message, &self.store) {
+            if &BroadcastMessage::from(existing_message.clone()) != message {
+                return Err(GossipMessageProcessingError::NewerMessageSaved(
+                    existing_message,
+                ));
+            } else {
+                return Ok(InsertMessageStatus::Duplicate);
             }
         }
 
@@ -1879,6 +1892,164 @@ impl<S: GossipMessageStore, C: CkbChainClient> ExtendedGossipMessageStoreState<S
             InsertMessageStatus::InsertedDuplicate
         } else {
             InsertMessageStatus::Inserted
+        })
+    }
+
+    fn cursor_for_known_message(&self, message: &BroadcastMessage) -> Option<Cursor> {
+        match message {
+            BroadcastMessage::ChannelAnnouncement(channel_announcement) => self
+                .store
+                .get_latest_channel_announcement(&channel_announcement.channel_outpoint)
+                .map(|(timestamp, _)| {
+                    Cursor::new(
+                        timestamp,
+                        BroadcastMessageID::ChannelAnnouncement(
+                            channel_announcement.channel_outpoint.clone(),
+                        ),
+                    )
+                }),
+            BroadcastMessage::ChannelUpdate(channel_update) => Some(Cursor::new(
+                channel_update.timestamp,
+                BroadcastMessageID::ChannelUpdate(channel_update.channel_outpoint.clone()),
+            )),
+            BroadcastMessage::NodeAnnouncement(node_announcement) => Some(Cursor::new(
+                node_announcement.timestamp,
+                BroadcastMessageID::NodeAnnouncement(node_announcement.node_id),
+            )),
+        }
+    }
+
+    async fn save_active_sync_messages(
+        &mut self,
+        peer: &Pubkey,
+        messages: Vec<BroadcastMessage>,
+    ) -> ActiveSyncSaveMessagesResult {
+        let mut verified_messages = Vec::new();
+        let mut result = None;
+        let mut latest_validated_cursor = None;
+        let now_ms = now_timestamp_as_millis_u64();
+
+        for message in messages {
+            if !self.allow_inbound_remote_broadcast_message(peer, &message, now_ms) {
+                result = Some(ActiveSyncSaveMessagesResult::Pending);
+                break;
+            }
+
+            match self.insert_message_to_be_saved_list(peer, &message).await {
+                Ok(InsertMessageStatus::Inserted) => {}
+                Ok(InsertMessageStatus::InsertedDuplicate) => {
+                    observe_duplicate_broadcast_message();
+                }
+                Ok(InsertMessageStatus::Duplicate) => {
+                    observe_duplicate_broadcast_message();
+                    match get_existing_broadcast_message(&message, &self.store) {
+                        Some(_) => {
+                            latest_validated_cursor = self.cursor_for_known_message(&message);
+                            continue;
+                        }
+                        None => {
+                            result = Some(ActiveSyncSaveMessagesResult::Pending);
+                            break;
+                        }
+                    }
+                }
+                Err(error @ GossipMessageProcessingError::NewerMessageSaved(_)) => {
+                    observe_rejected_broadcast_message(error.rejected_broadcast_metrics_reason());
+                    trace!("Failed to save message: {:?}, error: {:?}", message, error);
+                    latest_validated_cursor = self.cursor_for_known_message(&message);
+                    continue;
+                }
+                Err(error) => {
+                    observe_rejected_broadcast_message(error.rejected_broadcast_metrics_reason());
+                    trace!("Failed to save message: {:?}, error: {:?}", message, error);
+                    if let Some(violation) = error.violation() {
+                        self.gossip_actor
+                            .send_message(GossipActorMessage::MaliciousPeerFound {
+                                peer: *peer,
+                                violation,
+                            })
+                            .expect("gossip actor alive");
+                        result = Some(ActiveSyncSaveMessagesResult::Rejected(violation));
+                    } else {
+                        result = Some(ActiveSyncSaveMessagesResult::Pending);
+                    }
+                    break;
+                }
+            }
+
+            if !self.has_dependencies_available(&message) {
+                observe_missing_dependency_message(broadcast_message_type(&message));
+                result = Some(ActiveSyncSaveMessagesResult::Pending);
+                break;
+            }
+            if self.should_defer_message_verification(&message) {
+                result = Some(ActiveSyncSaveMessagesResult::Pending);
+                break;
+            }
+
+            match verify_and_save_broadcast_message(
+                &message,
+                &self.store,
+                &self.chain_actor,
+                &self.chain_client,
+            )
+            .await
+            {
+                Ok((verified_message, is_newly_applied)) => {
+                    self.remove_pending_message(&message, &[*peer]);
+                    latest_validated_cursor = Some(verified_message.cursor());
+                    if is_newly_applied {
+                        self.latest_remote_broadcast_timestamp
+                            .fetch_max(verified_message.cursor().timestamp, Ordering::AcqRel);
+                        observe_applied_broadcast_message();
+                        observe_applied_propagation_latency(&verified_message);
+                    } else {
+                        observe_duplicate_broadcast_message();
+                    }
+                    verified_messages.push(verified_message);
+                }
+                Err(
+                    error @ VerifyBroadcastMessageError::DeferredChannelAnnouncementVerification(
+                        _,
+                        _,
+                    ),
+                ) => {
+                    trace!(
+                        "Deferring active sync message verification for {:?}: {:?}",
+                        message,
+                        error
+                    );
+                    result = Some(ActiveSyncSaveMessagesResult::Pending);
+                    break;
+                }
+                Err(error) => {
+                    self.remove_pending_message(&message, &[*peer]);
+                    observe_rejected_broadcast_message(error.rejected_broadcast_metrics_reason());
+                    trace!(
+                        "Failed to verify and save message {:?}: {:?}",
+                        message,
+                        error
+                    );
+                    let violation =
+                        classify_verify_and_save_broadcast_message_error(&message, &error)
+                            .unwrap_or(GossipViolation::InvalidBroadcastMessage);
+                    self.gossip_actor
+                        .send_message(GossipActorMessage::MaliciousPeerFound {
+                            peer: *peer,
+                            violation,
+                        })
+                        .expect("gossip actor alive");
+                    result = Some(ActiveSyncSaveMessagesResult::Rejected(violation));
+                    break;
+                }
+            }
+        }
+
+        self.broadcast_messages(&verified_messages);
+        result.unwrap_or_else(|| {
+            latest_validated_cursor
+                .map(ActiveSyncSaveMessagesResult::Validated)
+                .unwrap_or(ActiveSyncSaveMessagesResult::Pending)
         })
     }
 
@@ -2165,6 +2336,11 @@ impl<S: GossipMessageStore + Send + Sync + 'static, C: CkbChainClient + Send + S
                 }
             }
 
+            ExtendedGossipMessageStoreMessage::SaveActiveSyncMessages(peer, messages, reply) => {
+                let result = state.save_active_sync_messages(&peer, messages).await;
+                let _ = reply.send(result);
+            }
+
             ExtendedGossipMessageStoreMessage::SaveAndBroadcastMessages(messages) => {
                 state.store_and_broadcast_messages(&messages);
             }
@@ -2207,7 +2383,7 @@ pub struct QueryResult {
 }
 
 #[derive(AsRefStr)]
-pub enum ExtendedGossipMessageStoreMessage {
+pub(crate) enum ExtendedGossipMessageStoreMessage {
     // A new subscription for gossip message updates. We will send a batch of messages to the subscriber
     // via the returned output port.
     NewSubscription(
@@ -2224,6 +2400,13 @@ pub enum ExtendedGossipMessageStoreMessage {
     // Save new broadcast messages to the store. The messages will be first saved to the memory,
     // then if all the dependencies are met, they are periodically saved to the store and sent to the subscribers.
     SaveMessages(Pubkey, Vec<BroadcastMessage>),
+    // Save messages received during active sync and reply with cursor advancement only after
+    // the last message in the batch is validated or already known locally.
+    SaveActiveSyncMessages(
+        Pubkey,
+        Vec<BroadcastMessage>,
+        RpcReplyPort<ActiveSyncSaveMessagesResult>,
+    ),
     // Save new messages to the store, and broadcast them to the subscribers immediately.
     // These messages will not be saved to the memory and wait for the dependencies to be met.
     // We normally use this variant to send our own messages to the subscribers.
@@ -2238,16 +2421,12 @@ pub enum ExtendedGossipMessageStoreMessage {
     Tick,
 }
 
-pub(crate) struct GossipActorState<S, C> {
+pub(crate) struct GossipActorState<S> {
     store: ExtendedGossipMessageStore<S>,
     control: Option<ServiceAsyncControl>,
     network_actor: Option<ActorRef<NetworkActorMessage>>,
     peer_channel_index: PeerChannelIndex,
     policy: GossipPolicyState,
-    // The number of active syncing peers that we have finished syncing with.
-    // Together with the number of current active syncing peers, this is
-    // used to determine if we should start a new active syncing peer.
-    num_finished_active_syncing_peers: usize,
     // The number of targeted active syncing peers that we want to have.
     // Currently we will only start this many active syncing peers.
     num_targeted_active_syncing_peers: usize,
@@ -2257,25 +2436,29 @@ pub(crate) struct GossipActorState<S, C> {
     // not isolated from the network.
     num_targeted_outbound_passive_syncing_peers: usize,
     next_request_id: u64,
+    next_active_sync_id: u64,
     myself: ActorRef<GossipActorMessage>,
-    chain_actor: ActorRef<CkbChainMessage>,
-    chain_client: C,
     delayed_outbound_messages: DelayedGossipMessageQueue,
     next_delayed_flush_at_ms: Option<u64>,
     query_reply_ports:
         HashMap<(Pubkey, u64), RpcReplyPort<Result<QueryBroadcastMessagesResult, GossipError>>>,
     peer_states: HashMap<Pubkey, PeerState>,
     latest_remote_broadcast_timestamp: Arc<AtomicU64>,
-    active_sync_started_at: HashMap<Pubkey, u64>,
 }
 
-impl<S, C> GossipActorState<S, C>
+impl<S> GossipActorState<S>
 where
     S: GossipMessageStore + Clone + Send + Sync + 'static,
-    C: CkbChainClient + Clone + Send + Sync + 'static,
 {
     fn is_ready_for_passive_syncing(&self) -> bool {
-        self.num_finished_active_syncing_peers > 0
+        self.num_of_finished_active_syncing_peers() > 0
+    }
+
+    fn num_of_finished_active_syncing_peers(&self) -> usize {
+        self.peer_states
+            .values()
+            .filter(|state| state.sync_status.is_finished_active_syncing())
+            .count()
     }
 
     fn num_of_active_syncing_peers(&self) -> usize {
@@ -2312,7 +2495,7 @@ where
 
     fn peers_to_start_active_syncing(&self) -> Vec<Pubkey> {
         match self.num_targeted_active_syncing_peers.checked_sub(
-            self.num_finished_active_syncing_peers + self.num_of_active_syncing_peers(),
+            self.num_of_finished_active_syncing_peers() + self.num_of_active_syncing_peers(),
         ) {
             None => vec![],
             Some(num) => self
@@ -2376,18 +2559,23 @@ where
     async fn start_new_active_syncer(&mut self, pubkey: &Pubkey) {
         let safe_cursor = self.get_safe_cursor_to_start_syncing();
         let started_at = now_timestamp_as_millis_u64();
+        let session_id = self
+            .get_peer_session(pubkey)
+            .expect("start active sync for connected peer");
+        let sync_id = self.next_active_sync_id;
+        self.next_active_sync_id += 1;
         let sync_actor = Actor::spawn_linked(
             Some(format!(
                 "gossip syncing actor to peer {:?} supervised by {:?}",
                 pubkey,
                 self.myself.get_id()
             )),
-            GossipSyncingActor::new(),
+            GossipSyncingActor::<S>::new(),
             (
                 *pubkey,
+                session_id,
+                sync_id,
                 self.myself.clone(),
-                self.chain_actor.clone(),
-                self.chain_client.clone(),
                 self.store.clone(),
                 safe_cursor,
             ),
@@ -2399,8 +2587,12 @@ where
         self.peer_states
             .get_mut(pubkey)
             .expect("get peer state")
-            .change_sync_status(PeerSyncStatus::ActiveGet(sync_actor.0));
-        self.active_sync_started_at.insert(*pubkey, started_at);
+            .change_sync_status(PeerSyncStatus::ActiveGet(ActiveSyncSession {
+                session_id,
+                sync_id,
+                actor: sync_actor.0,
+                started_at_ms: started_at,
+            }));
         observe_active_sync_started();
     }
 
@@ -2755,35 +2947,6 @@ pub(crate) struct GossipProtocolHandle {
     sender: Option<oneshot::Sender<ServiceAsyncControl>>,
 }
 
-async fn get_message_cursor<S: GossipMessageStore>(
-    message: &BroadcastMessage,
-    store: &S,
-    chain: &ActorRef<CkbChainMessage>,
-    client: &impl CkbChainClient,
-) -> Result<Cursor, Error> {
-    match message {
-        BroadcastMessage::ChannelAnnouncement(channel_announcement) => {
-            let timestamp =
-                get_channel_timestamp(&channel_announcement.channel_outpoint, store, chain, client)
-                    .await?;
-            Ok(Cursor::new(
-                timestamp,
-                BroadcastMessageID::ChannelAnnouncement(
-                    channel_announcement.channel_outpoint.clone(),
-                ),
-            ))
-        }
-        BroadcastMessage::ChannelUpdate(channel_update) => Ok(Cursor::new(
-            channel_update.timestamp,
-            BroadcastMessageID::ChannelUpdate(channel_update.channel_outpoint.clone()),
-        )),
-        BroadcastMessage::NodeAnnouncement(node_announcement) => Ok(Cursor::new(
-            node_announcement.timestamp,
-            BroadcastMessageID::NodeAnnouncement(node_announcement.node_id),
-        )),
-    }
-}
-
 fn get_existing_broadcast_message<S: GossipMessageStore>(
     message: &BroadcastMessage,
     store: &S,
@@ -2923,23 +3086,6 @@ async fn get_channel_tx(
             ),
         ),
     }
-}
-
-async fn get_channel_timestamp<S: GossipMessageStore>(
-    outpoint: &OutPoint,
-    store: &S,
-    chain: &ActorRef<CkbChainMessage>,
-    client: &impl CkbChainClient,
-) -> Result<u64, Error> {
-    if let Some((timestamp, _)) = store.get_latest_channel_announcement(outpoint) {
-        return Ok(timestamp);
-    }
-
-    let on_chain_info = get_channel_on_chain_info(outpoint, chain, client)
-        .await
-        .map_err(Error::from)?;
-
-    Ok(on_chain_info.timestamp)
 }
 
 async fn get_channel_on_chain_info(
@@ -3264,7 +3410,7 @@ where
     C: CkbChainClient + Clone + Send + Sync + 'static,
 {
     type Msg = GossipActorMessage;
-    type State = GossipActorState<S, C>;
+    type State = GossipActorState<S>;
     type Arguments = (
         Option<Pubkey>,
         oneshot::Receiver<ServiceAsyncControl>,
@@ -3362,16 +3508,13 @@ where
             num_targeted_active_syncing_peers,
             num_targeted_outbound_passive_syncing_peers,
             myself,
-            chain_actor,
-            chain_client,
             next_request_id: Default::default(),
+            next_active_sync_id: Default::default(),
             delayed_outbound_messages,
             next_delayed_flush_at_ms: Default::default(),
             query_reply_ports: Default::default(),
-            num_finished_active_syncing_peers: Default::default(),
             peer_states: Default::default(),
             latest_remote_broadcast_timestamp,
-            active_sync_started_at: Default::default(),
         };
         Ok(state)
     }
@@ -3444,7 +3587,6 @@ where
             }
             GossipActorMessage::PeerDisconnected(pubkey, _session) => {
                 state.peer_states.remove(&pubkey);
-                state.active_sync_started_at.remove(&pubkey);
                 state.drop_delayed_outbound_messages_for_peer(
                     &pubkey,
                     now_timestamp_as_millis_u64(),
@@ -3500,7 +3642,7 @@ where
                 trace!(
                     "Gossip network maintenance ticked, current state: num of peers: {}, num of finished syncing peers: {}, num of active syncing peers: {}, num of passive syncing peers: {}",
                     state.peer_states.len(),
-                    state.num_finished_active_syncing_peers,
+                    state.num_of_finished_active_syncing_peers(),
                     state.num_of_active_syncing_peers(),
                     state.num_of_passive_syncing_peers(),
                 );
@@ -3542,19 +3684,35 @@ where
                 }
             }
 
-            GossipActorMessage::ActiveSyncingFinished(pubkey, cursor) => {
-                state.num_finished_active_syncing_peers += 1;
-                if let Some(started_at) = state.active_sync_started_at.remove(&pubkey) {
-                    let now = now_timestamp_as_millis_u64();
-                    observe_active_sync_completion(now.saturating_sub(started_at));
+            GossipActorMessage::ActiveSyncingFinished {
+                peer,
+                session_id,
+                sync_id,
+                cursor,
+            } => {
+                let Some(peer_state) = state.peer_states.get_mut(&peer) else {
+                    return Ok(());
+                };
+                let PeerSyncStatus::ActiveGet(active_session) = &peer_state.sync_status else {
+                    return Ok(());
+                };
+                if peer_state.session_id != session_id
+                    || active_session.session_id != session_id
+                    || active_session.sync_id != sync_id
+                {
+                    return Ok(());
                 }
+                let now = now_timestamp_as_millis_u64();
+                observe_active_sync_completion(now.saturating_sub(active_session.started_at_ms));
                 observe_active_sync_finished();
-                if let Some(peer_state) = state.peer_states.get_mut(&pubkey) {
-                    peer_state.change_sync_status(PeerSyncStatus::FinishedActiveSyncing(
-                        now_timestamp_as_millis_u64(),
+                peer_state.change_sync_status(PeerSyncStatus::FinishedActiveSyncing(
+                    FinishedActiveSyncSession {
+                        session_id,
+                        sync_id,
+                        finished_at_ms: now,
                         cursor,
-                    ));
-                }
+                    },
+                ));
             }
 
             GossipActorMessage::MaliciousPeerFound { peer, violation } => {
@@ -3646,12 +3804,13 @@ where
                     );
                     let peer_state = state.peer_states.get(&pubkey);
                     if let Some(PeerState {
-                        sync_status: PeerSyncStatus::ActiveGet(actor),
+                        sync_status: PeerSyncStatus::ActiveGet(active_session),
                         ..
                     }) = peer_state
                     {
-                        let _ =
-                            actor.send_message(GossipSyncingActorMessage::ResponseReceived(result));
+                        let _ = active_session
+                            .actor
+                            .send_message(GossipSyncingActorMessage::ResponseReceived(result));
                     } else {
                         warn!(
                             "Received GetBroadcastMessagesResult from peer {:?} in state {:?}",

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -107,6 +107,10 @@ const MAX_NUM_CONCURRENT_QUERY_TASKS: usize = 10;
 const QUERY_BROADCAST_MESSAGES_TIMEOUT: Duration = Duration::from_secs(20);
 const UPDATE_PEER_FILTER_RETRY_DELAY: Duration = Duration::from_millis(500);
 const DEFERRED_SYNC_CURSOR_RETRY_DELAY: Duration = Duration::from_millis(500);
+#[cfg(test)]
+const ACTIVE_SYNC_FAILURE_RETRY_DELAY: Duration = Duration::from_millis(200);
+#[cfg(not(test))]
+const ACTIVE_SYNC_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(10);
 const GOSSIP_INGRESS_PASSIVE: &str = "passive";
 const GOSSIP_INGRESS_ACTIVE_GET: &str = "active_get";
 const GOSSIP_INGRESS_QUERY: &str = "query";
@@ -435,6 +439,12 @@ pub(crate) enum GossipActorMessage {
         session_id: SessionId,
         sync_id: u64,
         cursor: Cursor,
+    },
+    // The active syncing process stopped before completion for a peer.
+    ActiveSyncingAborted {
+        peer: Pubkey,
+        session_id: SessionId,
+        sync_id: u64,
     },
 
     // A malicious peer is found during gossip validation or policy checks.
@@ -942,6 +952,14 @@ where
                                 "Active sync response from peer {:?} rejected: {:?}",
                                 &state.peer_pubkey, violation
                             );
+                            state
+                                .gossip_actor
+                                .send_message(GossipActorMessage::ActiveSyncingAborted {
+                                    peer: state.peer_pubkey,
+                                    session_id: state.session_id,
+                                    sync_id: state.sync_id,
+                                })
+                                .expect("gossip actor alive");
                             myself.stop(Some("Rejected active sync response".to_string()));
                             return Ok(());
                         }
@@ -955,6 +973,14 @@ where
                                 .send_message(GossipActorMessage::MaliciousPeerFound {
                                     peer: state.peer_pubkey,
                                     violation: GossipViolation::InvalidSyncResponse,
+                                })
+                                .expect("gossip actor alive");
+                            state
+                                .gossip_actor
+                                .send_message(GossipActorMessage::ActiveSyncingAborted {
+                                    peer: state.peer_pubkey,
+                                    session_id: state.session_id,
+                                    sync_id: state.sync_id,
                                 })
                                 .expect("gossip actor alive");
                             myself.stop(Some("Failed to save active sync messages".to_string()));
@@ -1177,6 +1203,8 @@ enum PeerSyncStatus {
     // that we have received from the peer. The u64 here is the timestamp
     // of the finishing syncing time.
     FinishedActiveSyncing(FinishedActiveSyncSession),
+    // We attempted active syncing with the peer, but the sync actor failed before completion.
+    FailedActiveSyncing(u64),
 }
 
 impl PeerSyncStatus {
@@ -1192,10 +1220,14 @@ impl PeerSyncStatus {
         matches!(self, PeerSyncStatus::FinishedActiveSyncing(_))
     }
 
-    fn can_start_active_syncing(&self) -> bool {
-        !self.is_active_syncing()
-            && !self.is_passive_syncing()
-            && !self.is_finished_active_syncing()
+    fn can_start_active_syncing(&self, now_ms: u64) -> bool {
+        match self {
+            PeerSyncStatus::NotSyncing() => true,
+            PeerSyncStatus::FailedActiveSyncing(retry_after_ms) => now_ms >= *retry_after_ms,
+            PeerSyncStatus::ActiveGet(_)
+            | PeerSyncStatus::PassiveFilter(_)
+            | PeerSyncStatus::FinishedActiveSyncing(_) => false,
+        }
     }
 
     fn can_start_passive_syncing(&self) -> bool {
@@ -2494,6 +2526,7 @@ where
     }
 
     fn peers_to_start_active_syncing(&self) -> Vec<Pubkey> {
+        let now_ms = now_timestamp_as_millis_u64();
         match self.num_targeted_active_syncing_peers.checked_sub(
             self.num_of_finished_active_syncing_peers() + self.num_of_active_syncing_peers(),
         ) {
@@ -2501,7 +2534,7 @@ where
             Some(num) => self
                 .peer_states
                 .iter()
-                .filter(|(_, state)| state.sync_status.can_start_active_syncing())
+                .filter(|(_, state)| state.sync_status.can_start_active_syncing(now_ms))
                 .take(num)
                 .map(|(pubkey, _)| pubkey)
                 .cloned()
@@ -3713,6 +3746,32 @@ where
                         cursor,
                     },
                 ));
+            }
+
+            GossipActorMessage::ActiveSyncingAborted {
+                peer,
+                session_id,
+                sync_id,
+            } => {
+                let Some(peer_state) = state.peer_states.get_mut(&peer) else {
+                    return Ok(());
+                };
+                let PeerSyncStatus::ActiveGet(active_session) = &peer_state.sync_status else {
+                    return Ok(());
+                };
+                if peer_state.session_id != session_id
+                    || active_session.session_id != session_id
+                    || active_session.sync_id != sync_id
+                {
+                    return Ok(());
+                }
+                let retry_after_ms = now_timestamp_as_millis_u64()
+                    .saturating_add(ACTIVE_SYNC_FAILURE_RETRY_DELAY.as_millis() as u64);
+                peer_state.change_sync_status(PeerSyncStatus::FailedActiveSyncing(retry_after_ms));
+                myself.send_message(GossipActorMessage::TickNetworkMaintenance)?;
+                std::mem::drop(myself.send_after(ACTIVE_SYNC_FAILURE_RETRY_DELAY, || {
+                    GossipActorMessage::TickNetworkMaintenance
+                }));
             }
 
             GossipActorMessage::MaliciousPeerFound { peer, violation } => {

--- a/crates/fiber-lib/src/fiber/tests/gossip.rs
+++ b/crates/fiber-lib/src/fiber/tests/gossip.rs
@@ -6,7 +6,7 @@ use ckb_types::{
     prelude::{Builder, Entity, Unpack},
 };
 use molecule::prelude::Byte;
-use ractor::{concurrency::Duration, Actor, ActorProcessingErr, ActorRef};
+use ractor::{call, concurrency::Duration, Actor, ActorProcessingErr, ActorRef};
 use tokio::sync::RwLock;
 
 use crate::tests::test_utils::{
@@ -31,8 +31,8 @@ use crate::{
     ckb::{tests::test_utils::submit_tx, CkbChainMessage},
     fiber::{
         gossip::{
-            ExtendedGossipMessageStoreMessage, GossipMessageStore, GossipMessageUpdates,
-            SubscribableGossipMessageStore,
+            ActiveSyncSaveMessagesResult, ExtendedGossipMessageStoreMessage, GossipMessageStore,
+            GossipMessageUpdates, SubscribableGossipMessageStore,
         },
         types::{BroadcastMessage, BroadcastMessageWithTimestamp, Cursor},
     },
@@ -586,6 +586,30 @@ async fn test_saving_channel_update_independency() {
             test(node1_has_invalid_signature, node2_has_invalid_signature).await;
         }
     }
+}
+
+#[tokio::test]
+async fn test_active_sync_rejects_future_timestamp_without_saving() {
+    let context = GossipTestingContext::new().await;
+    let peer = crate::gen_rand_fiber_public_key();
+    let (_, mut announcement) = gen_rand_node_announcement();
+    announcement.timestamp = now_timestamp_as_millis_u64() + 120_000;
+
+    let result = call!(
+        context.get_extended_actor(),
+        ExtendedGossipMessageStoreMessage::SaveActiveSyncMessages,
+        peer,
+        vec![BroadcastMessage::NodeAnnouncement(announcement.clone())]
+    )
+    .expect("store actor alive");
+
+    assert!(matches!(result, ActiveSyncSaveMessagesResult::Rejected(_)));
+    assert_eq!(
+        context
+            .get_store()
+            .get_latest_node_announcement(&announcement.node_id),
+        None
+    );
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -118,6 +118,16 @@ fn create_fake_channel_announcement_message(
 }
 
 fn create_node_announcement_message_with_priv_key(priv_key: &Privkey) -> NodeAnnouncement {
+    create_node_announcement_message_with_priv_key_and_timestamp(
+        priv_key,
+        now_timestamp_as_millis_u64(),
+    )
+}
+
+fn create_node_announcement_message_with_priv_key_and_timestamp(
+    priv_key: &Privkey,
+    timestamp: u64,
+) -> NodeAnnouncement {
     let node_name = "fake node";
     let expected_peer_id =
         PeerId::from_public_key(&crate::fiber::types::pubkey_to_tentacle(priv_key.pubkey()));
@@ -130,7 +140,7 @@ fn create_node_announcement_message_with_priv_key(priv_key: &Privkey) -> NodeAnn
         addresses,
         priv_key,
         get_chain_hash(),
-        now_timestamp_as_millis_u64(),
+        timestamp,
         0,
         Default::default(),
         env!("CARGO_PKG_VERSION").to_string(),
@@ -1036,6 +1046,89 @@ async fn test_disconnected_finished_active_sync_peer_releases_budget() {
             .get_latest_node_announcement(&announcement.node_id)
             .is_some(),
         "disconnected active-sync peer must not keep consuming the active sync budget"
+    );
+}
+
+#[tokio::test]
+async fn test_rejected_active_sync_peer_releases_budget_while_connected() {
+    init_tracing();
+
+    const LARGE_INTERVAL_MS: u64 = 3_600_000;
+    let target_one_active_sync_peer = || {
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.gossip_network_maintenance_interval_ms = Some(LARGE_INTERVAL_MS);
+                config.gossip_network_num_targeted_active_syncing_peers = Some(1);
+            })
+            .build()
+    };
+
+    let mut victim = NetworkNode::new_with_config(target_one_active_sync_peer()).await;
+    let mut rejected_peer = NetworkNode::new_with_node_name("rejected-peer").await;
+    let future_sk = gen_rand_fiber_private_key();
+    let future_announcement = create_node_announcement_message_with_priv_key_and_timestamp(
+        &future_sk,
+        now_timestamp_as_millis_u64() + 120_000,
+    );
+    rejected_peer.send_message_to_gossip_actor(GossipActorMessage::TryBroadcastMessages(vec![
+        BroadcastMessageWithTimestamp::NodeAnnouncement(future_announcement),
+    ]));
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    victim.connect_to(&mut rejected_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    let mut honest_peer = NetworkNode::new_with_node_name("honest-peer").await;
+    let (_, announcement) = gen_rand_node_announcement();
+    honest_peer.send_message_to_gossip_actor(GossipActorMessage::TryBroadcastMessages(vec![
+        BroadcastMessageWithTimestamp::NodeAnnouncement(announcement.clone()),
+    ]));
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    victim.connect_to(&mut honest_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    assert!(
+        victim
+            .get_store()
+            .get_latest_node_announcement(&announcement.node_id)
+            .is_some(),
+        "rejected connected active-sync peer must not keep consuming the active sync budget"
+    );
+}
+
+#[tokio::test]
+async fn test_repeated_rejected_active_sync_peer_is_eventually_banned() {
+    init_tracing();
+
+    const LARGE_INTERVAL_MS: u64 = 3_600_000;
+    let target_one_active_sync_peer = || {
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.gossip_network_maintenance_interval_ms = Some(LARGE_INTERVAL_MS);
+                config.gossip_network_num_targeted_active_syncing_peers = Some(1);
+            })
+            .build()
+    };
+
+    let mut victim = NetworkNode::new_with_config(target_one_active_sync_peer()).await;
+    let mut rejected_peer = NetworkNode::new_with_node_name("rejected-peer").await;
+    let future_sk = gen_rand_fiber_private_key();
+    let future_announcement = create_node_announcement_message_with_priv_key_and_timestamp(
+        &future_sk,
+        now_timestamp_as_millis_u64() + 120_000,
+    );
+    rejected_peer.send_message_to_gossip_actor(GossipActorMessage::TryBroadcastMessages(vec![
+        BroadcastMessageWithTimestamp::NodeAnnouncement(future_announcement),
+    ]));
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    victim.connect_to(&mut rejected_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    assert!(
+        list_connected_peers(&victim).await.is_empty(),
+        "peer that repeatedly fails active sync should eventually be banned and disconnected"
     );
 }
 

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -16,7 +16,7 @@ use crate::{
         graph::ChannelUpdateInfo,
         network::{
             select_connect_peer_address, AcceptChannelCommand, DebugEvent, NetworkActorStateStore,
-            OpenChannelCommand,
+            OpenChannelCommand, PeerDisconnectReason,
         },
         payment::{SendPaymentCommand, SendPaymentDataExt},
         types::{
@@ -981,6 +981,62 @@ async fn test_sync_node_announcement_on_startup() {
 
     let node_info = node2.get_network_graph_node(&test_pub_key).await;
     assert!(node_info.is_some());
+}
+
+#[tokio::test]
+async fn test_disconnected_finished_active_sync_peer_releases_budget() {
+    init_tracing();
+
+    const LARGE_INTERVAL_MS: u64 = 3_600_000;
+    let target_one_active_sync_peer = || {
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.gossip_network_maintenance_interval_ms = Some(LARGE_INTERVAL_MS);
+                config.gossip_network_num_targeted_active_syncing_peers = Some(1);
+            })
+            .build()
+    };
+
+    let mut victim = NetworkNode::new_with_config(target_one_active_sync_peer()).await;
+    let mut empty_peer = NetworkNode::new_with_node_name("empty-peer").await;
+
+    victim.connect_to(&mut empty_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    victim
+        .network_actor
+        .send_message(NetworkActorMessage::new_command(
+            NetworkActorCommand::DisconnectPeer(
+                empty_peer.pubkey,
+                PeerDisconnectReason::Requested,
+                None,
+            ),
+        ))
+        .expect("victim alive");
+    empty_peer
+        .expect_event(|event| match event {
+            NetworkServiceEvent::PeerDisConnected(pubkey, _) => pubkey == &victim.pubkey,
+            _ => false,
+        })
+        .await;
+
+    let mut honest_peer = NetworkNode::new_with_node_name("honest-peer").await;
+    let (_, announcement) = gen_rand_node_announcement();
+    honest_peer.send_message_to_gossip_actor(GossipActorMessage::TryBroadcastMessages(vec![
+        BroadcastMessageWithTimestamp::NodeAnnouncement(announcement.clone()),
+    ]));
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    victim.connect_to(&mut honest_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    assert!(
+        victim
+            .get_store()
+            .get_latest_node_announcement(&announcement.node_id)
+            .is_some(),
+        "disconnected active-sync peer must not keep consuming the active sync budget"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fix active gossip sync state accounting so disconnected peers no longer consume the active sync budget, and make active sync cursor advancement depend on store validation instead of trusting the last remote response message.

## Root Cause

Active gossip sync used a monotonic global finished-peer counter. A transient peer could return an empty GetBroadcastMessagesResult, be counted as finished, disconnect, and leave that stale count consuming future active sync slots. Active sync also advanced its per-peer cursor from the last response message before store validation, allowing attacker supplied timestamps to poison sync progress.

## Changes

- Track active sync completion through current peer state instead of a stale global counter.
- Add session_id and sync_id guards to ignore stale completion messages from old sync actors or disconnected/reconnected peers.
- Move active sync cursor advancement behind store validation via SaveActiveSyncMessages.
- Reject future timestamp active sync messages without saving or advancing cursor.
- Add regressions for disconnected finished peers releasing budget and future timestamp active sync rejection.

## Validation

- cargo check -p fnn --tests --features rocksdb
- cargo clippy --all-targets --features rocksdb -p fnn -- -D warnings
- cargo nextest run -p fnn --features rocksdb test_active_sync_rejects_future_timestamp_without_saving
- cargo nextest run -p fnn --features rocksdb test_disconnected_finished_active_sync_peer_releases_budget
- cargo nextest run -p fnn --features rocksdb test_gossip_sync_starts_immediately_on_peer_connect
- cargo nextest run -p fnn --features rocksdb test_sync_node_announcement_on_startup
- cargo fmt --all -- --check
- git diff --check