### PR TITLE
fix: retry only failed payment attempts on channel ready

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -9643,16 +9643,17 @@ impl ChannelActorState {
     pub(crate) fn owns_payment_attempt(&self, payment_hash: Hash256, attempt_id: u64) -> bool {
         let attempt_id = Some(attempt_id);
 
-        self.tlc_state
-            .all_tlcs()
-            .any(|tlc| tlc.payment_hash == payment_hash && tlc.attempt_id == attempt_id)
-            || self.retryable_tlc_operations.iter().any(|operation| {
-                matches!(
-                    operation,
-                    RetryableTlcOperation::AddTlc(command)
-                        if command.payment_hash == payment_hash && command.attempt_id == attempt_id
-                )
-            })
+        self.tlc_state.all_tlcs().any(|tlc| {
+            !tlc.applied_flags.contains(AppliedFlags::REMOVE)
+                && tlc.payment_hash == payment_hash
+                && tlc.attempt_id == attempt_id
+        }) || self.retryable_tlc_operations.iter().any(|operation| {
+            matches!(
+                operation,
+                RetryableTlcOperation::AddTlc(command)
+                    if command.payment_hash == payment_hash && command.attempt_id == attempt_id
+            )
+        })
     }
 
     /// Perform the next step in shutting down the channel.

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -9640,6 +9640,21 @@ impl ChannelActorState {
         !self.retryable_tlc_operations.is_empty()
     }
 
+    pub(crate) fn owns_payment_attempt(&self, payment_hash: Hash256, attempt_id: u64) -> bool {
+        let attempt_id = Some(attempt_id);
+
+        self.tlc_state
+            .all_tlcs()
+            .any(|tlc| tlc.payment_hash == payment_hash && tlc.attempt_id == attempt_id)
+            || self.retryable_tlc_operations.iter().any(|operation| {
+                matches!(
+                    operation,
+                    RetryableTlcOperation::AddTlc(command)
+                        if command.payment_hash == payment_hash && command.attempt_id == attempt_id
+                )
+            })
+    }
+
     /// Perform the next step in shutting down the channel.
     async fn step_shutting_down(&mut self, flags: ShuttingDownFlags) -> ProcessingChannelResult {
         let mut flags = flags;

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -3051,7 +3051,10 @@ pub trait NetworkGraphStateStore {
     fn delete_attempts(&self, payment_hash: Hash256);
     /// Clears only the channel index entries for attempts, keeping the attempt records.
     fn clear_attempts_channel_index(&self, payment_hash: Hash256);
-    /// Returns all pending attempts (Created/Retrying status) using this channel as first hop.
+    /// Returns attempts that should be woken by a ChannelReady scan.
+    ///
+    /// Retrying attempts are always returned. Created attempts are returned only
+    /// when the channel state does not already own a matching TLC or queued AddTlc.
     fn get_pending_attempts_by_channel_outpoint(&self, channel_outpoint: &OutPoint)
         -> Vec<Attempt>;
 }

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -28,9 +28,9 @@ use ckb_types::packed::{OutPoint, Script};
 pub use fiber_types::PaymentSession;
 pub use fiber_types::SendPaymentData;
 use fiber_types::{
-    Attempt, BasicMppPaymentData, EntityHex, Hash256, HashAlgorithm, HopHint, PaymentCustomRecords,
-    PaymentHopData, PaymentStatus, PeeledPaymentOnionPacket, Privkey, Pubkey, RemoveTlcReason,
-    RouterHop, TlcErr, TlcErrData, TlcErrPacket, TlcErrorCode, TrampolineContext,
+    Attempt, AttemptStatus, BasicMppPaymentData, EntityHex, Hash256, HashAlgorithm, HopHint,
+    PaymentCustomRecords, PaymentHopData, PaymentStatus, PeeledPaymentOnionPacket, Privkey, Pubkey,
+    RemoveTlcReason, RouterHop, TlcErr, TlcErrData, TlcErrPacket, TlcErrorCode, TrampolineContext,
     DEFAULT_MAX_PARTS, DEFAULT_PAYMENT_MPP_ATTEMPT_TRY_LIMIT, USER_CUSTOM_RECORDS_MAX_INDEX,
 };
 use ractor::{call_t, Actor, ActorProcessingErr};
@@ -1585,6 +1585,17 @@ where
         }
     }
 
+    fn channel_owns_attempt(&self, attempt: &Attempt) -> bool {
+        let Some(channel_outpoint) = attempt.first_hop_channel_outpoint() else {
+            return false;
+        };
+        self.store
+            .get_channel_state_by_outpoint(channel_outpoint)
+            .is_some_and(|channel_state| {
+                channel_state.owns_payment_attempt(attempt.payment_hash, attempt.id)
+            })
+    }
+
     async fn send_attempt(
         &self,
         myself: ActorRef<PaymentActorMessage>,
@@ -1690,6 +1701,23 @@ where
                         return Err(err);
                     }
                     _ => {}
+                }
+            }
+            Some(mut attempt) if attempt.status == AttemptStatus::Created => {
+                if self.channel_owns_attempt(&attempt) {
+                    debug!(
+                        payment_hash = ?session.payment_hash(),
+                        attempt_id = attempt.id,
+                        "Skipping channel-owned Created payment attempt"
+                    );
+                } else {
+                    warn!(
+                        payment_hash = ?session.payment_hash(),
+                        attempt_id = attempt.id,
+                        "Retrying orphan Created payment attempt"
+                    );
+                    self.send_attempt(myself, state, session, &mut attempt)
+                        .await?;
                 }
             }
             Some(_) => {

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -1295,12 +1295,10 @@ impl NetworkGraphStateStore for Store {
                         .ok()?,
                 );
 
-                // Only return attempts that are pending (Created or Retrying)
+                // Channel-ready retries should only wake attempts that previously failed
+                // retryably. Fresh Created attempts may still be in their first send path.
                 let attempt = self.get_attempt(payment_hash, attempt_id)?;
-                if matches!(
-                    attempt.status,
-                    AttemptStatus::Created | AttemptStatus::Retrying
-                ) {
+                if matches!(attempt.status, AttemptStatus::Retrying) {
                     Some(attempt)
                 } else {
                     None

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -101,6 +101,13 @@ impl Store {
             watcher(change);
         }
     }
+
+    fn channel_owns_attempt(&self, channel_outpoint: &OutPoint, attempt: &Attempt) -> bool {
+        self.get_channel_state_by_outpoint(channel_outpoint)
+            .is_some_and(|channel_state| {
+                channel_state.owns_payment_attempt(attempt.payment_hash, attempt.id)
+            })
+    }
 }
 
 impl StorageBackend for Store {
@@ -1295,13 +1302,15 @@ impl NetworkGraphStateStore for Store {
                         .ok()?,
                 );
 
-                // Channel-ready retries should only wake attempts that previously failed
-                // retryably. Fresh Created attempts may still be in their first send path.
                 let attempt = self.get_attempt(payment_hash, attempt_id)?;
-                if matches!(attempt.status, AttemptStatus::Retrying) {
-                    Some(attempt)
-                } else {
-                    None
+                match attempt.status {
+                    AttemptStatus::Retrying => Some(attempt),
+                    AttemptStatus::Created
+                        if !self.channel_owns_attempt(channel_outpoint, &attempt) =>
+                    {
+                        Some(attempt)
+                    }
+                    _ => None,
                 }
             })
             .collect()

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -38,7 +38,9 @@ use ckb_types::H256;
 #[cfg(not(target_arch = "wasm32"))]
 use core::cmp::Ordering;
 use fiber_types::protocol::AnnouncedNodeName;
-use fiber_types::{AttemptStatus, CloseFlags, HashAlgorithm, PaymentHopData};
+use fiber_types::{
+    Attempt, AttemptStatus, CloseFlags, HashAlgorithm, PaymentHopData, RouterHop, SessionRoute,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use fiber_types::{SettlementTlc, TLCId};
 use musig2::secp::MaybeScalar;
@@ -1024,6 +1026,74 @@ fn test_store_payment_session() {
     assert_eq!(res.request.max_fee_amount, Some(1000));
     assert_eq!(res.status, PaymentStatus::Created);
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_channel_ready_retry_index_only_returns_retrying_attempts() {
+    let (store, _dir) = generate_store();
+    let payment_hash = gen_rand_sha256_hash();
+    let first_hop_funding_tx_hash = gen_rand_sha256_hash();
+    let first_hop_outpoint = OutPoint::new(first_hop_funding_tx_hash.into(), 0);
+    let target = gen_rand_fiber_public_key();
+    let first_hop = gen_rand_fiber_public_key();
+    let _payment_data = SendPaymentDataBuilder::new(target, 100, payment_hash)
+        .router(vec![RouterHop {
+            target: first_hop,
+            channel_outpoint: first_hop_outpoint.clone(),
+            amount_received: 100,
+            incoming_tlc_expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+        }])
+        .final_tlc_expiry_delta(DEFAULT_TLC_EXPIRY_DELTA)
+        .tlc_expiry_limit(MAX_PAYMENT_TLC_EXPIRY_LIMIT)
+        .timeout(Some(10))
+        .max_fee_amount(Some(1000))
+        .build()
+        .expect("valid payment_data");
+    let now = now_timestamp_as_millis_u64();
+    let route_hops = vec![PaymentHopData {
+        amount: 100,
+        expiry: now + DEFAULT_TLC_EXPIRY_DELTA,
+        payment_preimage: None,
+        hash_algorithm: HashAlgorithm::CkbHash,
+        funding_tx_hash: first_hop_funding_tx_hash,
+        next_hop: Some(target),
+        custom_records: None,
+    }];
+    let route = SessionRoute::new(first_hop, target, &route_hops);
+    let mut attempt = Attempt {
+        id: 1,
+        hash: payment_hash,
+        try_limit: 10,
+        tried_times: 1,
+        payment_hash,
+        route,
+        route_hops,
+        session_key: [0; 32],
+        preimage: None,
+        created_at: now,
+        last_updated_at: now,
+        last_error: None,
+        status: AttemptStatus::Created,
+    };
+
+    assert_eq!(attempt.status, AttemptStatus::Created);
+    store.insert_attempt(attempt.clone());
+    assert!(
+        store
+            .get_pending_attempts_by_channel_outpoint(&first_hop_outpoint)
+            .is_empty(),
+        "created attempts should not be woken by channel-ready retry"
+    );
+
+    attempt.status = AttemptStatus::Retrying;
+    store.insert_attempt(attempt.clone());
+    let retrying_attempts = store.get_pending_attempts_by_channel_outpoint(&first_hop_outpoint);
+    assert_eq!(retrying_attempts.len(), 1);
+    assert_eq!(retrying_attempts[0].id, attempt.id);
+    assert_eq!(retrying_attempts[0].status, AttemptStatus::Retrying);
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -38,11 +38,14 @@ use ckb_types::H256;
 #[cfg(not(target_arch = "wasm32"))]
 use core::cmp::Ordering;
 use fiber_types::protocol::AnnouncedNodeName;
+#[cfg(not(target_arch = "wasm32"))]
+use fiber_types::{
+    AddTlcCommand, AppliedFlags, CommitmentNumbers, OutboundTlcStatus, RetryableTlcOperation,
+    SettlementTlc, TLCId, TlcInfo, TlcStatus,
+};
 use fiber_types::{
     Attempt, AttemptStatus, CloseFlags, HashAlgorithm, PaymentHopData, RouterHop, SessionRoute,
 };
-#[cfg(not(target_arch = "wasm32"))]
-use fiber_types::{SettlementTlc, TLCId};
 use musig2::secp::MaybeScalar;
 #[cfg(not(target_arch = "wasm32"))]
 use musig2::CompactSignature;
@@ -1030,11 +1033,12 @@ fn test_store_payment_session() {
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-fn test_channel_ready_retry_index_only_returns_retrying_attempts() {
+fn test_channel_ready_retry_index_handles_created_attempt_channel_ownership() {
     let (store, _dir) = generate_store();
     let payment_hash = gen_rand_sha256_hash();
-    let first_hop_funding_tx_hash = gen_rand_sha256_hash();
-    let first_hop_outpoint = OutPoint::new(first_hop_funding_tx_hash.into(), 0);
+    let mut channel_state = sample_channel_actor_state(ChannelState::ChannelReady, None);
+    let first_hop_outpoint = channel_state.must_get_funding_transaction_outpoint();
+    let first_hop_funding_tx_hash = first_hop_outpoint.tx_hash().into();
     let target = gen_rand_fiber_public_key();
     let first_hop = gen_rand_fiber_public_key();
     let _payment_data = SendPaymentDataBuilder::new(target, 100, payment_hash)
@@ -1079,11 +1083,59 @@ fn test_channel_ready_retry_index_only_returns_retrying_attempts() {
 
     assert_eq!(attempt.status, AttemptStatus::Created);
     store.insert_attempt(attempt.clone());
+    let orphan_created_attempts =
+        store.get_pending_attempts_by_channel_outpoint(&first_hop_outpoint);
+    assert_eq!(orphan_created_attempts.len(), 1);
+    assert_eq!(orphan_created_attempts[0].id, attempt.id);
+    assert_eq!(orphan_created_attempts[0].status, AttemptStatus::Created);
+
+    channel_state.tlc_state.add_offered_tlc(TlcInfo {
+        status: TlcStatus::Outbound(OutboundTlcStatus::LocalAnnounced),
+        tlc_id: TLCId::Offered(0),
+        amount: 100,
+        payment_hash,
+        total_amount: None,
+        payment_secret: None,
+        attempt_id: Some(attempt.id),
+        expiry: now + DEFAULT_TLC_EXPIRY_DELTA,
+        hash_algorithm: HashAlgorithm::CkbHash,
+        onion_packet: None,
+        shared_secret: [0u8; 32],
+        is_trampoline_hop: false,
+        created_at: CommitmentNumbers::new(),
+        removed_reason: None,
+        forwarding_tlc: None,
+        removed_confirmed_at: None,
+        applied_flags: AppliedFlags::empty(),
+    });
+    store.insert_channel_actor_state(channel_state.clone());
     assert!(
         store
             .get_pending_attempts_by_channel_outpoint(&first_hop_outpoint)
             .is_empty(),
-        "created attempts should not be woken by channel-ready retry"
+        "created attempts already owned by channel TLCs should not be woken"
+    );
+
+    channel_state.tlc_state = Default::default();
+    channel_state
+        .retryable_tlc_operations
+        .push_back(RetryableTlcOperation::AddTlc(AddTlcCommand {
+            amount: 100,
+            payment_hash,
+            attempt_id: Some(attempt.id),
+            expiry: now + DEFAULT_TLC_EXPIRY_DELTA,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            onion_packet: None,
+            shared_secret: [0u8; 32],
+            is_trampoline_hop: false,
+            previous_tlc: None,
+        }));
+    store.insert_channel_actor_state(channel_state);
+    assert!(
+        store
+            .get_pending_attempts_by_channel_outpoint(&first_hop_outpoint)
+            .is_empty(),
+        "created attempts already owned by queued channel AddTlc should not be woken"
     );
 
     attempt.status = AttemptStatus::Retrying;

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -1116,6 +1116,25 @@ fn test_channel_ready_retry_index_handles_created_attempt_channel_ownership() {
         "created attempts already owned by channel TLCs should not be woken"
     );
 
+    let terminal_tlc = channel_state
+        .tlc_state
+        .offered_tlcs
+        .tlcs
+        .first_mut()
+        .expect("offered TLC exists");
+    terminal_tlc.status = TlcStatus::Outbound(OutboundTlcStatus::RemoveAckConfirmed);
+    terminal_tlc.applied_flags |= AppliedFlags::REMOVE;
+    terminal_tlc.removed_confirmed_at = Some(1);
+    store.insert_channel_actor_state(channel_state.clone());
+    let orphan_created_attempts =
+        store.get_pending_attempts_by_channel_outpoint(&first_hop_outpoint);
+    assert_eq!(
+        orphan_created_attempts.len(),
+        1,
+        "created attempts with terminal channel TLCs should be woken"
+    );
+    assert_eq!(orphan_created_attempts[0].id, attempt.id);
+
     channel_state.tlc_state = Default::default();
     channel_state
         .retryable_tlc_operations


### PR DESCRIPTION

When a payment attempt is in `Created` status, there maybe two concrete state:
1. the ChannelActor haven't processed SendPaymentCommand
2. the ChannelActor already processed AddTlc, or there is already a retrying tlc task in queue.

So we can not just Resend the attempt with `Created` status.