### PR TITLE
Fix CCH pending expiry reconciliation

### DIFF
--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -17,7 +17,7 @@ use crate::cch::{
 use crate::fiber::config::MAX_PAYMENT_TLC_EXPIRY_LIMIT;
 use crate::fiber::payment::MAX_FEE_RATE_DENOMINATOR;
 use crate::invoice::CkbInvoice;
-use crate::time::{SystemTime, UNIX_EPOCH};
+use crate::now_timestamp_as_millis_u64;
 use fiber_types::{payment::PaymentStatus, CchInvoice, CchOrder, CchOrderStatus, Hash256};
 
 const BTC_PAYMENT_TIMEOUT_SECONDS: i32 = 60;
@@ -246,10 +246,7 @@ impl SendOutgoingPaymentDispatcher {
         state: &CchState<S>,
         order: &CchOrder,
     ) -> Option<u64> {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("System time should always be after UNIX_EPOCH")
-            .as_secs();
+        let now = now_timestamp_as_millis_u64() / 1000;
         let elapsed = now.saturating_sub(order.created_at);
 
         // The incoming TLC/HTLC was accepted with at least this many seconds of expiry.

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -25,7 +25,7 @@ use crate::cch::trackers::{
 use crate::cch::{CchConfig, CchError, CchOrderStore, CchStoreError};
 use crate::ckb::contracts::{get_script_by_contract, Contract};
 use crate::fiber::NetworkActorMessage;
-use crate::invoice::{CkbInvoice, Currency, InvoiceBuilder};
+use crate::invoice::{CkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder};
 use crate::store::store_impl::StoreChange;
 use crate::time::{Duration, SystemTime, UNIX_EPOCH};
 use fiber_types::{AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, HashAlgorithm};
@@ -569,6 +569,15 @@ impl<S: CchOrderStore> CchState<S> {
 
         let payment_hash = Hash256::from(*invoice.payment_hash());
 
+        let invoice_created_at = invoice.duration_since_epoch().as_secs();
+        let order_created_at = duration_since_epoch.as_secs();
+        if invoice_created_at > order_created_at {
+            return Err(CchError::BTCInvoiceCreationTimeInFuture {
+                invoice_created_at,
+                order_created_at,
+            });
+        }
+
         // Validate that outgoing BTC invoice's final CLTV is less than half of incoming CKB invoice's final TLC expiry.
         // This ensures the CCH operator has sufficient time to settle the incoming side before the outgoing side expires.
         // BTC uses blocks (~10 min each), CKB uses seconds.
@@ -706,6 +715,14 @@ impl<S: CchOrderStore> CchState<S> {
         }
 
         let duration_since_epoch = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        let order_created_at_ms = duration_since_epoch.as_millis();
+        if invoice.data.timestamp > order_created_at_ms {
+            return Err(CchError::CKBInvoiceCreationTimeInFuture {
+                invoice_created_at_ms: invoice.data.timestamp,
+                order_created_at_ms,
+            });
+        }
+
         // Convert timestamp + expiry_time to the expiry time relative to `duration_since`.
         let outgoing_invoice_expiry_delta_seconds = match invoice.expiry_time() {
             Some(expiry) => invoice
@@ -791,6 +808,30 @@ impl<S: CchOrderStore> CchState<S> {
             None => return Ok(vec![]),
             Some(order) => order,
         };
+
+        if order.status == CchOrderStatus::Pending
+            && matches!(
+                &event,
+                CchTrackingEvent::InvoiceChanged {
+                    status: CkbInvoiceStatus::Received,
+                    ..
+                }
+            )
+        {
+            let current_time = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("System time should always be after UNIX_EPOCH")
+                .as_secs();
+            if order.update_if_expired_with_reason(current_time, "Order expired") {
+                self.store.update_cch_order(order.clone());
+                self.schedule_job_on_entering(&order);
+                tracing::info!(
+                    "Rejected incoming invoice event for expired pending order {:x}",
+                    order.payment_hash
+                );
+                return Ok(vec![]);
+            }
+        }
 
         if CchOrderStateMachine::apply(&mut order, event.into())?.is_some() {
             self.store.update_cch_order(order.clone());

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -26,8 +26,9 @@ use crate::cch::{CchConfig, CchError, CchOrderStore, CchStoreError};
 use crate::ckb::contracts::{get_script_by_contract, Contract};
 use crate::fiber::NetworkActorMessage;
 use crate::invoice::{CkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder};
+use crate::now_timestamp_as_millis_u64;
 use crate::store::store_impl::StoreChange;
-use crate::time::{Duration, SystemTime, UNIX_EPOCH};
+use crate::time::Duration;
 use fiber_types::{AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, HashAlgorithm};
 use fiber_types::{Hash256, Privkey};
 
@@ -253,10 +254,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
         myself: ActorRef<Self::Msg>,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
-        let current_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("System time should always be after UNIX_EPOCH")
-            .as_secs();
+        let current_time = now_timestamp_as_millis_u64() / 1000;
 
         // Load all orders from the database
         for mut order in state
@@ -539,7 +537,7 @@ impl<S: CchOrderStore> CchState<S> {
     }
 
     async fn send_btc(&self, send_btc: SendBTC) -> Result<CchOrder, CchError> {
-        let duration_since_epoch = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        let order_created_at = now_timestamp_as_millis_u64() / 1000;
 
         // Validate that the currency matches the configured CKB network (#981)
         if send_btc.currency != self.currency {
@@ -570,7 +568,6 @@ impl<S: CchOrderStore> CchState<S> {
         let payment_hash = Hash256::from(*invoice.payment_hash());
 
         let invoice_created_at = invoice.duration_since_epoch().as_secs();
-        let order_created_at = duration_since_epoch.as_secs();
         if invoice_created_at > order_created_at {
             return Err(CchError::BTCInvoiceCreationTimeInFuture {
                 invoice_created_at,
@@ -592,8 +589,7 @@ impl<S: CchOrderStore> CchState<S> {
 
         let outgoing_invoice_expiry_delta_seconds = invoice
             .expires_at()
-            .and_then(|expired_at| expired_at.checked_sub(duration_since_epoch))
-            .map(|duration| duration.as_secs())
+            .and_then(|expired_at| expired_at.as_secs().checked_sub(order_created_at))
             .ok_or(CchError::BTCInvoiceExpired)?;
         if outgoing_invoice_expiry_delta_seconds
             < self.config.min_outgoing_invoice_expiry_delta_seconds
@@ -647,7 +643,7 @@ impl<S: CchOrderStore> CchState<S> {
 
         let order = CchOrder {
             amount_sats: invoice_amount_sats,
-            created_at: duration_since_epoch.as_secs(),
+            created_at: order_created_at,
             expiry_delta_seconds: self.config.order_expiry_delta_seconds,
             failure_reason: None,
             incoming_invoice: CchInvoice::Fiber(invoice),
@@ -714,12 +710,12 @@ impl<S: CchOrderStore> CchState<S> {
             return Err(CchError::CKBInvoiceFinalTlcExpiryDeltaTooLarge);
         }
 
-        let duration_since_epoch = SystemTime::now().duration_since(UNIX_EPOCH)?;
-        let order_created_at_ms = duration_since_epoch.as_millis();
-        if invoice.data.timestamp > order_created_at_ms {
+        let order_created_at_ms = now_timestamp_as_millis_u64();
+        let order_created_at = order_created_at_ms / 1000;
+        if invoice.data.timestamp > u128::from(order_created_at_ms) {
             return Err(CchError::CKBInvoiceCreationTimeInFuture {
                 invoice_created_at_ms: invoice.data.timestamp,
-                order_created_at_ms,
+                order_created_at_ms: u128::from(order_created_at_ms),
             });
         }
 
@@ -732,7 +728,7 @@ impl<S: CchOrderStore> CchState<S> {
                 .and_then(|expiry_at| {
                     u64::try_from(expiry_at / 1000)
                         .unwrap_or(u64::MAX)
-                        .checked_sub(duration_since_epoch.as_secs())
+                        .checked_sub(order_created_at)
                 })
                 .ok_or(CchError::OutgoingInvoiceExpiryTooShort)?,
             // CKB invoice has no default expiry, use minimal * 2 to create the invoice
@@ -786,7 +782,7 @@ impl<S: CchOrderStore> CchState<S> {
         let incoming_invoice = Bolt11Invoice::from_str(&add_invoice_resp.payment_request)?;
 
         let order = CchOrder {
-            created_at: duration_since_epoch.as_secs(),
+            created_at: order_created_at,
             expiry_delta_seconds: self.config.order_expiry_delta_seconds,
             failure_reason: None,
             incoming_invoice: CchInvoice::Lightning(incoming_invoice),
@@ -818,10 +814,7 @@ impl<S: CchOrderStore> CchState<S> {
                 }
             )
         {
-            let current_time = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("System time should always be after UNIX_EPOCH")
-                .as_secs();
+            let current_time = now_timestamp_as_millis_u64() / 1000;
             if order.update_if_expired_with_reason(current_time, "Order expired") {
                 self.store.update_cch_order(order.clone());
                 self.schedule_job_on_entering(&order);

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -22,6 +22,13 @@ pub enum CchError {
     OutgoingInvoiceExpiryTooShort,
     #[error("BTC invoice parse error: {0}")]
     BTCInvoiceParseError(lightning_invoice::ParseOrSemanticError),
+    #[error(
+        "BTC invoice creation timestamp {invoice_created_at} is newer than CCH order creation timestamp {order_created_at}"
+    )]
+    BTCInvoiceCreationTimeInFuture {
+        invoice_created_at: u64,
+        order_created_at: u64,
+    },
     #[error("BTC invoice expired")]
     BTCInvoiceExpired,
     #[error("BTC invoice missing amount")]
@@ -30,6 +37,13 @@ pub enum CchError {
     BTCInvoiceFinalTlcExpiryDeltaTooLarge,
     #[error("CKB invoice error: {0}")]
     CKBInvoiceError(#[from] crate::invoice::InvoiceError),
+    #[error(
+        "CKB invoice creation timestamp {invoice_created_at_ms} is newer than CCH order creation timestamp {order_created_at_ms}"
+    )]
+    CKBInvoiceCreationTimeInFuture {
+        invoice_created_at_ms: u128,
+        order_created_at_ms: u128,
+    },
     #[error("CKB invoice expired")]
     CKBInvoiceExpired,
     #[error("CKB invoice missing amount")]

--- a/crates/fiber-lib/src/cch/order/state_machine.rs
+++ b/crates/fiber-lib/src/cch/order/state_machine.rs
@@ -42,6 +42,11 @@ impl CchOrderStateMachine {
                 payment_preimage,
                 failure_reason,
             } => {
+                let to = status.into();
+                if order.status == CchOrderStatus::Pending {
+                    // A pending order can only be accepted by the incoming invoice tracker.
+                    return Err(CchError::InvalidTransition(order.status, to));
+                }
                 if status == PaymentStatus::Created
                     && matches!(
                         order.status,
@@ -61,7 +66,7 @@ impl CchOrderStateMachine {
                         return Err(CchError::PreimageHashMismatch);
                     }
                 }
-                let new_status = Self::try_transite_to(order, status.into(), move || {
+                let new_status = Self::try_transite_to(order, to, move || {
                     failure_reason
                         .unwrap_or_else(|| format!("outgoing payment failed: {:?}", status))
                 })?;

--- a/crates/fiber-lib/src/cch/scheduler.rs
+++ b/crates/fiber-lib/src/cch/scheduler.rs
@@ -277,6 +277,15 @@ impl<S: CchOrderStore> SchedulerState<S> {
             return Ok(());
         }
 
+        if order.status != CchOrderStatus::Pending {
+            tracing::debug!(
+                "Order {:x} is {:?}, skipping pending-order expiry",
+                payment_hash,
+                order.status
+            );
+            return Ok(());
+        }
+
         // Store order info before updating
         let created_at = order.created_at;
         let expiry_delta_seconds = order.expiry_delta_seconds;

--- a/crates/fiber-lib/src/cch/scheduler.rs
+++ b/crates/fiber-lib/src/cch/scheduler.rs
@@ -6,7 +6,7 @@ use tokio::task::AbortHandle;
 use tokio::time::Duration;
 
 use crate::cch::{order::CchOrderStore, trackers::LndTrackerMessage, CchError};
-use crate::time::{SystemTime, UNIX_EPOCH};
+use crate::now_timestamp_as_millis_u64;
 use fiber_types::{CchOrderStatus, Hash256};
 
 const PRUNE_DELAY_DAYS: u64 = 21;
@@ -14,10 +14,7 @@ pub const PRUNE_DELAY_SECONDS: u64 = PRUNE_DELAY_DAYS * 24 * 60 * 60;
 
 /// Get the current time in seconds since UNIX epoch
 fn current_time_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("System time should always be after UNIX_EPOCH")
-        .as_secs()
+    now_timestamp_as_millis_u64() / 1000
 }
 
 /// Scheduled job types for order expiry and pruning

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -584,6 +584,19 @@ async fn setup_store_backed_test_harness() -> StoreBackedTestHarness {
 fn create_test_lightning_invoice_with_payment_hash(
     payment_hash: Hash256,
 ) -> lightning_invoice::Bolt11Invoice {
+    let duration_since_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time");
+    create_test_lightning_invoice_with_payment_hash_and_timestamp(
+        payment_hash,
+        duration_since_epoch,
+    )
+}
+
+fn create_test_lightning_invoice_with_payment_hash_and_timestamp(
+    payment_hash: Hash256,
+    duration_since_epoch: std::time::Duration,
+) -> lightning_invoice::Bolt11Invoice {
     use bitcoin::hashes::Hash as _;
     use lightning_invoice::{Currency as LnCurrency, InvoiceBuilder as LnInvoiceBuilder};
 
@@ -601,9 +614,6 @@ fn create_test_lightning_invoice_with_payment_hash(
     // Build the invoice with current timestamp (will be valid for 1 hour)
     // Use 36 blocks (~6 hours) for final CLTV, which is less than half of the default
     // CKB final TLC expiry (20 hours), satisfying the cross-chain safety requirement.
-    let duration_since_epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("time");
     LnInvoiceBuilder::new(LnCurrency::Bitcoin)
         .description("test invoice".to_string())
         .payment_hash(payment_hash_btc)
@@ -922,6 +932,221 @@ async fn test_receive_btc_store_attempt_inflight_updates_payment_and_cch_status(
     assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
 }
 
+async fn insert_receive_btc_order_with_expiry(
+    harness: &TestHarness,
+    payment_hash: Hash256,
+    expiry_delta_seconds: u64,
+) {
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    insert_receive_btc_order_with_created_at_and_expiry(
+        harness,
+        payment_hash,
+        created_at,
+        expiry_delta_seconds,
+    )
+    .await;
+}
+
+async fn insert_receive_btc_order_with_created_at_and_expiry(
+    harness: &TestHarness,
+    payment_hash: Hash256,
+    created_at: u64,
+    expiry_delta_seconds: u64,
+) {
+    let fiber_invoice = create_test_fiber_invoice_with_expiry(payment_hash, 60_000);
+    let lightning_invoice = create_test_lightning_invoice_with_cltv(
+        payment_hash,
+        DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS,
+    );
+    let order = CchOrder {
+        created_at,
+        expiry_delta_seconds,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: fiber_invoice.to_string(),
+        incoming_invoice: CchInvoice::Lightning(lightning_invoice),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::Pending,
+        failure_reason: None,
+    };
+    harness.insert_order_directly(order).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_receive_btc_expired_pending_order_rejects_late_incoming_invoice() {
+    let (_preimage, payment_hash) = create_valid_preimage_pair(210);
+    let order_expiry_delta_seconds = 1u64;
+    let harness = setup_test_harness().await;
+    let current_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let created_at = current_time - order_expiry_delta_seconds - 1;
+
+    insert_receive_btc_order_with_created_at_and_expiry(
+        &harness,
+        payment_hash,
+        created_at,
+        order_expiry_delta_seconds,
+    )
+    .await;
+
+    harness.simulate_incoming_invoice_received(payment_hash);
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::Failed, 1000)
+        .await;
+
+    assert_eq!(order.status, CchOrderStatus::Failed);
+    assert!(order
+        .failure_reason
+        .as_deref()
+        .unwrap_or_default()
+        .contains("expired"));
+    assert!(
+        !harness.was_fiber_payment_sent(payment_hash),
+        "expired pending order must not dispatch outgoing Fiber payment"
+    );
+}
+
+#[tokio::test]
+async fn test_receive_btc_pending_order_rejects_incoming_invoice_at_expiry_cutoff() {
+    let order_expiry_delta_seconds = 1u64;
+    let harness = setup_test_harness().await;
+
+    for seed in 213u8..223 {
+        let (_preimage, payment_hash) = create_valid_preimage_pair(seed);
+        let current_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let cutoff_time = current_time + 1;
+        let created_at = cutoff_time - order_expiry_delta_seconds;
+
+        insert_receive_btc_order_with_created_at_and_expiry(
+            &harness,
+            payment_hash,
+            created_at,
+            order_expiry_delta_seconds,
+        )
+        .await;
+
+        loop {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            if now >= cutoff_time {
+                if now != cutoff_time {
+                    break;
+                }
+
+                harness.simulate_incoming_invoice_received(payment_hash);
+                let order = harness
+                    .wait_for_order_status(payment_hash, CchOrderStatus::Failed, 1000)
+                    .await;
+
+                assert_eq!(order.status, CchOrderStatus::Failed);
+                assert!(order
+                    .failure_reason
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("expired"));
+                assert!(
+                    !harness.was_fiber_payment_sent(payment_hash),
+                    "pending order at expiry cutoff must not dispatch outgoing Fiber payment"
+                );
+                return;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+        }
+    }
+
+    panic!("could not deliver incoming invoice event at the exact expiry cutoff");
+}
+
+#[tokio::test]
+async fn test_receive_btc_late_preimage_after_order_expiry_is_reconciled() {
+    let (preimage, payment_hash) = create_valid_preimage_pair(211);
+    let order_expiry_delta_seconds = 2u64;
+    let harness = setup_test_harness().await;
+
+    insert_receive_btc_order_with_expiry(&harness, payment_hash, order_expiry_delta_seconds).await;
+
+    harness.simulate_incoming_invoice_received(payment_hash);
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::OutgoingInFlight, 2000)
+        .await;
+    assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
+    assert!(harness.was_fiber_payment_sent(payment_hash));
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(
+        order_expiry_delta_seconds + 2,
+    ))
+    .await;
+
+    harness.simulate_fiber_payment_success(payment_hash, preimage);
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::OutgoingSuccess, 2000)
+        .await;
+
+    assert_eq!(
+        order.status,
+        CchOrderStatus::OutgoingSuccess,
+        "late outgoing Fiber preimage should keep receive_btc reconciliation active"
+    );
+    assert_eq!(
+        order.payment_preimage,
+        Some(preimage),
+        "late outgoing Fiber preimage should be persisted for incoming settlement"
+    );
+
+    harness.simulate_lightning_invoice_settled(payment_hash);
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::Success, 1000)
+        .await;
+    assert_eq!(order.status, CchOrderStatus::Success);
+    assert_eq!(order.payment_preimage, Some(preimage));
+    assert!(order.failure_reason.is_none());
+}
+
+#[tokio::test]
+async fn test_receive_btc_order_expiry_does_not_fail_after_incoming_accepted() {
+    let (_preimage, payment_hash) = create_valid_preimage_pair(212);
+    let order_expiry_delta_seconds = 2u64;
+    let harness = setup_test_harness().await;
+
+    insert_receive_btc_order_with_expiry(&harness, payment_hash, order_expiry_delta_seconds).await;
+
+    harness.simulate_incoming_invoice_received(payment_hash);
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::OutgoingInFlight, 2000)
+        .await;
+    assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
+    assert!(harness.was_fiber_payment_sent(payment_hash));
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(
+        order_expiry_delta_seconds + 2,
+    ))
+    .await;
+
+    let order = harness.get_order(payment_hash).await.unwrap();
+    assert_eq!(
+        order.status,
+        CchOrderStatus::OutgoingInFlight,
+        "receive_btc order should remain active after incoming payment is accepted"
+    );
+    assert!(
+        !order.is_final(),
+        "accepted receive_btc order must not become final from the original quote TTL"
+    );
+    assert!(order.failure_reason.is_none());
+}
+
 /// Drive a ReceiveBTC-style order (incoming Lightning, outgoing Fiber) up to the point where
 /// the outgoing Fiber `SendPayment` has been dispatched, and return the `max_fee_amount` that
 /// was attached to the `SendPaymentCommand`.
@@ -1058,6 +1283,39 @@ async fn test_resume_expired_order_marked_as_failed() {
         .failure_reason
         .unwrap()
         .contains("Order expired on startup"));
+}
+
+#[tokio::test]
+async fn test_resume_expired_non_pending_order_is_not_marked_as_failed() {
+    let (_preimage, payment_hash) = create_valid_preimage_pair(154);
+    let store = MockCchOrderStore::new();
+
+    let current_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expired_order = CchOrder {
+        created_at: current_time - 7200,
+        expiry_delta_seconds: 3600,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: "test".to_string(),
+        incoming_invoice: CchInvoice::Fiber(create_test_fiber_invoice(payment_hash)),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::IncomingAccepted,
+        failure_reason: None,
+    };
+
+    store.insert_cch_order(expired_order).unwrap();
+
+    let harness = setup_test_harness_with_store(store).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let order = harness.get_order(payment_hash).await.unwrap();
+    assert_eq!(order.status, CchOrderStatus::IncomingAccepted);
+    assert!(order.failure_reason.is_none());
 }
 
 /// Tests that non-expired active orders have tracking resumed on startup.
@@ -1287,6 +1545,42 @@ async fn test_send_btc_rejects_btc_invoice_network_mismatch() {
     }
 }
 
+#[tokio::test]
+async fn test_send_btc_rejects_future_btc_invoice_timestamp() {
+    let harness = setup_test_harness().await;
+
+    let (_, payment_hash) = create_valid_preimage_pair(104);
+    let future_timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time")
+        + std::time::Duration::from_secs(3600);
+    let lightning_invoice = create_test_lightning_invoice_with_payment_hash_and_timestamp(
+        payment_hash,
+        future_timestamp,
+    );
+    let btc_pay_req = lightning_invoice.to_string();
+
+    let result = call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::actor::SendBTC {
+            btc_pay_req,
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed");
+
+    match result {
+        Err(CchError::BTCInvoiceCreationTimeInFuture {
+            invoice_created_at,
+            order_created_at,
+        }) => {
+            assert!(invoice_created_at > order_created_at);
+        }
+        other => panic!("Expected BTCInvoiceCreationTimeInFuture, got {:?}", other),
+    }
+}
+
 /// Tests that receive_btc rejects when the CKB invoice currency doesn't match the configured network.
 /// Issue #982: receive_btc should fail when invoice currency (e.g. Fibt) doesn't match node's network (e.g. Fibd)
 #[tokio::test]
@@ -1312,6 +1606,42 @@ async fn test_receive_btc_rejects_currency_mismatch() {
             assert_eq!(actual, Currency::Fibt);
         }
         other => panic!("Expected CKBInvoiceNetworkMismatch, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_receive_btc_rejects_future_fiber_invoice_timestamp() {
+    let harness = setup_test_harness().await;
+
+    let (_, payment_hash) = create_valid_preimage_pair(105);
+    let mut invoice = create_test_fiber_invoice_with_expiry(payment_hash, 10_000);
+    invoice.data.timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        + u128::from(60_000u64);
+    let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
+    invoice
+        .update_signature(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
+        .unwrap();
+
+    let result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::actor::ReceiveBTC {
+            fiber_pay_req: invoice.to_string(),
+        }
+    )
+    .expect("actor call failed");
+
+    match result {
+        Err(CchError::CKBInvoiceCreationTimeInFuture {
+            invoice_created_at_ms,
+            order_created_at_ms,
+        }) => {
+            assert!(invoice_created_at_ms > order_created_at_ms);
+        }
+        other => panic!("Expected CKBInvoiceCreationTimeInFuture, got {:?}", other),
     }
 }
 

--- a/crates/fiber-lib/src/cch/tests/scheduler_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/scheduler_tests.rs
@@ -210,6 +210,55 @@ async fn test_expiry_skips_final_orders() {
 }
 
 #[tokio::test]
+async fn test_expiry_skips_non_pending_active_orders() {
+    let (scheduler, store, _) = setup_scheduler().await;
+
+    let current_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expiry_delta_seconds = 3600;
+    let created_at = current_time - expiry_delta_seconds - 100;
+
+    for (idx, status) in [
+        CchOrderStatus::IncomingAccepted,
+        CchOrderStatus::OutgoingInFlight,
+        CchOrderStatus::OutgoingSuccess,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let payment_hash = test_payment_hash(20 + idx as u8);
+        let order = create_test_order(payment_hash, created_at, expiry_delta_seconds, status);
+        store.insert_cch_order(order).unwrap();
+
+        scheduler
+            .send_message(SchedulerMessage::ScheduleExpiry {
+                payment_hash,
+                created_at,
+                expiry_delta_seconds,
+            })
+            .unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    for (idx, status) in [
+        CchOrderStatus::IncomingAccepted,
+        CchOrderStatus::OutgoingInFlight,
+        CchOrderStatus::OutgoingSuccess,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let payment_hash = test_payment_hash(20 + idx as u8);
+        let order_after = store.get_cch_order(&payment_hash).unwrap();
+        assert_eq!(order_after.status, status);
+        assert!(order_after.failure_reason.is_none());
+    }
+}
+
+#[tokio::test]
 async fn test_schedule_prune_job() {
     let (scheduler, store, _) = setup_scheduler().await;
 

--- a/crates/fiber-lib/src/cch/tests/state_machine_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/state_machine_tests.rs
@@ -4,7 +4,7 @@
 //! - Valid state transitions
 //! - Invalid state transitions
 //! - on_entering actions for each status
-//! - Failure transitions from any state
+//! - Failure transitions from active states
 
 use crate::cch::order::{state_machine::CchOrderEvent, CchOrderStateMachine};
 use crate::cch::CchError;
@@ -253,6 +253,21 @@ fn test_staying_in_pending_via_invoice_open() {
 }
 
 #[test]
+fn test_staying_in_incoming_accepted_via_payment_created() {
+    let mut order = create_test_order(CchOrderStatus::IncomingAccepted);
+    let event = CchOrderEvent::OutgoingPaymentChanged {
+        status: PaymentStatus::Created,
+        payment_preimage: None,
+        failure_reason: None,
+    };
+
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
+
+    assert!(transition.is_none());
+    assert_eq!(order.status, CchOrderStatus::IncomingAccepted);
+}
+
+#[test]
 fn test_staying_in_outgoing_in_flight_via_payment_inflight() {
     let mut order = create_test_order(CchOrderStatus::OutgoingInFlight);
     let event = CchOrderEvent::OutgoingPaymentChanged {
@@ -272,6 +287,27 @@ fn test_staying_in_outgoing_in_flight_via_payment_inflight() {
 // ============================================================================
 
 #[test]
+fn test_invalid_transition_pending_rejects_outgoing_payment_created() {
+    let mut order = create_test_order(CchOrderStatus::Pending);
+    let event = CchOrderEvent::OutgoingPaymentChanged {
+        status: PaymentStatus::Created,
+        payment_preimage: None,
+        failure_reason: None,
+    };
+
+    let result = CchOrderStateMachine::apply(&mut order, event);
+
+    assert!(matches!(
+        result,
+        Err(CchError::InvalidTransition(
+            CchOrderStatus::Pending,
+            CchOrderStatus::IncomingAccepted
+        ))
+    ));
+    assert_eq!(order.status, CchOrderStatus::Pending);
+}
+
+#[test]
 fn test_invalid_transition_pending_to_outgoing_in_flight() {
     let mut order = create_test_order(CchOrderStatus::Pending);
     let event = CchOrderEvent::OutgoingPaymentChanged {
@@ -283,6 +319,7 @@ fn test_invalid_transition_pending_to_outgoing_in_flight() {
     let result = CchOrderStateMachine::apply(&mut order, event);
 
     assert!(matches!(result, Err(CchError::InvalidTransition(_, _))));
+    assert_eq!(order.status, CchOrderStatus::Pending);
 }
 
 #[test]
@@ -298,6 +335,30 @@ fn test_invalid_transition_pending_to_outgoing_succeeded() {
     let result = CchOrderStateMachine::apply(&mut order, event);
 
     assert!(matches!(result, Err(CchError::InvalidTransition(_, _))));
+    assert_eq!(order.status, CchOrderStatus::Pending);
+    assert_eq!(order.payment_preimage, None);
+}
+
+#[test]
+fn test_invalid_transition_pending_rejects_outgoing_payment_failed() {
+    let mut order = create_test_order(CchOrderStatus::Pending);
+    let event = CchOrderEvent::OutgoingPaymentChanged {
+        status: PaymentStatus::Failed,
+        payment_preimage: None,
+        failure_reason: Some("test failure".to_string()),
+    };
+
+    let result = CchOrderStateMachine::apply(&mut order, event);
+
+    assert!(matches!(
+        result,
+        Err(CchError::InvalidTransition(
+            CchOrderStatus::Pending,
+            CchOrderStatus::Failed
+        ))
+    ));
+    assert_eq!(order.status, CchOrderStatus::Pending);
+    assert_eq!(order.failure_reason, None);
 }
 
 #[test]
@@ -361,23 +422,8 @@ fn test_payment_success_without_preimage_returns_error() {
 }
 
 // ============================================================================
-// Tests for failure transitions from any state
+// Tests for failure transitions from active states
 // ============================================================================
-
-#[test]
-fn test_failure_from_pending() {
-    let mut order = create_test_order(CchOrderStatus::Pending);
-    let event = CchOrderEvent::OutgoingPaymentChanged {
-        status: PaymentStatus::Failed,
-        payment_preimage: None,
-        failure_reason: Some("test failure".to_string()),
-    };
-
-    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
-
-    assert!(transition.is_some());
-    assert_eq!(order.status, CchOrderStatus::Failed);
-}
 
 #[test]
 fn test_failure_from_incoming_accepted() {

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -3828,6 +3828,89 @@ async fn test_restarted_offline_channel_force_closes_expired_offered_tlc() {
 }
 
 #[tokio::test]
+async fn test_offered_tlc_survives_force_close_transition() {
+    init_tracing();
+
+    let (mut node_a, mut node_b, channel_id, _) =
+        NetworkNode::new_2_nodes_with_established_channel(HUGE_CKB_AMOUNT, HUGE_CKB_AMOUNT, true)
+            .await;
+
+    let preimage: [u8; 32] = [211u8; 32];
+    let payment_hash: Hash256 = HashAlgorithm::CkbHash.hash(preimage).into();
+    let expiry = now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA;
+    let add_tlc_result = call!(node_a.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
+            ChannelCommandWithId {
+                channel_id,
+                command: ChannelCommand::AddTlc(
+                    create_mock_pending_add_tlc_command(
+                        &node_a,
+                        &node_b,
+                        3_000_000,
+                        HashAlgorithm::CkbHash,
+                        payment_hash,
+                        expiry,
+                    ),
+                    rpc_reply,
+                ),
+            },
+        ))
+    })
+    .expect("node_a alive")
+    .expect("successfully added offered tlc");
+    let tlc_id = TLCId::Offered(add_tlc_result.tlc_id);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let state_before = node_a.get_channel_actor_state(channel_id);
+    let tlc_before = state_before
+        .tlc_state
+        .get(&tlc_id)
+        .expect("offered tlc exists");
+    assert_eq!(tlc_before.payment_hash, payment_hash);
+    assert_eq!(tlc_before.outbound_status(), OutboundTlcStatus::Committed);
+
+    node_b.stop().await;
+    node_a.stop().await;
+    let mut saved_state = node_a.get_channel_actor_state(channel_id);
+    saved_state
+        .tlc_state
+        .get_mut(&tlc_id)
+        .expect("offered tlc exists")
+        .expiry = now_timestamp_as_millis_u64().saturating_sub(1);
+    node_a.store.insert_channel_actor_state(saved_state);
+    node_a.start().await;
+
+    let mut state_after = node_a.get_channel_actor_state(channel_id);
+    for _ in 0..20 {
+        if !matches!(state_after.state, ChannelState::ChannelReady) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        state_after = node_a.get_channel_actor_state(channel_id);
+    }
+
+    match &state_after.state {
+        ChannelState::ShuttingDown(_) => {}
+        ChannelState::Closed(flags) => {
+            assert!(flags.contains(CloseFlags::UNCOOPERATIVE_LOCAL))
+        }
+        _ => panic!(
+            "Channel did NOT force-close. State: {:?}",
+            state_after.state
+        ),
+    }
+
+    let tlc_after = state_after
+        .tlc_state
+        .get(&tlc_id)
+        .expect("offered TLC must persist after force-close");
+    assert_eq!(
+        tlc_after.payment_hash, payment_hash,
+        "TLC payment_hash preserved after force-close transition"
+    );
+}
+
+#[tokio::test]
 async fn do_test_add_tlc_duplicated() {
     init_tracing();
     let node_a_funding_amount = 100000000000;

--- a/crates/fiber-types/src/cch.rs
+++ b/crates/fiber-types/src/cch.rs
@@ -103,14 +103,31 @@ impl CchOrder {
     /// Returns `true` if the order was expired (and has been marked as Failed).
     /// Updates `status` to `Failed` and sets `failure_reason` when expired.
     pub fn update_if_expired(&mut self, current_time: u64) -> bool {
+        self.update_if_expired_with_reason(current_time, "Order expired on startup")
+    }
+
+    /// Check if the order is expired given the current time, and mark it as Failed with
+    /// `expired_reason` if expired.
+    ///
+    /// Returns `true` if the order was expired (and has been marked as Failed).
+    /// Updates `status` to `Failed` and sets `failure_reason` when expired.
+    pub fn update_if_expired_with_reason(
+        &mut self,
+        current_time: u64,
+        expired_reason: &str,
+    ) -> bool {
+        if self.status != CchOrderStatus::Pending {
+            return false;
+        }
+
         let Some(expiry_time) = self.created_at.checked_add(self.expiry_delta_seconds) else {
             self.status = CchOrderStatus::Failed;
             self.failure_reason = Some("Order expiry time overflows".to_string());
             return true;
         };
-        if expiry_time < current_time {
+        if expiry_time <= current_time {
             self.status = CchOrderStatus::Failed;
-            self.failure_reason = Some("Order expired on startup".to_string());
+            self.failure_reason = Some(expired_reason.to_string());
             true
         } else {
             false


### PR DESCRIPTION
## Summary

This PR fixes several CCH order state and expiry edge cases that could prevent cross-chain orders from reconciling correctly:

- Limit CCH quote expiry to orders that are still `Pending`. Once the incoming leg has been accepted or an outgoing payment is active, the original quote TTL no longer marks the order as failed.
- Re-check pending-order expiry before accepting an incoming invoice `Received` event, including the exact scheduler cutoff second, so a late event cannot race the scheduler and start an outgoing payment after the quote expired.
- Enforce the state-machine invariant that a `Pending` order can only advance to `IncomingAccepted` from an incoming invoice event. Outgoing payment events are now invalid while the order is still pending.
- Reject user-submitted invoice timestamps that are newer than the CCH order creation time so expiry calculations cannot be based on a future invoice timestamp.
- Add regression coverage for the CCH expiry/reconciliation cases and a channel regression ensuring offered TLC data survives a force-close transition.

## Root Cause

The order TTL was previously treated like a general order expiry even after the order had moved beyond quote acceptance. That could finalize an externally active order as `Failed`, causing later successful payment or preimage events to be ignored.

There was also a scheduler race: `handle_tracking_event` could apply `Pending -> IncomingAccepted` without checking whether the pending quote had already expired, while the scheduler would later skip the order once it was no longer pending.

Finally, the state machine mapped both incoming invoice events and outgoing payment events into the same target CCH statuses. Because `PaymentStatus::Created` maps to `IncomingAccepted`, a `PaymentChanged(Created)` event could incorrectly advance a still-pending order.

## How This Fixes It

Pending quote expiry is now enforced only before the incoming leg is accepted. Scheduler expiry and startup expiry both skip non-pending active orders, allowing outgoing payment tracking and incoming settlement to continue.

The actor now validates pending expiry immediately before accepting an incoming invoice `Received` event. If the quote has expired, the order is persisted as `Failed` and no outgoing payment action is dispatched.

The state machine now rejects all outgoing payment events while the order is still `Pending`. This makes the event source explicit: `Pending -> IncomingAccepted` is only valid for `IncomingInvoiceChanged(Received)`.

## Validation

Focused checks run:

- `cargo nextest run -p fnn --features sqlite test_receive_btc_expired_pending_order_rejects_late_incoming_invoice`
- `cargo nextest run -p fnn --features sqlite test_receive_btc_pending_order_rejects_incoming_invoice_at_expiry_cutoff`
- `cargo nextest run -p fnn --features sqlite test_receive_btc_late_preimage_after_order_expiry_is_reconciled test_receive_btc_order_expiry_does_not_fail_after_incoming_accepted test_resume_expired_non_pending_order_is_not_marked_as_failed test_expiry_skips_non_pending_active_orders`
- `cargo nextest run -p fnn --features sqlite test_resume_expired_order_marked_as_failed test_schedule_expiry_job test_expiry_skips_final_orders test_expiry_schedules_prune_job`
- `cargo nextest run -p fnn --features sqlite state_machine_tests`
- `cargo nextest run -p fnn --features sqlite future`
- `cargo nextest run --features sqlite -p fnn test_offered_tlc_survives_force_close_transition`
- `cargo fmt --all -- --check`
