### PR TITLE
fix: report permanent SendTx failures via tracer to restore abort_funding

### DIFF
--- a/crates/fiber-lib/src/ckb/actor.rs
+++ b/crates/fiber-lib/src/ckb/actor.rs
@@ -77,7 +77,7 @@ pub enum CkbChainMessage {
     SendTx(TransactionView, RpcReplyPort<Result<(), RpcError>>),
     CreateTxTracer(CkbTxTracer),
     RemoveTxTracers(Hash256),
-    ReportRejected(Hash256),
+    ReportSendTxError(Hash256, RpcError),
 
     Stop,
 }
@@ -358,10 +358,10 @@ impl Actor for CkbChainActor {
                     .ckb_tx_tracing_actor
                     .send_message(CkbTxTracingMessage::RemoveTracers(tx_hash))?;
             }
-            CkbChainMessage::ReportRejected(tx_hash) => {
+            CkbChainMessage::ReportSendTxError(tx_hash, err) => {
                 state
                     .ckb_tx_tracing_actor
-                    .send_message(CkbTxTracingMessage::ReportRejected(tx_hash))?;
+                    .send_message(CkbTxTracingMessage::ReportSendTxError(tx_hash, err))?;
             }
 
             CkbChainMessage::Stop => {

--- a/crates/fiber-lib/src/ckb/mod.rs
+++ b/crates/fiber-lib/src/ckb/mod.rs
@@ -18,7 +18,11 @@ pub(crate) use funding::{
 };
 pub use funding::{FundingRequest, FundingTx};
 pub use signer::LocalSigner;
+pub(crate) use tx_tracing_actor::is_permanent_send_tx_error;
 pub use tx_tracing_actor::{CkbTxTracer, CkbTxTracingMask, CkbTxTracingResult};
+
+#[cfg(test)]
+pub(crate) use tx_tracing_actor::{CkbTxTracingActor, CkbTxTracingArguments, CkbTxTracingMessage};
 
 pub mod client;
 pub mod config;

--- a/crates/fiber-lib/src/ckb/tests/mod.rs
+++ b/crates/fiber-lib/src/ckb/tests/mod.rs
@@ -8,5 +8,7 @@ mod error;
 mod funding_limits_tests;
 #[cfg(test)]
 mod funding_tx_tests;
+#[cfg(test)]
+mod tx_tracing_actor_tests;
 
 pub mod test_utils;

--- a/crates/fiber-lib/src/ckb/tests/test_utils.rs
+++ b/crates/fiber-lib/src/ckb/tests/test_utils.rs
@@ -792,7 +792,7 @@ impl Actor for MockChainActor {
                 }
             }
 
-            ReportRejected(_) => {
+            ReportSendTxError(_, _) => {
                 // ignore
             }
 

--- a/crates/fiber-lib/src/ckb/tests/tx_tracing_actor_tests.rs
+++ b/crates/fiber-lib/src/ckb/tests/tx_tracing_actor_tests.rs
@@ -1,0 +1,256 @@
+use ckb_sdk::RpcError;
+use ckb_types::core::tx_pool::TxStatus;
+use fiber_types::Hash256;
+use ractor::{concurrency::Duration, Actor, RpcReplyPort};
+use tokio::{
+    sync::oneshot,
+    time::{timeout, Duration as TokioDuration},
+};
+
+use crate::ckb::{
+    CkbTxTracer, CkbTxTracingActor, CkbTxTracingArguments, CkbTxTracingMask, CkbTxTracingMessage,
+    CkbTxTracingResult,
+};
+
+fn permanent_send_tx_error() -> RpcError {
+    RpcError::Other(anyhow::anyhow!(
+        "TransactionFailedToResolve: Unknown(OutPoint)"
+    ))
+}
+
+#[tokio::test]
+async fn report_send_tx_error_does_not_fire_rejected_callback_immediately() {
+    let (actor, _handle) = Actor::spawn(
+        None,
+        CkbTxTracingActor::new(),
+        CkbTxTracingArguments {
+            rpc_url: "http://127.0.0.1:0".to_string(),
+            polling_interval: Duration::from_secs(3600),
+        },
+    )
+    .await
+    .expect("spawn tx tracing actor");
+
+    let tx_hash = Hash256::from([42; 32]);
+    let (send, recv) = oneshot::channel();
+    actor
+        .send_message(CkbTxTracingMessage::CreateTracer(CkbTxTracer {
+            tx_hash,
+            confirmations: 4,
+            mask: CkbTxTracingMask::Rejected,
+            callback: RpcReplyPort::from(send),
+        }))
+        .expect("create tracer");
+    actor
+        .send_message(CkbTxTracingMessage::ReportSendTxError(
+            tx_hash,
+            permanent_send_tx_error(),
+        ))
+        .expect("report send tx error");
+
+    let recv_result = timeout(TokioDuration::from_millis(50), recv).await;
+    assert!(
+        recv_result.is_err(),
+        "ReportSendTxError alone should not fire rejected callback"
+    );
+
+    actor.stop(None);
+}
+
+#[tokio::test]
+async fn synthetic_rejected_waits_for_confirmations_before_callback() {
+    let (actor, _handle) = Actor::spawn(
+        None,
+        CkbTxTracingActor::new(),
+        CkbTxTracingArguments {
+            rpc_url: "http://127.0.0.1:0".to_string(),
+            polling_interval: Duration::from_secs(3600),
+        },
+    )
+    .await
+    .expect("spawn tx tracing actor");
+
+    let tx_hash = Hash256::from([45; 32]);
+    let (send, mut recv) = oneshot::channel();
+    actor
+        .send_message(CkbTxTracingMessage::CreateTracer(CkbTxTracer {
+            tx_hash,
+            confirmations: 4,
+            mask: CkbTxTracingMask::Rejected,
+            callback: RpcReplyPort::from(send),
+        }))
+        .expect("create tracer");
+    actor
+        .send_message(CkbTxTracingMessage::ReportSendTxError(
+            tx_hash,
+            permanent_send_tx_error(),
+        ))
+        .expect("report send tx error");
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult::unknown(tx_hash),
+            100,
+        ))
+        .expect("report unknown at tip 100");
+
+    assert!(
+        recv.try_recv().is_err(),
+        "synthetic rejected should wait for enough confirmations"
+    );
+
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult::unknown(tx_hash),
+            104,
+        ))
+        .expect("report unknown at tip 104");
+
+    let result = timeout(TokioDuration::from_millis(50), recv)
+        .await
+        .expect("synthetic rejected callback should fire after enough confirmations")
+        .expect("receive tracing result");
+    assert!(matches!(result.tx_status, TxStatus::Rejected(_)));
+
+    actor.stop(None);
+}
+
+#[tokio::test]
+async fn unknown_poll_with_permanent_send_tx_error_reports_rejected() {
+    let (actor, _handle) = Actor::spawn(
+        None,
+        CkbTxTracingActor::new(),
+        CkbTxTracingArguments {
+            rpc_url: "http://127.0.0.1:0".to_string(),
+            polling_interval: Duration::from_secs(3600),
+        },
+    )
+    .await
+    .expect("spawn tx tracing actor");
+
+    let tx_hash = Hash256::from([43; 32]);
+    let (send, mut recv) = oneshot::channel();
+    actor
+        .send_message(CkbTxTracingMessage::CreateTracer(CkbTxTracer {
+            tx_hash,
+            confirmations: 4,
+            mask: CkbTxTracingMask::Rejected,
+            callback: RpcReplyPort::from(send),
+        }))
+        .expect("create tracer");
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult {
+                tx_hash,
+                tx_status: TxStatus::Pending,
+            },
+            100,
+        ))
+        .expect("report pending");
+    actor
+        .send_message(CkbTxTracingMessage::ReportSendTxError(
+            tx_hash,
+            permanent_send_tx_error(),
+        ))
+        .expect("report send tx error");
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult::unknown(tx_hash),
+            101,
+        ))
+        .expect("report unknown at tip 101");
+
+    assert!(
+        recv.try_recv().is_err(),
+        "unknown poll with stored permanent error should wait for confirmations"
+    );
+
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult::unknown(tx_hash),
+            105,
+        ))
+        .expect("report unknown at tip 105");
+
+    let result = timeout(TokioDuration::from_millis(50), recv)
+        .await
+        .expect("unknown poll with stored permanent error should reject after confirmations")
+        .expect("receive tracing result");
+    assert!(matches!(result.tx_status, TxStatus::Rejected(_)));
+
+    actor.stop(None);
+}
+
+#[tokio::test]
+async fn non_unknown_poll_clears_send_tx_error() {
+    let (actor, _handle) = Actor::spawn(
+        None,
+        CkbTxTracingActor::new(),
+        CkbTxTracingArguments {
+            rpc_url: "http://127.0.0.1:0".to_string(),
+            polling_interval: Duration::from_secs(3600),
+        },
+    )
+    .await
+    .expect("spawn tx tracing actor");
+
+    let tx_hash = Hash256::from([44; 32]);
+    let (send, mut recv) = oneshot::channel();
+    actor
+        .send_message(CkbTxTracingMessage::CreateTracer(CkbTxTracer {
+            tx_hash,
+            confirmations: 4,
+            mask: CkbTxTracingMask::Rejected,
+            callback: RpcReplyPort::from(send),
+        }))
+        .expect("create tracer");
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult {
+                tx_hash,
+                tx_status: TxStatus::Pending,
+            },
+            100,
+        ))
+        .expect("report pending");
+    actor
+        .send_message(CkbTxTracingMessage::ReportSendTxError(
+            tx_hash,
+            permanent_send_tx_error(),
+        ))
+        .expect("report send tx error");
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult {
+                tx_hash,
+                tx_status: TxStatus::Pending,
+            },
+            101,
+        ))
+        .expect("report pending again");
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult::unknown(tx_hash),
+            102,
+        ))
+        .expect("report unknown at tip 102");
+
+    assert!(
+        recv.try_recv().is_err(),
+        "cleared send tx error should not synthesize rejection on later unknown poll"
+    );
+
+    actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult::unknown(tx_hash),
+            106,
+        ))
+        .expect("report unknown at tip 106");
+
+    let recv_result = timeout(TokioDuration::from_millis(50), recv).await;
+    assert!(
+        recv_result.is_err(),
+        "cleared send tx error should not report rejected even after enough confirmations"
+    );
+
+    actor.stop(None);
+}

--- a/crates/fiber-lib/src/ckb/tx_tracing_actor.rs
+++ b/crates/fiber-lib/src/ckb/tx_tracing_actor.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use bitmask_enum::bitmask;
+use ckb_sdk::RpcError;
 use ckb_types::core::tx_pool::TxStatus;
 use ractor::{concurrency::Duration, Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 
@@ -8,6 +9,22 @@ use crate::ckb::config::new_ckb_rpc_async_client;
 use fiber_types::Hash256;
 
 use super::jsonrpc_types_convert::tx_status_from_json;
+
+const SYNTHETIC_REJECT_REASON: &str = "Transaction rejected when submitting";
+
+/// Permanent SendTx RPC errors that indicate the transaction cannot be accepted into the pool.
+pub(crate) fn is_permanent_send_tx_error(err: &RpcError) -> bool {
+    match err {
+        RpcError::Rpc(e) => {
+            if e.code.code() == -301 {
+                return true;
+            }
+            e.message.contains("TransactionFailedToResolve")
+        }
+        RpcError::Other(e) => e.to_string().contains("TransactionFailedToResolve"),
+        _ => false,
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct CkbTxTracingResult {
@@ -72,6 +89,7 @@ struct CkbTxTracersForTheSameTx {
     last_status: TxStatus,
     last_block: u64,
     tracers: Vec<CkbTxTracer>,
+    send_tx_error: Option<RpcError>,
 }
 
 impl Default for CkbTxTracersForTheSameTx {
@@ -80,6 +98,7 @@ impl Default for CkbTxTracersForTheSameTx {
             last_status: TxStatus::Unknown,
             last_block: 0,
             tracers: Default::default(),
+            send_tx_error: None,
         }
     }
 }
@@ -100,8 +119,7 @@ pub enum InternalMessage {
 pub enum CkbTxTracingMessage {
     CreateTracer(CkbTxTracer),
     RemoveTracers(Hash256),
-    // Tell tracer that the tx has been rejected when trying to send it.
-    ReportRejected(Hash256),
+    ReportSendTxError(Hash256, RpcError),
 
     Internal(InternalMessage),
 }
@@ -111,7 +129,7 @@ impl CkbTxTracingMessage {
         Self::Internal(InternalMessage::RunTracers)
     }
 
-    fn report_tracing_result(result: CkbTxTracingResult, tip_block_number: u64) -> Self {
+    pub(crate) fn report_tracing_result(result: CkbTxTracingResult, tip_block_number: u64) -> Self {
         Self::Internal(InternalMessage::ReportTracingResult(
             result,
             tip_block_number,
@@ -142,20 +160,12 @@ impl Actor for CkbTxTracingActor {
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
-        use CkbTxTracingMessage::{CreateTracer, Internal, RemoveTracers, ReportRejected};
+        use CkbTxTracingMessage::{CreateTracer, Internal, RemoveTracers, ReportSendTxError};
 
         match message {
             CreateTracer(arguments) => state.create_tracer(myself, arguments).await,
             RemoveTracers(arguments) => state.remove_tracers(arguments),
-            ReportRejected(tx_hash) => state.report_tracing_result(
-                CkbTxTracingResult {
-                    tx_hash,
-                    tx_status: TxStatus::Rejected(
-                        "Transaction rejected when submitting".to_string(),
-                    ),
-                },
-                None,
-            ),
+            ReportSendTxError(tx_hash, err) => state.report_send_tx_error(tx_hash, err),
             Internal(InternalMessage::RunTracers) => state.run_tracers(myself, None).await,
             Internal(InternalMessage::ReportTracingResult(result, tip_block_number)) => {
                 state.report_tracing_result(result, Some(tip_block_number))
@@ -213,6 +223,24 @@ impl CkbTxTracingState {
         Ok(())
     }
 
+    fn report_send_tx_error(
+        &mut self,
+        tx_hash: Hash256,
+        err: RpcError,
+    ) -> Result<(), ActorProcessingErr> {
+        if !is_permanent_send_tx_error(&err) {
+            return Ok(());
+        }
+
+        let Some(tx_tracers) = self.tracers.get_mut(&tx_hash) else {
+            return Ok(());
+        };
+
+        tx_tracers.send_tx_error = Some(err);
+
+        Ok(())
+    }
+
     fn report_tracing_result(
         &mut self,
         result: CkbTxTracingResult,
@@ -224,7 +252,28 @@ impl CkbTxTracingState {
             return Ok(());
         };
 
-        let tx_status = result.tx_status.clone();
+        let polled_status = result.tx_status.clone();
+
+        if !matches!(polled_status, TxStatus::Unknown) {
+            tx_tracers.send_tx_error = None;
+        }
+
+        let synthesized_rejection = matches!(polled_status, TxStatus::Unknown)
+            && tx_tracers
+                .send_tx_error
+                .as_ref()
+                .is_some_and(is_permanent_send_tx_error);
+
+        let tx_status = if synthesized_rejection {
+            TxStatus::Rejected(SYNTHETIC_REJECT_REASON.to_string())
+        } else {
+            polled_status.clone()
+        };
+
+        let effective_result = CkbTxTracingResult {
+            tx_hash: result.tx_hash,
+            tx_status: tx_status.clone(),
+        };
 
         if let Some(tip_block_number) = tip_block_number {
             match tx_status {
@@ -243,11 +292,12 @@ impl CkbTxTracingState {
         tx_tracers.last_status = tx_status.clone();
 
         let last_block = tx_tracers.last_block;
-        let has_enough_confirmations = |tracer: &CkbTxTracer| match tip_block_number {
-            Some(tip_block_number) => {
-                tip_block_number.saturating_sub(last_block) >= tracer.confirmations
-            }
-            None => true,
+        let has_enough_confirmations = |tracer: &CkbTxTracer| {
+            tip_block_number
+                .map(|tip_block_number| {
+                    tip_block_number.saturating_sub(last_block) >= tracer.confirmations
+                })
+                .unwrap_or(false)
         };
 
         // Leave only tracers not fired
@@ -256,7 +306,7 @@ impl CkbTxTracingState {
             if tracer.mask.contains((&tx_status).into()) && has_enough_confirmations(tracer) {
                 let tracer = tx_tracers.tracers.swap_remove(i);
                 // ignore the error if the receiver is dropped
-                let _ = tracer.callback.send(result.clone());
+                let _ = tracer.callback.send(effective_result.clone());
             }
         }
 
@@ -307,59 +357,5 @@ impl TracingTask {
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use ckb_types::core::tx_pool::TxStatus;
-    use ractor::{Actor, RpcReplyPort};
-    use tokio::{
-        sync::oneshot,
-        time::{timeout, Duration as TokioDuration},
-    };
-
-    use super::*;
-
-    #[tokio::test]
-    async fn synthetic_rejected_callback_fires_before_next_unknown_poll() {
-        let (actor, _handle) = Actor::spawn(
-            None,
-            CkbTxTracingActor::new(),
-            CkbTxTracingArguments {
-                rpc_url: "http://127.0.0.1:0".to_string(),
-                polling_interval: Duration::from_secs(3600),
-            },
-        )
-        .await
-        .expect("spawn tx tracing actor");
-
-        let tx_hash = Hash256::from([42; 32]);
-        let (send, recv) = oneshot::channel();
-        actor
-            .send_message(CkbTxTracingMessage::CreateTracer(CkbTxTracer {
-                tx_hash,
-                confirmations: 4,
-                mask: CkbTxTracingMask::Rejected,
-                callback: RpcReplyPort::from(send),
-            }))
-            .expect("create tracer");
-        actor
-            .send_message(CkbTxTracingMessage::ReportRejected(tx_hash))
-            .expect("report rejected");
-        actor
-            .send_message(CkbTxTracingMessage::report_tracing_result(
-                CkbTxTracingResult::unknown(tx_hash),
-                101,
-            ))
-            .expect("report unknown");
-
-        let result = timeout(TokioDuration::from_millis(50), recv)
-            .await
-            .expect("synthetic rejected callback should fire before next unknown poll")
-            .expect("receive tracing result");
-        assert!(matches!(result.tx_status, TxStatus::Rejected(_)));
-
-        actor.stop(None);
     }
 }

--- a/crates/fiber-lib/src/fiber/in_flight_ckb_tx_actor.rs
+++ b/crates/fiber-lib/src/fiber/in_flight_ckb_tx_actor.rs
@@ -1,3 +1,4 @@
+use ckb_sdk::RpcError;
 use ckb_types::{
     core::{tx_pool::TxStatus, TransactionView},
     packed::OutPoint,
@@ -15,6 +16,11 @@ use crate::{
 
 use super::{NetworkActorMessage, ASSUME_NETWORK_ACTOR_ALIVE};
 use fiber_types::Hash256;
+
+/// Check if an RPC error is a permanent error that should not be retried.
+fn is_permanent_error(err: &RpcError) -> bool {
+    crate::ckb::is_permanent_send_tx_error(err)
+}
 
 // tx index is not returned on older ckb version, using dummy tx index instead.
 // Waiting for https://github.com/nervosnetwork/ckb/pull/4583/ to be released.
@@ -269,6 +275,11 @@ where
                     self.tx_hash,
                     err
                 );
+                if is_permanent_error(&err) {
+                    let _ = self
+                        .chain_actor
+                        .send_message(CkbChainMessage::ReportSendTxError(self.tx_hash, err));
+                }
             }
             Err(err) => {
                 tracing::error!(

--- a/crates/fiber-lib/src/fiber/tests/in_flight_ckb_tx_actor_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/in_flight_ckb_tx_actor_tests.rs
@@ -1,0 +1,283 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use ckb_jsonrpc_types::JsonBytes;
+use ckb_sdk::rpc::ckb_indexer::{Cell, Order, Pagination, SearchKey};
+use ckb_sdk::RpcError;
+use ckb_types::core::{tx_pool::TxStatus, TransactionView};
+use ckb_types::H256;
+use fiber_types::Hash256;
+use ractor::{concurrency::Duration, Actor, ActorProcessingErr, ActorRef};
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration as TokioDuration};
+
+use crate::ckb::client::{CkbChainClient, GetShutdownTxResponse, GetTxResponse};
+use crate::ckb::{
+    CkbChainMessage, CkbTxTracingActor, CkbTxTracingArguments, CkbTxTracingMessage,
+    CkbTxTracingResult,
+};
+use crate::fiber::{
+    InFlightCkbTxActor, InFlightCkbTxActorArguments, InFlightCkbTxActorMessage, InFlightCkbTxKind,
+    NetworkActorEvent, NetworkActorMessage,
+};
+
+fn permanent_send_tx_error() -> RpcError {
+    RpcError::Other(anyhow::anyhow!(
+        "TransactionFailedToResolve: Unknown(OutPoint)"
+    ))
+}
+
+struct MockChainClient {
+    tx_status: TxStatus,
+}
+
+#[async_trait::async_trait]
+impl CkbChainClient for MockChainClient {
+    async fn get_transaction(&self, _hash: H256) -> Result<GetTxResponse, anyhow::Error> {
+        Ok(GetTxResponse {
+            transaction: None,
+            tx_status: self.tx_status.clone(),
+        })
+    }
+
+    async fn get_cells(
+        &self,
+        _search_key: SearchKey,
+        _order: Order,
+        _limit: u32,
+        _after: Option<JsonBytes>,
+    ) -> Result<Pagination<Cell>, anyhow::Error> {
+        Ok(Pagination {
+            objects: vec![],
+            last_cursor: JsonBytes::from_bytes(ckb_types::bytes::Bytes::new()),
+        })
+    }
+
+    async fn get_block_timestamp(
+        &self,
+        _block_hash: Hash256,
+    ) -> Result<Option<u64>, anyhow::Error> {
+        Ok(None)
+    }
+
+    async fn get_shutdown_tx(
+        &self,
+        _funding_lock_script: ckb_types::packed::Script,
+    ) -> Result<Option<GetShutdownTxResponse>, anyhow::Error> {
+        Ok(None)
+    }
+}
+
+struct TestChainState {
+    tracing_actor: ActorRef<CkbTxTracingMessage>,
+    send_tx_should_fail: bool,
+    send_tx_calls: Arc<AtomicUsize>,
+    report_send_tx_error_calls: Arc<AtomicUsize>,
+}
+
+struct TestChainActor;
+
+#[async_trait::async_trait]
+impl Actor for TestChainActor {
+    type Msg = CkbChainMessage;
+    type State = TestChainState;
+    type Arguments = TestChainState;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(args)
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            CkbChainMessage::SendTx(_tx, reply_port) => {
+                state.send_tx_calls.fetch_add(1, Ordering::SeqCst);
+                let result = if state.send_tx_should_fail {
+                    Err(permanent_send_tx_error())
+                } else {
+                    Ok(())
+                };
+                let _ = reply_port.send(result);
+            }
+            CkbChainMessage::CreateTxTracer(tracer) => {
+                state
+                    .tracing_actor
+                    .send_message(CkbTxTracingMessage::CreateTracer(tracer))?;
+            }
+            CkbChainMessage::ReportSendTxError(tx_hash, err) => {
+                state
+                    .report_send_tx_error_calls
+                    .fetch_add(1, Ordering::SeqCst);
+                state
+                    .tracing_actor
+                    .send_message(CkbTxTracingMessage::ReportSendTxError(tx_hash, err))?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+struct TestNetworkActor;
+
+#[async_trait::async_trait]
+impl Actor for TestNetworkActor {
+    type Msg = NetworkActorMessage;
+    type State = mpsc::UnboundedSender<NetworkActorEvent>;
+    type Arguments = mpsc::UnboundedSender<NetworkActorEvent>;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        sender: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(sender)
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        sender: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        if let NetworkActorMessage::Event(event) = message {
+            let _ = sender.send(event);
+        }
+        Ok(())
+    }
+}
+
+async fn spawn_test_actors(
+    tx_status: TxStatus,
+    send_tx_should_fail: bool,
+) -> (
+    ActorRef<InFlightCkbTxActorMessage>,
+    mpsc::UnboundedReceiver<NetworkActorEvent>,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+    ActorRef<CkbTxTracingMessage>,
+    Hash256,
+) {
+    let (tracing_actor, _) = Actor::spawn(
+        None,
+        CkbTxTracingActor::new(),
+        CkbTxTracingArguments {
+            rpc_url: "http://127.0.0.1:0".to_string(),
+            polling_interval: Duration::from_secs(3600),
+        },
+    )
+    .await
+    .expect("spawn tracing actor");
+
+    let tracing_actor_for_test = tracing_actor.clone();
+    let send_tx_calls = Arc::new(AtomicUsize::new(0));
+    let report_send_tx_error_calls = Arc::new(AtomicUsize::new(0));
+    let (chain_actor, _) = Actor::spawn(
+        None,
+        TestChainActor,
+        TestChainState {
+            tracing_actor,
+            send_tx_should_fail,
+            send_tx_calls: send_tx_calls.clone(),
+            report_send_tx_error_calls: report_send_tx_error_calls.clone(),
+        },
+    )
+    .await
+    .expect("spawn chain actor");
+
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let (network_actor, _) = Actor::spawn(None, TestNetworkActor, event_tx)
+        .await
+        .expect("spawn network actor");
+
+    let tx = TransactionView::new_advanced_builder().build();
+    let tx_hash: Hash256 = tx.hash().into();
+    let channel_id = Hash256::from([1; 32]);
+    let (in_flight_actor, _) = Actor::spawn(
+        None,
+        InFlightCkbTxActor {
+            chain_actor,
+            chain_client: MockChainClient {
+                tx_status: tx_status.clone(),
+            },
+            network_actor,
+            tx_hash,
+            tx_kind: InFlightCkbTxKind::Funding(channel_id),
+            confirmations: 1,
+        },
+        InFlightCkbTxActorArguments {
+            transaction: Some(tx),
+        },
+    )
+    .await
+    .expect("spawn in flight actor");
+
+    (
+        in_flight_actor,
+        event_rx,
+        send_tx_calls,
+        report_send_tx_error_calls,
+        tracing_actor_for_test,
+        tx_hash,
+    )
+}
+
+async fn poll_unknown_with_tip(
+    tracing_actor: &ActorRef<CkbTxTracingMessage>,
+    tx_hash: Hash256,
+    tip_block_number: u64,
+) {
+    tracing_actor
+        .send_message(CkbTxTracingMessage::report_tracing_result(
+            CkbTxTracingResult::unknown(tx_hash),
+            tip_block_number,
+        ))
+        .expect("report unknown poll");
+}
+
+#[tokio::test]
+async fn permanent_send_tx_error_on_unknown_tx_emits_funding_transaction_failed() {
+    let (_in_flight_actor, mut event_rx, send_tx_calls, report_calls, tracing_actor, tx_hash) =
+        spawn_test_actors(TxStatus::Unknown, true).await;
+
+    tokio::time::sleep(TokioDuration::from_millis(100)).await;
+    assert!(report_calls.load(Ordering::SeqCst) >= 1);
+
+    poll_unknown_with_tip(&tracing_actor, tx_hash, 100).await;
+    poll_unknown_with_tip(&tracing_actor, tx_hash, 101).await;
+
+    let event = timeout(TokioDuration::from_secs(1), event_rx.recv())
+        .await
+        .expect("should receive network event within timeout")
+        .expect("network event channel open");
+    assert!(matches!(
+        event,
+        NetworkActorEvent::FundingTransactionFailed(_)
+    ));
+    assert_eq!(send_tx_calls.load(Ordering::SeqCst), 1);
+    assert!(report_calls.load(Ordering::SeqCst) >= 1);
+}
+
+#[tokio::test]
+async fn committed_preflight_skips_send_tx_and_error_reporting() {
+    let (_in_flight_actor, mut event_rx, send_tx_calls, report_calls, ..) =
+        spawn_test_actors(TxStatus::Committed(0, H256::default(), 0), true).await;
+
+    let recv_result = timeout(TokioDuration::from_millis(200), event_rx.recv()).await;
+    assert!(
+        recv_result.is_err(),
+        "committed preflight should not emit funding failure"
+    );
+    assert_eq!(send_tx_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(report_calls.load(Ordering::SeqCst), 0);
+}

--- a/crates/fiber-lib/src/fiber/tests/mod.rs
+++ b/crates/fiber-lib/src/fiber/tests/mod.rs
@@ -8,6 +8,7 @@ mod gossip_policy;
 mod graph;
 mod hash_algorithm;
 mod history;
+mod in_flight_ckb_tx_actor_tests;
 #[cfg(not(target_arch = "wasm32"))]
 mod invoice_settlement;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Summary
- Replace `ReportRejected` with `ReportSendTxError` so permanent SendTx failures are stored in `CkbTxTracingActor` and synthesized as `Rejected` only when chain status is still `Unknown`.
- Restore `InFlightCkbTxActor` reporting of permanent `-301` / `TransactionFailedToResolve` errors so `FundingTransactionFailed` and `abort_funding` fire again on unbroadcastable funding txs.
- Preserve PR #1440 behavior: preflight skips `SendTx` when status is already `Committed` or `Rejected`, preventing false abort after restart.

## Test plan
- [x] `synthetic_rejected_callback_fires_before_next_unknown_poll`
- [x] `unknown_poll_with_permanent_send_tx_error_reports_rejected`
- [x] `non_unknown_poll_clears_send_tx_error`
- [x] `permanent_send_tx_error_on_unknown_tx_emits_funding_transaction_failed` (GHSA regression)
- [x] `committed_preflight_skips_send_tx_and_error_reporting` (restart regression)