### PR TITLE
fix: remove panic paths from UDT regex and CKB RPC byte responses

### DIFF
--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -33,10 +33,14 @@ impl From<Option<ckb_jsonrpc_types::TransactionWithStatusResponse>> for GetTxRes
     fn from(value: Option<ckb_jsonrpc_types::TransactionWithStatusResponse>) -> Self {
         match value {
             Some(response) => Self {
-                transaction: response.transaction.map(|tx| match tx.inner {
-                    ckb_jsonrpc_types::Either::Left(json) => transaction_view_from_json(json),
-                    ckb_jsonrpc_types::Either::Right(_) => {
-                        panic!("bytes response format not used");
+                transaction: response.transaction.and_then(|tx| match tx.inner {
+                    ckb_jsonrpc_types::Either::Left(json) => Some(transaction_view_from_json(json)),
+                    ckb_jsonrpc_types::Either::Right(bytes) => {
+                        tracing::warn!(
+                            "CKB RPC returned unexpected bytes transaction format ({} bytes), ignoring",
+                            bytes.len()
+                        );
+                        None
                     }
                 }),
                 tx_status: tx_status_from_json(response.tx_status),
@@ -66,10 +70,14 @@ impl From<Option<ckb_jsonrpc_types::TransactionWithStatusResponse>> for GetShutd
     fn from(value: Option<ckb_jsonrpc_types::TransactionWithStatusResponse>) -> Self {
         match value {
             Some(response) => Self {
-                transaction: response.transaction.map(|tx| match tx.inner {
-                    ckb_jsonrpc_types::Either::Left(json) => transaction_view_from_json(json),
-                    ckb_jsonrpc_types::Either::Right(_) => {
-                        panic!("bytes response format not used");
+                transaction: response.transaction.and_then(|tx| match tx.inner {
+                    ckb_jsonrpc_types::Either::Left(json) => Some(transaction_view_from_json(json)),
+                    ckb_jsonrpc_types::Either::Right(bytes) => {
+                        tracing::warn!(
+                            "CKB RPC returned unexpected bytes transaction format ({} bytes), ignoring",
+                            bytes.len()
+                        );
+                        None
                     }
                 }),
                 tx_status: tx_status_from_json(response.tx_status),

--- a/crates/fiber-lib/src/ckb/config.rs
+++ b/crates/fiber-lib/src/ckb/config.rs
@@ -180,7 +180,16 @@ impl UdtCfgInfosExt for UdtCfgInfos {
                     && udt.script.hash_type == hash_type
                 {
                     let args = format!("0x{:x}", udt_script.args().raw_data());
-                    let pattern = Regex::new(&udt.script.args).expect("invalid expression");
+                    let pattern = match Regex::new(&udt.script.args) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            tracing::warn!(
+                                "Invalid UDT regex pattern '{}': {e}, skipping",
+                                udt.script.args
+                            );
+                            continue;
+                        }
+                    };
                     if pattern.is_match(&args) {
                         return Some(udt);
                     }


### PR DESCRIPTION
## Summary

Removes unconditional panics that could crash the node:

1. **UDT regex**: `Regex::new(&udt.script.args).expect("invalid expression")` → uses `match` to handle invalid regex, logs warning and skips entry
2. **CKB RPC bytes format**: `panic!("bytes response format not used")` in two `From` impls → uses `and_then` to return `None` for the transaction field, logs warning

## Verification
- [x] `cargo clippy -p fnn --features rocksdb --all-targets -- -D warnings` passes
- [x] `cargo fmt --all` passes