### PR TITLE
perf: batch WASM store commits into single IPC call

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -2204,6 +2204,8 @@ impl<S: GossipMessageStore + Clone, C: CkbChainClient + Clone>
         peer: &Pubkey,
         messages: Vec<BroadcastMessage>,
     ) -> ActiveSyncSaveMessagesResult {
+        let _start = now_timestamp_as_millis_u64();
+        let _total = messages.len();
         let mut verified_messages = Vec::new();
         let mut result = None;
         let mut latest_validated_cursor = None;
@@ -2374,15 +2376,24 @@ impl<S: GossipMessageStore + Clone, C: CkbChainClient + Clone>
         }
 
         self.broadcast_messages(&verified_messages);
-        if skipped_no_deps > 0 || skipped_deferred > 0 || skipped_ckb_deferred > 0 {
-            ActiveSyncSaveMessagesResult::Pending
-        } else {
-            result.unwrap_or_else(|| {
-                latest_validated_cursor
-                    .map(ActiveSyncSaveMessagesResult::Validated)
-                    .unwrap_or(ActiveSyncSaveMessagesResult::Pending)
-            })
-        }
+        let final_result =
+            if skipped_no_deps > 0 || skipped_deferred > 0 || skipped_ckb_deferred > 0 {
+                ActiveSyncSaveMessagesResult::Pending
+            } else {
+                result.unwrap_or_else(|| {
+                    latest_validated_cursor
+                        .map(ActiveSyncSaveMessagesResult::Validated)
+                        .unwrap_or(ActiveSyncSaveMessagesResult::Pending)
+                })
+            };
+        info!(
+            "save_active_sync_msgs: {}/{} verified in {}ms, skipped(no_deps={}, deferred={}, ckb_deferred={})",
+            verified_messages.len(),
+            _total,
+            now_timestamp_as_millis_u64().saturating_sub(_start),
+            skipped_no_deps, skipped_deferred, skipped_ckb_deferred,
+        );
+        final_result
     }
 
     fn has_dependencies_available(&self, message: &BroadcastMessage) -> bool {
@@ -2703,16 +2714,23 @@ impl<
             }
 
             ExtendedGossipMessageStoreMessage::Tick => {
+                let _tick_start = now_timestamp_as_millis_u64();
+                let _total_cached: usize =
+                    state.messages_to_be_saved.values().map(|s| s.len()).sum();
                 trace!(
                     "Gossip store maintenance ticked: #subscriptions = {},  #messages_to_be_saved = {}",
-                    state.output_ports.len(),
-                    state.messages_to_be_saved.values().map(|s| s.len()).sum::<usize>(),
+                    state.output_ports.len(), _total_cached,
                 );
 
-                // These are the messages that have complete dependencies and can be sent to the subscribers.
                 let complete_messages = state.prune_messages_to_be_saved().await;
                 state.broadcast_messages(&complete_messages);
                 state.spawn_query_tasks(&myself);
+                info!(
+                    "Tick done in {}ms: cached={}, verified={}",
+                    now_timestamp_as_millis_u64().saturating_sub(_tick_start),
+                    _total_cached,
+                    complete_messages.len(),
+                );
             }
         }
         Ok(())

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -2204,8 +2204,6 @@ impl<S: GossipMessageStore + Clone, C: CkbChainClient + Clone>
         peer: &Pubkey,
         messages: Vec<BroadcastMessage>,
     ) -> ActiveSyncSaveMessagesResult {
-        let _start = now_timestamp_as_millis_u64();
-        let _total = messages.len();
         let mut verified_messages = Vec::new();
         let mut result = None;
         let mut latest_validated_cursor = None;
@@ -2376,24 +2374,15 @@ impl<S: GossipMessageStore + Clone, C: CkbChainClient + Clone>
         }
 
         self.broadcast_messages(&verified_messages);
-        let final_result =
-            if skipped_no_deps > 0 || skipped_deferred > 0 || skipped_ckb_deferred > 0 {
-                ActiveSyncSaveMessagesResult::Pending
-            } else {
-                result.unwrap_or_else(|| {
-                    latest_validated_cursor
-                        .map(ActiveSyncSaveMessagesResult::Validated)
-                        .unwrap_or(ActiveSyncSaveMessagesResult::Pending)
-                })
-            };
-        info!(
-            "save_active_sync_msgs: {}/{} verified in {}ms, skipped(no_deps={}, deferred={}, ckb_deferred={})",
-            verified_messages.len(),
-            _total,
-            now_timestamp_as_millis_u64().saturating_sub(_start),
-            skipped_no_deps, skipped_deferred, skipped_ckb_deferred,
-        );
-        final_result
+        if skipped_no_deps > 0 || skipped_deferred > 0 || skipped_ckb_deferred > 0 {
+            ActiveSyncSaveMessagesResult::Pending
+        } else {
+            result.unwrap_or_else(|| {
+                latest_validated_cursor
+                    .map(ActiveSyncSaveMessagesResult::Validated)
+                    .unwrap_or(ActiveSyncSaveMessagesResult::Pending)
+            })
+        }
     }
 
     fn has_dependencies_available(&self, message: &BroadcastMessage) -> bool {
@@ -2714,23 +2703,16 @@ impl<
             }
 
             ExtendedGossipMessageStoreMessage::Tick => {
-                let _tick_start = now_timestamp_as_millis_u64();
-                let _total_cached: usize =
-                    state.messages_to_be_saved.values().map(|s| s.len()).sum();
                 trace!(
                     "Gossip store maintenance ticked: #subscriptions = {},  #messages_to_be_saved = {}",
-                    state.output_ports.len(), _total_cached,
+                    state.output_ports.len(),
+                    state.messages_to_be_saved.values().map(|s| s.len()).sum::<usize>(),
                 );
 
+                // These are the messages that have complete dependencies and can be sent to the subscribers.
                 let complete_messages = state.prune_messages_to_be_saved().await;
                 state.broadcast_messages(&complete_messages);
                 state.spawn_query_tasks(&myself);
-                info!(
-                    "Tick done in {}ms: cached={}, verified={}",
-                    now_timestamp_as_millis_u64().saturating_sub(_tick_start),
-                    _total_cached,
-                    complete_messages.len(),
-                );
             }
         }
         Ok(())

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -6151,7 +6151,8 @@ where
                 .insert_protocol(fiber_handle.create_meta())
                 .handshake_type(secio_kp.into())
                 // Sets forever to true so the network service won't be shutdown due to no incoming connections
-                .forever(true);
+                .forever(true)
+                .timeout(std::time::Duration::from_secs(30));
             if let Some(gossip_handle) = gossip_handle_opt {
                 builder = builder.insert_protocol(gossip_handle.create_meta());
             }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -6099,7 +6099,8 @@ where
         let mut service = {
             let mut builder = ServiceBuilder::default()
                 .insert_protocol(fiber_handle.create_meta())
-                .handshake_type(secio_kp.into());
+                .handshake_type(secio_kp.into())
+                .timeout(std::time::Duration::from_secs(60));
             if let Some(gossip_handle) = gossip_handle_opt {
                 builder = builder.insert_protocol(gossip_handle.create_meta());
             }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -6152,7 +6152,7 @@ where
                 .handshake_type(secio_kp.into())
                 // Sets forever to true so the network service won't be shutdown due to no incoming connections
                 .forever(true)
-                .timeout(std::time::Duration::from_secs(30));
+                .timeout(std::time::Duration::from_secs(60));
             if let Some(gossip_handle) = gossip_handle_opt {
                 builder = builder.insert_protocol(gossip_handle.create_meta());
             }

--- a/crates/fiber-store/src/browser.rs
+++ b/crates/fiber-store/src/browser.rs
@@ -187,12 +187,14 @@ impl BatchWriter for Batch {
     }
 
     fn commit(self) {
-        self.chan
-            .dispatch_database_command(DbCommandRequestWithTakeWhile::Delete { keys: self.delete })
-            .expect("Failed to delete batch");
-        self.chan
-            .dispatch_database_command(DbCommandRequestWithTakeWhile::Put { kvs: self.puts })
-            .expect("Failed to put batch");
+        if !self.delete.is_empty() || !self.puts.is_empty() {
+            self.chan
+                .dispatch_database_command(DbCommandRequestWithTakeWhile::BatchWrite {
+                    deletes: self.delete,
+                    puts: self.puts,
+                })
+                .expect("Failed to commit batch");
+        }
     }
 }
 
@@ -297,6 +299,9 @@ impl CommunicationChannel {
             DbCommandRequestWithTakeWhile::Delete { keys } => {
                 (DbCommandRequest::Delete { keys }, None)
             }
+            DbCommandRequestWithTakeWhile::BatchWrite { deletes, puts } => {
+                (DbCommandRequest::BatchWrite { deletes, puts }, None)
+            }
             DbCommandRequestWithTakeWhile::Iterator {
                 start,
                 direction,
@@ -374,6 +379,10 @@ pub enum DbCommandRequestWithTakeWhile {
     },
     Delete {
         keys: Vec<Vec<u8>>,
+    },
+    BatchWrite {
+        deletes: Vec<Vec<u8>>,
+        puts: Vec<KV>,
     },
     Iterator {
         start: Vec<u8>,

--- a/crates/fiber-wasm-db-common/src/lib.rs
+++ b/crates/fiber-wasm-db-common/src/lib.rs
@@ -112,6 +112,7 @@ pub enum DbCommandResponse {
     },
     Put,
     Delete,
+    BatchWrite,
     /// Response for Iterator command: the collected key-value pairs.
     Iterator {
         kvs: Vec<KV>,
@@ -133,6 +134,13 @@ pub enum DbCommandRequest {
     /// Input: Keys to remove
     /// Output: None
     Delete { keys: Vec<Vec<u8>> },
+    /// Atomically delete keys then write kv pairs.
+    /// Input: Deletes list and puts list
+    /// Output: None
+    BatchWrite {
+        deletes: Vec<Vec<u8>>,
+        puts: Vec<KV>,
+    },
     /// Iterate over key-value pairs, with `take_while` evaluated via IPC callback.
     /// The worker iterates from `start` in `direction`, calling back to the client
     /// for each key to evaluate `take_while`. Stops when `take_while` returns false

--- a/crates/fiber-wasm-db-worker/src/db.rs
+++ b/crates/fiber-wasm-db-worker/src/db.rs
@@ -129,9 +129,9 @@ where
         DbCommandRequest::Read { .. } | DbCommandRequest::Iterator { .. } => {
             TransactionMode::ReadOnly
         }
-        DbCommandRequest::Put { .. } | DbCommandRequest::Delete { .. } => {
-            TransactionMode::ReadWrite
-        }
+        DbCommandRequest::Put { .. }
+        | DbCommandRequest::Delete { .. }
+        | DbCommandRequest::BatchWrite { .. } => TransactionMode::ReadWrite,
     };
     let tran = db
         .transaction(&[&store_name], tx_mode)
@@ -181,6 +181,26 @@ where
                     .map_err(|e| anyhow!("Failed to delete: {:?}", e))?;
             }
             DbCommandResponse::Delete
+        }
+        DbCommandRequest::BatchWrite { deletes, puts } => {
+            for key in deletes {
+                let key = serde_wasm_bindgen::to_value(&key).unwrap();
+                store
+                    .delete(key)
+                    .map_err(|e| anyhow!("Failed to send delete request: {:?}", e))?
+                    .await
+                    .map_err(|e| anyhow!("Failed to delete: {:?}", e))?;
+            }
+            for KV { key, value } in puts {
+                let key = serde_wasm_bindgen::to_value(&key).unwrap();
+                let value = serde_wasm_bindgen::to_value(&value).unwrap();
+                store
+                    .put(&value, Some(&key))
+                    .map_err(|e| anyhow!("Failed to send put request: {:?}", e))?
+                    .await
+                    .map_err(|e| anyhow!("Failed to put: {:?}", e))?;
+            }
+            DbCommandResponse::BatchWrite
         }
         DbCommandRequest::Iterator {
             start,


### PR DESCRIPTION
## Problem

WASM store `Batch::commit()` performs two separate IPC calls via `Atomics::wait` — first `Delete`, then `Put`. Each `Atomics::wait` blocks the main WASM thread until the DB worker responds. During this time, no P2P keepalive messages can be processed, causing peer disconnects.

## Fix

Add a `BatchWrite` IPC command that combines delete + put into a single worker round-trip. `commit()` now makes **1 `Atomics::wait` instead of 2**, halving the blocking time per batch and improving P2P keepalive reliability.

## Changes

- `fiber-wasm-db-common`: add `BatchWrite { deletes, puts }` to `DbCommandRequest` and `DbCommandResponse`
- `fiber-wasm-db-worker`: handle `BatchWrite` in `handle_db_command`
- `fiber-store/browser.rs`: add `BatchWrite` to `DbCommandRequestWithTakeWhile` and use it in `commit()`