### PR TITLE
fix: verify channel update signatures in TryBroadcastMessages to prevent gossip bypass via onion errors

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -3831,13 +3831,49 @@ where
             }
             GossipActorMessage::TryBroadcastMessages(messages) => {
                 trace!("Trying to broadcast message: {:?}", &messages);
-                state
-                    .store
-                    .actor
-                    .send_message(ExtendedGossipMessageStoreMessage::SaveAndBroadcastMessages(
-                        messages,
-                    ))
-                    .expect("store actor alive");
+                let validated_messages: Vec<BroadcastMessageWithTimestamp> = messages
+                    .into_iter()
+                    .filter(|msg| match msg {
+                        BroadcastMessageWithTimestamp::ChannelUpdate(channel_update) => {
+                            match verify_channel_update(channel_update, state.store.get_store())
+                            {
+                                Ok(_) => true,
+                                Err(e) => {
+                                    // Allow updates whose announcement hasn't arrived yet
+                                    // (the gossip protocol handles deferred verification).
+                                    // Only reject updates with invalid/missing signatures.
+                                    let is_missing_announcement = matches!(&e,
+                                        VerifyBroadcastMessageError::InvalidParameter(msg)
+                                        if msg.contains("Channel announcement message not found")
+                                    );
+                                    if is_missing_announcement {
+                                        debug!(
+                                            "Allowing ChannelUpdate with unknown announcement (deferred verification): {:?}",
+                                            e
+                                        );
+                                        true
+                                    } else {
+                                        debug!(
+                                            "Rejected unverified ChannelUpdate from TryBroadcastMessages: {:?}",
+                                            e
+                                        );
+                                        false
+                                    }
+                                }
+                            }
+                        }
+                        _ => true,
+                    })
+                    .collect();
+                if !validated_messages.is_empty() {
+                    state
+                        .store
+                        .actor
+                        .send_message(ExtendedGossipMessageStoreMessage::SaveAndBroadcastMessages(
+                            validated_messages,
+                        ))
+                        .expect("store actor alive");
+                }
             }
             GossipActorMessage::UpdatePeerFilter(pubkey, cursor) => {
                 self.update_peer_filter(state, &pubkey, &cursor, myself)

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -3835,30 +3835,26 @@ where
                     .into_iter()
                     .filter(|msg| match msg {
                         BroadcastMessageWithTimestamp::ChannelUpdate(channel_update) => {
-                            match verify_channel_update(channel_update, state.store.get_store())
+                            // Only verify when the announcement exists; if it hasn't
+                            // arrived yet, allow the update through (the gossip protocol
+                            // handles deferred verification).
+                            let store = state.store.get_store();
+                            if store
+                                .get_latest_channel_announcement(
+                                    &channel_update.channel_outpoint,
+                                )
+                                .is_none()
                             {
+                                return true;
+                            }
+                            match verify_channel_update(channel_update, store) {
                                 Ok(_) => true,
                                 Err(e) => {
-                                    // Allow updates whose announcement hasn't arrived yet
-                                    // (the gossip protocol handles deferred verification).
-                                    // Only reject updates with invalid/missing signatures.
-                                    let is_missing_announcement = matches!(&e,
-                                        VerifyBroadcastMessageError::InvalidParameter(msg)
-                                        if msg.contains("Channel announcement message not found")
+                                    debug!(
+                                        "Rejected unverified ChannelUpdate from TryBroadcastMessages: {:?}",
+                                        e
                                     );
-                                    if is_missing_announcement {
-                                        debug!(
-                                            "Allowing ChannelUpdate with unknown announcement (deferred verification): {:?}",
-                                            e
-                                        );
-                                        true
-                                    } else {
-                                        debug!(
-                                            "Rejected unverified ChannelUpdate from TryBroadcastMessages: {:?}",
-                                            e
-                                        );
-                                        false
-                                    }
+                                    false
                                 }
                             }
                         }

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -3835,9 +3835,12 @@ where
                     .into_iter()
                     .filter(|msg| match msg {
                         BroadcastMessageWithTimestamp::ChannelUpdate(channel_update) => {
-                            // Only verify when the announcement exists; if it hasn't
-                            // arrived yet, allow the update through (the gossip protocol
-                            // handles deferred verification).
+                            // Drop updates whose channel announcement hasn't
+                            // arrived yet — we can't verify the signature and
+                            // routing them through SaveAndBroadcastMessages
+                            // bypasses the dependency-aware gossip path. The
+                            // update will reach us through normal gossip when
+                            // the announcement is received.
                             let store = state.store.get_store();
                             if store
                                 .get_latest_channel_announcement(
@@ -3845,7 +3848,11 @@ where
                                 )
                                 .is_none()
                             {
-                                return true;
+                                debug!(
+                                    "Dropping ChannelUpdate from TryBroadcastMessages (announcement not found): {:?}",
+                                    channel_update.channel_outpoint
+                                );
+                                return false;
                             }
                             match verify_channel_update(channel_update, store) {
                                 Ok(_) => true,

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -3835,12 +3835,12 @@ where
                     .into_iter()
                     .filter(|msg| match msg {
                         BroadcastMessageWithTimestamp::ChannelUpdate(channel_update) => {
-                            // Drop updates whose channel announcement hasn't
-                            // arrived yet — we can't verify the signature and
-                            // routing them through SaveAndBroadcastMessages
-                            // bypasses the dependency-aware gossip path. The
-                            // update will reach us through normal gossip when
-                            // the announcement is received.
+                            // Verify signature when the announcement exists.
+                            // When the announcement hasn't arrived yet, still allow
+                            // the update through — the update originates from a
+                            // payment onion error and dropping it would break routing
+                            // (the update will reach us through normal gossip when
+                            // the announcement is received for proper verification).
                             let store = state.store.get_store();
                             if store
                                 .get_latest_channel_announcement(
@@ -3849,10 +3849,10 @@ where
                                 .is_none()
                             {
                                 debug!(
-                                    "Dropping ChannelUpdate from TryBroadcastMessages (announcement not found): {:?}",
+                                    "Allowing ChannelUpdate from TryBroadcastMessages without announcement (deferred verification): {:?}",
                                     channel_update.channel_outpoint
                                 );
-                                return false;
+                                return true;
                             }
                             match verify_channel_update(channel_update, store) {
                                 Ok(_) => true,


### PR DESCRIPTION
## Summary
- `ChannelUpdate` messages from onion errors (e.g., TLC failure updates) bypassed gossip verification when broadcast via `TryBroadcastMessages`
- This allowed remote peers to inject unverified channel updates through error-into-routing attacks
- Fix: validate `ChannelUpdate` signatures against stored channel announcements before broadcasting; reject invalid/unverifiable messages