### PR TITLE
fix: validate next_per_commitment_point in RevokeAndAck against tlc_basepoint

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -8172,6 +8172,14 @@ impl ChannelActorState {
             next_revocation_nonce,
         } = revoke_and_ack;
 
+        let remote_tlc_base_key = &self.get_remote_channel_public_keys().tlc_base_key;
+        if !is_tlc_key_derivation_safe(remote_tlc_base_key, &next_per_commitment_point) {
+            return Err(ProcessingChannelError::InvalidParameter(
+                "peer tlc_basepoint and next_per_commitment_point in RevokeAndAck derive to invalid key"
+                    .to_string(),
+            ));
+        }
+
         let sign_ctx = match self.get_revoke_sign_context(true) {
             Some(ctx) => ctx,
             None => {

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -58,7 +58,7 @@ use fiber_types::{
     AwaitingChannelReadyFlags, AwaitingTxSignaturesFlags, ChannelConstraints, ChannelOpeningStatus,
     ChannelState, CollaboratingFundingTxFlags, HashAlgorithm, InMemorySigner, InboundTlcStatus,
     NegotiatingFundingFlags, OutboundTlcStatus, PaymentHopData, PaymentStatus, Privkey, RemoveTlc,
-    RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation, ShuttingDownFlags,
+    RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation, RevokeAndAck, ShuttingDownFlags,
     SigningCommitmentFlags, TLCId, TlcErrPacket, TlcErrorCode, TlcInfo, TlcStatus,
     NO_SHARED_SECRET,
 };
@@ -325,6 +325,113 @@ fn test_malicious_keys_would_have_caused_panic() {
     assert!(
         result.is_err(),
         "malicious TLC basepoint and commitment point should cause a panic in derive_tlc_pubkey"
+    );
+}
+
+#[test]
+fn test_revoke_and_ack_bypass_safe_initial_keys_with_malicious_later_key() {
+    use fiber_types::derive_tlc_pubkey;
+    let (malicious_tlc_basepoint, bad_commitment_point) =
+        malicious_tlc_basepoint_and_commitment_point();
+
+    let signer = InMemorySigner::generate_from_seed(b"safe-commitment-for-open-channel");
+    let safe_first_commitment_point = signer.get_commitment_point(1);
+    let safe_second_commitment_point = signer.get_commitment_point(2);
+
+    assert!(
+        is_tlc_key_derivation_safe(&malicious_tlc_basepoint, &safe_first_commitment_point),
+        "first_per_commitment_point should pass validation at OpenChannel"
+    );
+    assert!(
+        is_tlc_key_derivation_safe(&malicious_tlc_basepoint, &safe_second_commitment_point),
+        "second_per_commitment_point should pass validation at OpenChannel"
+    );
+
+    assert!(
+        !is_tlc_key_derivation_safe(&malicious_tlc_basepoint, &bad_commitment_point),
+        "malicious next_per_commitment_point in RevokeAndAck should be rejected by the fix"
+    );
+
+    let result = std::panic::catch_unwind(|| {
+        let _ = derive_tlc_pubkey(&malicious_tlc_basepoint, &bad_commitment_point);
+    });
+    assert!(
+        result.is_err(),
+        "without validation, the malicious next_per_commitment_point would cause a panic"
+    );
+}
+
+#[tokio::test]
+async fn test_revoke_and_ack_rejects_malicious_next_per_commitment_point() {
+    init_tracing();
+    let (mut node_a, node_b, channel_id, _) =
+        NetworkNode::new_2_nodes_with_established_channel(100000000000, 100000000000, true).await;
+
+    let (malicious_tlc_basepoint, bad_commitment_point) =
+        malicious_tlc_basepoint_and_commitment_point();
+
+    let mut state = node_a.get_channel_actor_state(channel_id);
+    let initial_commitment_points_len = state.remote_commitment_points.len();
+    state
+        .remote_channel_public_keys
+        .as_mut()
+        .unwrap()
+        .tlc_base_key = malicious_tlc_basepoint;
+    state.tlc_state.set_waiting_ack(true);
+    node_a.update_channel_actor_state(state, None).await;
+
+    while tokio::time::timeout(Duration::from_millis(25), node_a.event_emitter.recv())
+        .await
+        .is_ok()
+    {}
+
+    let dummy_partial_sig =
+        musig2::PartialSignature::from_slice(&[1u8; 32]).expect("valid partial signature bytes");
+    let dummy_nonce = musig2::SecNonceBuilder::new([1u8; 32])
+        .build()
+        .public_nonce();
+
+    node_b
+        .network_actor
+        .send_message(NetworkActorMessage::Command(
+            NetworkActorCommand::SendFiberMessage(FiberMessageWithTarget::new(
+                node_a.pubkey,
+                FiberMessage::revoke_and_ack(RevokeAndAck {
+                    channel_id,
+                    revocation_partial_signature: dummy_partial_sig,
+                    next_per_commitment_point: bad_commitment_point,
+                    next_revocation_nonce: dummy_nonce,
+                }),
+            )),
+        ))
+        .expect("send malicious RevokeAndAck");
+
+    let mut saw_rejection = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(1000);
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let Ok(Some(event)) = tokio::time::timeout(remaining, node_a.event_emitter.recv()).await
+        else {
+            break;
+        };
+        if let NetworkServiceEvent::DebugEvent(DebugEvent::Common(msg)) = &event {
+            if msg.contains("next_per_commitment_point in RevokeAndAck derive to invalid key") {
+                saw_rejection = true;
+                break;
+            }
+        }
+    }
+
+    assert!(
+        saw_rejection,
+        "node_a should reject the malicious next_per_commitment_point in RevokeAndAck"
+    );
+
+    let state = node_a.get_channel_actor_state(channel_id);
+    assert_eq!(
+        state.remote_commitment_points.len(),
+        initial_commitment_points_len,
+        "remote_commitment_points should not include the malicious point"
     );
 }
 


### PR DESCRIPTION
## Summary

This commit was originally part of the security fix in #1449, but was likely lost during a force push when consolidating the security advisory commits.

#1449 added `is_tlc_key_derivation_safe()` validation at `OpenChannel` and `AcceptChannel` entry points to prevent a malicious peer from crafting `tlc_basepoint` and `per_commitment_point` pairs that cause `derive_tlc_pubkey` to produce the point at infinity. However, the `next_per_commitment_point` received via `RevokeAndAck` was not subject to the same validation, leaving a bypass path:

1. Malicious peer crafts `tlc_basepoint = -tweak(Q_bad) * G` and sends it during channel open
2. Provides safe `first_per_commitment_point` / `second_per_commitment_point` that pass validation
3. Later sends `Q_bad` as `next_per_commitment_point` in `RevokeAndAck`
4. `derive_tlc_pubkey(tlc_basepoint, Q_bad)` produces the point at infinity → panic

## Changes

- **`crates/fiber-lib/src/fiber/channel.rs`** — Add `is_tlc_key_derivation_safe()` check at the entry of `handle_revoke_and_ack_peer_message`, right after destructuring and before signature verification, matching the validation pattern used in `handle_accept_channel_message` and `pre_start` (OpenChannel)
- **`crates/fiber-lib/src/fiber/tests/channel.rs`** — Add two tests:
  - `test_revoke_and_ack_bypass_safe_initial_keys_with_malicious_later_key`: unit test demonstrating the bypass — same `tlc_basepoint` passes validation with safe initial points but fails with the crafted later point
  - `test_revoke_and_ack_rejects_malicious_next_per_commitment_point`: integration test that establishes a real channel, injects a malicious `RevokeAndAck`, and verifies the `InvalidParameter` rejection via debug event

## Security Audit

All three code paths that store remote commitment points are now guarded:

| Source Message | Validation |
|---|---|
| `OpenChannel` (`first/second_per_commitment_point`) | ✅ #1449 |
| `AcceptChannel` (`first/second_per_commitment_point`) | ✅ #1449 |
| `RevokeAndAck` (`next_per_commitment_point`) | ✅ this PR |

`ReestablishChannel` does not carry commitment points — no action needed.