### PR TITLE
fix: validate peer tlc_basepoint and per_commitment_point before accept

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -57,18 +57,18 @@ use ckb_types::{
     H256,
 };
 use fiber_types::{
-    blake2b_hash_with_salt, derive_tlc_pubkey, AddTlcCommand, AppliedFlags,
-    AwaitingChannelReadyFlags, AwaitingTxSignaturesFlags, BasicMppPaymentData, ChannelActorData,
-    ChannelAnnouncement, ChannelBasePublicKeys, ChannelConnectivityState, ChannelConstraints,
-    ChannelFlags, ChannelOpenRecord, ChannelState, ChannelTlcInfo, ChannelUpdate,
-    ChannelUpdateChannelFlags, ChannelUpdateMessageFlags, CloseFlags, CollaboratingFundingTxFlags,
-    CommitmentNumbers, EcdsaSignature, ExternalFundingPersistState, Hash256, InMemorySigner,
-    InboundTlcStatus, Musig2Context, NegotiatingFundingFlags, OutboundTlcStatus,
-    PaymentCustomRecords, PeeledPaymentOnionPacket, PendingNotifySettleTlc, PrevTlcInfo, Privkey,
-    Pubkey, PublicChannelInfo, RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation,
-    RevocationData, RevokeAndAck, SettlementData, SettlementTlc, ShutdownInfo, ShuttingDownFlags,
-    SigningCommitmentFlags, TLCId, TlcErr, TlcErrPacket, TlcErrorCode, TlcInfo, TlcStatus,
-    NO_SHARED_SECRET,
+    blake2b_hash_with_salt, derive_tlc_pubkey, is_tlc_key_derivation_safe, AddTlcCommand,
+    AppliedFlags, AwaitingChannelReadyFlags, AwaitingTxSignaturesFlags, BasicMppPaymentData,
+    ChannelActorData, ChannelAnnouncement, ChannelBasePublicKeys, ChannelConnectivityState,
+    ChannelConstraints, ChannelFlags, ChannelOpenRecord, ChannelState, ChannelTlcInfo,
+    ChannelUpdate, ChannelUpdateChannelFlags, ChannelUpdateMessageFlags, CloseFlags,
+    CollaboratingFundingTxFlags, CommitmentNumbers, EcdsaSignature, ExternalFundingPersistState,
+    Hash256, InMemorySigner, InboundTlcStatus, Musig2Context, NegotiatingFundingFlags,
+    OutboundTlcStatus, PaymentCustomRecords, PeeledPaymentOnionPacket, PendingNotifySettleTlc,
+    PrevTlcInfo, Privkey, Pubkey, PublicChannelInfo, RemoveTlcFulfill, RemoveTlcReason,
+    RetryableTlcOperation, RevocationData, RevokeAndAck, SettlementData, SettlementTlc,
+    ShutdownInfo, ShuttingDownFlags, SigningCommitmentFlags, TLCId, TlcErr, TlcErrPacket,
+    TlcErrorCode, TlcInfo, TlcStatus, NO_SHARED_SECRET,
 };
 pub use fiber_types::{
     CommitDiff, CommitmentSignedTemplate, ReplayOrderHint, TlcReplayUpdate,
@@ -3610,7 +3610,7 @@ where
                     &open_channel, &pubkey
                 );
 
-                let counterpart_pubkeys = (&open_channel).into();
+                let counterpart_pubkeys: ChannelBasePublicKeys = (&open_channel).into();
                 let public = open_channel.is_public();
                 let is_one_way = open_channel.is_one_way();
                 let OpenChannel {
@@ -3674,6 +3674,19 @@ where
                     max_tlc_number_in_flight,
                     *remote_max_tlc_number_in_flight,
                 )?;
+
+                if !is_tlc_key_derivation_safe(
+                    &counterpart_pubkeys.tlc_base_key,
+                    first_per_commitment_point,
+                ) || !is_tlc_key_derivation_safe(
+                    &counterpart_pubkeys.tlc_base_key,
+                    second_per_commitment_point,
+                ) {
+                    return Err(Box::new(ProcessingChannelError::InvalidParameter(
+                        "peer tlc_basepoint and per_commitment_point derive to invalid key"
+                            .to_string(),
+                    )));
+                }
 
                 let mut state = ChannelActorState::new_inbound_channel(
                     *channel_id,
@@ -7281,6 +7294,18 @@ impl ChannelActorState {
             self.local_constraints.max_tlc_number_in_flight,
             accept_channel.max_tlc_number_in_flight,
         )?;
+
+        if !is_tlc_key_derivation_safe(
+            &accept_channel.tlc_basepoint,
+            &accept_channel.first_per_commitment_point,
+        ) || !is_tlc_key_derivation_safe(
+            &accept_channel.tlc_basepoint,
+            &accept_channel.second_per_commitment_point,
+        ) {
+            return Err(ProcessingChannelError::InvalidParameter(
+                "peer tlc_basepoint and per_commitment_point derive to invalid key".to_string(),
+            ));
+        }
 
         self.update_state(ChannelState::NegotiatingFunding(
             NegotiatingFundingFlags::INIT_SENT,

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -54,16 +54,16 @@ use ckb_types::{
     prelude::{AsTransactionBuilder, Builder, Entity, IntoTransactionView, Pack, Unpack},
 };
 use fiber_types::{
-    derive_private_key, derive_tlc_pubkey, AddTlcCommand, AwaitingChannelReadyFlags,
-    AwaitingTxSignaturesFlags, ChannelConstraints, ChannelOpeningStatus, ChannelState,
-    CollaboratingFundingTxFlags, HashAlgorithm, InMemorySigner, NegotiatingFundingFlags,
-    OutboundTlcStatus, PaymentHopData, PaymentStatus, Privkey, RemoveTlc, RemoveTlcFulfill,
-    RemoveTlcReason, RetryableTlcOperation, ShuttingDownFlags, SigningCommitmentFlags, TLCId,
-    TlcErrPacket, TlcErrorCode, TlcStatus, NO_SHARED_SECRET,
+    derive_private_key, derive_tlc_pubkey, is_tlc_key_derivation_safe, AddTlcCommand,
+    AwaitingChannelReadyFlags, AwaitingTxSignaturesFlags, ChannelConstraints, ChannelOpeningStatus,
+    ChannelState, CollaboratingFundingTxFlags, HashAlgorithm, InMemorySigner,
+    NegotiatingFundingFlags, OutboundTlcStatus, PaymentHopData, PaymentStatus, Privkey, RemoveTlc,
+    RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation, ShuttingDownFlags,
+    SigningCommitmentFlags, TLCId, TlcErrPacket, TlcErrorCode, TlcStatus, NO_SHARED_SECRET,
 };
 use fiber_types::{CloseFlags, FeatureVector};
 use molecule::bytes::BytesMut;
-use musig2::secp::Point;
+use musig2::secp::{Point, Scalar};
 use musig2::KeyAggContext;
 use ractor::{call, ActorProcessingErr, ActorRef};
 use secp256k1::SECP256K1;
@@ -269,6 +269,62 @@ fn test_derive_private_and_public_tlc_keys() {
     let derived_privkey = derive_private_key(&privkey, &per_commitment_point);
     let derived_pubkey = derive_tlc_pubkey(&privkey.pubkey(), &per_commitment_point);
     assert_eq!(derived_privkey.pubkey(), derived_pubkey);
+}
+
+/// Generates a malicious (tlc_basepoint, commitment_point) pair where the TLC
+/// key derivation would produce the point at infinity.
+fn malicious_tlc_basepoint_and_commitment_point() -> (Pubkey, Pubkey) {
+    for i in 0..1024u64 {
+        let seed = format!("byzantine-ptlc-poc-{i}");
+        let signer = InMemorySigner::generate_from_seed(seed.as_bytes());
+        let commitment_point = signer.get_commitment_point(1);
+        let tweak = fiber_types::get_tweak_by_commitment_point(&commitment_point);
+
+        if let Ok(scalar) = Scalar::from_slice(&tweak) {
+            let tlc_basepoint: Pubkey = (-scalar).base_point_mul().into();
+            return (tlc_basepoint, commitment_point);
+        }
+    }
+
+    panic!("failed to find a commitment point with a valid tweak scalar");
+}
+
+#[test]
+fn test_is_tlc_key_derivation_safe_rejects_malicious_keys() {
+    let (tlc_basepoint, commitment_point) = malicious_tlc_basepoint_and_commitment_point();
+
+    // Verify the malicious pair is NOT considered safe
+    assert!(
+        !is_tlc_key_derivation_safe(&tlc_basepoint, &commitment_point),
+        "malicious TLC basepoint and commitment point should be rejected"
+    );
+}
+
+#[test]
+fn test_is_tlc_key_derivation_safe_accepts_honest_keys() {
+    let signer = InMemorySigner::generate_from_seed(b"honest-seed");
+    let tlc_basepoint = signer.tlc_base_key.pubkey();
+    let commitment_point = signer.get_commitment_point(1);
+
+    assert!(
+        is_tlc_key_derivation_safe(&tlc_basepoint, &commitment_point),
+        "honest TLC basepoint and commitment point should be accepted"
+    );
+}
+
+#[test]
+fn test_malicious_keys_would_have_caused_panic() {
+    use fiber_types::derive_tlc_pubkey;
+    let (tlc_basepoint, commitment_point) = malicious_tlc_basepoint_and_commitment_point();
+
+    let result = std::panic::catch_unwind(|| {
+        let _ = derive_tlc_pubkey(&tlc_basepoint, &commitment_point);
+    });
+
+    assert!(
+        result.is_err(),
+        "malicious TLC basepoint and commitment point should cause a panic in derive_tlc_pubkey"
+    );
 }
 
 #[tokio::test]

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -18,6 +18,7 @@ use ckb_types::packed::Transaction;
 use ckb_types::prelude::{Pack, Unpack};
 use ckb_types::H256;
 use molecule::prelude::{Builder, Entity};
+use musig2::secp::{Point, Scalar};
 use musig2::BinaryEncoding;
 use musig2::PartialSignature;
 use musig2::PubNonce;
@@ -1189,6 +1190,22 @@ pub fn derive_public_key(base_key: &Pubkey, commitment_point: &Pubkey) -> Pubkey
 /// Derive the TLC public key from a base key and commitment point.
 pub fn derive_tlc_pubkey(base_key: &Pubkey, commitment_point: &Pubkey) -> Pubkey {
     derive_public_key(base_key, commitment_point)
+}
+
+/// Check if the TLC key derivation for a given base key and commitment point
+/// would produce a valid (non-infinity) result.
+///
+/// This is used to validate peer-provided keys before accepting them,
+/// preventing a malicious peer from crafting key pairs that would cause
+/// `derive_tlc_pubkey` to panic with "valid public key" due to infinity.
+pub fn is_tlc_key_derivation_safe(base_key: &Pubkey, commitment_point: &Pubkey) -> bool {
+    let tweak = get_tweak_by_commitment_point(commitment_point);
+    let Ok(scalar) = Scalar::from_slice(&tweak) else {
+        return false;
+    };
+    let base_point = Point::from(base_key);
+    let result = base_point + scalar.base_point_mul();
+    result.not_inf().is_ok()
 }
 
 /// Derive the commitment secret for a given commitment number from a seed.


### PR DESCRIPTION
## Summary
- Fixes a vulnerability where a malicious peer can craft `tlc_basepoint = -h*G` and `first_per_commitment_point = Q` (where `h = blake2b(Q.serialize())`) to cause `derive_tlc_pubkey` to produce the point at infinity, triggering `expect("valid public key")` panic in `Pubkey::tweak`
- Adds `is_tlc_key_derivation_safe()` in `fiber-types` to pre-validate peer-provided key pairs without panicking
- Validates peer keys at both OpenChannel (inbound) and AcceptChannel (outbound) entry points, rejecting invalid pairs with `InvalidParameter`
- Includes PoC test verifying the malicious key pair would have caused a panic, and that the new validation correctly rejects it

## Changes
- `crates/fiber-types/src/channel.rs` — add `is_tlc_key_derivation_safe()` validation function
- `crates/fiber-lib/src/fiber/channel.rs` — call validation at inbound channel open (`pre_start`) and outbound channel accept (`handle_accept_channel_message`)
- `crates/fiber-lib/src/fiber/tests/channel.rs` — add three unit tests covering malicious key generation, safety check rejection, and regression test