### PR TITLE
Fix payment TLC expiry limit random delta

### DIFF
--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1995,6 +1995,11 @@ where
         let mut hops_data = Vec::with_capacity(route.len() + 1);
         let last_expiry_delta =
             final_hop_expiry_delta_override.unwrap_or(payment_data.final_tlc_expiry_delta);
+
+        // `RouterHop::incoming_tlc_expiry` and `last_expiry_delta` are relative expiry
+        // budgets. `PaymentHopData::expiry` below is an absolute timestamp after adding `now`
+        // and the privacy random delta. The largest base budget decides how much room is left
+        // for the actual random delta while still honoring `tlc_expiry_limit` as a hard cap.
         let max_base_expiry_delta = route
             .iter()
             .map(|r| r.incoming_tlc_expiry)
@@ -2125,6 +2130,11 @@ where
         DEFAULT_TLC_EXPIRY_DELTA
     }
 
+    // Path finding runs before the actual random expiry delta is selected, so this helper is
+    // intentionally a deterministic reserve, not the real random value. Reserving the minimum
+    // possible random delta prevents path finding from choosing a route that already consumes the
+    // whole `tlc_expiry_limit`. `build_router_from_path` still caps the actual random delta against
+    // the selected route's remaining budget and performs the final absolute-expiry hard check.
     fn route_tlc_expiry_limit(&self, tlc_expiry_limit: u64) -> Result<u64, PathFindError> {
         let random_expiry_reserve = self.min_rand_tlc_expiry_delta();
         tlc_expiry_limit

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -1403,6 +1403,7 @@ where
     ) -> Result<(), PathFindError> {
         let mut from = source;
         let mut previous_hop: Option<&RouterHop> = None;
+        let route_tlc_expiry_limit = self.route_tlc_expiry_limit(payment_data.tlc_expiry_limit)?;
 
         for hop in route {
             if hop.amount_received == 0 {
@@ -1410,9 +1411,9 @@ where
                     "route hop amount_received must be greater than 0".to_string(),
                 ));
             }
-            if hop.incoming_tlc_expiry > payment_data.tlc_expiry_limit {
+            if hop.incoming_tlc_expiry > route_tlc_expiry_limit {
                 return Err(PathFindError::Overflow(format!(
-                    "route hop incoming_tlc_expiry {} exceeds tlc_expiry_limit {}",
+                    "route hop incoming_tlc_expiry {} exceeds tlc_expiry_limit {} after random expiry reserve",
                     hop.incoming_tlc_expiry, payment_data.tlc_expiry_limit
                 )));
             }
@@ -1554,6 +1555,12 @@ where
                     low_total_trampoline_fee, high_total_trampoline_fee, max_fee_amount
                 )));
         }
+        let route_tlc_expiry_limit = self.route_tlc_expiry_limit(payment_data.tlc_expiry_limit)?;
+        let trampoline_forward_expiry_delta = self.trampoline_forward_expiry_delta(
+            payment_data.final_tlc_expiry_delta,
+            hops,
+            route_tlc_expiry_limit,
+        )?;
 
         let mut route_to_trampoline = self.find_path(
             source,
@@ -1565,12 +1572,8 @@ where
             )?),
             Some(max_fee_amount),
             payment_data.udt_type_script.clone(),
-            self.trampoline_forward_expiry_delta(
-                payment_data.final_tlc_expiry_delta,
-                hops,
-                payment_data.tlc_expiry_limit,
-            )?,
-            payment_data.tlc_expiry_limit,
+            trampoline_forward_expiry_delta,
+            route_tlc_expiry_limit,
             payment_data.allow_self_payment,
             &payment_data.hop_hints,
             &payment_data.channel_stats,
@@ -1673,7 +1676,7 @@ where
                 tlc_expiry_delta: self.trampoline_forward_expiry_delta(
                     payment_data.final_tlc_expiry_delta,
                     remaining_trampoline_hops,
-                    payment_data.tlc_expiry_limit,
+                    route_tlc_expiry_limit,
                 )?,
                 max_parts: if payment_data.allow_mpp() {
                     Some(payment_data.max_parts() as u64)
@@ -1709,11 +1712,7 @@ where
             hops: route_to_trampoline,
             amount: checked_add_u128(final_amount, remaining_fee, "trampoline resolved amount")?,
             trampoline_onion: Some(trampoline_onion),
-            final_hop_expiry_delta_override: Some(self.trampoline_forward_expiry_delta(
-                payment_data.final_tlc_expiry_delta,
-                hops,
-                payment_data.tlc_expiry_limit,
-            )?),
+            final_hop_expiry_delta_override: Some(trampoline_forward_expiry_delta),
         });
     }
 
@@ -1793,6 +1792,7 @@ where
             *stats.entry(payment_data.payment_hash).or_insert(0) += 1;
         }
 
+        let route_tlc_expiry_limit = self.route_tlc_expiry_limit(payment_data.tlc_expiry_limit)?;
         self.find_path(
             source,
             payment_data.target_pubkey,
@@ -1800,7 +1800,7 @@ where
             max_fee_amount,
             payment_data.udt_type_script.clone(),
             payment_data.final_tlc_expiry_delta,
-            payment_data.tlc_expiry_limit,
+            route_tlc_expiry_limit,
             payment_data.allow_self_payment,
             &payment_data.hop_hints,
             &payment_data.channel_stats,
@@ -1818,6 +1818,7 @@ where
             *stats.entry(payment_data.payment_hash).or_insert(0) += 1;
         }
 
+        let route_tlc_expiry_limit = self.route_tlc_expiry_limit(payment_data.tlc_expiry_limit)?;
         match self.find_path(
             self.get_source_pubkey(),
             payment_data.target_pubkey,
@@ -1825,7 +1826,7 @@ where
             None,
             payment_data.udt_type_script.clone(),
             payment_data.final_tlc_expiry_delta,
-            payment_data.tlc_expiry_limit,
+            route_tlc_expiry_limit,
             payment_data.allow_self_payment,
             &payment_data.hop_hints,
             &payment_data.channel_stats,
@@ -1961,6 +1962,7 @@ where
         route: &[RouterHop],
         payment_data: &SendPaymentState,
     ) -> Result<std::vec::Vec<RouterHop>, PathFindError> {
+        let route_tlc_expiry_limit = self.route_tlc_expiry_limit(payment_data.tlc_expiry_limit)?;
         self.inner_find_path(
             source,
             payment_data.target_pubkey,
@@ -1968,7 +1970,7 @@ where
             payment_data.max_fee_amount,
             payment_data.udt_type_script.clone(),
             payment_data.final_tlc_expiry_delta,
-            payment_data.tlc_expiry_limit,
+            route_tlc_expiry_limit,
             &payment_data.hop_hints,
             &payment_data.channel_stats,
             payment_data.allow_mpp(),
@@ -1991,7 +1993,38 @@ where
         let route_len = route.len();
         let now = now_timestamp_as_millis_u64();
         let mut hops_data = Vec::with_capacity(route.len() + 1);
-        let mut rand_tlc_expiry_delta = self.rand_tlc_expiry_delta(route);
+        let last_expiry_delta =
+            final_hop_expiry_delta_override.unwrap_or(payment_data.final_tlc_expiry_delta);
+        let max_base_expiry_delta = route
+            .iter()
+            .map(|r| r.incoming_tlc_expiry)
+            .chain(std::iter::once(last_expiry_delta))
+            .max()
+            .unwrap_or(last_expiry_delta);
+        let max_random_expiry_delta = payment_data
+            .tlc_expiry_limit
+            .checked_sub(max_base_expiry_delta)
+            .ok_or_else(|| {
+                PathFindError::Overflow(format!(
+                    "route base expiry {} exceeds tlc_expiry_limit {}",
+                    max_base_expiry_delta, payment_data.tlc_expiry_limit
+                ))
+            })?;
+        let max_payment_expiry = checked_add_u64(
+            now,
+            payment_data.tlc_expiry_limit,
+            "payment tlc_expiry_limit",
+        )?;
+        let check_tlc_expiry_limit = |expiry: u64, context: &str| -> Result<(), PathFindError> {
+            if expiry > max_payment_expiry {
+                return Err(PathFindError::Overflow(format!(
+                    "{} {} exceeds tlc_expiry_limit {} (max actual expiry {})",
+                    context, expiry, payment_data.tlc_expiry_limit, max_payment_expiry
+                )));
+            }
+            Ok(())
+        };
+        let mut rand_tlc_expiry_delta = self.rand_tlc_expiry_delta(route, max_random_expiry_delta);
         if let Some(max_expiry) = payment_data
             .trampoline_context
             .as_ref()
@@ -2011,6 +2044,7 @@ where
                 rand_tlc_expiry_delta,
                 "payment hop expiry random delta",
             )?;
+            check_tlc_expiry_limit(expiry, "payment hop expiry")?;
             hops_data.push(PaymentHopData {
                 amount: r.amount_received,
                 next_hop: Some(r.target),
@@ -2032,14 +2066,13 @@ where
                 ),
             };
 
-        let last_expiry_delta =
-            final_hop_expiry_delta_override.unwrap_or(payment_data.final_tlc_expiry_delta);
         let last_expiry = checked_add_u64(now, last_expiry_delta, "final payment hop expiry")?;
         let last_expiry = checked_add_u64(
             last_expiry,
             rand_tlc_expiry_delta,
             "final payment hop expiry random delta",
         )?;
+        check_tlc_expiry_limit(last_expiry, "final payment hop expiry")?;
 
         let mut last_hop = PaymentHopData {
             amount: last_amount,
@@ -2084,7 +2117,27 @@ where
             .unwrap_or(true)
     }
 
-    fn rand_tlc_expiry_delta(&self, route: &[RouterHop]) -> u64 {
+    fn min_rand_tlc_expiry_delta(&self) -> u64 {
+        #[cfg(test)]
+        if let Some(expiry_delta) = self.fixed_rand_expiry_delta {
+            return expiry_delta;
+        }
+        DEFAULT_TLC_EXPIRY_DELTA
+    }
+
+    fn route_tlc_expiry_limit(&self, tlc_expiry_limit: u64) -> Result<u64, PathFindError> {
+        let random_expiry_reserve = self.min_rand_tlc_expiry_delta();
+        tlc_expiry_limit
+            .checked_sub(random_expiry_reserve)
+            .ok_or_else(|| {
+                PathFindError::Overflow(format!(
+                    "tlc_expiry_limit {} is too small for random expiry reserve {}",
+                    tlc_expiry_limit, random_expiry_reserve
+                ))
+            })
+    }
+
+    fn rand_tlc_expiry_delta(&self, route: &[RouterHop], max_random_expiry_delta: u64) -> u64 {
         #[cfg(test)]
         if let Some(expiry_delta) = self.fixed_rand_expiry_delta {
             return expiry_delta;
@@ -2094,6 +2147,7 @@ where
         // This makes it harder for the intermediate nodes to infer their position in the route.
         let max_rand_expiry_num = MAX_PAYMENT_TLC_EXPIRY_LIMIT
             .saturating_sub(route.first().map(|r| r.incoming_tlc_expiry).unwrap_or(0))
+            .min(max_random_expiry_delta)
             / DEFAULT_TLC_EXPIRY_DELTA;
 
         thread_rng().gen_range(1..max_rand_expiry_num.max(2)) * DEFAULT_TLC_EXPIRY_DELTA

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -7881,14 +7881,14 @@ async fn test_send_payment_will_succeed_with_large_tlc_expiry_limit() {
     let source_node = &mut node_0;
     let target_pubkey = node_3.pubkey;
 
-    let expected_minimal_tlc_expiry_limit =
-        DEFAULT_TLC_EXPIRY_DELTA * 2 + DEFAULT_FINAL_TLC_EXPIRY_DELTA;
+    let base_route_tlc_expiry_limit = DEFAULT_TLC_EXPIRY_DELTA * 2 + DEFAULT_FINAL_TLC_EXPIRY_DELTA;
+    let expected_minimal_tlc_expiry_limit = base_route_tlc_expiry_limit + DEFAULT_TLC_EXPIRY_DELTA;
 
     let res = source_node
         .send_payment(SendPaymentCommand {
             target_pubkey: Some(target_pubkey),
             amount: Some(999),
-            tlc_expiry_limit: Some(expected_minimal_tlc_expiry_limit - 1),
+            tlc_expiry_limit: Some(base_route_tlc_expiry_limit - 1),
             keysend: Some(true),
             ..Default::default()
         })

--- a/crates/fiber-lib/src/fiber/tests/graph.rs
+++ b/crates/fiber-lib/src/fiber/tests/graph.rs
@@ -3,6 +3,7 @@ use crate::fiber::config::{
     DEFAULT_TLC_EXPIRY_DELTA, MAX_PAYMENT_TLC_EXPIRY_LIMIT, MIN_TLC_EXPIRY_DELTA,
 };
 use crate::fiber::gossip::GossipMessageStore;
+use crate::fiber::graph::GraphChannelStat;
 use crate::fiber::graph::NetworkGraph;
 use crate::fiber::graph::PathFindError;
 use crate::fiber::graph::SendPaymentState;
@@ -34,6 +35,15 @@ use crate::{
 const TLC_EXPIRY_DELTA_IN_TESTS: u64 = 42 * 60 * 1000;
 // Default final tlc expiry delta used in this test environment.
 const FINAL_TLC_EXPIRY_DELTA_IN_TESTS: u64 = 43 * 60 * 1000;
+
+fn assert_tlc_expiry_limit_error<T: std::fmt::Debug>(result: Result<T, PathFindError>) {
+    let err = result.expect_err("route should reject actual expiry over tlc_expiry_limit");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("tlc_expiry_limit"),
+        "unexpected error message: {msg}"
+    );
+}
 
 fn generate_key_pairs(num: usize) -> Vec<(SecretKey, PublicKey)> {
     let mut keys = vec![];
@@ -1513,6 +1523,180 @@ fn test_graph_build_route_with_expiry_limit() {
         true,
     );
     assert!(route.is_err());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_build_route_rejects_random_expiry_over_tlc_limit() {
+    let mut network = MockNetworkGraph::new(3);
+    network
+        .graph
+        .set_fixed_rand_expiry_delta(DEFAULT_TLC_EXPIRY_DELTA);
+
+    network.set_source(network.keys[1]);
+    network.add_edge(1, 2, Some(10_000), Some(0));
+    network.add_edge(2, 3, Some(10_000), Some(0));
+
+    let target = network.keys[3];
+    let base_route_expiry = FINAL_TLC_EXPIRY_DELTA_IN_TESTS + TLC_EXPIRY_DELTA_IN_TESTS;
+    let payment_state: SendPaymentState =
+        SendPaymentDataBuilder::new(target.into(), 1000, Hash256::default())
+            .final_tlc_expiry_delta(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)
+            .tlc_expiry_limit(base_route_expiry)
+            .max_fee_amount(Some(1000))
+            .build()
+            .expect("valid payment data")
+            .into();
+
+    assert_tlc_expiry_limit_error(network.graph.build_route(
+        payment_state.amount,
+        None,
+        None,
+        &payment_state,
+    ));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_build_route_allows_random_expiry_within_tlc_limit() {
+    let mut network = MockNetworkGraph::new(3);
+    network
+        .graph
+        .set_fixed_rand_expiry_delta(DEFAULT_TLC_EXPIRY_DELTA);
+
+    network.set_source(network.keys[1]);
+    network.add_edge(1, 2, Some(10_000), Some(0));
+    network.add_edge(2, 3, Some(10_000), Some(0));
+
+    let target = network.keys[3];
+    let base_route_expiry = FINAL_TLC_EXPIRY_DELTA_IN_TESTS + TLC_EXPIRY_DELTA_IN_TESTS;
+    let tlc_expiry_limit = base_route_expiry + DEFAULT_TLC_EXPIRY_DELTA;
+    let payment_state: SendPaymentState =
+        SendPaymentDataBuilder::new(target.into(), 1000, Hash256::default())
+            .final_tlc_expiry_delta(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)
+            .tlc_expiry_limit(tlc_expiry_limit)
+            .max_fee_amount(Some(1000))
+            .build()
+            .expect("valid payment data")
+            .into();
+
+    let route = network
+        .graph
+        .build_route(payment_state.amount, None, None, &payment_state)
+        .expect("route should fit after accounting for random expiry delta");
+    let after = now_timestamp_as_millis_u64();
+
+    for hop in &route {
+        assert!(
+            hop.expiry <= after + tlc_expiry_limit,
+            "actual hop expiry {} exceeds limit {}",
+            hop.expiry,
+            after + tlc_expiry_limit
+        );
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_mpp_route_rejects_random_expiry_over_tlc_limit() {
+    let mut network = MockNetworkGraph::new(3);
+    network
+        .graph
+        .set_fixed_rand_expiry_delta(DEFAULT_TLC_EXPIRY_DELTA);
+
+    network.set_source(network.keys[1]);
+    network.add_edge(1, 2, Some(10_000), Some(0));
+    network.add_edge(2, 3, Some(10_000), Some(0));
+
+    let target = network.keys[3];
+    let base_route_expiry = FINAL_TLC_EXPIRY_DELTA_IN_TESTS + TLC_EXPIRY_DELTA_IN_TESTS;
+    let payment_data = SendPaymentDataBuilder::new(target.into(), 1000, Hash256::default())
+        .final_tlc_expiry_delta(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)
+        .tlc_expiry_limit(base_route_expiry)
+        .max_fee_amount(Some(1000))
+        .max_parts(Some(2))
+        .allow_mpp(true)
+        .build()
+        .expect("valid payment data");
+    let payment_state = SendPaymentState::with_channel_stats(
+        payment_data,
+        GraphChannelStat::new(Some(network.graph.channel_stats())),
+    );
+
+    assert_tlc_expiry_limit_error(network.graph.build_route(
+        payment_state.amount,
+        Some(1),
+        None,
+        &payment_state,
+    ));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_trampoline_route_rejects_random_expiry_over_tlc_limit() {
+    let mut network = MockNetworkGraph::new(3);
+    network
+        .graph
+        .set_fixed_rand_expiry_delta(DEFAULT_TLC_EXPIRY_DELTA);
+
+    network.set_source(network.keys[1]);
+    let first_trampoline = network.keys[2];
+    let target = network.keys[3];
+    network.add_edge(1, 2, Some(10_000), Some(0));
+
+    let base_final = FINAL_TLC_EXPIRY_DELTA_IN_TESTS.max(MIN_TLC_EXPIRY_DELTA);
+    let segment_budget =
+        TRAMPOLINE_FORWARDING_ROUTE_DELTA_COUNT * DEFAULT_TLC_EXPIRY_DELTA + MIN_TLC_EXPIRY_DELTA;
+    let tlc_expiry_limit = base_final + segment_budget;
+    let payment_state: SendPaymentState =
+        SendPaymentDataBuilder::new(target.into(), 1000, Hash256::default())
+            .final_tlc_expiry_delta(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)
+            .tlc_expiry_limit(tlc_expiry_limit)
+            .max_fee_amount(Some(1000))
+            .trampoline_hops(Some(vec![first_trampoline.into()]))
+            .build()
+            .expect("valid payment data")
+            .into();
+
+    assert_tlc_expiry_limit_error(network.graph.build_route(
+        payment_state.amount,
+        None,
+        None,
+        &payment_state,
+    ));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_graph_explicit_router_rejects_random_expiry_over_tlc_limit() {
+    let mut network = MockNetworkGraph::new(1);
+    network
+        .graph
+        .set_fixed_rand_expiry_delta(DEFAULT_TLC_EXPIRY_DELTA);
+    network.add_edge(0, 1, Some(10_000), Some(0));
+
+    let target = network.keys[1];
+    let payment_state: SendPaymentState =
+        SendPaymentDataBuilder::new(target.into(), 1000, Hash256::default())
+            .final_tlc_expiry_delta(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)
+            .tlc_expiry_limit(FINAL_TLC_EXPIRY_DELTA_IN_TESTS)
+            .max_fee_amount(Some(0))
+            .router(vec![RouterHop {
+                target: target.into(),
+                channel_outpoint: network.edges[0].2.clone(),
+                amount_received: 1000,
+                incoming_tlc_expiry: FINAL_TLC_EXPIRY_DELTA_IN_TESTS,
+            }])
+            .build()
+            .expect("valid payment data")
+            .into();
+
+    assert_tlc_expiry_limit_error(network.graph.build_route(
+        payment_state.amount,
+        None,
+        None,
+        &payment_state,
+    ));
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -4223,7 +4223,7 @@ async fn test_send_payment_with_invalid_tlc_expiry() {
             target_pubkey: Some(nodes[1].pubkey),
             amount: Some(1000),
             keysend: Some(true),
-            tlc_expiry_limit: Some(DEFAULT_FINAL_TLC_EXPIRY_DELTA + 1), // Ok now
+            tlc_expiry_limit: Some(DEFAULT_FINAL_TLC_EXPIRY_DELTA + DEFAULT_TLC_EXPIRY_DELTA),
             ..Default::default()
         })
         .await;
@@ -7939,13 +7939,16 @@ async fn test_network_with_hops_max_number_limit() {
     )
     .await;
 
+    let thirteen_hop_base_limit = DEFAULT_TLC_EXPIRY_DELTA * 12 + DEFAULT_FINAL_TLC_EXPIRY_DELTA;
+    let thirteen_hop_limit = thirteen_hop_base_limit + DEFAULT_TLC_EXPIRY_DELTA;
+
     let payment = nodes[0]
         .send_payment(SendPaymentCommand {
             target_pubkey: Some(nodes[14].pubkey), // can not make a payment with 14 hops
             amount: Some(1000),
             keysend: Some(true),
             max_fee_rate: Some(1000),
-            tlc_expiry_limit: Some(DEFAULT_TLC_EXPIRY_DELTA * 12 + DEFAULT_FINAL_TLC_EXPIRY_DELTA), // 13 hops limit
+            tlc_expiry_limit: Some(thirteen_hop_limit),
             ..Default::default()
         })
         .await;
@@ -7959,7 +7962,7 @@ async fn test_network_with_hops_max_number_limit() {
             amount: Some(1000),
             keysend: Some(true),
             max_fee_rate: Some(1000),
-            tlc_expiry_limit: Some(DEFAULT_TLC_EXPIRY_DELTA * 12 + DEFAULT_FINAL_TLC_EXPIRY_DELTA), // 13 hops limit
+            tlc_expiry_limit: Some(thirteen_hop_limit),
             ..Default::default()
         })
         .await


### PR DESCRIPTION
## Summary

- Reserve the random TLC expiry delta in route validation so `tlc_expiry_limit` remains a hard budget for actual outgoing `PaymentHopData.expiry`.
- Add a final hard check when building payment hops to reject any actual expiry beyond `now + tlc_expiry_limit`.
- Add regression coverage for normal routing, MPP routing, trampoline routing, and explicit routers.
- Update existing tight-limit tests to account for the random expiry reserve.

## Root Cause

`tlc_expiry_limit` was checked against the route-computed `incoming_tlc_expiry`, but `build_router_from_path()` added `rand_tlc_expiry_delta` afterward. A route could pass validation and still emit outgoing hop expiries beyond the caller's intended budget.

Fixes #1218.

## Validation

- `cargo nextest run -p fnn --no-default-features --features sqlite,watchtower random_expiry`
- `cargo nextest run -p fnn --no-default-features --features sqlite,watchtower fiber::tests::graph`
- `cargo nextest run -p fnn --no-default-features --features sqlite,watchtower tlc_expiry`
- `cargo fmt --all -- --check`
- `cargo check -p fnn --no-default-features --features sqlite`

`cargo clippy -p fnn --no-default-features --features sqlite -- -D warnings` still fails on existing warnings outside this change:

- `crates/fiber-lib/src/store/store_impl/mod.rs:47` unused import `tracing::warn`
- `crates/fiber-lib/src/ckb/client.rs:155` unused function `find_first_input_tx_hash`
