### PR TITLE
[codex] Track Fiber attempt status changes for CCH orders

### DIFF
--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -28,7 +28,7 @@ use crate::fiber::NetworkActorMessage;
 use crate::invoice::{CkbInvoice, Currency, InvoiceBuilder};
 use crate::store::store_impl::StoreChange;
 use crate::time::{Duration, SystemTime, UNIX_EPOCH};
-use fiber_types::{CchInvoice, CchOrder, CchOrderStatus, HashAlgorithm};
+use fiber_types::{AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, HashAlgorithm};
 use fiber_types::{Hash256, Privkey};
 
 pub const ACTION_RETRY_BASE_MILLIS: u64 = 1000; // 1 second initial delay
@@ -833,6 +833,19 @@ impl<S: CchOrderStore> CchState<S> {
                     }]
                 }
             }
+            StoreChange::PutAttempt {
+                payment_hash,
+                attempt_status: AttemptStatus::Inflight,
+            } => {
+                use fiber_types::payment::PaymentStatus;
+                vec![CchTrackingEvent::PaymentChanged {
+                    payment_hash: *payment_hash,
+                    payment_preimage: None,
+                    status: PaymentStatus::Inflight,
+                    failure_reason: None,
+                }]
+            }
+            StoreChange::PutAttempt { .. } => vec![],
             StoreChange::PutPreimage {
                 payment_hash,
                 payment_preimage,
@@ -1015,6 +1028,11 @@ pub(crate) fn redacted_store_change_summary(change: &StoreChange) -> RedactedSto
         },
         StoreChange::PutPaymentSession { payment_hash, .. } => RedactedStoreChangeSummary {
             kind: "PutPaymentSession",
+            payment_hash: *payment_hash,
+            has_payment_preimage: false,
+        },
+        StoreChange::PutAttempt { payment_hash, .. } => RedactedStoreChangeSummary {
+            kind: "PutAttempt",
             payment_hash: *payment_hash,
             has_payment_preimage: false,
         },

--- a/crates/fiber-lib/src/cch/order/state_machine.rs
+++ b/crates/fiber-lib/src/cch/order/state_machine.rs
@@ -42,6 +42,14 @@ impl CchOrderStateMachine {
                 payment_preimage,
                 failure_reason,
             } => {
+                if status == PaymentStatus::Created
+                    && matches!(
+                        order.status,
+                        CchOrderStatus::OutgoingInFlight | CchOrderStatus::OutgoingSuccess
+                    )
+                {
+                    return Ok(None);
+                }
                 if status == PaymentStatus::Success && payment_preimage.is_none() {
                     return Err(CchError::SettledPaymentMissingPreimage);
                 }

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -20,12 +20,19 @@ use crate::cch::{
     CchConfig, CchError, CchStoreError,
 };
 use crate::fiber::{
-    network::SendPaymentResponse, payment::SendPaymentCommand, NetworkActorCommand,
-    NetworkActorMessage,
+    graph::NetworkGraphStateStore,
+    network::SendPaymentResponse,
+    payment::{PaymentSessionExt, SendPaymentCommand, SendPaymentDataBuilder},
+    NetworkActorCommand, NetworkActorMessage,
 };
 use crate::invoice::{Attribute, CkbInvoice, CkbInvoiceStatus, Currency, InvoiceData};
+use crate::store::{store_impl::StoreChange, Store};
+use crate::tests::test_utils::{generate_store, TempDir};
 use crate::time::{Duration, SystemTime, UNIX_EPOCH};
-use fiber_types::{CchInvoice, CchOrder, CchOrderStatus, Hash256, HashAlgorithm, PaymentStatus};
+use fiber_types::{
+    AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, Hash256, HashAlgorithm, PaymentHopData,
+    PaymentStatus,
+};
 use ractor::{call, port::OutputPortSubscriberTrait, Actor, ActorRef, OutputPort};
 use secp256k1::{Secp256k1, SecretKey};
 use std::collections::HashMap;
@@ -113,7 +120,7 @@ fn create_valid_preimage_pair(seed: u8) -> (Hash256, Hash256) {
 }
 
 /// Shared state for the mock network actor
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct MockNetworkState {
     /// Reference to CchActor to send callbacks
     cch_actor: Arc<Mutex<Option<ActorRef<CchMessage>>>>,
@@ -123,6 +130,8 @@ struct MockNetworkState {
     sent_fiber_payments: Arc<Mutex<std::collections::HashSet<Hash256>>>,
     /// Tracks the `max_fee_amount` of each outgoing Fiber SendPayment, keyed by payment hash.
     sent_fiber_payment_fees: Arc<Mutex<std::collections::HashMap<Hash256, Option<u128>>>>,
+    /// Status returned by mocked outgoing Fiber SendPayment.
+    send_payment_status: Arc<Mutex<PaymentStatus>>,
 }
 
 /// Mock network actor that handles commands from action executors
@@ -171,9 +180,10 @@ impl Actor for MockNetworkActor {
                         .insert(payment_hash, cmd.max_fee_amount);
 
                     // Return success response - the executor will create CchTrackingEvent
+                    let status = *state.send_payment_status.lock().unwrap();
                     let response = SendPaymentResponse {
                         payment_hash,
-                        status: PaymentStatus::Inflight,
+                        status,
                         created_at: SystemTime::now()
                             .duration_since(UNIX_EPOCH)
                             .unwrap()
@@ -234,6 +244,15 @@ struct TestHarness {
     /// Event port to inject external events (simulates trackers)
     event_port: Arc<OutputPort<CchTrackingEvent>>,
     /// Shared mock state for tracking sent payments
+    mock_state: MockNetworkState,
+}
+
+struct StoreBackedTestHarness {
+    actor: ActorRef<CchMessage>,
+    event_port: Arc<OutputPort<CchTrackingEvent>>,
+    _store_change_port: Arc<OutputPort<StoreChange>>,
+    store: Store,
+    _store_dir: TempDir,
     mock_state: MockNetworkState,
 }
 
@@ -299,6 +318,19 @@ impl TestHarness {
             .unwrap()
             .get(&payment_hash)
             .copied()
+    }
+
+    fn set_send_payment_status(&self, status: PaymentStatus) {
+        *self.mock_state.send_payment_status.lock().unwrap() = status;
+    }
+
+    fn simulate_fiber_attempt_status(&self, payment_hash: Hash256, attempt_status: AttemptStatus) {
+        self.actor
+            .send_message(CchMessage::StoreChangeEvent(StoreChange::PutAttempt {
+                payment_hash,
+                attempt_status,
+            }))
+            .expect("actor should accept store change");
     }
 
     /// Simulate outgoing Fiber payment succeeding with preimage
@@ -375,6 +407,64 @@ impl TestHarness {
     }
 }
 
+impl StoreBackedTestHarness {
+    async fn get_order(&self, payment_hash: Hash256) -> Result<CchOrder, CchError> {
+        call!(self.actor, CchMessage::GetCchOrder, payment_hash).expect("actor call failed")
+    }
+
+    async fn wait_for_order_status(
+        &self,
+        payment_hash: Hash256,
+        expected_status: CchOrderStatus,
+        timeout_ms: u64,
+    ) -> CchOrder {
+        let start = std::time::Instant::now();
+        let poll_interval = tokio::time::Duration::from_millis(10);
+        let timeout = tokio::time::Duration::from_millis(timeout_ms);
+
+        loop {
+            let order = self.get_order(payment_hash).await.unwrap();
+
+            if order.status == expected_status {
+                return order;
+            }
+
+            if start.elapsed() > timeout {
+                panic!(
+                    "Timeout waiting for order status {:?}. Current status: {:?}",
+                    expected_status, order.status
+                );
+            }
+
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    fn set_send_payment_status(&self, status: PaymentStatus) {
+        *self.mock_state.send_payment_status.lock().unwrap() = status;
+    }
+
+    fn simulate_incoming_invoice_received(&self, payment_hash: Hash256) {
+        self.event_port.send(CchTrackingEvent::InvoiceChanged {
+            payment_hash,
+            status: CkbInvoiceStatus::Received,
+            failure_reason: None,
+        });
+    }
+
+    fn was_fiber_payment_sent(&self, payment_hash: Hash256) -> bool {
+        self.mock_state
+            .sent_fiber_payments
+            .lock()
+            .unwrap()
+            .contains(&payment_hash)
+    }
+
+    async fn insert_order_directly(&self, order: CchOrder) -> Result<(), CchError> {
+        call!(self.actor, CchMessage::InsertOrder, order).expect("actor call failed")
+    }
+}
+
 /// Set up a test harness with mocked dependencies
 async fn setup_test_harness() -> TestHarness {
     setup_test_harness_with_store(MockCchOrderStore::new()).await
@@ -405,6 +495,7 @@ async fn setup_test_harness_with_config_and_store(
         event_port: event_port.clone(),
         sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
         sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
     };
 
     let (network_actor, _) = Actor::spawn(None, MockNetworkActor, mock_state.clone())
@@ -431,6 +522,60 @@ async fn setup_test_harness_with_config_and_store(
     TestHarness {
         actor: actor_ref,
         event_port,
+        mock_state,
+    }
+}
+
+async fn setup_store_backed_test_harness() -> StoreBackedTestHarness {
+    let event_port = Arc::new(OutputPort::<CchTrackingEvent>::default());
+    let store_change_port = Arc::new(OutputPort::<StoreChange>::default());
+    let (mut store, store_dir) = generate_store();
+    let store_change_port_clone = store_change_port.clone();
+    store.set_watcher(Arc::new(move |change| {
+        store_change_port_clone.send(change);
+    }));
+
+    let mock_state = MockNetworkState {
+        cch_actor: Arc::new(Mutex::new(None)),
+        event_port: event_port.clone(),
+        sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
+        sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
+    };
+
+    let (network_actor, _) = Actor::spawn(None, MockNetworkActor, mock_state.clone())
+        .await
+        .expect("spawn mock network actor");
+
+    let args = CchArgs {
+        config: CchConfig {
+            lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+            wrapped_btc_type_script_args: "0x".to_string(),
+            min_outgoing_invoice_expiry_delta_seconds: 60,
+            ..Default::default()
+        },
+        tracker: TaskTracker::new(),
+        token: CancellationToken::new(),
+        network_actor: Some(network_actor),
+        node_keypair: Some(crate::fiber::KeyPair::try_from([42u8; 32].as_slice()).unwrap()),
+        store: store.clone(),
+        currency: Currency::Fibb,
+    };
+
+    let (actor_ref, _handle) = Actor::spawn(None, CchActor::default(), args)
+        .await
+        .expect("spawn cch actor");
+
+    actor_ref.subscribe_to_port(&event_port);
+    actor_ref.subscribe_to_port(&store_change_port);
+    *mock_state.cch_actor.lock().unwrap() = Some(actor_ref.clone());
+
+    StoreBackedTestHarness {
+        actor: actor_ref,
+        event_port,
+        _store_change_port: store_change_port,
+        store,
+        _store_dir: store_dir,
         mock_state,
     }
 }
@@ -651,6 +796,130 @@ async fn test_receive_btc_happy_path() {
     assert!(order.is_final());
     assert_eq!(order.payment_preimage, Some(preimage));
     assert!(order.failure_reason.is_none());
+}
+
+#[tokio::test]
+async fn test_receive_btc_outgoing_fiber_attempt_inflight_marks_outgoing_inflight() {
+    let (_preimage, payment_hash) = create_valid_preimage_pair(98);
+    let harness = setup_test_harness().await;
+    harness.set_send_payment_status(PaymentStatus::Created);
+
+    let fiber_invoice = create_test_fiber_invoice_with_expiry(payment_hash, 10_000);
+    let lightning_invoice = create_test_lightning_invoice_with_cltv(
+        payment_hash,
+        DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS,
+    );
+    let order = CchOrder {
+        created_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        expiry_delta_seconds: 3600,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: fiber_invoice.to_string(),
+        incoming_invoice: CchInvoice::Lightning(lightning_invoice),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::Pending,
+        failure_reason: None,
+    };
+    harness.insert_order_directly(order).await.unwrap();
+
+    harness.simulate_incoming_invoice_received(payment_hash);
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    assert!(harness.was_fiber_payment_sent(payment_hash));
+    let order = harness.get_order(payment_hash).await.unwrap();
+    assert_eq!(order.status, CchOrderStatus::IncomingAccepted);
+
+    harness.simulate_fiber_attempt_status(payment_hash, AttemptStatus::Inflight);
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::OutgoingInFlight, 1000)
+        .await;
+    assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
+}
+
+#[tokio::test]
+async fn test_receive_btc_store_attempt_inflight_updates_payment_and_cch_status() {
+    let (_preimage, payment_hash) = create_valid_preimage_pair(99);
+    let harness = setup_store_backed_test_harness().await;
+    harness.set_send_payment_status(PaymentStatus::Created);
+
+    let fiber_invoice = create_test_fiber_invoice_with_expiry(payment_hash, 10_000);
+    let lightning_invoice = create_test_lightning_invoice_with_cltv(
+        payment_hash,
+        DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS,
+    );
+    let order = CchOrder {
+        created_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        expiry_delta_seconds: 3600,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: fiber_invoice.to_string(),
+        incoming_invoice: CchInvoice::Lightning(lightning_invoice),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::Pending,
+        failure_reason: None,
+    };
+    harness.insert_order_directly(order).await.unwrap();
+
+    harness.simulate_incoming_invoice_received(payment_hash);
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    assert!(harness.was_fiber_payment_sent(payment_hash));
+    let order = harness.get_order(payment_hash).await.unwrap();
+    assert_eq!(order.status, CchOrderStatus::IncomingAccepted);
+
+    let payment_data =
+        SendPaymentDataBuilder::new(crate::gen_rand_fiber_public_key(), 100_000, payment_hash)
+            .final_tlc_expiry_delta(10_000)
+            .tlc_expiry_limit(10_000)
+            .timeout(Some(10))
+            .max_fee_amount(Some(1_000))
+            .build()
+            .expect("valid payment_data");
+    let payment_session =
+        fiber_types::PaymentSession::new_session(&harness.store, payment_data, 10);
+    harness
+        .store
+        .insert_payment_session(payment_session.clone());
+
+    let route_hops = vec![PaymentHopData {
+        amount: 100_000,
+        expiry: 10_000,
+        payment_preimage: None,
+        hash_algorithm: HashAlgorithm::default(),
+        funding_tx_hash: crate::gen_rand_sha256_hash(),
+        next_hop: None,
+        custom_records: None,
+    }];
+    let mut attempt = payment_session.new_attempt(
+        1,
+        crate::gen_rand_fiber_public_key(),
+        crate::gen_rand_fiber_public_key(),
+        route_hops,
+    );
+    harness.store.insert_attempt(attempt.clone());
+    attempt.set_inflight_status();
+    harness.store.insert_attempt(attempt);
+
+    let payment = harness
+        .store
+        .get_payment_session(payment_hash)
+        .expect("payment session should exist");
+    assert_eq!(payment.status, PaymentStatus::Inflight);
+
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::OutgoingInFlight, 1000)
+        .await;
+    assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
 }
 
 /// Drive a ReceiveBTC-style order (incoming Lightning, outgoing Fiber) up to the point where

--- a/crates/fiber-lib/src/cch/tests/event_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/event_tests.rs
@@ -10,7 +10,7 @@ use crate::cch::order::state_machine::CchOrderEvent;
 use crate::cch::trackers::{CchTrackingEvent, RedactedCchTrackingEvent};
 use crate::store::store_impl::StoreChange;
 use fiber_types::invoice::CkbInvoiceStatus;
-use fiber_types::{CchOrderStatus, Hash256, PaymentStatus};
+use fiber_types::{AttemptStatus, CchOrderStatus, Hash256, PaymentStatus};
 
 /// Helper function to create a test payment hash
 fn test_payment_hash(value: u8) -> Hash256 {
@@ -177,6 +177,21 @@ fn test_redacted_store_change_summary_masks_preimage() {
     assert!(summary.has_payment_preimage);
     assert!(redacted.contains("has_payment_preimage"));
     assert!(!redacted.contains(&preimage_hex));
+}
+
+#[test]
+fn test_redacted_store_change_summary_handles_attempt() {
+    let payment_hash = test_payment_hash(9);
+    let change = StoreChange::PutAttempt {
+        payment_hash,
+        attempt_status: AttemptStatus::Inflight,
+    };
+
+    let summary = redacted_store_change_summary(&change);
+
+    assert_eq!(summary.kind, "PutAttempt");
+    assert_eq!(summary.payment_hash, payment_hash);
+    assert!(!summary.has_payment_preimage);
 }
 
 // =============================================================================

--- a/crates/fiber-lib/src/cch/tests/state_machine_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/state_machine_tests.rs
@@ -188,6 +188,21 @@ fn test_transition_outgoing_in_flight_to_outgoing_succeeded_via_payment_success(
 }
 
 #[test]
+fn test_stale_payment_created_after_outgoing_in_flight_is_ignored() {
+    let mut order = create_test_order(CchOrderStatus::OutgoingInFlight);
+    let event = CchOrderEvent::OutgoingPaymentChanged {
+        status: PaymentStatus::Created,
+        payment_preimage: None,
+        failure_reason: None,
+    };
+
+    let transition = CchOrderStateMachine::apply(&mut order, event).unwrap();
+
+    assert!(transition.is_none());
+    assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
+}
+
+#[test]
 fn test_transition_incoming_accepted_to_failed_via_payment_failed() {
     let mut order = create_test_order(CchOrderStatus::IncomingAccepted);
     let event = CchOrderEvent::OutgoingPaymentChanged {

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -413,6 +413,10 @@ pub enum StoreChange {
         payment_hash: Hash256,
         payment_session: PaymentSession,
     },
+    PutAttempt {
+        payment_hash: Hash256,
+        attempt_status: AttemptStatus,
+    },
 }
 
 pub trait StoreKeyValue {
@@ -1182,6 +1186,10 @@ impl NetworkGraphStateStore for Store {
         }
 
         batch.commit();
+        self.notify(StoreChange::PutAttempt {
+            payment_hash: attempt.payment_hash,
+            attempt_status: attempt.status,
+        });
     }
 
     fn get_attempts(&self, payment_hash: Hash256) -> Vec<Attempt> {

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -38,7 +38,7 @@ use ckb_types::H256;
 #[cfg(not(target_arch = "wasm32"))]
 use core::cmp::Ordering;
 use fiber_types::protocol::AnnouncedNodeName;
-use fiber_types::CloseFlags;
+use fiber_types::{AttemptStatus, CloseFlags, HashAlgorithm, PaymentHopData};
 #[cfg(not(target_arch = "wasm32"))]
 use fiber_types::{SettlementTlc, TLCId};
 use musig2::secp::MaybeScalar;
@@ -1280,12 +1280,38 @@ fn test_store_change_watcher() {
         .insert_invoice(invoice.clone(), Some(preimage))
         .unwrap();
 
+    let payment_data = SendPaymentDataBuilder::new(gen_rand_fiber_public_key(), 100, payment_hash)
+        .final_tlc_expiry_delta(DEFAULT_TLC_EXPIRY_DELTA)
+        .tlc_expiry_limit(MAX_PAYMENT_TLC_EXPIRY_LIMIT)
+        .timeout(Some(10))
+        .max_fee_amount(Some(1000))
+        .build()
+        .expect("valid payment_data");
+    let payment_session = PaymentSession::new_session(&store, payment_data, 10);
+    let source = gen_rand_fiber_public_key();
+    let target = gen_rand_fiber_public_key();
+    let route_hops = vec![PaymentHopData {
+        amount: 100,
+        expiry: DEFAULT_TLC_EXPIRY_DELTA,
+        payment_preimage: None,
+        hash_algorithm: HashAlgorithm::default(),
+        funding_tx_hash: gen_rand_sha256_hash(),
+        next_hop: None,
+        custom_records: None,
+    }];
+    let mut attempt = payment_session.new_attempt(1, source, target, route_hops);
+    attempt.set_inflight_status();
+    store.insert_attempt(attempt);
+
     let changes = saver.changes.read().unwrap();
     assert!(changes.iter().any(
         |e| matches!(e, StoreChange::PutCkbInvoiceStatus { payment_hash: h, invoice_status: CkbInvoiceStatus::Open } if h == &payment_hash)
     ));
     assert!(changes.iter().any(
         |e| matches!(e, StoreChange::PutPreimage { payment_hash: h, payment_preimage: i } if h == &payment_hash && i == &preimage)
+    ));
+    assert!(changes.iter().any(
+        |e| matches!(e, StoreChange::PutAttempt { payment_hash: h, attempt_status: AttemptStatus::Inflight } if h == &payment_hash)
     ));
 }
 


### PR DESCRIPTION
## Summary

- Add `StoreChange::PutAttempt { payment_hash, attempt_status }` and emit it when attempts are stored.
- Map `AttemptStatus::Inflight` store changes to CCH outgoing payment in-flight events.
- Ignore stale `PaymentStatus::Created` events after an order has already advanced past the created stage.
- Add regression and store-backed integration coverage for the `receive_btc` outgoing Fiber payment flow.

## Root Cause

In the CCH `receive_btc` flow, CCH tracked outgoing Fiber payment progress from `PutPaymentSession` events. Fiber derives a visible `PaymentStatus::Inflight` from attempts, but attempt updates did not produce store changes. As a result, `get_payment` could report `Inflight` while `get_cch_order` remained stuck at `IncomingAccepted`.

## Impact

CCH orders now advance to `OutgoingInFlight` when the outgoing Fiber attempt actually becomes in-flight, matching the status returned by payment queries and avoiding stale split state.

## Validation

- `cargo nextest run -p fnn --features sqlite test_receive_btc_store_attempt_inflight_updates_payment_and_cch_status`
- `cargo nextest run -p fnn --features sqlite cch::tests`
- `cargo nextest run -p fnn --features sqlite test_store_change_watcher`
- `cargo fmt --all -- --check`

Fixes #1491
