### PR TITLE
Stabilize trampoline rand expiry

### DIFF
--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -8,6 +8,7 @@ use super::types::BroadcastMessageWithTimestamp;
 use crate::fiber::channel::DEFAULT_FEE_RATE;
 use crate::fiber::config::{
     DEFAULT_FINAL_TLC_EXPIRY_DELTA, DEFAULT_TLC_EXPIRY_DELTA, MAX_PAYMENT_TLC_EXPIRY_LIMIT,
+    MIN_TLC_EXPIRY_DELTA,
 };
 use crate::fiber::fee::calculate_tlc_forward_fee;
 use crate::fiber::history::SentNode;
@@ -44,6 +45,8 @@ use thiserror::Error;
 use tracing::log::error;
 use tracing::{debug, info, trace, warn};
 const DEFAULT_MIN_PROBABILITY: f64 = 0.01;
+// Budget a short forwarding route for each remaining trampoline segment.
+pub(crate) const TRAMPOLINE_FORWARDING_ROUTE_DELTA_COUNT: u64 = 3;
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 static FIND_PATH_CALL_COUNT_FOR_TESTS: AtomicU64 = AtomicU64::new(0);
@@ -1747,15 +1750,22 @@ where
         remaining_trampoline_hops: &[Pubkey],
         tlc_expiry_limit: u64,
     ) -> Result<u64, PathFindError> {
-        let slack = remaining_trampoline_hops
-            .iter()
-            .map(|_h| DEFAULT_TLC_EXPIRY_DELTA)
-            .try_fold(0u64, |acc, d| {
-                acc.checked_add(d).ok_or_else(|| {
-                    PathFindError::Other("trampoline tlc_expiry_delta overflow".to_string())
-                })
+        let remaining_segments = u64::try_from(remaining_trampoline_hops.len()).map_err(|_| {
+            PathFindError::Other("trampoline tlc_expiry_delta overflow".to_string())
+        })?;
+        let segment_budget = DEFAULT_TLC_EXPIRY_DELTA
+            .checked_mul(TRAMPOLINE_FORWARDING_ROUTE_DELTA_COUNT)
+            .and_then(|budget| budget.checked_add(MIN_TLC_EXPIRY_DELTA))
+            .ok_or_else(|| {
+                PathFindError::Other("trampoline tlc_expiry_delta overflow".to_string())
+            })?;
+        let slack = segment_budget
+            .checked_mul(remaining_segments)
+            .ok_or_else(|| {
+                PathFindError::Other("trampoline tlc_expiry_delta overflow".to_string())
             })?;
 
+        let base_final = base_final.max(MIN_TLC_EXPIRY_DELTA);
         let total = base_final.checked_add(slack).ok_or_else(|| {
             PathFindError::Other("trampoline tlc_expiry_delta overflow".to_string())
         })?;

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -1030,14 +1030,17 @@ fn test_graph_trampoline_routing_trampoline_hops_specified() {
         .expect("trampoline route should be built");
     let after = now_timestamp_as_millis_u64();
 
-    // The expiry to the first trampoline must include slack for each trampoline hop.
-    let expected_delta = FINAL_TLC_EXPIRY_DELTA_IN_TESTS
-        + (payment_state
-            .trampoline_hops
-            .as_ref()
-            .expect("trampoline_hops")
-            .len() as u64)
-            * DEFAULT_TLC_EXPIRY_DELTA;
+    // The expiry to the first trampoline must include the forwarding-route budget for
+    // each remaining trampoline segment.
+    let base_final = FINAL_TLC_EXPIRY_DELTA_IN_TESTS.max(MIN_TLC_EXPIRY_DELTA);
+    let segment_budget =
+        TRAMPOLINE_FORWARDING_ROUTE_DELTA_COUNT * DEFAULT_TLC_EXPIRY_DELTA + MIN_TLC_EXPIRY_DELTA;
+    let remaining_segments = payment_state
+        .trampoline_hops
+        .as_ref()
+        .expect("trampoline_hops")
+        .len() as u64;
+    let expected_delta = base_final + remaining_segments * segment_budget;
     let last_expiry = route.last().expect("last hop").expiry;
     assert!(
         last_expiry >= before + expected_delta && last_expiry <= after + expected_delta,

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -1,9 +1,12 @@
 #![allow(clippy::needless_range_loop)]
-use crate::fiber::config::{DEFAULT_TLC_EXPIRY_DELTA, MAX_PAYMENT_TLC_EXPIRY_LIMIT};
+use crate::fiber::config::{
+    DEFAULT_TLC_EXPIRY_DELTA, MAX_PAYMENT_TLC_EXPIRY_LIMIT, MIN_TLC_EXPIRY_DELTA,
+};
 use crate::fiber::gossip::GossipMessageStore;
 use crate::fiber::graph::NetworkGraph;
 use crate::fiber::graph::PathFindError;
 use crate::fiber::graph::SendPaymentState;
+use crate::fiber::graph::TRAMPOLINE_FORWARDING_ROUTE_DELTA_COUNT;
 use crate::fiber::network::{get_chain_hash, BuildRouterCommand};
 use crate::fiber::payment::{SendPaymentCommand, SendPaymentDataBuilder, SendPaymentDataExt};
 use crate::fiber::types::new_channel_update_unsigned;
@@ -1134,9 +1137,11 @@ fn test_graph_trampoline_routing_tlc_expiry_limit_too_small_fails() {
     network.add_edge(2, 3, Some(10_000), Some(0));
     network.add_edge(3, 4, Some(10_000), Some(0));
 
-    // Required delta is FINAL + 3*DEFAULT (since we have 3 trampoline hops).
-    // Set a limit that is smaller than that.
-    let too_small_limit = FINAL_TLC_EXPIRY_DELTA_IN_TESTS + 2 * DEFAULT_TLC_EXPIRY_DELTA;
+    // Set a limit that is smaller than the per-segment trampoline forwarding budget.
+    let base_final = FINAL_TLC_EXPIRY_DELTA_IN_TESTS.max(MIN_TLC_EXPIRY_DELTA);
+    let segment_budget =
+        TRAMPOLINE_FORWARDING_ROUTE_DELTA_COUNT * DEFAULT_TLC_EXPIRY_DELTA + MIN_TLC_EXPIRY_DELTA;
+    let too_small_limit = base_final + 3 * segment_budget - 1;
 
     let payment_state: SendPaymentState =
         SendPaymentDataBuilder::new(final_recipient.into(), 1000, Hash256::default())

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -135,16 +135,6 @@ async fn expect_add_tlc_failed(
     );
 }
 
-async fn pin_trampoline_routing_rand_expiry_delta(nodes: &[&NetworkNode]) {
-    for node in nodes {
-        // Keep routing tests deterministic while preserving a small wall-clock slack for actors.
-        node.with_network_graph_mut(|graph| {
-            graph.set_fixed_rand_expiry_delta(MIN_TLC_EXPIRY_DELTA)
-        })
-        .await;
-    }
-}
-
 #[tokio::test]
 async fn test_trampoline_routing_basic() {
     init_tracing();
@@ -164,7 +154,6 @@ async fn test_trampoline_routing_basic() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // ================================================================
     // Create an invoice on C.
@@ -233,7 +222,6 @@ async fn test_trampoline_routing_with_sync_disabled_on_sender() {
 
     wait_until_async_timeout(|| async { !node_a.get_network_graph_channels().await.is_empty() })
         .await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     let channel_outpoint = node_a
         .get_channel_outpoint(&channel_id)
@@ -352,7 +340,6 @@ async fn test_trampoline_routing_udt_private_last_will_success() {
 
     // Ensure B learns C supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_b, &node_c).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_b, &node_c]).await;
 
     let amount: u128 = 1000;
 
@@ -474,7 +461,6 @@ async fn test_trampoline_routing_udt_to_ckb_private_last_hop_no_path() {
     // Ensure A learns C supports trampoline routing and has public path to C.
     wait_until_node_supports_trampoline_routing(&node_a, &node_c).await;
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_c]).await;
 
     let amount: u128 = 1000;
     let preimage_ad = gen_rand_sha256_hash();
@@ -577,7 +563,6 @@ async fn test_trampoline_routing_keysend_success() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     let amount: u128 = 1000;
     let res = node_a
@@ -638,7 +623,6 @@ async fn test_trampoline_keysend_when_trampoline_use_default_fee() {
     .await;
 
     let [node_a, node_b, node_c, node_d] = nodes.try_into().expect("4 nodes");
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_c]).await;
 
     // Record initial balances for first payment test
     let node_a_initial_1 = node_a.get_local_balance_from_channel(channels[0]);
@@ -838,7 +822,6 @@ async fn test_trampoline_routing_multi_trampoline_hops_keysend_success() {
 
     // Ensure A learns enough public channels to reach the first trampoline.
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     let amount: u128 = 1000;
     let res = node_a
@@ -875,7 +858,6 @@ async fn test_trampoline_routing_private_last_hop_payment_success() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Create an invoice on C.
     let amount: u128 = 1000;
@@ -964,7 +946,6 @@ async fn test_trampoline_routing_with_two_networks() {
     .await;
 
     let [mut node_d, _node_e, node_f] = nodes.try_into().expect("3 nodes");
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b, &node_d]).await;
 
     // no direct connection between node_b and node_d
     // ---------------------------------------------------------------
@@ -1042,7 +1023,6 @@ async fn test_trampoline_routing_multi_trampoline_hops() {
 
     // Wait until A learns enough public channels to reach the first trampoline.
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1086,8 +1066,6 @@ async fn test_trampoline_routing_four_private_trampoline_hops_payment_success() 
 
     // Wait until A learns enough public channels to reach the first trampoline.
     wait_until_node_has_public_channels_at_least(&node_a, 1).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2, &node_t3, &node_t4])
-        .await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1152,11 +1130,6 @@ async fn test_trampoline_routing_max_trampoline_hops_success() {
     wait_until_graph_channel_updates_along_path(&node_t2, &[&node_t2, &node_x23, &node_t3]).await;
     wait_until_graph_channel_updates_along_path(&node_t3, &[&node_t3, &node_x34, &node_t4]).await;
     wait_until_graph_channel_updates_along_path(&node_t4, &[&node_t4, &node_x45, &node_t5]).await;
-
-    pin_trampoline_routing_rand_expiry_delta(&[
-        &node_a, &node_t1, &node_t2, &node_t3, &node_t4, &node_t5,
-    ])
-    .await;
 
     // Trampoline forwarding will call into routing/path finding.
     reset_find_path_call_count_for_tests();
@@ -1242,7 +1215,6 @@ async fn test_trampoline_single_hop_long_public_path() {
         ],
     )
     .await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t5]).await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1352,7 +1324,6 @@ async fn test_trampoline_routing_four_hops_with_public_paths_between_trampolines
 
     // Wait until T3 has the public graph needed to route to T4 via Y.
     wait_until_node_has_public_channels_at_least(&node_t3, 2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t2, &node_t4]).await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1505,7 +1476,6 @@ async fn test_trampoline_forwarding_prefers_better_channel_private_vs_public() {
 
     // Ensure A has a usable public channel update to reach the first trampoline.
     wait_until_graph_channel_has_update(&node_a, &node_a, &node_t1).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1]).await;
 
     // Create an invoice on C that explicitly allows trampoline routing.
     let amount: u128 = 1000;
@@ -1722,7 +1692,6 @@ async fn test_trampoline_error_wrapping_propagates_to_payer() {
 
     // Wait until A learns enough public channels to reach the first trampoline.
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     // Build an invoice for C but do NOT insert it on C, so the payment fails at the final
     // recipient (beyond the trampoline boundary) and must be wrapped for the payer.
@@ -1786,7 +1755,6 @@ async fn test_trampoline_forwarding_fee_insufficient_due_to_rate_cap() {
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1]).await;
 
     let amount: u128 = 2000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1882,7 +1850,6 @@ async fn test_trampoline_hop_feature_disabled_during_payment() {
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_supports_trampoline_routing(&node_a, &node_t2).await;
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1969,7 +1936,6 @@ async fn test_trampoline_multi_hops_fee_insufficient_then_success() {
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
     wait_until_node_has_public_channels_at_least(&node_t1, 2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     let amount: u128 = 2000;
     let attempts = [1, 5];
@@ -2608,7 +2574,6 @@ async fn test_trampoline_routing_loop_failure_insufficient_fee() {
     wait_until_node_supports_trampoline_routing(&node_a, &node_c).await;
     wait_until_node_supports_trampoline_routing(&node_a, &node_d).await;
     wait_until_node_supports_trampoline_routing(&node_a, &node_e).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b, &node_c, &node_d]).await;
 
     let amount = 1000;
     let (invoice, _preimage) = node_e.gen_basic_invoice(amount);
@@ -2711,7 +2676,6 @@ async fn test_trampoline_routing_retry_with_intermediate_failure() {
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
     wait_until_node_has_public_channels_at_least(&node_b, 5).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Drain P1 -> C
     let drain_amount = usable_cap - 1000;
@@ -2879,8 +2843,6 @@ async fn test_trampoline_routing_two_hops_both_retry_success() {
     wait_until_node_has_public_channels_at_least(&node_t1, 9).await; // 9 total channels in network
     wait_until_node_has_public_channels_at_least(&node_t2, 9).await;
 
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
-
     // Drain P1 (T1 -> P1 -> T2 path)
     let drain_amount = usable_cap - 1000;
 
@@ -3024,7 +2986,6 @@ async fn test_trampoline_routing_mid_failure_propagates_back() {
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_supports_trampoline_routing(&node_a, &node_t2).await;
     wait_until_node_has_public_channels_at_least(&node_t2, 6).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     // Drain Q1->C
     {
@@ -3138,7 +3099,6 @@ async fn test_trampoline_routing_concurrent_payments() {
     wait_until_node_has_public_channels_at_least(&node_t, 4).await;
     wait_until_node_has_public_channels_at_least(&node_a, 4).await;
     wait_until_node_has_public_channels_at_least(&node_c, 4).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_c, &node_t]).await;
 
     // Prepare Payment 1: A -> T -> B
     let amount1 = 1000;
@@ -3203,7 +3163,6 @@ async fn test_trampoline_routing_no_path_found() {
     let [node_a, node_t, node_b] = nodes.try_into().expect("3 nodes");
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_t).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t]).await;
 
     let amount = 1000;
     let (invoice, _preimage) = node_b.gen_basic_invoice(amount);
@@ -3276,7 +3235,6 @@ async fn test_trampoline_routing_race_same_invoice() {
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_supports_trampoline_routing(&node_b, &node_t2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b, &node_t1, &node_t2]).await;
 
     // C creates invoice
     let amount = 1000;
@@ -3411,7 +3369,6 @@ async fn test_trampoline_routing_failure_invalid_payment_secret() {
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_t).await;
     wait_until_node_supports_trampoline_routing(&node_b, &node_t).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t]).await;
 
     // 1. Create correct invoice on B with explicit secret
     let amount = 1000;
@@ -3480,7 +3437,6 @@ async fn test_trampoline_node_restart() {
 
     // Wait until A learns B (public channel).
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Create an invoice on C.
     // Use a large timeout so we have time to restart B.
@@ -3798,7 +3754,6 @@ async fn test_trampoline_routing_mpp_last_hop() {
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Use a larger amount than single channel capacity (1000000000) to force MPP
     let amount: u128 = 1500000000;
@@ -3873,7 +3828,6 @@ async fn test_trampoline_routing_invoice_not_allow_mpp_will_fail() {
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Use a larger amount than single channel capacity (1000000000) to force MPP
     let amount: u128 = 1500000000;
@@ -4000,7 +3954,6 @@ async fn test_trampoline_routing_dry_run_basic() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Create an invoice on C.
     let amount: u128 = 1000;
@@ -4134,7 +4087,6 @@ async fn test_trampoline_routing_dry_run_get_default_fee() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Create an invoice on C.
     let amount: u128 = 1000;
@@ -4294,7 +4246,6 @@ async fn test_trampoline_mpp_with_oneway() {
 
     // Wait until node1 learns node2 supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node1, &node2).await;
-    pin_trampoline_routing_rand_expiry_delta(&[&node1, &node2]).await;
 
     async fn run_with_hash_algo(
         node1: &NetworkNode,

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -2855,6 +2855,16 @@ async fn test_trampoline_routing_two_hops_both_retry_success() {
     wait_until_node_has_public_channels_at_least(&node_t1, 9).await; // 9 total channels in network
     wait_until_node_has_public_channels_at_least(&node_t2, 9).await;
 
+    // The retry paths insert one public intermediate hop between each trampoline hop.
+    // Pin the privacy expiry slack so success does not depend on the random minimum.
+    let fixed_rand_expiry_delta = DEFAULT_TLC_EXPIRY_DELTA * 3;
+    for node in [&node_a, &node_t1, &node_t2] {
+        node.with_network_graph_mut(|graph| {
+            graph.set_fixed_rand_expiry_delta(fixed_rand_expiry_delta)
+        })
+        .await;
+    }
+
     // Drain P1 (T1 -> P1 -> T2 path)
     let drain_amount = usable_cap - 1000;
 

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -135,6 +135,16 @@ async fn expect_add_tlc_failed(
     );
 }
 
+async fn pin_trampoline_routing_rand_expiry_delta(nodes: &[&NetworkNode]) {
+    let fixed_rand_expiry_delta = DEFAULT_TLC_EXPIRY_DELTA * 6;
+    for node in nodes {
+        node.with_network_graph_mut(|graph| {
+            graph.set_fixed_rand_expiry_delta(fixed_rand_expiry_delta)
+        })
+        .await;
+    }
+}
+
 #[tokio::test]
 async fn test_trampoline_routing_basic() {
     init_tracing();
@@ -154,6 +164,7 @@ async fn test_trampoline_routing_basic() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // ================================================================
     // Create an invoice on C.
@@ -222,6 +233,7 @@ async fn test_trampoline_routing_with_sync_disabled_on_sender() {
 
     wait_until_async_timeout(|| async { !node_a.get_network_graph_channels().await.is_empty() })
         .await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     let channel_outpoint = node_a
         .get_channel_outpoint(&channel_id)
@@ -340,6 +352,7 @@ async fn test_trampoline_routing_udt_private_last_will_success() {
 
     // Ensure B learns C supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_b, &node_c).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_b, &node_c]).await;
 
     let amount: u128 = 1000;
 
@@ -461,6 +474,7 @@ async fn test_trampoline_routing_udt_to_ckb_private_last_hop_no_path() {
     // Ensure A learns C supports trampoline routing and has public path to C.
     wait_until_node_supports_trampoline_routing(&node_a, &node_c).await;
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_c]).await;
 
     let amount: u128 = 1000;
     let preimage_ad = gen_rand_sha256_hash();
@@ -563,6 +577,7 @@ async fn test_trampoline_routing_keysend_success() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     let amount: u128 = 1000;
     let res = node_a
@@ -623,6 +638,7 @@ async fn test_trampoline_keysend_when_trampoline_use_default_fee() {
     .await;
 
     let [node_a, node_b, node_c, node_d] = nodes.try_into().expect("4 nodes");
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_c]).await;
 
     // Record initial balances for first payment test
     let node_a_initial_1 = node_a.get_local_balance_from_channel(channels[0]);
@@ -822,6 +838,7 @@ async fn test_trampoline_routing_multi_trampoline_hops_keysend_success() {
 
     // Ensure A learns enough public channels to reach the first trampoline.
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     let amount: u128 = 1000;
     let res = node_a
@@ -858,6 +875,7 @@ async fn test_trampoline_routing_private_last_hop_payment_success() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Create an invoice on C.
     let amount: u128 = 1000;
@@ -946,6 +964,7 @@ async fn test_trampoline_routing_with_two_networks() {
     .await;
 
     let [mut node_d, _node_e, node_f] = nodes.try_into().expect("3 nodes");
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b, &node_d]).await;
 
     // no direct connection between node_b and node_d
     // ---------------------------------------------------------------
@@ -1023,6 +1042,7 @@ async fn test_trampoline_routing_multi_trampoline_hops() {
 
     // Wait until A learns enough public channels to reach the first trampoline.
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1066,6 +1086,8 @@ async fn test_trampoline_routing_four_private_trampoline_hops_payment_success() 
 
     // Wait until A learns enough public channels to reach the first trampoline.
     wait_until_node_has_public_channels_at_least(&node_a, 1).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2, &node_t3, &node_t4])
+        .await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1131,15 +1153,10 @@ async fn test_trampoline_routing_max_trampoline_hops_success() {
     wait_until_graph_channel_updates_along_path(&node_t3, &[&node_t3, &node_x34, &node_t4]).await;
     wait_until_graph_channel_updates_along_path(&node_t4, &[&node_t4, &node_x45, &node_t5]).await;
 
-    // This synthetic max-hop topology inserts public intermediate nodes between trampoline hops.
-    // Pin the privacy expiry slack so success does not depend on the random delta chosen in CI.
-    let fixed_rand_expiry_delta = DEFAULT_TLC_EXPIRY_DELTA * 6;
-    for node in [&node_a, &node_t1, &node_t2, &node_t3, &node_t4, &node_t5] {
-        node.with_network_graph_mut(|graph| {
-            graph.set_fixed_rand_expiry_delta(fixed_rand_expiry_delta)
-        })
-        .await;
-    }
+    pin_trampoline_routing_rand_expiry_delta(&[
+        &node_a, &node_t1, &node_t2, &node_t3, &node_t4, &node_t5,
+    ])
+    .await;
 
     // Trampoline forwarding will call into routing/path finding.
     reset_find_path_call_count_for_tests();
@@ -1225,6 +1242,7 @@ async fn test_trampoline_single_hop_long_public_path() {
         ],
     )
     .await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t5]).await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1334,6 +1352,7 @@ async fn test_trampoline_routing_four_hops_with_public_paths_between_trampolines
 
     // Wait until T3 has the public graph needed to route to T4 via Y.
     wait_until_node_has_public_channels_at_least(&node_t3, 2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t2, &node_t4]).await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1486,6 +1505,7 @@ async fn test_trampoline_forwarding_prefers_better_channel_private_vs_public() {
 
     // Ensure A has a usable public channel update to reach the first trampoline.
     wait_until_graph_channel_has_update(&node_a, &node_a, &node_t1).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1]).await;
 
     // Create an invoice on C that explicitly allows trampoline routing.
     let amount: u128 = 1000;
@@ -1704,6 +1724,7 @@ async fn test_trampoline_error_wrapping_propagates_to_payer() {
 
     // Wait until A learns enough public channels to reach the first trampoline.
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     // Build an invoice for C but do NOT insert it on C, so the payment fails at the final
     // recipient (beyond the trampoline boundary) and must be wrapped for the payer.
@@ -1767,6 +1788,7 @@ async fn test_trampoline_forwarding_fee_insufficient_due_to_rate_cap() {
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1]).await;
 
     let amount: u128 = 2000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1862,6 +1884,7 @@ async fn test_trampoline_hop_feature_disabled_during_payment() {
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_supports_trampoline_routing(&node_a, &node_t2).await;
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
@@ -1948,6 +1971,7 @@ async fn test_trampoline_multi_hops_fee_insufficient_then_success() {
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_has_public_channels_at_least(&node_a, 2).await;
     wait_until_node_has_public_channels_at_least(&node_t1, 2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     let amount: u128 = 2000;
     let attempts = [1, 5];
@@ -2586,6 +2610,7 @@ async fn test_trampoline_routing_loop_failure_insufficient_fee() {
     wait_until_node_supports_trampoline_routing(&node_a, &node_c).await;
     wait_until_node_supports_trampoline_routing(&node_a, &node_d).await;
     wait_until_node_supports_trampoline_routing(&node_a, &node_e).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b, &node_c, &node_d]).await;
 
     let amount = 1000;
     let (invoice, _preimage) = node_e.gen_basic_invoice(amount);
@@ -2688,6 +2713,7 @@ async fn test_trampoline_routing_retry_with_intermediate_failure() {
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
     wait_until_node_has_public_channels_at_least(&node_b, 5).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Drain P1 -> C
     let drain_amount = usable_cap - 1000;
@@ -2855,15 +2881,7 @@ async fn test_trampoline_routing_two_hops_both_retry_success() {
     wait_until_node_has_public_channels_at_least(&node_t1, 9).await; // 9 total channels in network
     wait_until_node_has_public_channels_at_least(&node_t2, 9).await;
 
-    // The retry paths insert one public intermediate hop between each trampoline hop.
-    // Pin the privacy expiry slack so success does not depend on the random minimum.
-    let fixed_rand_expiry_delta = DEFAULT_TLC_EXPIRY_DELTA * 3;
-    for node in [&node_a, &node_t1, &node_t2] {
-        node.with_network_graph_mut(|graph| {
-            graph.set_fixed_rand_expiry_delta(fixed_rand_expiry_delta)
-        })
-        .await;
-    }
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     // Drain P1 (T1 -> P1 -> T2 path)
     let drain_amount = usable_cap - 1000;
@@ -3008,6 +3026,7 @@ async fn test_trampoline_routing_mid_failure_propagates_back() {
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_supports_trampoline_routing(&node_a, &node_t2).await;
     wait_until_node_has_public_channels_at_least(&node_t2, 6).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t1, &node_t2]).await;
 
     // Drain Q1->C
     {
@@ -3121,6 +3140,7 @@ async fn test_trampoline_routing_concurrent_payments() {
     wait_until_node_has_public_channels_at_least(&node_t, 4).await;
     wait_until_node_has_public_channels_at_least(&node_a, 4).await;
     wait_until_node_has_public_channels_at_least(&node_c, 4).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_c, &node_t]).await;
 
     // Prepare Payment 1: A -> T -> B
     let amount1 = 1000;
@@ -3185,6 +3205,7 @@ async fn test_trampoline_routing_no_path_found() {
     let [node_a, node_t, node_b] = nodes.try_into().expect("3 nodes");
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_t).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t]).await;
 
     let amount = 1000;
     let (invoice, _preimage) = node_b.gen_basic_invoice(amount);
@@ -3257,6 +3278,7 @@ async fn test_trampoline_routing_race_same_invoice() {
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_t1).await;
     wait_until_node_supports_trampoline_routing(&node_b, &node_t2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b, &node_t1, &node_t2]).await;
 
     // C creates invoice
     let amount = 1000;
@@ -3391,6 +3413,7 @@ async fn test_trampoline_routing_failure_invalid_payment_secret() {
 
     wait_until_node_supports_trampoline_routing(&node_a, &node_t).await;
     wait_until_node_supports_trampoline_routing(&node_b, &node_t).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_t]).await;
 
     // 1. Create correct invoice on B with explicit secret
     let amount = 1000;
@@ -3459,6 +3482,7 @@ async fn test_trampoline_node_restart() {
 
     // Wait until A learns B (public channel).
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Create an invoice on C.
     // Use a large timeout so we have time to restart B.
@@ -3776,6 +3800,7 @@ async fn test_trampoline_routing_mpp_last_hop() {
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Use a larger amount than single channel capacity (1000000000) to force MPP
     let amount: u128 = 1500000000;
@@ -3850,6 +3875,7 @@ async fn test_trampoline_routing_invoice_not_allow_mpp_will_fail() {
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Use a larger amount than single channel capacity (1000000000) to force MPP
     let amount: u128 = 1500000000;
@@ -3976,6 +4002,7 @@ async fn test_trampoline_routing_dry_run_basic() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Create an invoice on C.
     let amount: u128 = 1000;
@@ -4109,6 +4136,7 @@ async fn test_trampoline_routing_dry_run_get_default_fee() {
 
     // Wait until A learns B supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node_a, &node_b).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node_a, &node_b]).await;
 
     // Create an invoice on C.
     let amount: u128 = 1000;
@@ -4268,6 +4296,7 @@ async fn test_trampoline_mpp_with_oneway() {
 
     // Wait until node1 learns node2 supports trampoline routing.
     wait_until_node_supports_trampoline_routing(&node1, &node2).await;
+    pin_trampoline_routing_rand_expiry_delta(&[&node1, &node2]).await;
 
     async fn run_with_hash_algo(
         node1: &NetworkNode,

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -136,10 +136,10 @@ async fn expect_add_tlc_failed(
 }
 
 async fn pin_trampoline_routing_rand_expiry_delta(nodes: &[&NetworkNode]) {
-    let fixed_rand_expiry_delta = DEFAULT_TLC_EXPIRY_DELTA * 6;
     for node in nodes {
+        // Keep routing tests deterministic while preserving a small wall-clock slack for actors.
         node.with_network_graph_mut(|graph| {
-            graph.set_fixed_rand_expiry_delta(fixed_rand_expiry_delta)
+            graph.set_fixed_rand_expiry_delta(MIN_TLC_EXPIRY_DELTA)
         })
         .await;
     }
@@ -1654,12 +1654,12 @@ async fn test_trampoline_routing_connect_two_networks() {
 }
 
 #[tokio::test]
-async fn test_trampoline_forwarding_respects_tlc_expiry_limit_from_payload() {
+async fn test_trampoline_routing_rejects_tlc_expiry_limit_below_segment_budget() {
     init_tracing();
 
     // A --(public)--> T1 --(private)--> X --(private)--> C
     // A can only route to T1; T1 must forward over 2 private hops.
-    // Set a tight `tlc_expiry_limit` that is sufficient for A->T1, but insufficient for T1->X->C.
+    // Set a tight `tlc_expiry_limit` that cannot cover the trampoline segment budget.
     let (nodes, _channels) = create_n_nodes_network_with_visibility(
         &[
             ((0, 1), (MIN_RESERVED_CKB + 100000, HUGE_CKB_AMOUNT), true),
@@ -1679,9 +1679,9 @@ async fn test_trampoline_forwarding_respects_tlc_expiry_limit_from_payload() {
     let amount: u128 = 1000;
     let (invoice, _preimage) = node_c.gen_basic_invoice(amount);
 
-    // Tight limit: large enough for payer's trampoline slack (final + 1*DEFAULT), but too small
-    // for T1 to reach C over 2 hops (final + 2*DEFAULT).
-    let tight_limit = DEFAULT_FINAL_TLC_EXPIRY_DELTA + DEFAULT_TLC_EXPIRY_DELTA + 1;
+    let segment_budget =
+        TRAMPOLINE_FORWARDING_ROUTE_DELTA_COUNT * DEFAULT_TLC_EXPIRY_DELTA + MIN_TLC_EXPIRY_DELTA;
+    let tight_limit = DEFAULT_FINAL_TLC_EXPIRY_DELTA + segment_budget - 1;
 
     let res = node_a
         .send_payment(SendPaymentCommand {
@@ -1691,13 +1691,11 @@ async fn test_trampoline_forwarding_respects_tlc_expiry_limit_from_payload() {
             trampoline_hops: Some(vec![node_t1.get_public_key()]),
             ..Default::default()
         })
-        .await;
-    assert!(res.is_ok());
-
-    let payment_hash = res.unwrap().payment_hash;
-    node_a.wait_until_failed(payment_hash).await;
-    let payment_res = node_a.get_payment_result(payment_hash).await;
-    assert!(payment_res.failed_error.is_some());
+        .await
+        .expect_err("tlc_expiry_limit below trampoline segment budget should fail locally");
+    assert!(res
+        .to_string()
+        .contains("trampoline tlc_expiry_delta exceeds tlc_expiry_limit"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
https://github.com/nervosnetwork/fiber/actions/runs/27792535961/job/82244803824 is not stable.

Now develop have more strict `expiry` check for last hop, trampoline routing expiry rand need to be robust, https://github.com/nervosnetwork/fiber/pull/1465 is not a complete fix.
