### PR TITLE
fix: skip sign funding tx when channel no longer exists

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -3700,6 +3700,15 @@ where
         funding_tx: Transaction,
         partial_witnesses: Option<Vec<Vec<u8>>>,
     ) -> crate::Result<()> {
+        // Guard against stale retries: if the channel has been aborted
+        // or closed since the retry was scheduled, skip signing.
+        if state.store.get_channel_actor_state(&channel_id).is_none() {
+            debug!(
+                "Skipping do_sign_funding_tx: channel {:?} no longer exists (likely aborted)",
+                channel_id
+            );
+            return Ok(());
+        }
         let tx_hash: Hash256 = funding_tx.calc_tx_hash().into();
         let has_partial_witnesses = partial_witnesses.is_some();
         debug!(


### PR DESCRIPTION
## Summary

Prevents stale `RetrySignFundingTx` from signing a funding transaction for a channel that has already been aborted (#7).

When a peer sends `TxAbort` during the retry window, the funding channel is deleted — but the delayed retry still signs the captured funding tx and broadcasts it. The fix adds a channel existence check at the start of `do_sign_funding_tx` to skip signing when the channel is gone.

## Fix

Check `state.store.get_channel_actor_state(&channel_id).is_none()` before proceeding with signing. If the channel doesn't exist, return early.

## Verification
- [x] `cargo check -p fnn --features rocksdb` passes
- [x] `cargo fmt --all` passes