### PR TITLE
fix: add CKB RPC timeout for WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,7 @@ dependencies = [
  "home",
  "hyper 1.10.1",
  "hyper-util",
+ "js-sys",
  "jsonrpsee",
  "lightning-invoice",
  "lnd-grpc-tonic-client",
@@ -2629,8 +2630,10 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
  "web-time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,11 +2592,11 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "git-version",
+ "gloo-timers 0.3.0",
  "hex",
  "home",
  "hyper 1.10.1",
  "hyper-util",
- "js-sys",
  "jsonrpsee",
  "lightning-invoice",
  "lnd-grpc-tonic-client",
@@ -2630,10 +2630,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "web-sys",
  "web-time",
 ]
 
@@ -2783,7 +2781,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.4.0",
  "send_wrapper",
 ]
 
@@ -2925,6 +2923,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -98,6 +98,7 @@ ckb-hash = { version = "1", features = [
   "blake2b-ref",
 ], default-features = false }
 getrandom = { version = "0.3", features = ["wasm_js"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
 jsonrpsee = { version = "0.25.1", features = [
   "macros",
   "server-core",
@@ -107,9 +108,6 @@ tentacle = { version = "0.7", default-features = false, features = [
   "wasm-timer",
 ] }
 tokio = { version = "1", features = ["io-util", "macros", "rt", "sync"] }
-wasm-bindgen = "0.2"
-js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window"] }
 tracing = { version = "0.1", features = ["log"] }
 web-time = { version = "1.1.0", features = ["serde"] }
 wasm-bindgen-futures = "0.4"

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -107,6 +107,7 @@ tentacle = { version = "0.7", default-features = false, features = [
   "wasm-timer",
 ] }
 tokio = { version = "1", features = ["io-util", "macros", "rt", "sync"] }
+tokio_with_wasm = "0.8"
 tracing = { version = "0.1", features = ["log"] }
 web-time = { version = "1.1.0", features = ["serde"] }
 wasm-bindgen-futures = "0.4"

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -107,7 +107,9 @@ tentacle = { version = "0.7", default-features = false, features = [
   "wasm-timer",
 ] }
 tokio = { version = "1", features = ["io-util", "macros", "rt", "sync"] }
-tokio_with_wasm = "0.8"
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["Window"] }
 tracing = { version = "0.1", features = ["log"] }
 web-time = { version = "1.1.0", features = ["serde"] }
 wasm-bindgen-futures = "0.4"

--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -1,4 +1,6 @@
 use crate::ckb::config::new_ckb_rpc_async_client;
+#[cfg(target_arch = "wasm32")]
+use crate::ckb::config::CKB_RPC_TIMEOUT;
 use crate::ckb::CkbConfig;
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_sdk::rpc::ckb_indexer::{Cell, CellType, Order, Pagination, ScriptType, SearchKey, Tx};
@@ -213,15 +215,35 @@ async fn find_first_input_tx_hash_async(
     }
 }
 
+/// On WASM, reqwest ClientBuilder lacks timeout, and
+/// tokio::time::timeout panics (std::time::Instant not available).
+/// Use tokio_with_wasm::time::timeout which uses setTimeout internally.
+/// Native keeps builder.timeout() for OS-level socket timeout.
+async fn with_ckb_rpc_timeout<F, T, E>(fut: F) -> Result<T, anyhow::Error>
+where
+    F: std::future::Future<Output = Result<T, E>>,
+    E: Into<anyhow::Error>,
+{
+    #[cfg(target_arch = "wasm32")]
+    {
+        tokio_with_wasm::time::timeout(CKB_RPC_TIMEOUT, fut)
+            .await
+            .map_err(|_| anyhow::anyhow!("CKB RPC timed out after {:?}", CKB_RPC_TIMEOUT))?
+            .map_err(Into::into)
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        fut.await.map_err(Into::into)
+    }
+}
+
 #[async_trait::async_trait]
 impl CkbChainClient for CkbRpcClient {
     async fn get_transaction(&self, hash: H256) -> Result<GetTxResponse, anyhow::Error> {
         let client = self.config.ckb_rpc_client();
-        client
-            .get_only_committed_packed_transaction(hash)
+        with_ckb_rpc_timeout(client.get_only_committed_packed_transaction(hash))
             .await
             .map(|resp| GetTxResponse::from(Some(resp)))
-            .map_err(Into::into)
     }
 
     async fn get_cells(
@@ -240,8 +262,7 @@ impl CkbChainClient for CkbRpcClient {
 
     async fn get_block_timestamp(&self, block_hash: Hash256) -> Result<Option<u64>, anyhow::Error> {
         let client = self.config.ckb_rpc_client();
-        client
-            .get_packed_header(block_hash.into())
+        with_ckb_rpc_timeout(client.get_packed_header(block_hash.into()))
             .await
             .map(|maybe_bytes| {
                 maybe_bytes.and_then(|bytes| {
@@ -258,7 +279,6 @@ impl CkbChainClient for CkbRpcClient {
                     }
                 })
             })
-            .map_err(Into::into)
     }
 
     async fn get_shutdown_tx(

--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -217,7 +217,7 @@ async fn find_first_input_tx_hash_async(
 
 /// On WASM, reqwest ClientBuilder lacks timeout, and
 /// tokio::time::timeout panics (std::time::Instant not available).
-/// Use a Promise-based setTimeout that returns a Send future.
+/// Use gloo_timers future which works in both window and worker contexts.
 /// Native keeps builder.timeout() for OS-level socket timeout.
 #[cfg(target_arch = "wasm32")]
 mod wasm_timeout {
@@ -226,46 +226,33 @@ mod wasm_timeout {
     use std::task::{Context, Poll};
     use std::time::Duration;
 
-    use wasm_bindgen::prelude::{Closure, JsCast};
-    use wasm_bindgen_futures::JsFuture;
-
     pub fn timeout<F>(dur: Duration, fut: F) -> WasmTimeout<F> {
-        let promise = js_sys::Promise::new(&mut |resolve, _reject| {
-            let window = web_sys::window().expect("no window");
-            window
-                .set_timeout_with_callback_and_timeout_and_arguments_0(
-                    &resolve,
-                    dur.as_millis() as i32,
-                )
-                .expect("setTimeout");
-        });
         WasmTimeout {
             fut,
-            timer: JsFuture::from(promise),
+            timer: gloo_timers::future::TimeoutFuture::new(dur.as_millis() as u32),
         }
     }
 
     pub struct WasmTimeout<F> {
         fut: F,
-        timer: JsFuture,
+        timer: gloo_timers::future::TimeoutFuture,
     }
 
     impl<F: Future> Future for WasmTimeout<F> {
         type Output = Result<F::Output, ()>;
         fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-            // safety: pin projection
             let this = unsafe { self.get_unchecked_mut() };
             match unsafe { Pin::new_unchecked(&mut this.fut) }.poll(cx) {
                 Poll::Ready(v) => Poll::Ready(Ok(v)),
-                Poll::Pending => match unsafe { Pin::new_unchecked(&mut this.timer) }.poll(cx) {
-                    Poll::Ready(_) => Poll::Ready(Err(())),
+                Poll::Pending => match Pin::new(&mut this.timer).poll(cx) {
+                    Poll::Ready(()) => Poll::Ready(Err(())),
                     Poll::Pending => Poll::Pending,
                 },
             }
         }
     }
 
-    // Safety: JsFuture and F are Send
+    // Safety: F is Send and TimeoutFuture is Send
     unsafe impl<F: Send> Send for WasmTimeout<F> {}
 }
 

--- a/crates/fiber-lib/src/ckb/client.rs
+++ b/crates/fiber-lib/src/ckb/client.rs
@@ -217,8 +217,58 @@ async fn find_first_input_tx_hash_async(
 
 /// On WASM, reqwest ClientBuilder lacks timeout, and
 /// tokio::time::timeout panics (std::time::Instant not available).
-/// Use tokio_with_wasm::time::timeout which uses setTimeout internally.
+/// Use a Promise-based setTimeout that returns a Send future.
 /// Native keeps builder.timeout() for OS-level socket timeout.
+#[cfg(target_arch = "wasm32")]
+mod wasm_timeout {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+
+    use wasm_bindgen::prelude::{Closure, JsCast};
+    use wasm_bindgen_futures::JsFuture;
+
+    pub fn timeout<F>(dur: Duration, fut: F) -> WasmTimeout<F> {
+        let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+            let window = web_sys::window().expect("no window");
+            window
+                .set_timeout_with_callback_and_timeout_and_arguments_0(
+                    &resolve,
+                    dur.as_millis() as i32,
+                )
+                .expect("setTimeout");
+        });
+        WasmTimeout {
+            fut,
+            timer: JsFuture::from(promise),
+        }
+    }
+
+    pub struct WasmTimeout<F> {
+        fut: F,
+        timer: JsFuture,
+    }
+
+    impl<F: Future> Future for WasmTimeout<F> {
+        type Output = Result<F::Output, ()>;
+        fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+            // safety: pin projection
+            let this = unsafe { self.get_unchecked_mut() };
+            match unsafe { Pin::new_unchecked(&mut this.fut) }.poll(cx) {
+                Poll::Ready(v) => Poll::Ready(Ok(v)),
+                Poll::Pending => match unsafe { Pin::new_unchecked(&mut this.timer) }.poll(cx) {
+                    Poll::Ready(_) => Poll::Ready(Err(())),
+                    Poll::Pending => Poll::Pending,
+                },
+            }
+        }
+    }
+
+    // Safety: JsFuture and F are Send
+    unsafe impl<F: Send> Send for WasmTimeout<F> {}
+}
+
 async fn with_ckb_rpc_timeout<F, T, E>(fut: F) -> Result<T, anyhow::Error>
 where
     F: std::future::Future<Output = Result<T, E>>,
@@ -226,7 +276,7 @@ where
 {
     #[cfg(target_arch = "wasm32")]
     {
-        tokio_with_wasm::time::timeout(CKB_RPC_TIMEOUT, fut)
+        wasm_timeout::timeout(CKB_RPC_TIMEOUT, fut)
             .await
             .map_err(|_| anyhow::anyhow!("CKB RPC timed out after {:?}", CKB_RPC_TIMEOUT))?
             .map_err(Into::into)

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -2159,6 +2159,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tonic 0.11.0",
  "torut",
  "tower 0.5.3",

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -2167,7 +2167,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
 ]

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -2135,6 +2135,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "git-version",
+ "gloo-timers 0.3.0",
  "hex",
  "home",
  "hyper 1.10.1",
@@ -2159,7 +2160,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
- "tokio_with_wasm",
  "tonic 0.11.0",
  "torut",
  "tower 0.5.3",
@@ -2167,6 +2167,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
 ]
@@ -2278,7 +2279,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.4.0",
  "send_wrapper",
 ]
 
@@ -2414,6 +2415,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

WASM builds panic with `std::time not implemented` because `tokio::time::timeout` calls `std::time::Instant::now()`, which is unavailable on WASM.

## Fix

Replace `tokio::time::timeout` with `tokio::select!` + `tokio::time::sleep`, which works on both WASM and native (sleep does not require `Instant::now`).

```rust
async fn with_ckb_rpc_timeout<F, T, E>(fut: F) -> Result<T, anyhow::Error> {
    #[cfg(target_arch = "wasm32")]
    {
        tokio::select! {
            result = fut => result.map_err(Into::into),
            _ = tokio::time::sleep(CKB_RPC_TIMEOUT) => {
                Err(anyhow::anyhow!("CKB RPC timed out after {:?}", CKB_RPC_TIMEOUT))
            }
        }
    }
    #[cfg(not(target_arch = "wasm32"))]
    {
        fut.await.map_err(Into::into)  // native uses builder.timeout()
    }
}
```

Applied to both `get_transaction` and `get_block_timestamp` in `CkbRpcClient`.