### PR TITLE
Fix WASM DB worker IPC synchronization over SharedArrayBuffer

### DIFF
--- a/crates/fiber-store/src/browser.rs
+++ b/crates/fiber-store/src/browser.rs
@@ -1,7 +1,9 @@
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
+use fiber_wasm_db_common::load_command;
 use fiber_wasm_db_common::read_command_payload;
+use fiber_wasm_db_common::store_command;
 use fiber_wasm_db_common::write_command_with_payload;
 use fiber_wasm_db_common::DbCommandRequest;
 use fiber_wasm_db_common::DbCommandResponse;
@@ -66,7 +68,7 @@ impl Store {
             output_i32_arr,
             ..
         } = &self.chan;
-        output_i32_arr.set_index(0, InputCommand::Waiting as i32);
+        store_command(output_i32_arr, OutputCommand::Waiting as i32).unwrap();
         write_command_with_payload(
             InputCommand::Shutdown as i32,
             (),
@@ -257,7 +259,7 @@ impl CommunicationChannel {
             output_i32_arr,
             output_u8_arr,
         } = &self;
-        output_i32_arr.set_index(0, InputCommand::Waiting as i32);
+        store_command(output_i32_arr, OutputCommand::Waiting as i32).unwrap();
         write_command_with_payload(
             InputCommand::OpenDatabase as i32,
             store_name,
@@ -266,8 +268,14 @@ impl CommunicationChannel {
         )
         .with_context(|| anyhow!("Failed to write db command"))
         .unwrap();
-        Atomics::wait(output_i32_arr, 0, OutputCommand::Waiting as i32).unwrap();
-        let output_cmd = OutputCommand::try_from(output_i32_arr.get_index(0)).unwrap();
+        let output_cmd = loop {
+            Atomics::wait(output_i32_arr, 0, OutputCommand::Waiting as i32).unwrap();
+            let output_cmd =
+                OutputCommand::try_from(load_command(output_i32_arr).unwrap()).unwrap();
+            if !matches!(output_cmd, OutputCommand::Waiting) {
+                break output_cmd;
+            }
+        };
         match output_cmd {
             OutputCommand::OpenDatabaseResponse => {
                 DB_INITIALIZED.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -322,7 +330,7 @@ impl CommunicationChannel {
             output_i32_arr,
             output_u8_arr,
         } = self;
-        output_i32_arr.set_index(0, InputCommand::Waiting as i32);
+        store_command(output_i32_arr, OutputCommand::Waiting as i32).unwrap();
         write_command_with_payload(
             InputCommand::DbRequest as i32,
             ipc_cmd,
@@ -332,8 +340,11 @@ impl CommunicationChannel {
         .with_context(|| anyhow!("Failed to write db command"))?;
         loop {
             Atomics::wait(output_i32_arr, 0, OutputCommand::Waiting as i32).unwrap();
-            let output_cmd = OutputCommand::try_from(output_i32_arr.get_index(0)).unwrap();
-            output_i32_arr.set_index(0, 0);
+            let output_cmd = OutputCommand::try_from(load_command(output_i32_arr)?).unwrap();
+            if matches!(output_cmd, OutputCommand::Waiting) {
+                continue;
+            }
+            store_command(output_i32_arr, OutputCommand::Waiting as i32)?;
             match output_cmd {
                 OutputCommand::OpenDatabaseResponse | OutputCommand::Waiting => unreachable!(),
                 OutputCommand::RequestTakeWhile => {

--- a/crates/fiber-wasm-db-common/src/lib.rs
+++ b/crates/fiber-wasm-db-common/src/lib.rs
@@ -171,13 +171,33 @@ pub fn write_command_with_payload<T: Serialize>(
     let result_buf = bincode::serde::encode_to_vec(&data, bincode::config::standard())
         .with_context(|| anyhow!("Failed to serialize command payload"))?;
 
-    i32arr.set_index(1, result_buf.len() as i32);
+    store_i32(i32arr, 1, result_buf.len() as i32)?;
     u8arr
         .subarray(8, 8 + result_buf.len() as u32)
         .copy_from(&result_buf);
-    i32arr.set_index(0, cmd);
+    store_command(i32arr, cmd)?;
     Atomics::notify(i32arr, 0).map_err(|e| anyhow!("Failed to notify: {e:?}"))?;
     Ok(())
+}
+
+/// Atomically load the command word from a shared IPC buffer.
+pub fn load_command(i32arr: &Int32Array) -> anyhow::Result<i32> {
+    load_i32(i32arr, 0)
+}
+
+/// Atomically store the command word in a shared IPC buffer.
+pub fn store_command(i32arr: &Int32Array, cmd: i32) -> anyhow::Result<()> {
+    store_i32(i32arr, 0, cmd)
+}
+
+fn load_i32(i32arr: &Int32Array, index: u32) -> anyhow::Result<i32> {
+    Atomics::load(i32arr, index).map_err(|e| anyhow!("Failed to load IPC word {index}: {e:?}"))
+}
+
+fn store_i32(i32arr: &Int32Array, index: u32, value: i32) -> anyhow::Result<()> {
+    Atomics::store(i32arr, index, value)
+        .map(|_| ())
+        .map_err(|e| anyhow!("Failed to store IPC word {index}: {e:?}"))
 }
 
 /// Read the payload from the given input buffer/output buffer.
@@ -187,7 +207,7 @@ pub fn read_command_payload<T: DeserializeOwned>(
     i32arr: &Int32Array,
     u8arr: &Uint8Array,
 ) -> anyhow::Result<T> {
-    let length = i32arr.get_index(1) as u32;
+    let length = load_i32(i32arr, 1)? as u32;
     let mut buf = vec![0u8; length as usize];
     u8arr.subarray(8, 8 + length).copy_to(&mut buf);
 

--- a/crates/fiber-wasm-db-worker/src/lib.rs
+++ b/crates/fiber-wasm-db-worker/src/lib.rs
@@ -2,7 +2,8 @@ use std::{cell::RefCell, str::FromStr};
 
 use db::{STORE_NAME, handle_db_command, open_database};
 use fiber_wasm_db_common::{
-    InputCommand, KV, OutputCommand, read_command_payload, write_command_with_payload,
+    InputCommand, KV, OutputCommand, load_command, read_command_payload, store_command,
+    write_command_with_payload,
 };
 use idb::Database;
 use log::info;
@@ -66,7 +67,8 @@ pub async fn main_loop(log_level: &str) {
             .await
             .expect("Unable to wait for command");
         // Clean it to avoid infinite loop
-        input_i32_arr.set_index(0, InputCommand::Waiting as i32);
+        store_command(&input_i32_arr, InputCommand::Waiting as i32)
+            .expect("Unable to reset input command");
         match cmd {
             InputCommand::OpenDatabase => {
                 let database_name =
@@ -98,7 +100,8 @@ pub async fn main_loop(log_level: &str) {
                 let db_cmd = read_command_payload(&input_i32_arr, &input_u8_arr).unwrap();
                 let db = db.as_ref().expect("Database not opened yet");
                 let result = handle_db_command(db, STORE_NAME, db_cmd, |key| {
-                    input_i32_arr.set_index(0, InputCommand::Waiting as i32);
+                    store_command(&input_i32_arr, InputCommand::Waiting as i32)
+                        .expect("Unable to reset input command");
                     write_command_with_payload(
                         OutputCommand::RequestTakeWhile as i32,
                         key.to_vec(),
@@ -109,17 +112,20 @@ pub async fn main_loop(log_level: &str) {
                     // Sync wait here, so transaction of IndexedDB won't be committed (it will be committed once control flow was returned from sync call stack)
                     wait_for_command_sync(&input_i32_arr, InputCommand::Waiting).unwrap();
 
-                    let cmd = InputCommand::try_from(input_i32_arr.get_index(0))
-                        .expect("Invalid input command from client");
+                    let raw_cmd =
+                        load_command(&input_i32_arr).expect("Unable to load input command");
+                    let cmd =
+                        InputCommand::try_from(raw_cmd).expect("Invalid input command from client");
                     assert!(
                         matches!(cmd, InputCommand::ResponseTakeWhile),
                         "Expected ResponseTakeWhile, got {:?}",
-                        input_i32_arr.get_index(0)
+                        raw_cmd
                     );
 
                     let result =
                         read_command_payload::<bool>(&input_i32_arr, &input_u8_arr).unwrap();
-                    input_i32_arr.set_index(0, InputCommand::Waiting as i32);
+                    store_command(&input_i32_arr, InputCommand::Waiting as i32)
+                        .expect("Unable to reset input command");
                     result
                 })
                 .await;
@@ -141,7 +147,10 @@ pub async fn main_loop(log_level: &str) {
                 };
             }
             InputCommand::Shutdown => break,
-            InputCommand::Waiting | InputCommand::ResponseTakeWhile => unreachable!(),
+            InputCommand::Waiting => {}
+            InputCommand::ResponseTakeWhile => {
+                log::error!("Ignoring stale ResponseTakeWhile received in db worker main loop");
+            }
         }
     }
     info!("Db worker main loop exited");

--- a/crates/fiber-wasm-db-worker/src/util.rs
+++ b/crates/fiber-wasm-db-worker/src/util.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use anyhow::anyhow;
-use fiber_wasm_db_common::InputCommand;
+use fiber_wasm_db_common::{InputCommand, load_command};
 use serde::Deserialize;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
@@ -12,10 +12,15 @@ pub(crate) fn wait_for_command_sync(
     state_arr: &Int32Array,
     holding_command: InputCommand,
 ) -> anyhow::Result<InputCommand> {
-    Atomics::wait(state_arr, 0, holding_command as i32)
-        .map_err(|e| anyhow!("Failed to call wait async: {:?}", e))?;
-
-    InputCommand::try_from(state_arr.get_index(0)).with_context(|| anyhow!("Bad command"))
+    let holding_command = holding_command as i32;
+    loop {
+        let current = load_command(state_arr)?;
+        if current != holding_command {
+            return InputCommand::try_from(current).with_context(|| anyhow!("Bad command"));
+        }
+        Atomics::wait(state_arr, 0, holding_command)
+            .map_err(|e| anyhow!("Failed to call wait: {:?}", e))?;
+    }
 }
 
 #[derive(Deserialize)]
@@ -30,28 +35,34 @@ pub(crate) async fn wait_for_command(
     state_arr: &Int32Array,
     holding_command: InputCommand,
 ) -> anyhow::Result<InputCommand> {
-    let obj = Atomics::wait_async(state_arr, 0, holding_command as i32)
-        .map_err(|e| anyhow!("Failed to call wait async: {:?}", e))?;
-    let resp = serde_wasm_bindgen::from_value::<WaitAsyncResponse>((&obj).into())
-        .map_err(|e| anyhow!("Failed to deserialize result of wait async: {:?}", e))?;
+    let holding_command = holding_command as i32;
+    loop {
+        let current = load_command(state_arr)?;
+        if current != holding_command {
+            return InputCommand::try_from(current).with_context(|| anyhow!("Bad command"));
+        }
 
-    if resp.async_ {
-        JsFuture::from(
-            resp.value
-                .dyn_into::<Promise>()
-                .expect("Value must be casted into promise!"),
-        )
-        .await
-        .expect("value must not fail!");
-    } else {
-        let value = resp
-            .value
-            .as_string()
-            .expect("Value must be casted to string");
-        if value != "not-equal" {
-            panic!("Value must be not-equal if should_wait_async is false");
+        let obj = Atomics::wait_async(state_arr, 0, holding_command)
+            .map_err(|e| anyhow!("Failed to call wait async: {:?}", e))?;
+        let resp = serde_wasm_bindgen::from_value::<WaitAsyncResponse>((&obj).into())
+            .map_err(|e| anyhow!("Failed to deserialize result of wait async: {:?}", e))?;
+
+        if resp.async_ {
+            JsFuture::from(
+                resp.value
+                    .dyn_into::<Promise>()
+                    .expect("Value must be casted into promise!"),
+            )
+            .await
+            .expect("value must not fail!");
+        } else {
+            let value = resp
+                .value
+                .as_string()
+                .expect("Value must be casted to string");
+            if value != "not-equal" {
+                panic!("Value must be not-equal if should_wait_async is false");
+            }
         }
     }
-
-    InputCommand::try_from(state_arr.get_index(0)).with_context(|| anyhow!("Bad command"))
 }


### PR DESCRIPTION
## Summary

Fixes a WASM runtime panic in `fiber-wasm-db-worker` caused by fragile IPC synchronization between `fiber-wasm` and `fiber-wasm-db-worker`.

The IPC protocol uses `SharedArrayBuffer` with `Atomics.wait/notify`, but the command words were previously read and written with normal `Int32Array` accessors. This could let the DB worker observe an unexpected command state, such as `Waiting` or stale `ResponseTakeWhile`, and hit `unreachable!()` in the main loop.

## Changes

- Add atomic IPC helpers in `fiber-wasm-db-common` for command word load/store.
- Use atomic stores when publishing commands and clearing command states.
- Use atomic loads when reading command states.
- Make DB worker wait helpers loop until the command state actually changes.
- Make browser-side DB response waits tolerate wakeups where the state is still `Waiting`.
- Avoid panicking on stale top-level `ResponseTakeWhile`; log and continue instead.

## Verification

- `cargo fmt --all`
- `cargo check -p fiber-wasm-db-common -p fiber-wasm-db-worker -p fiber-store --target wasm32-unknown-unknown`
- `cargo clippy -p fiber-wasm-db-common -p fiber-wasm-db-worker -p fiber-store --target wasm32-unknown-unknown -- -D warnings`