### PR TITLE
fix: gate external funding TxUpdate sync on is_acceptor or signed_submitted

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -587,6 +587,8 @@ where
             FiberChannelMessage::TxUpdate(tx) => {
                 if state.ephemeral_config.external_funding.enabled
                     && state.state.is_awaiting_external_funding()
+                    && (state.is_acceptor
+                        || state.ephemeral_config.external_funding.signed_submitted)
                 {
                     self.handle_external_funding_tx_sync(myself, state, tx.tx)
                         .await?;


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #1391 (commit `d75916d`), identified by @chainTe in a [security review on #1391](https://github.com/nervosnetwork/fiber/pull/1391#issuecomment-4677205931).

## Problem

Commit `d75916d` removed the `signed_submitted` check from the `TxUpdate` handler that was originally introduced in `bd834319` (#1388). This reintroduced a vulnerability where a malicious peer can send a `TxUpdate` to the initiator during `AWAITING_EXTERNAL_FUNDING` state before the local operator has submitted the signed funding tx, causing:

1. `signed_submitted` to be set to `true` prematurely
2. The external funding submission timeout to be disabled (`started_at` is cleared)
3. The operator `SubmitSignedFundingTx` RPC to fail with `RepeatedProcessing`

However, the fix from `bd834319` was too broad — it required `signed_submitted` for ALL nodes, which broke the acceptor. The acceptor never calls `SubmitSignedFundingTx`; it relies on receiving the initiator's `TxUpdate` via the sync path as part of normal flow.

## Fix

Gate the sync path on `(is_acceptor || signed_submitted)`:

- **Acceptor**: always allowed — receives initiator's signed tx as normal flow
- **Initiator**: only allowed after local operator submission — prevents unsolicited peer `TxUpdate` from bypassing the external wallet signature requirement

## Verification

All 26 external funding tests pass:
```
Summary [ 3.636s] 26 tests run: 26 passed, 929 skipped
```

`cargo clippy` passes clean with `-D warnings`.
