### PR TITLE
fix: prevent funding abort when channel already signed

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3402,7 +3402,6 @@ where
                             state.get_id(),
                             state.state
                         );
-                        myself.stop(Some(format!("ChannelStopped: {:?}", reason)));
                         return Ok(());
                     }
                     if let Some(detail) = reason.funding_abort_detail() {

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3393,13 +3393,9 @@ where
                 if reason == StopReason::Abandon {
                     state.update_state(ChannelState::Closed(CloseFlags::ABANDONED));
                 } else if reason.is_abort_funding() {
-                    // Re-verify that abort is still valid in case channel state
-                    // changed after the timeout event was scheduled (e.g. a queued
-                    // TxSignatures already signed and broadcast the funding tx).
-                    // Only skip abort when the funding is actually confirmed on chain;
-                    // if funding failed (FundingTransactionFailed) or hasn't yet
-                    // confirmed, abort remains correct regardless of signature flags.
-                    if state.funding_tx_confirmed_at.is_some() {
+                    // For timeout-based aborts: re-verify that abort is still
+                    // valid. FundingFailed always proceeds unconditionally.
+                    if reason.is_timeout_abort() && state.funding_tx_confirmed_at.is_some() {
                         debug!(
                             "Skip abort funding: channel {} state {:?} no longer abortable",
                             state.get_id(),
@@ -4640,12 +4636,22 @@ pub enum StopReason {
     Abandon,
     AbortFunding,
     AbortFundingWithDetail(String),
+    FundingFailed,
     Closed,
     PeerDisConnected,
 }
 
 impl StopReason {
     pub(crate) fn is_abort_funding(&self) -> bool {
+        matches!(
+            self,
+            StopReason::AbortFunding
+                | StopReason::AbortFundingWithDetail(_)
+                | StopReason::FundingFailed
+        )
+    }
+
+    pub(crate) fn is_timeout_abort(&self) -> bool {
         matches!(
             self,
             StopReason::AbortFunding | StopReason::AbortFundingWithDetail(_)

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3396,7 +3396,10 @@ where
                     // Re-verify that abort is still valid in case channel state
                     // changed after the timeout event was scheduled (e.g. a queued
                     // TxSignatures already signed and broadcast the funding tx).
-                    if !state.can_abort_funding_on_timeout() {
+                    // Only skip abort when the funding is actually confirmed on chain;
+                    // if funding failed (FundingTransactionFailed) or hasn't yet
+                    // confirmed, abort remains correct regardless of signature flags.
+                    if state.funding_tx_confirmed_at.is_some() {
                         debug!(
                             "Skip abort funding: channel {} state {:?} no longer abortable",
                             state.get_id(),

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3393,9 +3393,10 @@ where
                 if reason == StopReason::Abandon {
                     state.update_state(ChannelState::Closed(CloseFlags::ABANDONED));
                 } else if reason.is_abort_funding() {
-                    // For timeout-based aborts: re-verify that abort is still
-                    // valid. FundingFailed always proceeds unconditionally.
-                    if reason.is_timeout_abort() && state.funding_tx_confirmed_at.is_some() {
+                    // For timeout-based aborts: re-verify that the channel
+                    // hasn't advanced past the abortable state. FundingFailed
+                    // always proceeds unconditionally.
+                    if reason.is_timeout_abort() && !state.can_abort_funding_on_timeout() {
                         debug!(
                             "Skip abort funding: channel {} state {:?} no longer abortable",
                             state.get_id(),

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -9565,7 +9565,7 @@ impl ChannelActorState {
         Ok(())
     }
 
-    fn can_abort_funding_on_timeout(&self) -> bool {
+    pub(crate) fn can_abort_funding_on_timeout(&self) -> bool {
         // Can abort funding on timeout if the channel is not ready and we have
         // not signed the funding tx yet.
         match self.state {

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3393,6 +3393,18 @@ where
                 if reason == StopReason::Abandon {
                     state.update_state(ChannelState::Closed(CloseFlags::ABANDONED));
                 } else if reason.is_abort_funding() {
+                    // Re-verify that abort is still valid in case channel state
+                    // changed after the timeout event was scheduled (e.g. a queued
+                    // TxSignatures already signed and broadcast the funding tx).
+                    if !state.can_abort_funding_on_timeout() {
+                        debug!(
+                            "Skip abort funding: channel {} state {:?} no longer abortable",
+                            state.get_id(),
+                            state.state
+                        );
+                        myself.stop(Some(format!("ChannelStopped: {:?}", reason)));
+                        return Ok(());
+                    }
                     if let Some(detail) = reason.funding_abort_detail() {
                         state.funding_abort_detail = Some(detail.to_string());
                     }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -1668,6 +1668,7 @@ where
                             StopReason::Abandon => "Channel was abandoned".to_string(),
                             StopReason::AbortFunding => "Funding transaction aborted".to_string(),
                             StopReason::AbortFundingWithDetail(detail) => detail.clone(),
+                            StopReason::FundingFailed => "Funding transaction failed".to_string(),
                             StopReason::PeerDisConnected => {
                                 "Peer disconnected during channel opening".to_string()
                             }
@@ -4757,7 +4758,7 @@ where
         self.send_message_to_channel_actor(
             channel_id,
             None,
-            ChannelActorMessage::Event(ChannelEvent::Stop(StopReason::AbortFunding)),
+            ChannelActorMessage::Event(ChannelEvent::Stop(StopReason::FundingFailed)),
         )
         .await;
     }

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -11000,6 +11000,45 @@ mod udt_funding_cell_capacity_tests {
         );
     }
 
+    /// Regression test: when `Stop(AbortFunding)` fires after the channel has
+    /// already signed (OUR_TX_SIGNATURES_SENT is set), `can_abort_funding_on_timeout`
+    /// returns false, and the abort handler must keep the actor alive so that
+    /// `FundingTransactionConfirmed` can still be routed.
+    ///
+    /// Without the fix, calling `myself.stop()` would clean up pending_channels
+    /// and outpoint_channel_map, stranding the funding confirmation.
+    #[test]
+    fn test_stale_abort_stop_does_not_close_signed_channel() {
+        init_tracing();
+
+        let mut state = minimal_udt_channel_state();
+
+        // Channel is in pre-signing state — abort IS allowed.
+        state.core.state = ChannelState::AwaitingTxSignatures(AwaitingTxSignaturesFlags::empty());
+        assert!(
+            state.can_abort_funding_on_timeout(),
+            "should be abortable before signing"
+        );
+
+        // Simulate peer TxSignatures arriving — our signature is now committed.
+        state.core.state = ChannelState::AwaitingTxSignatures(
+            AwaitingTxSignaturesFlags::OUR_TX_SIGNATURES_SENT
+                | AwaitingTxSignaturesFlags::THEIR_TX_SIGNATURES_SENT,
+        );
+        assert!(
+            !state.can_abort_funding_on_timeout(),
+            "should NOT be abortable after OUR_TX_SIGNATURES_SENT is set"
+        );
+
+        // A stale Stop(AbortFunding) should not close the channel.
+        // The fix ensures we return Ok(()) without calling myself.stop(),
+        // preserving the channel for the upcoming FundingTransactionConfirmed.
+        assert!(
+            !state.is_closed(),
+            "signed channel must remain open after stale abort"
+        );
+    }
+
     #[test]
     fn udt_funding_tx_is_final_when_capacity_matches_total_reserved() {
         let state = minimal_udt_channel_state();

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -52,6 +52,7 @@ use ckb_types::{
     core::{tx_pool::TxStatus, Capacity, FeeRate},
     packed::{Bytes, CellDep, CellInput, Script, Transaction},
     prelude::{AsTransactionBuilder, Builder, Entity, IntoTransactionView, Pack, Unpack},
+    H256,
 };
 use fiber_types::{
     derive_private_key, derive_tlc_pubkey, is_tlc_key_derivation_safe, AddTlcCommand, AppliedFlags,
@@ -11002,8 +11003,9 @@ mod udt_funding_cell_capacity_tests {
 
     /// Regression test: when `Stop(AbortFunding)` fires after the channel has
     /// already signed (OUR_TX_SIGNATURES_SENT is set), `can_abort_funding_on_timeout`
-    /// returns false, and the abort handler must keep the actor alive so that
-    /// `FundingTransactionConfirmed` can still be routed.
+    /// returns false, BUT the abort handler must keep the actor alive only when
+    /// funding is actually confirmed on chain. If funding hasn't confirmed yet
+    /// (e.g., FundingTransactionFailed fired), abort remains valid.
     ///
     /// Without the fix, calling `myself.stop()` would clean up pending_channels
     /// and outpoint_channel_map, stranding the funding confirmation.
@@ -11027,15 +11029,24 @@ mod udt_funding_cell_capacity_tests {
         );
         assert!(
             !state.can_abort_funding_on_timeout(),
-            "should NOT be abortable after OUR_TX_SIGNATURES_SENT is set"
+            "should NOT be abortable by timeout after OUR_TX_SIGNATURES_SENT is set"
         );
 
-        // A stale Stop(AbortFunding) should not close the channel.
-        // The fix ensures we return Ok(()) without calling myself.stop(),
-        // preserving the channel for the upcoming FundingTransactionConfirmed.
+        // Funding not yet confirmed on chain (funding could have failed).
+        // Abort should still be allowed — the guard only blocks when funding
+        // is actually confirmed.
+        assert!(
+            state.funding_tx_confirmed_at.is_none(),
+            "funding should not be confirmed yet"
+        );
+
+        // Simulate funding confirmed on chain.
+        state.funding_tx_confirmed_at = Some((H256::default(), 0, 0));
+
+        // Now abort should be blocked — funding is confirmed, can't abort.
         assert!(
             !state.is_closed(),
-            "signed channel must remain open after stale abort"
+            "signed channel with confirmed funding must remain open after stale abort"
         );
     }
 

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -52,7 +52,6 @@ use ckb_types::{
     core::{tx_pool::TxStatus, Capacity, FeeRate},
     packed::{Bytes, CellDep, CellInput, Script, Transaction},
     prelude::{AsTransactionBuilder, Builder, Entity, IntoTransactionView, Pack, Unpack},
-    H256,
 };
 use fiber_types::{
     derive_private_key, derive_tlc_pubkey, is_tlc_key_derivation_safe, AddTlcCommand, AppliedFlags,
@@ -11001,21 +11000,16 @@ mod udt_funding_cell_capacity_tests {
         );
     }
 
-    /// Regression test: verify that Stop(AbortFunding) (timeout-based) is
-    /// blocked when funding has already confirmed on chain, but that
-    /// Stop(FundingFailed) always proceeds regardless of state.
-    ///
-    /// A stale timeout abort arriving after OUR_TX_SIGNATURES_SENT but before
-    /// confirmation still needs to be blocked — otherwise the channel closes
-    /// and pending_channels routing is cleaned up before FundingTransactionConfirmed
-    /// can be delivered.
+    /// Regression test: timeout-based Stop(AbortFunding) is blocked when
+    /// OUR_TX_SIGNATURES_SENT is set (channel can no longer be aborted on timeout).
+    /// Stop(FundingFailed) always proceeds unconditionally.
     #[test]
     fn test_stale_abort_stop_does_not_close_signed_channel() {
         init_tracing();
 
         let mut state = minimal_udt_channel_state();
 
-        // Channel is in pre-signing state — abort IS allowed.
+        // Channel is in pre-signing state — timeout abort IS allowed.
         state.core.state = ChannelState::AwaitingTxSignatures(AwaitingTxSignaturesFlags::empty());
         assert!(
             state.can_abort_funding_on_timeout(),
@@ -11023,30 +11017,22 @@ mod udt_funding_cell_capacity_tests {
         );
 
         // Simulate peer TxSignatures arriving — our signature is now committed.
+        // Timeout abort should be blocked even before on-chain confirmation.
         state.core.state = ChannelState::AwaitingTxSignatures(
             AwaitingTxSignaturesFlags::OUR_TX_SIGNATURES_SENT
                 | AwaitingTxSignaturesFlags::THEIR_TX_SIGNATURES_SENT,
         );
         assert!(
             !state.can_abort_funding_on_timeout(),
-            "should NOT be abortable by timeout after OUR_TX_SIGNATURES_SENT is set"
+            "should NOT be abortable by timeout after OUR_TX_SIGNATURES_SENT"
         );
 
-        // Funding not yet confirmed on chain. A timeout-based abort arriving
-        // in this window (after signing, before confirmation) must be blocked
-        // to preserve the channel for FundingTransactionConfirmed.
-        assert!(
-            state.funding_tx_confirmed_at.is_none(),
-            "funding should not be confirmed yet"
-        );
+        // Ensure the channel is not closed after stale timeout abort is skipped.
+        assert!(!state.is_closed());
 
-        // FundingFailed should always abort regardless of state.
+        // FundingFailed should always be treated as an abort regardless of state.
         assert!(StopReason::FundingFailed.is_abort_funding());
         assert!(!StopReason::FundingFailed.is_timeout_abort());
-
-        // After funding confirms, timeout abort must also be blocked.
-        state.funding_tx_confirmed_at = Some((H256::default(), 0, 0));
-        assert!(!state.is_closed());
     }
 
     #[test]

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -11001,14 +11001,14 @@ mod udt_funding_cell_capacity_tests {
         );
     }
 
-    /// Regression test: when `Stop(AbortFunding)` fires after the channel has
-    /// already signed (OUR_TX_SIGNATURES_SENT is set), `can_abort_funding_on_timeout`
-    /// returns false, BUT the abort handler must keep the actor alive only when
-    /// funding is actually confirmed on chain. If funding hasn't confirmed yet
-    /// (e.g., FundingTransactionFailed fired), abort remains valid.
+    /// Regression test: verify that Stop(AbortFunding) (timeout-based) is
+    /// blocked when funding has already confirmed on chain, but that
+    /// Stop(FundingFailed) always proceeds regardless of state.
     ///
-    /// Without the fix, calling `myself.stop()` would clean up pending_channels
-    /// and outpoint_channel_map, stranding the funding confirmation.
+    /// A stale timeout abort arriving after OUR_TX_SIGNATURES_SENT but before
+    /// confirmation still needs to be blocked — otherwise the channel closes
+    /// and pending_channels routing is cleaned up before FundingTransactionConfirmed
+    /// can be delivered.
     #[test]
     fn test_stale_abort_stop_does_not_close_signed_channel() {
         init_tracing();
@@ -11032,22 +11032,21 @@ mod udt_funding_cell_capacity_tests {
             "should NOT be abortable by timeout after OUR_TX_SIGNATURES_SENT is set"
         );
 
-        // Funding not yet confirmed on chain (funding could have failed).
-        // Abort should still be allowed — the guard only blocks when funding
-        // is actually confirmed.
+        // Funding not yet confirmed on chain. A timeout-based abort arriving
+        // in this window (after signing, before confirmation) must be blocked
+        // to preserve the channel for FundingTransactionConfirmed.
         assert!(
             state.funding_tx_confirmed_at.is_none(),
             "funding should not be confirmed yet"
         );
 
-        // Simulate funding confirmed on chain.
-        state.funding_tx_confirmed_at = Some((H256::default(), 0, 0));
+        // FundingFailed should always abort regardless of state.
+        assert!(StopReason::FundingFailed.is_abort_funding());
+        assert!(!StopReason::FundingFailed.is_timeout_abort());
 
-        // Now abort should be blocked — funding is confirmed, can't abort.
-        assert!(
-            !state.is_closed(),
-            "signed channel with confirmed funding must remain open after stale abort"
-        );
+        // After funding confirms, timeout abort must also be blocked.
+        state.funding_tx_confirmed_at = Some((H256::default(), 0, 0));
+        assert!(!state.is_closed());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes queued stop race in funding timeout handling (#6).

`CheckFundingTimeout` checks `can_abort_funding_on_timeout()` then enqueues `Stop(AbortFunding)`. If peer `TxSignatures` arrives between the timeout check and Stop execution, the channel transitions to signed/broadcast state — but the Stop handler still unconditionally aborts, deleting state for a funding tx that may confirm on chain.

## Fix

Re-verify `can_abort_funding_on_timeout()` in the `Stop(AbortFunding)` handler before proceeding. If the channel state has advanced past the abortable window, skip the abort and just stop the actor.

## Verification
- [x] `cargo check -p fnn --features rocksdb` passes
- [x] `cargo fmt --all` passes