### PR TITLE
fix: adjust CA timestamp to sort before its own CUs

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -3273,11 +3273,13 @@ async fn verify_and_save_broadcast_message<S: GossipMessageStore>(
                         .await?;
                 let _ = verify_channel_announcement(channel_announcement, &on_chain_info, store)
                     .await?;
-                store.save_channel_announcement(
-                    on_chain_info.timestamp,
-                    channel_announcement.clone(),
-                );
-                (on_chain_info.timestamp, true)
+                // Subtracting 1 from the block timestamp ensures the CA always
+                // sorts before its own ChannelUpdates in get_broadcast_messages,
+                // even when a CU's local timestamp happens to be slightly before
+                // the on-chain block confirmation time.
+                let adjusted_timestamp = on_chain_info.timestamp.saturating_sub(1);
+                store.save_channel_announcement(adjusted_timestamp, channel_announcement.clone());
+                (adjusted_timestamp, true)
             }
         }
         BroadcastMessage::ChannelUpdate(channel_update) => {

--- a/crates/fiber-lib/src/fiber/tests/gossip.rs
+++ b/crates/fiber-lib/src/fiber/tests/gossip.rs
@@ -13,7 +13,7 @@ use crate::tests::test_utils::{
     establish_channel_between_nodes, ChannelParameters, NetworkNode, NetworkNodeConfigBuilder,
 };
 use crate::{
-    ckb::tests::test_utils::{MockChainActor, MockChainState},
+    ckb::tests::test_utils::{set_next_block_timestamp, MockChainActor, MockChainState},
     fiber::types::{ChannelUpdateChannelFlags, NodeAnnouncement},
 };
 use crate::{
@@ -607,8 +607,63 @@ async fn test_active_sync_rejects_future_timestamp_without_saving() {
     assert_eq!(
         context
             .get_store()
-            .get_latest_node_announcement(&announcement.node_id),
-        None
+            .get_broadcast_messages(&Cursor::default(), 0),
+        vec![]
+    );
+}
+
+// Verifies that a ChannelAnnouncement's stored timestamp is adjusted to be
+// strictly before the on-chain block timestamp, so it always sorts before
+// its own ChannelUpdates in get_broadcast_messages regardless of local
+// clock skew.
+#[tokio::test]
+async fn test_ca_adjusted_timestamp_sorts_before_cu() {
+    let block_ts = now_timestamp_as_millis_u64();
+    set_next_block_timestamp(block_ts).await;
+
+    let context = GossipTestingContext::new().await;
+    let channel_context = ChannelTestContext::gen().await;
+    let channel_outpoint = channel_context.channel_outpoint().clone();
+
+    // Save and confirm the CA (gets stored with adjusted timestamp)
+    context.save_message(BroadcastMessage::ChannelAnnouncement(
+        channel_context.channel_announcement.clone(),
+    ));
+    context.submit_tx(channel_context.funding_tx.clone()).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert!(context
+        .get_store()
+        .get_latest_channel_announcement(&channel_outpoint)
+        .is_some());
+
+    // Save a CU with the same block timestamp (simulating local clock == block time)
+    let cu = channel_context.create_channel_update_of_node1(
+        ChannelUpdateChannelFlags::empty(),
+        144,
+        0,
+        0,
+        Some(block_ts),
+    );
+    context.save_message(BroadcastMessage::ChannelUpdate(cu));
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Query all messages and verify CA sorts before CU
+    let messages = context
+        .get_store()
+        .get_broadcast_messages(&Cursor::default(), 0);
+    let ca_pos = messages.iter().position(|m| {
+        matches!(m, BroadcastMessageWithTimestamp::ChannelAnnouncement(_, ca) if ca.channel_outpoint == channel_outpoint)
+    });
+    let cu_pos = messages.iter().position(|m| {
+        matches!(m, BroadcastMessageWithTimestamp::ChannelUpdate(cu) if cu.channel_outpoint == channel_outpoint)
+    });
+
+    assert!(ca_pos.is_some(), "CA should be in the store");
+    assert!(cu_pos.is_some(), "CU should be in the store");
+    assert!(
+        ca_pos.unwrap() < cu_pos.unwrap(),
+        "CA should sort before CU (adjusted CA timestamp < CU timestamp)"
     );
 }
 


### PR DESCRIPTION
## Problem

`ChannelAnnouncement` gets its stored timestamp from the CKB block confirmation time, while `ChannelUpdate` uses the node's local clock. When a CU is generated before the funding tx is confirmed on-chain, the CU timestamp can be earlier than the CA block timestamp.

In `get_broadcast_messages`, messages are sorted by timestamp ascending. This means a CU can appear before its own CA in active sync responses, triggering the dependency-ordering deadlock addressed in #1495.

## Fix

Subtract 1ms from the block timestamp when storing a `ChannelAnnouncement` via `verify_and_save_broadcast_message`. This ensures the CA always has a strictly earlier timestamp than its CUs in the DB cursor ordering, regardless of local clock skew.

The adjustment uses `saturating_sub(1)` so it is safe even when the block timestamp is 0.

## Test

Added `test_ca_adjusted_timestamp_sorts_before_cu` which:
1. Sets a known block timestamp
2. Saves a CA (gets adjusted to block_ts - 1) and its CU (timestamp = block_ts)
3. Asserts via `get_broadcast_messages` that the CA sorts before its CU