### PR TITLE
fix: only set THEIR_SHUTDOWN_SENT when peer actually sent Shutdown, not on reestablish

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1874,7 +1874,9 @@ where
             signature: None,
         });
 
-        state.step_shutting_down(flags).await?;
+        state
+            .step_shutting_down(flags | ShuttingDownFlags::THEIR_SHUTDOWN_SENT)
+            .await?;
         Ok(())
     }
 
@@ -9555,7 +9557,7 @@ impl ChannelActorState {
 
     /// Perform the next step in shutting down the channel.
     async fn step_shutting_down(&mut self, flags: ShuttingDownFlags) -> ProcessingChannelResult {
-        let mut flags = flags | ShuttingDownFlags::THEIR_SHUTDOWN_SENT;
+        let mut flags = flags;
 
         // Only automatically reply shutdown if only their shutdown message is sent.
         // If we are in a state other than only their shutdown is sent,


### PR DESCRIPTION
## Summary
- `step_shutting_down` unconditionally set `THEIR_SHUTDOWN_SENT`, causing reestablish to mark the peer's shutdown as received when it wasn't
- This caused legitimate `Shutdown` messages to be rejected as duplicates, blocking cooperative close
- Fix: move `THEIR_SHUTDOWN_SENT` flag setting from `step_shutting_down` to `process_shutdown` (where we actually receive the peer's Shutdown message), so reestablish preserves the correct state