### PR TITLE
fiber-js: adapt newer TypeScript version

### DIFF
--- a/crates/fiber-wasm-db-worker/tsconfig.json
+++ b/crates/fiber-wasm-db-worker/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "es6",
     "target": "ES2015",
     "allowJs": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "declaration": true,
     "declarationDir": "dist",

--- a/crates/fiber-wasm/tsconfig.json
+++ b/crates/fiber-wasm/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "esnext",
     "target": "es2017",
     "allowJs": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "declaration": true,
     "declarationDir": "dist",

--- a/fiber-js/src/index.ts
+++ b/fiber-js/src/index.ts
@@ -15,8 +15,8 @@ const DEFAULT_BUFFER_SIZE = 50 * (1 << 20);
  * A Fiber Wasm instance
  */
 class Fiber {
-    private dbWorker: Worker | null
-    private fiberWorker: Worker | null
+    private dbWorker: Worker
+    private fiberWorker: Worker
     private inputBuffer: SharedArrayBuffer
     private outputBuffer: SharedArrayBuffer
     private commandInvokeLock: Mutex;


### PR DESCRIPTION
In newer typescript version:
- `"moduleResolution": "node"` was deprecated
- `dbWorker` and `fiberWorker` declarations in `fiber/fiber-js/src/index.ts` was rejected as they might be null

This PR fixes these issues.