### PR TITLE
test: stabilize max trampoline hops routing

### DIFF
--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -471,7 +471,7 @@ pub struct NetworkGraph<S> {
     announce_private_addr: bool,
 
     #[cfg(test)]
-    pub(crate) add_rand_expiry_delta: bool,
+    pub(crate) fixed_rand_expiry_delta: Option<u64>,
 
     #[cfg(any(feature = "metrics", test, feature = "bench"))]
     pub(crate) payment_find_path_stats: Arc<Mutex<HashMap<Hash256, u128>>>,
@@ -535,7 +535,7 @@ where
             history: PaymentHistory::new(source, None, store),
             announce_private_addr,
             #[cfg(test)]
-            add_rand_expiry_delta: true,
+            fixed_rand_expiry_delta: None,
             #[cfg(any(feature = "metrics", test, feature = "bench"))]
             payment_find_path_stats: Default::default(),
         };
@@ -558,8 +558,8 @@ where
     }
 
     #[cfg(test)]
-    pub(crate) fn set_add_rand_expiry_delta(&mut self, add: bool) {
-        self.add_rand_expiry_delta = add;
+    pub(crate) fn set_fixed_rand_expiry_delta(&mut self, expiry_delta: u64) {
+        self.fixed_rand_expiry_delta = Some(expiry_delta);
     }
 
     pub(crate) fn reset_channel_stats_for_direct_channel(
@@ -2076,8 +2076,8 @@ where
 
     fn rand_tlc_expiry_delta(&self, route: &[RouterHop]) -> u64 {
         #[cfg(test)]
-        if !self.add_rand_expiry_delta {
-            return 0;
+        if let Some(expiry_delta) = self.fixed_rand_expiry_delta {
+            return expiry_delta;
         }
         // https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#recommendations-for-routing
         // Add a small random tlc_expiry_delta to each hop for privacy reason.

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -868,7 +868,7 @@ fn test_graph_trampoline_routing_outer_route_fee_is_deducted_from_budget() {
     // The B->C forwarding fee must consume part of max_fee_amount before the remaining
     // budget is allocated to the inner trampoline payload.
     let mut network = MockNetworkGraph::new(4);
-    network.graph.set_add_rand_expiry_delta(false);
+    network.graph.set_fixed_rand_expiry_delta(0);
 
     let sender = network.keys[1];
     network.set_source(sender);
@@ -915,7 +915,7 @@ fn test_graph_trampoline_routing_outer_route_fee_can_exhaust_inner_budget() {
     init_tracing();
 
     let mut network = MockNetworkGraph::new(4);
-    network.graph.set_add_rand_expiry_delta(false);
+    network.graph.set_fixed_rand_expiry_delta(0);
 
     let sender = network.keys[1];
     network.set_source(sender);
@@ -997,7 +997,7 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
     let mut network = MockNetworkGraph::new(5);
 
     // Make expiries deterministic for assertions.
-    network.graph.set_add_rand_expiry_delta(false);
+    network.graph.set_fixed_rand_expiry_delta(0);
 
     let sender = network.keys[1];
     network.set_source(sender);
@@ -1121,7 +1121,7 @@ fn test_graph_trampoline_routing_tlc_expiry_limit_too_small_fails() {
     // Topology: sender(A)=node1 --(public)--> t1=node2 --(public)--> t2=node3 --(public)--> t3=node4
     // final=node5 disconnected. We set tlc_expiry_limit too small for the required trampoline slack.
     let mut network = MockNetworkGraph::new(5);
-    network.graph.set_add_rand_expiry_delta(false);
+    network.graph.set_fixed_rand_expiry_delta(0);
 
     let sender = network.keys[1];
     network.set_source(sender);
@@ -1168,7 +1168,7 @@ fn test_graph_trampoline_routing_service_fee_budget_too_low_fails() {
     // With an explicit trampoline hop fee_rate, if max_fee_amount is too low to cover
     // trampoline service fees, building the trampoline route should fail.
     let mut network = MockNetworkGraph::new(3);
-    network.graph.set_add_rand_expiry_delta(false);
+    network.graph.set_fixed_rand_expiry_delta(0);
 
     let sender = network.keys[1];
     network.set_source(sender);
@@ -1208,7 +1208,7 @@ fn test_graph_trampoline_routing_fee_rate_explicit_zero_allows_zero_fee_budget()
     // If trampoline hop fee_rate is explicitly set to 0. With max_fee_amount=0,
     // building a trampoline route should still succeed (route only needs to reach the first trampoline).
     let mut network = MockNetworkGraph::new(3);
-    network.graph.set_add_rand_expiry_delta(false);
+    network.graph.set_fixed_rand_expiry_delta(0);
 
     let sender = network.keys[1];
     network.set_source(sender);
@@ -1247,7 +1247,7 @@ fn test_graph_trampoline_routing_fee_fields_match_precompute() {
     // - amount_to_forward ladder derived from per-hop fee_rate
     // - build_max_fee_amount derived from remaining fee budget allocation.
     let mut network = MockNetworkGraph::new(5);
-    network.graph.set_add_rand_expiry_delta(false);
+    network.graph.set_fixed_rand_expiry_delta(0);
 
     let sender = network.keys[1];
     network.set_source(sender);
@@ -1562,7 +1562,7 @@ fn do_test_graph_build_route_expiry(n_nodes: usize) {
     let timestamp_before_building_route = now_timestamp_as_millis_u64();
     // Send a payment from the first node to the last node
 
-    network.graph.set_add_rand_expiry_delta(false);
+    network.graph.set_fixed_rand_expiry_delta(0);
     let payment_state: SendPaymentState =
         SendPaymentDataBuilder::new(last_node.into(), 100, Hash256::default())
             .final_tlc_expiry_delta(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -2334,7 +2334,7 @@ async fn test_send_payment_with_router_rpc_rejects_overflowing_onion_expiry() {
     let [node_0, node_1, node_2] = nodes.try_into().expect("3 nodes");
 
     node_0
-        .with_network_graph_mut(|graph| graph.set_add_rand_expiry_delta(false))
+        .with_network_graph_mut(|graph| graph.set_fixed_rand_expiry_delta(0))
         .await;
     let router = node_0
         .build_router(BuildRouterCommand {

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -1131,6 +1131,16 @@ async fn test_trampoline_routing_max_trampoline_hops_success() {
     wait_until_graph_channel_updates_along_path(&node_t3, &[&node_t3, &node_x34, &node_t4]).await;
     wait_until_graph_channel_updates_along_path(&node_t4, &[&node_t4, &node_x45, &node_t5]).await;
 
+    // This synthetic max-hop topology inserts public intermediate nodes between trampoline hops.
+    // Pin the privacy expiry slack so success does not depend on the random delta chosen in CI.
+    let fixed_rand_expiry_delta = DEFAULT_TLC_EXPIRY_DELTA * 6;
+    for node in [&node_a, &node_t1, &node_t2, &node_t3, &node_t4, &node_t5] {
+        node.with_network_graph_mut(|graph| {
+            graph.set_fixed_rand_expiry_delta(fixed_rand_expiry_delta)
+        })
+        .await;
+    }
+
     // Trampoline forwarding will call into routing/path finding.
     reset_find_path_call_count_for_tests();
 
@@ -2349,7 +2359,7 @@ async fn test_trampoline_forwarding_rejects_outgoing_expiry_beyond_upstream_budg
     let channel_ab = channels[0];
 
     node_b
-        .with_network_graph_mut(|graph| graph.set_add_rand_expiry_delta(false))
+        .with_network_graph_mut(|graph| graph.set_fixed_rand_expiry_delta(0))
         .await;
     wait_until_graph_channel_has_update(&node_b, &node_b, &node_c).await;
 


### PR DESCRIPTION
Fix flaky test: https://github.com/nervosnetwork/fiber/actions/runs/27581966006/job/81544050755

Fix a flaky `test_trampoline_routing_max_trampoline_hops_success` test by making the test expiry padding deterministic.

The test topology inserts public intermediate hops between trampoline hops, so its success could depend on the random expiry slack chosen during route building. This PR adds a test-only fixed expiry delta override and uses it in the max trampoline hops test to avoid relying on randomness.
