### PR TITLE
fix: add CKB RPC timeout for WASM

### DIFF
--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -1,4 +1,6 @@
 use crate::ckb::config::new_ckb_rpc_async_client;
+#[cfg(target_arch = "wasm32")]
+use crate::ckb::config::CKB_RPC_TIMEOUT;
 use crate::ckb::CkbConfig;
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_sdk::rpc::ckb_indexer::{Cell, CellType, Order, Pagination, ScriptType, SearchKey, Tx};
@@ -213,15 +215,33 @@ async fn find_first_input_tx_hash_async(
     }
 }
 
+/// On WASM, reqwest's ClientBuilder has no timeout method, so we wrap the
+/// future with tokio::time::timeout instead. Native uses builder.timeout().
+async fn with_ckb_rpc_timeout<F, T, E>(fut: F) -> Result<T, anyhow::Error>
+where
+    F: std::future::Future<Output = Result<T, E>>,
+    E: Into<anyhow::Error>,
+{
+    #[cfg(target_arch = "wasm32")]
+    {
+        tokio::time::timeout(CKB_RPC_TIMEOUT, fut)
+            .await
+            .map_err(|_| anyhow::anyhow!("CKB RPC timed out after {:?}", CKB_RPC_TIMEOUT))?
+            .map_err(Into::into)
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        fut.await.map_err(Into::into)
+    }
+}
+
 #[async_trait::async_trait]
 impl CkbChainClient for CkbRpcClient {
     async fn get_transaction(&self, hash: H256) -> Result<GetTxResponse, anyhow::Error> {
         let client = self.config.ckb_rpc_client();
-        client
-            .get_only_committed_packed_transaction(hash)
+        with_ckb_rpc_timeout(client.get_only_committed_packed_transaction(hash))
             .await
             .map(|resp| GetTxResponse::from(Some(resp)))
-            .map_err(Into::into)
     }
 
     async fn get_cells(
@@ -240,8 +260,7 @@ impl CkbChainClient for CkbRpcClient {
 
     async fn get_block_timestamp(&self, block_hash: Hash256) -> Result<Option<u64>, anyhow::Error> {
         let client = self.config.ckb_rpc_client();
-        client
-            .get_packed_header(block_hash.into())
+        with_ckb_rpc_timeout(client.get_packed_header(block_hash.into()))
             .await
             .map(|maybe_bytes| {
                 maybe_bytes.and_then(|bytes| {
@@ -258,7 +277,6 @@ impl CkbChainClient for CkbRpcClient {
                     }
                 })
             })
-            .map_err(Into::into)
     }
 
     async fn get_shutdown_tx(


### PR DESCRIPTION
## Problem

WASM nodes report syncing only 10+ NodeAnnouncements in 5 minutes, then stalling. The root cause is that WASM's `reqwest` `ClientBuilder` has no `timeout()` method, so CKB RPC calls (`get_transaction`, `get_block_timestamp`) can hang indefinitely during gossip CA verification.

When Tick calls `prune_messages_to_be_saved()` → `verify_and_save_broadcast_message()` → `get_channel_tx()` → CKB RPC hangs, the entire store maintenance loop is blocked. NAs (which don't need CKB RPC) get processed, but CAs stall forever.

## Fix

Add `with_ckb_rpc_timeout()` helper that wraps RPC calls with `tokio::time::timeout` on WASM only. Native continues to use `builder.timeout()` for OS-level socket timeout.

```rust
async fn with_ckb_rpc_timeout<F, T, E>(fut: F) -> Result<T, anyhow::Error> {
    #[cfg(target_arch = "wasm32")]
    { tokio::time::timeout(CKB_RPC_TIMEOUT, fut).await?? }
    #[cfg(not(target_arch = "wasm32"))]
    { fut.await.map_err(Into::into) }
}
```

Applied to both `get_transaction` and `get_block_timestamp` in `CkbRpcClient`.