### PR TITLE
fix: move TLC cleanup after commitment signature verification

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -7678,8 +7678,6 @@ impl ChannelActorState {
             }
         };
 
-        self.clean_up_failed_tlcs();
-
         #[cfg(debug_assertions)]
         {
             debug!(
@@ -7691,6 +7689,8 @@ impl ChannelActorState {
 
         let (commitment_tx, settlement_data) =
             self.verify_and_complete_tx(commitment_signed.funding_tx_partial_signature)?;
+
+        self.clean_up_failed_tlcs();
 
         // Notify outside observers.
         self.network()


### PR DESCRIPTION
## Summary
- `clean_up_failed_tlcs()` was called before `verify_and_complete_tx()` in `process_commitment_signed`, which mutates TLC state before signature verification
- If the peer sent an invalid CommitmentSigned, the mutated TLC state is persisted without rollback, corrupting channel state
- Fix: move cleanup to after successful signature verification so that on verification failure, no state mutation occurs