### PR TITLE
Fix preimage cleanup for TLCs that share the same payment hash

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1898,13 +1898,7 @@ where
                     .update_invoice_status(&tlc_info.payment_hash, CkbInvoiceStatus::Paid)
                     .expect("update invoice status failed");
             }
-            // Keep the preimage for outbound forwarded TLCs until the inbound side finishes.
-            // For inbound forwarded TLCs, keep it while another same-hash TLC still needs
-            // on-chain settlement.
-            let should_remove_preimage = tlc_info.forwarding_tlc.is_none()
-                || (tlc_info.is_received()
-                    && !self.has_onchain_tlc_for_payment_hash(state, tlc_info.payment_hash));
-            if should_remove_preimage {
+            if !has_pending_tlc_for_payment_hash(&self.store, state, tlc_info.payment_hash) {
                 self.remove_preimage(tlc_info.payment_hash);
             }
         }
@@ -1946,45 +1940,6 @@ where
             }
         }
         Ok(())
-    }
-
-    fn has_onchain_tlc_for_payment_hash(
-        &self,
-        current_state: &ChannelActorState,
-        payment_hash: Hash256,
-    ) -> bool {
-        let is_waiting_onchain_resolution = |channel_state: &ChannelState| {
-            matches!(
-                channel_state,
-                ChannelState::Closed(flags)
-                    if flags.contains(CloseFlags::WAITING_ONCHAIN_SETTLEMENT)
-            ) || matches!(
-                channel_state,
-                ChannelState::ShuttingDown(flags)
-                    if flags.contains(ShuttingDownFlags::WAITING_COMMITMENT_CONFIRMATION)
-            )
-        };
-        let has_onchain_tlc = |state: &ChannelActorState| {
-            is_waiting_onchain_resolution(&state.state)
-                && state
-                    .tlc_state
-                    .all_tlcs()
-                    .any(|tlc| tlc.payment_hash == payment_hash)
-        };
-
-        if has_onchain_tlc(current_state) {
-            return true;
-        }
-
-        let current_channel_id = current_state.get_id();
-        self.store
-            .get_channel_states(None)
-            .into_iter()
-            .filter(|(_, channel_id, channel_state)| {
-                *channel_id != current_channel_id && is_waiting_onchain_resolution(channel_state)
-            })
-            .filter_map(|(_, channel_id, _)| self.store.get_channel_actor_state(&channel_id))
-            .any(|state| has_onchain_tlc(&state))
     }
 
     fn remove_preimage(&self, payment_hash: Hash256) {
@@ -9680,6 +9635,34 @@ impl ChannelActorState {
 
         Ok(())
     }
+}
+
+pub(crate) fn has_pending_tlc_for_payment_hash<S>(
+    store: &S,
+    current_state: &ChannelActorState,
+    payment_hash: Hash256,
+) -> bool
+where
+    S: ChannelActorStateStore,
+{
+    let has_matching_tlc = |state: &ChannelActorState| {
+        state
+            .tlc_state
+            .all_tlcs()
+            .any(|tlc| tlc.payment_hash == payment_hash)
+    };
+
+    if has_matching_tlc(current_state) {
+        return true;
+    }
+
+    let current_channel_id = current_state.get_id();
+    store
+        .get_channel_states(None)
+        .into_iter()
+        .filter(|(_, channel_id, _)| *channel_id != current_channel_id)
+        .filter_map(|(_, channel_id, _)| store.get_channel_actor_state(&channel_id))
+        .any(|state| has_matching_tlc(&state))
 }
 
 pub trait ChannelActorStateStore {

--- a/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
@@ -1,6 +1,8 @@
 //! Tests for SettleTlcSetCommand
 
-use crate::fiber::channel::{ChannelActorState, ChannelActorStateStore, CommitDiff};
+use crate::fiber::channel::{
+    has_pending_tlc_for_payment_hash, ChannelActorState, ChannelActorStateStore, CommitDiff,
+};
 use crate::fiber::settle_tlc_set_command::{SettleTlcSetCommand, TlcSettlement};
 use crate::fiber::types::{Hash256, HoldTlc, Pubkey, RemoveTlcReason};
 use crate::gen_rand_sha256_hash;
@@ -147,7 +149,11 @@ impl ChannelActorStateStore for MockStore {
     }
 
     fn get_channel_states(&self, _pubkey: Option<Pubkey>) -> Vec<(Pubkey, Hash256, ChannelState)> {
-        vec![]
+        self.channel_states
+            .borrow()
+            .values()
+            .map(|state| (state.remote_pubkey, state.id, state.state))
+            .collect()
     }
 
     fn get_channel_state_by_outpoint(&self, _id: &OutPoint) -> Option<ChannelActorState> {
@@ -343,6 +349,42 @@ fn get_error_code(settlement: &TlcSettlement) -> Option<TlcErrorCode> {
         }
         _ => None,
     }
+}
+
+#[test]
+fn test_preimage_cleanup_detects_pending_same_hash_tlc_in_other_channel() {
+    let payment_hash = gen_rand_sha256_hash();
+    let current_channel_id = gen_rand_sha256_hash();
+    let other_channel_id = gen_rand_sha256_hash();
+    let mut current_state =
+        create_test_channel_state_with_tlc(current_channel_id, 0, 1000, payment_hash, None);
+    current_state.tlc_state.apply_remove_tlc(TLCId::Received(0));
+    let other_state =
+        create_test_channel_state_with_tlc(other_channel_id, 0, 1000, payment_hash, None);
+    let store = MockStore::new()
+        .with_channel_state(current_state.clone())
+        .with_channel_state(other_state);
+
+    assert!(
+        has_pending_tlc_for_payment_hash(&store, &current_state, payment_hash),
+        "preimage should stay while another channel has a same-hash tlc"
+    );
+}
+
+#[test]
+fn test_preimage_cleanup_ignores_stale_current_channel_state() {
+    let payment_hash = gen_rand_sha256_hash();
+    let current_channel_id = gen_rand_sha256_hash();
+    let persisted_current_state =
+        create_test_channel_state_with_tlc(current_channel_id, 0, 1000, payment_hash, None);
+    let mut current_state = persisted_current_state.clone();
+    current_state.tlc_state.apply_remove_tlc(TLCId::Received(0));
+    let store = MockStore::new().with_channel_state(persisted_current_state);
+
+    assert!(
+        !has_pending_tlc_for_payment_hash(&store, &current_state, payment_hash),
+        "stale persisted state for the channel currently applying removal must not keep preimage"
+    );
 }
 
 #[test]


### PR DESCRIPTION


Previously, Fiber could remove a preimage after one fulfilled TLC was applied, even when another channel still had a pending TLC with the same payment hash. Since preimages are stored globally by payment hash, this could prevent the remaining TLC from being fulfilled later.

This PR keeps the preimage until no pending TLC with the same payment hash exists across channel states.

