### PR TITLE
fix: allow FNN_EVENT_WAIT_TIMEOUT_SECS to override wait_until_async_timeout

### DIFF
--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -2119,7 +2119,15 @@ where
 {
     let start = tokio::time::Instant::now();
     let interval = Duration::from_millis(200);
-    let max_wait_time = Duration::from_secs(10);
+    let max_wait_time = if let Some(timeout_secs) = env::var(EVENT_WAIT_TIMEOUT_OVERRIDE_SECS_ENV)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+    {
+        Duration::from_secs(timeout_secs)
+    } else {
+        Duration::from_secs(10)
+    };
     loop {
         if f().await {
             return;
@@ -2127,8 +2135,8 @@ where
         tokio::time::sleep(interval).await;
         if start.elapsed() > max_wait_time {
             panic!(
-                "Wait timeout after {:?} (interval {:?})",
-                max_wait_time, interval
+                "Wait timeout after {:?} (interval {:?}). You can adjust it with {}",
+                max_wait_time, interval, EVENT_WAIT_TIMEOUT_OVERRIDE_SECS_ENV
             );
         }
     }


### PR DESCRIPTION
## Summary

`wait_until_async_timeout` in test_utils uses a hardcoded 10-second timeout, which is too short for CI's sqlite backend where the serialized `Mutex<Connection>` slows gossip propagation. This causes `test_trampoline_routing_max_trampoline_hops_success` to fail in CI (sqlite) while passing locally.

## Root Cause

- `wait_until_async_timeout` hardcodes 10 seconds
- The test calls it 14 times sequentially before sending a payment
- SQLite backend uses `Mutex<Connection>` which serializes all DB access per node
- With 11 nodes processing gossip in CI's slower environment, propagation exceeds the 10-second window

## Fix

Reuse the existing `FNN_EVENT_WAIT_TIMEOUT_SECS` env var pattern already used by `event_wait_timeout()` in the same file. When the env var is set (and > 0), use it as the timeout; otherwise keep the 10-second default.

## Verification

- [x] `cargo check -p fnn --no-default-features --features sqlite` passes
- [x] `cargo fmt --all` passes