### PR TITLE
Validate custom records size

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -34,10 +34,11 @@ use crate::{
             get_chain_hash, sign_network_message, FiberMessageWithTarget, CHECK_CHANNELS_INTERVAL,
         },
         types::{
-            peeled_packet_mpp_custom_records, AcceptChannel, AddTlc, AnnouncementSignatures,
-            ChannelReady, ClosingSigned, CommitmentSigned, FiberChannelMessage, FiberMessage,
-            HoldTlc, OpenChannel, ReestablishChannel, RemoveTlc, Shutdown, TrampolineHopPayload,
-            TrampolineOnionPacket, TxCollaborationMsg, TxComplete, TxUpdate,
+            peeled_packet_mpp_custom_records, validate_payment_custom_records_size, AcceptChannel,
+            AddTlc, AnnouncementSignatures, ChannelReady, ClosingSigned, CommitmentSigned,
+            FiberChannelMessage, FiberMessage, HoldTlc, OpenChannel, ReestablishChannel, RemoveTlc,
+            Shutdown, TrampolineHopPayload, TrampolineOnionPacket, TxCollaborationMsg, TxComplete,
+            TxUpdate,
         },
         NetworkActorCommand, NetworkActorEvent, NetworkActorMessage, ASSUME_NETWORK_ACTOR_ALIVE,
     },
@@ -1726,6 +1727,8 @@ where
             }
 
             if let Some(custom_records) = final_custom_records {
+                validate_payment_custom_records_size(&custom_records)
+                    .map_err(ProcessingChannelError::InvalidParameter)?;
                 self.store
                     .insert_payment_custom_records(&payment_hash, custom_records);
             }

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use super::network::{SendOnionPacketCommand, SendPaymentResponse, ASSUME_NETWORK_MYSELF_ALIVE};
-use super::types::BroadcastMessageWithTimestamp;
+use super::types::{validate_payment_custom_records_size, BroadcastMessageWithTimestamp};
 use crate::fiber::channel::{ChannelActorStateStore, ProcessingChannelError};
 use crate::fiber::config::{
     DEFAULT_FINAL_TLC_EXPIRY_DELTA, MAX_PAYMENT_TLC_EXPIRY_LIMIT, MIN_TLC_EXPIRY_DELTA,
@@ -15,7 +15,6 @@ use crate::fiber::graph::{
 };
 use crate::fiber::network::{
     NetworkActorStateStore, DEFAULT_CHAIN_ACTOR_TIMEOUT, DEFAULT_PAYMENT_TRY_LIMIT,
-    MAX_CUSTOM_RECORDS_SIZE,
 };
 use crate::fiber::{
     KeyPair, NetworkActorCommand, NetworkActorEvent, NetworkActorMessage,
@@ -268,14 +267,7 @@ impl SendPaymentDataBuilder {
         }
 
         if let Some(custom_records) = &self.custom_records {
-            if custom_records.data.values().map(|v| v.len()).sum::<usize>()
-                > MAX_CUSTOM_RECORDS_SIZE
-            {
-                return Err(format!(
-                    "the sum size of custom_records's value can not more than {} bytes",
-                    MAX_CUSTOM_RECORDS_SIZE
-                ));
-            }
+            validate_payment_custom_records_size(custom_records)?;
         }
 
         if let Some(max_parts) = self.max_parts {

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -338,10 +338,10 @@ async fn test_send_payment_custom_records_with_limit_error() {
         .await;
 
     let err = res.unwrap_err().to_string();
-    assert!(err.contains("the sum size of custom_records's value can not more than"));
+    assert!(err.contains("custom_records encoded size"));
 
     // normal case
-    let long_value = "a".repeat(1024 * 2);
+    let long_value = "a".repeat(1024);
     let data: HashMap<_, _> = vec![(1, long_value.into_bytes())].into_iter().collect();
     let custom_records = PaymentCustomRecords { data };
     let res = source_node
@@ -362,6 +362,99 @@ async fn test_send_payment_custom_records_with_limit_error() {
         .expect("custom records");
     assert_eq!(got_custom_records, custom_records);
     assert_eq!(source_node.get_inflight_payment_count().await, 0);
+}
+
+#[tokio::test]
+async fn test_receive_payment_rejects_oversized_custom_records() {
+    init_tracing();
+
+    let (nodes, channels) = create_n_nodes_network(
+        &[
+            ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
+            ((0, 1), (MIN_RESERVED_CKB + 10000000000, MIN_RESERVED_CKB)),
+        ],
+        2,
+    )
+    .await;
+    let [node_0, mut node_1] = nodes.try_into().expect("2 nodes");
+
+    let amount = 1000;
+    let hash_algorithm = HashAlgorithm::Sha256;
+    let payment_preimage = gen_rand_sha256_hash();
+    let payment_hash: Hash256 = hash_algorithm.hash(payment_preimage).into();
+    let expiry = now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA;
+    let custom_records = PaymentCustomRecords {
+        data: vec![(1, vec![1; MAX_CUSTOM_RECORDS_SIZE + 1])]
+            .into_iter()
+            .collect(),
+    };
+
+    let hops_infos = vec![
+        PaymentHopData {
+            amount,
+            expiry,
+            next_hop: Some(node_1.pubkey),
+            hash_algorithm,
+            ..Default::default()
+        },
+        PaymentHopData {
+            amount,
+            expiry,
+            payment_preimage: Some(payment_preimage),
+            hash_algorithm,
+            custom_records: Some(custom_records),
+            ..Default::default()
+        },
+    ];
+
+    let packet = PeeledPaymentOnionPacket::create(
+        node_0.get_private_key().clone(),
+        hops_infos,
+        Some(payment_hash.as_ref().to_vec()),
+        SECP256K1,
+    )
+    .expect("create peeled packet");
+
+    let add_tlc_result = ractor::call!(node_0.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
+            ChannelCommandWithId {
+                channel_id: channels[0],
+                command: ChannelCommand::AddTlc(
+                    AddTlcCommand {
+                        amount,
+                        hash_algorithm,
+                        payment_hash,
+                        expiry,
+                        onion_packet: packet.next.clone(),
+                        shared_secret: packet.shared_secret,
+                        is_trampoline_hop: false,
+                        previous_tlc: None,
+                        attempt_id: None,
+                    },
+                    rpc_reply,
+                ),
+            },
+        ))
+    })
+    .expect("node alive");
+    assert!(add_tlc_result.is_ok());
+
+    let target_pubkey = node_1.pubkey;
+    node_1
+        .expect_event(|event| match event {
+            NetworkServiceEvent::DebugEvent(DebugEvent::AddTlcFailed(
+                pubkey,
+                failed_payment_hash,
+                err,
+            )) => {
+                pubkey == &target_pubkey
+                    && failed_payment_hash == &payment_hash
+                    && err.error_code == TlcErrorCode::IncorrectOrUnknownPaymentDetails
+            }
+            _ => false,
+        })
+        .await;
+    assert!(node_1.get_payment_custom_records(&payment_hash).is_none());
 }
 
 // This test will send two payments from node_0 to node_1, the first payment will run

--- a/crates/fiber-lib/src/fiber/types.rs
+++ b/crates/fiber-lib/src/fiber/types.rs
@@ -33,7 +33,6 @@ use std::fmt::Display;
 use thiserror::Error;
 
 pub(crate) const MAX_NUM_OF_BROADCAST_MESSAGES: u16 = 1000;
-
 /// Convert a `tentacle::secio::PublicKey` to a `Pubkey`.
 pub fn pubkey_from_tentacle(pk: tentacle::secio::PublicKey) -> Pubkey {
     secp256k1::PublicKey::from_slice(pk.inner_ref())
@@ -83,6 +82,22 @@ fn check_broadcast_message_vec_len(len: usize, field: &str) -> Result<(), Error>
             "{field} length {len} exceeds gossip limit {limit}"
         )));
     }
+    Ok(())
+}
+
+pub(crate) fn validate_payment_custom_records_size(
+    custom_records: &PaymentCustomRecords,
+) -> Result<(), String> {
+    let molecule_custom_records: molecule_fiber::CustomRecords = custom_records.clone().into();
+    let encoded_size = molecule_custom_records.as_slice().len();
+
+    if encoded_size > super::network::MAX_CUSTOM_RECORDS_SIZE {
+        return Err(format!(
+            "custom_records encoded size {encoded_size} exceeds limit {} bytes",
+            super::network::MAX_CUSTOM_RECORDS_SIZE
+        ));
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Add a more proper size validation for `custom_records`, also check the size of this field in `apply_final_hop_tlc_onion_packet`.