### PR TITLE
fix: prevent overflow panic on commitment_number=0 in watchtower settlement

### DIFF
--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -958,9 +958,12 @@ fn build_settlement_tx<S: WatchtowerStore>(
         if channel_data
             .revocation_data
             .as_ref()
-            .map(|r| r.commitment_number)
-            .unwrap_or_default()
-            == commitment_number - 1
+            .and_then(|r| {
+                commitment_number
+                    .checked_sub(1)
+                    .map(|prev| r.commitment_number == prev)
+            })
+            .unwrap_or(false)
         {
             channel_data.remote_settlement_data.clone()
         } else {


### PR DESCRIPTION
## Summary
- `commitment_number - 1` panics with overflow when `commitment_number == 0` (initial commitment) in watchtower settlement
- A malicious peer can broadcast the initial remote commitment to trigger this panic, crashing the watchtower actor
- Fix: use `checked_sub(1)` with proper `Option` handling to safely handle commitment_number == 0