### PR TITLE
Avoid supervisor panic on actor failure

### DIFF
--- a/crates/fiber-lib/src/actors.rs
+++ b/crates/fiber-lib/src/actors.rs
@@ -1,6 +1,10 @@
 use ractor::{Actor, ActorProcessingErr, ActorRef, SupervisionEvent};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::debug;
+use tracing::{debug, error};
+
+pub(crate) fn log_actor_failed(who: impl std::fmt::Debug, err: impl std::fmt::Debug) {
+    error!("Actor unexpectedly panicked (id: {:?}): {:?}", who, err);
+}
 
 /// A root actor that listens for cancellation token and stops all sub actors (those who started by spawn_linked).
 pub struct RootActor;
@@ -20,6 +24,58 @@ impl RootActor {
         .await
         .expect("start root actor")
         .0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct PanickingActor;
+
+    #[async_trait::async_trait]
+    impl Actor for PanickingActor {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _args: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+
+        async fn handle(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _message: Self::Msg,
+            _state: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            panic!("child actor panic for supervision test");
+        }
+    }
+
+    #[tokio::test]
+    async fn root_actor_does_not_panic_when_linked_child_fails() {
+        let root = RootActor::start(TaskTracker::new(), CancellationToken::new()).await;
+        let (child, _) = Actor::spawn_linked(
+            Some("panicking child".to_string()),
+            PanickingActor,
+            (),
+            root.get_cell(),
+        )
+        .await
+        .expect("start panicking actor");
+
+        child
+            .send_message(())
+            .expect("child receives panic trigger");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        root.send_message("root should still accept messages".to_string())
+            .expect("root actor should remain alive after linked child failure");
     }
 }
 
@@ -75,7 +131,7 @@ impl Actor for RootActor {
                 }
             },
             SupervisionEvent::ActorFailed(who, err) => {
-                panic!("Actor unexpectedly panicked (id: {:?}): {:?}", who, err);
+                log_actor_failed(who, err);
             }
             _ => {}
         }

--- a/crates/fiber-lib/src/actors.rs
+++ b/crates/fiber-lib/src/actors.rs
@@ -27,58 +27,6 @@ impl RootActor {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    struct PanickingActor;
-
-    #[async_trait::async_trait]
-    impl Actor for PanickingActor {
-        type Msg = ();
-        type State = ();
-        type Arguments = ();
-
-        async fn pre_start(
-            &self,
-            _myself: ActorRef<Self::Msg>,
-            _args: Self::Arguments,
-        ) -> Result<Self::State, ActorProcessingErr> {
-            Ok(())
-        }
-
-        async fn handle(
-            &self,
-            _myself: ActorRef<Self::Msg>,
-            _message: Self::Msg,
-            _state: &mut Self::State,
-        ) -> Result<(), ActorProcessingErr> {
-            panic!("child actor panic for supervision test");
-        }
-    }
-
-    #[tokio::test]
-    async fn root_actor_does_not_panic_when_linked_child_fails() {
-        let root = RootActor::start(TaskTracker::new(), CancellationToken::new()).await;
-        let (child, _) = Actor::spawn_linked(
-            Some("panicking child".to_string()),
-            PanickingActor,
-            (),
-            root.get_cell(),
-        )
-        .await
-        .expect("start panicking actor");
-
-        child
-            .send_message(())
-            .expect("child receives panic trigger");
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-        root.send_message("root should still accept messages".to_string())
-            .expect("root actor should remain alive after linked child failure");
-    }
-}
-
 #[async_trait::async_trait]
 impl Actor for RootActor {
     type Msg = RootActorMessage;
@@ -136,5 +84,57 @@ impl Actor for RootActor {
             _ => {}
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct PanickingActor;
+
+    #[async_trait::async_trait]
+    impl Actor for PanickingActor {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _args: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+
+        async fn handle(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _message: Self::Msg,
+            _state: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            panic!("child actor panic for supervision test");
+        }
+    }
+
+    #[tokio::test]
+    async fn root_actor_does_not_panic_when_linked_child_fails() {
+        let root = RootActor::start(TaskTracker::new(), CancellationToken::new()).await;
+        let (child, _) = Actor::spawn_linked(
+            Some("panicking child".to_string()),
+            PanickingActor,
+            (),
+            root.get_cell(),
+        )
+        .await
+        .expect("start panicking actor");
+
+        child
+            .send_message(())
+            .expect("child receives panic trigger");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        root.send_message("root should still accept messages".to_string())
+            .expect("root actor should remain alive after linked child failure");
     }
 }

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -37,6 +37,7 @@ use tokio::sync::oneshot;
 use tokio_util::codec::length_delimited;
 use tracing::{debug, error, info, trace, warn};
 
+use crate::actors::log_actor_failed;
 #[cfg(any(test, feature = "bench"))]
 use crate::fiber::network::DEFAULT_CHAIN_ACTOR_TIMEOUT;
 use crate::{
@@ -3911,7 +3912,7 @@ where
                 debug!("{:?} terminated", who);
             }
             SupervisionEvent::ActorFailed(who, err) => {
-                panic!("Actor unexpectedly panicked (id: {:?}): {:?}", who, err);
+                log_actor_failed(who, err);
             }
             _ => {}
         }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -66,6 +66,7 @@ use super::{
     FiberConfig, InFlightCkbTxActor, InFlightCkbTxActorArguments, InFlightCkbTxActorMessage,
     InFlightCkbTxKind, ASSUME_NETWORK_ACTOR_ALIVE,
 };
+use crate::actors::log_actor_failed;
 use crate::ckb::client::CkbChainClient;
 use crate::ckb::config::UdtCfgInfosExt;
 use crate::ckb::contracts::{
@@ -6500,7 +6501,7 @@ where
                 debug!("Actor {:?} terminated with reason {:?}", who, reason);
             }
             SupervisionEvent::ActorFailed(who, err) => {
-                panic!("Actor unexpectedly panicked (id: {:?}): {:?}", who, err);
+                log_actor_failed(who, err);
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary
- log linked child actor failures instead of re-panicking from supervisors
- apply the behavior consistently to root, network, and gossip supervisors
- add regression coverage that a linked child actor failure does not stop the root actor

## Tests
- cargo nextest run -p fnn --features sqlite root_actor_does_not_panic_when_linked_child_fails
- cargo fmt --all -- --check