### PR TITLE
fix: gossip CKB flood + npm release supply-chain hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,12 @@ env:
   CARGO_TERM_COLOR: always
 permissions:
   contents: write
-  id-token: write
-  packages: write
 jobs:
   release-npm:
     name: Build & Release fiber-js
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - name: Checkout the Repository
       uses: actions/checkout@v6
@@ -21,7 +21,7 @@ jobs:
         node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
     - run: |
-        npm install
+        npm ci --ignore-scripts
     - run: |
         npm run build -ws
     - name: Check if version exists

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ tests/nodes/.ports
 /*.info
 .vscode
 /migrate/target
-/package-lock.json
 *.txt
 /node_modules
 /index.html

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -3196,17 +3196,25 @@ async fn verify_and_save_broadcast_message<S: GossipMessageStore>(
 
     let (timestamp, is_newly_applied) = match message {
         BroadcastMessage::ChannelAnnouncement(channel_announcement) => {
-            let on_chain_info =
-                get_channel_on_chain_info(channel_announcement.out_point(), chain, client).await?;
-            let already_saved =
-                verify_channel_announcement(channel_announcement, &on_chain_info, store).await?;
-            if !already_saved {
+            // Check store cache first to skip expensive CKB RPC calls for
+            // already-known announcements.
+            let already_saved = store
+                .get_latest_channel_announcement(&channel_announcement.channel_outpoint)
+                .is_some_and(|(_, existing)| existing == *channel_announcement);
+            if already_saved {
+                (0, false)
+            } else {
+                let on_chain_info =
+                    get_channel_on_chain_info(channel_announcement.out_point(), chain, client)
+                        .await?;
+                let _ = verify_channel_announcement(channel_announcement, &on_chain_info, store)
+                    .await?;
                 store.save_channel_announcement(
                     on_chain_info.timestamp,
                     channel_announcement.clone(),
                 );
+                (on_chain_info.timestamp, true)
             }
-            (on_chain_info.timestamp, !already_saved)
         }
         BroadcastMessage::ChannelUpdate(channel_update) => {
             let already_saved = verify_channel_update(channel_update, store)?;


### PR DESCRIPTION
## Summary

Fixes 3 related security issues:

1. **Gossip announcements flood CKB RPC (#9)** — Moved store cache check before on-chain RPC calls in `verify_and_save_broadcast_message` so duplicate `ChannelAnnouncement` messages skip expensive `get_transaction` + `get_block_timestamp` calls.

2. **Privileged npm release (#15-16)** — Changed `npm install` to `npm ci --ignore-scripts` to prevent dependency lifecycle scripts from executing with elevated CI permissions. Removed `/package-lock.json` from `.gitignore` so the lockfile is properly tracked and verified. Reduced workflow permissions to job-level `id-token: write` only.

## Verification
- [x] `cargo check -p fnn --features rocksdb` passes
- [x] `cargo fmt --all` passes