### PR TITLE
fix: skip node announcement without announced addresses

### DIFF
--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -6105,8 +6105,7 @@ where
         let mut service = {
             let mut builder = ServiceBuilder::default()
                 .insert_protocol(fiber_handle.create_meta())
-                .handshake_type(secio_kp.into())
-                .timeout(std::time::Duration::from_secs(60));
+                .handshake_type(secio_kp.into());
             if let Some(gossip_handle) = gossip_handle_opt {
                 builder = builder.insert_protocol(gossip_handle.create_meta());
             }
@@ -6158,8 +6157,7 @@ where
                 .insert_protocol(fiber_handle.create_meta())
                 .handshake_type(secio_kp.into())
                 // Sets forever to true so the network service won't be shutdown due to no incoming connections
-                .forever(true)
-                .timeout(std::time::Duration::from_secs(60));
+                .forever(true);
             if let Some(gossip_handle) = gossip_handle_opt {
                 builder = builder.insert_protocol(gossip_handle.create_meta());
             }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -2656,14 +2656,15 @@ where
             }
             NetworkActorCommand::BroadcastLocalInfo(kind) => match kind {
                 LocalInfoKind::NodeAnnouncement => {
-                    let message = state.get_or_create_new_node_announcement_message();
-                    myself
-                        .send_message(NetworkActorMessage::new_command(
-                            NetworkActorCommand::BroadcastMessages(vec![
-                                BroadcastMessageWithTimestamp::NodeAnnouncement(message),
-                            ]),
-                        ))
-                        .expect(ASSUME_NETWORK_MYSELF_ALIVE);
+                    if let Some(message) = state.get_or_create_new_node_announcement_message() {
+                        myself
+                            .send_message(NetworkActorMessage::new_command(
+                                NetworkActorCommand::BroadcastMessages(vec![
+                                    BroadcastMessageWithTimestamp::NodeAnnouncement(message),
+                                ]),
+                            ))
+                            .expect(ASSUME_NETWORK_MYSELF_ALIVE);
+                    }
                 }
             },
             NetworkActorCommand::NodeInfo(_, rpc) => {
@@ -4128,7 +4129,13 @@ where
         }
     }
 
-    pub fn get_or_create_new_node_announcement_message(&mut self) -> NodeAnnouncement {
+    pub fn get_or_create_new_node_announcement_message(&mut self) -> Option<NodeAnnouncement> {
+        if self.announced_addrs.is_empty() {
+            debug!("Skipping node announcement because no announced address is configured");
+            self.last_node_announcement_message = None;
+            return None;
+        }
+
         let now = now_timestamp_as_millis_u64();
         match self.last_node_announcement_message {
             // If the last node announcement message is still relatively new, we don't need to create a new one.
@@ -4160,9 +4167,7 @@ where
                 self.last_node_announcement_message = Some(announcement);
             }
         }
-        self.last_node_announcement_message
-            .clone()
-            .expect("last node announcement message is present")
+        self.last_node_announcement_message.clone()
     }
 
     pub fn get_public_key(&self) -> Pubkey {
@@ -5360,16 +5365,17 @@ where
         }
 
         if self.auto_announce {
-            let message = self.get_or_create_new_node_announcement_message();
-            debug!(
-                "Auto announcing our node to peer {:?} (message: {:?})",
-                remote_pubkey, &message
-            );
-            let _ = self.network.send_message(NetworkActorMessage::new_command(
-                NetworkActorCommand::BroadcastMessages(vec![
-                    BroadcastMessageWithTimestamp::NodeAnnouncement(message),
-                ]),
-            ));
+            if let Some(message) = self.get_or_create_new_node_announcement_message() {
+                debug!(
+                    "Auto announcing our node to peer {:?} (message: {:?})",
+                    remote_pubkey, &message
+                );
+                let _ = self.network.send_message(NetworkActorMessage::new_command(
+                    NetworkActorCommand::BroadcastMessages(vec![
+                        BroadcastMessageWithTimestamp::NodeAnnouncement(message),
+                    ]),
+                ));
+            }
         } else {
             debug!(
                 "Auto announcing is disabled, skipping node announcement to peer {:?}",
@@ -6351,8 +6357,7 @@ where
             inflight_tracers: Default::default(),
         };
 
-        let node_announcement = state.get_or_create_new_node_announcement_message();
-        {
+        if let Some(node_announcement) = state.get_or_create_new_node_announcement_message() {
             let mut graph = self.network_graph.write().await;
             graph.process_node_announcement(node_announcement);
         }

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -1146,6 +1146,38 @@ async fn test_sync_node_announcement_of_connected_nodes() {
     assert!(node_info.is_some());
 }
 
+#[tokio::test]
+async fn test_node_without_announced_addresses_does_not_announce_itself() {
+    init_tracing();
+
+    let silent_node_config = NetworkNodeConfigBuilder::new()
+        .node_name(Some("silent-node".to_string()))
+        .fiber_config_updater(|config| {
+            config.announce_listening_addr = Some(false);
+            config.announce_private_addr = Some(false);
+            config.announced_addrs.clear();
+        })
+        .build();
+    let mut silent_node = NetworkNode::new_with_config(silent_node_config).await;
+    let mut observer = NetworkNode::new_with_node_name("observer").await;
+
+    silent_node.connect_to(&mut observer).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    assert_eq!(
+        silent_node.fiber_config.announced_addrs,
+        Vec::<String>::new()
+    );
+    assert!(silent_node
+        .get_store()
+        .get_latest_node_announcement(&silent_node.pubkey)
+        .is_none());
+    assert!(observer
+        .get_network_graph_node(&silent_node.pubkey)
+        .await
+        .is_none());
+}
+
 // Test that we can sync the network graph with peers.
 // We will first create a node and announce a fake node announcement to the network.
 // Then we will create another node and connect to the first node.


### PR DESCRIPTION
## Summary
- Skip creating, caching, broadcasting, or inserting a local node announcement when no announced addresses are configured
- Avoid sending empty-address node announcements from WASM/browser nodes that do not announce listen addresses
- Add a regression test for a node with no announced addresses

## Verification
- cargo fmt --all -- --check
- cargo nextest run -p fnn --features rocksdb test_node_without_announced_addresses_does_not_announce_itself
- cargo nextest run -p fnn --features rocksdb test_sync_node_announcement
- cargo build --locked -p fiber-bin --bin fnn
- npm run build -ws
- npm run build in /tmp/fiber-wasm-user-e2e
- CI_SCENARIO=testnet-graph-sync-rate CI_GRAPH_SYNC_RATE_MINUTES=2 CI_GRAPH_SYNC_RATE_SAMPLE_SECONDS=10 CI_FIBER_CONFIG=... npm run ci:scenario against a local native node

## Manual repro result
- Native log shows the WASM peer skipped node announcement creation instead of triggering private-address policy rejection
- No private address node announcement / Malicious gossip peer / PeerNotFound errors observed
- WASM synced all 753 channels from the local native node