### PR TITLE
fix: delete stale channel-open records on peer disconnect

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -5276,10 +5276,9 @@ where
             .map(|(channel_id, _)| *channel_id)
             .collect();
         for channel_id in failed_channels {
-            if let Some(mut record) = self.store.get_channel_open_record(&channel_id) {
-                record.fail("Peer disconnected during channel opening".to_string());
-                self.store.insert_channel_open_record(record);
-            }
+            // Delete the persisted record to prevent unbounded accumulation
+            // of stale channel-open entries from repeated connect/disconnect cycles.
+            self.store.delete_channel_open_record(&channel_id);
             self.to_be_accepted_channels.remove(&channel_id);
         }
 


### PR DESCRIPTION
## Summary

Prevents unbounded accumulation of `ChannelOpenRecord` entries from repeated connect/disconnect cycles (#11-12).

When a peer disconnects during channel opening, pending `ChannelOpenRecord` entries were marked as `Failed` but never deleted. This allowed a malicious peer to repeatedly connect, open a channel, and disconnect, causing unbounded database growth and degrading `list_channels` performance.

## Fix

Delete the persisted `ChannelOpenRecord` when a peer disconnects with pending inbound channels, instead of retaining it in `Failed` state.

## Verification
- [x] `cargo check -p fnn --features rocksdb` passes
- [x] `cargo fmt --all` passes