### PR TITLE
fix: enforce commitment delay epoch check on non-first watchtower settlements

### DIFF
--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -1057,7 +1057,11 @@ fn build_settlement_tx<S: WatchtowerStore>(
                                 }
                             }
 
-                            if pending_tlcs_count == 0 {
+                            if pending_tlcs_count == 0
+                                && cell_header_epoch.to_rational()
+                                    + delay_epoch.to_rational()
+                                    <= current_epoch.to_rational()
+                            {
                                 unlock_option = Some((
                                     Unlock {
                                         unlock_type: 0xFF,
@@ -1158,7 +1162,11 @@ fn build_settlement_tx<S: WatchtowerStore>(
                             }
                         }
 
-                        if pending_tlcs_count == 0 {
+                        if pending_tlcs_count == 0
+                            && cell_header_epoch.to_rational()
+                                + delay_epoch.to_rational()
+                                <= current_epoch.to_rational()
+                        {
                             unlock_option = Some((
                                 Unlock {
                                     unlock_type: 0xFE,

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -1058,8 +1058,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
                             }
 
                             if pending_tlcs_count == 0
-                                && cell_header_epoch.to_rational()
-                                    + delay_epoch.to_rational()
+                                && cell_header_epoch.to_rational() + delay_epoch.to_rational()
                                     <= current_epoch.to_rational()
                             {
                                 unlock_option = Some((
@@ -1163,8 +1162,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
                         }
 
                         if pending_tlcs_count == 0
-                            && cell_header_epoch.to_rational()
-                                + delay_epoch.to_rational()
+                            && cell_header_epoch.to_rational() + delay_epoch.to_rational()
                                 <= current_epoch.to_rational()
                         {
                             unlock_option = Some((


### PR DESCRIPTION
## Summary
- Non-first watchtower settlements (settlement_witness: Some path) did not check that the full commitment delay had elapsed before allowing remaining balance settlement after TLC processing
- This allowed a malicious peer to settle stale commitment balances after only a reduced TLC delay (1/3 or 2/3 of full commitment delay)
- Fix: add `cell_header_epoch + delay_epoch <= current_epoch` checks before allowing remaining balance settlement in non-first settlement paths