### PR TITLE
fix: remove watchtower channel entries on funding abort

### DIFF
--- a/crates/fiber-lib/src/event_handler.rs
+++ b/crates/fiber-lib/src/event_handler.rs
@@ -62,7 +62,8 @@ pub async fn forward_event_to_client<T: WatchtowerRpcClient + Sync>(
                 .map_err(|e| format!("Failed to create watch channel: {e}"))?;
         }
         NetworkServiceEvent::ChannelClosed(_, channel_id, _)
-        | NetworkServiceEvent::ChannelAbandon(channel_id) => {
+        | NetworkServiceEvent::ChannelAbandon(channel_id)
+        | NetworkServiceEvent::ChannelFundingAborted(channel_id) => {
             watchtower_client
                 .remove_watch_channel(RemoveWatchChannelParams {
                     channel_id: channel_id.into(),


### PR DESCRIPTION
## Summary
- `ChannelFundingAborted` event was not handled in the watchtower event forwarder, leaving stale watchtower entries for channels that were aborted during funding
- Fix: add `ChannelFundingAborted` alongside `ChannelClosed`/`ChannelAbandon` so the watchtower cleans up entries for aborted channels