### PR TITLE
Disable standalone watchtower RPC key export

### DIFF
--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -216,6 +216,10 @@ async fn run_node(
 
             info!("Starting fiber");
 
+            fiber_config
+                .validate_standalone_watchtower_rpc()
+                .map_err(ExitMessage)?;
+
             let chain_client = CkbRpcClient::new(&ckb_config);
             let network_actor: ActorRef<NetworkActorMessage> = start_network(
                 fiber_config.clone(),

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -599,6 +599,17 @@ impl FiberConfig {
             .unwrap_or(DEFAULT_SYNC_NETWORK_GRAPH)
     }
 
+    pub fn validate_standalone_watchtower_rpc(&self) -> std::result::Result<(), String> {
+        if self.standalone_watchtower_rpc_url.is_some() {
+            return Err(
+                "standalone watchtower RPC is disabled because it exports settlement private keys; use the built-in watchtower instead"
+                    .to_string(),
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn gen_node_features(&self) -> FeatureVector {
         // TODO: override default features from config settings
         // ...
@@ -643,5 +654,33 @@ impl FromStr for FiberScript {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standalone_watchtower_rpc_url_is_rejected() {
+        let config = FiberConfig {
+            standalone_watchtower_rpc_url: Some("http://127.0.0.1:8227".to_string()),
+            ..Default::default()
+        };
+
+        let error = config
+            .validate_standalone_watchtower_rpc()
+            .expect_err("standalone watchtower RPC should be disabled");
+
+        assert!(error.contains("standalone watchtower RPC is disabled"));
+    }
+
+    #[test]
+    fn built_in_watchtower_config_is_allowed() {
+        let config = FiberConfig::default();
+
+        config
+            .validate_standalone_watchtower_rpc()
+            .expect("built-in watchtower config should be allowed");
     }
 }

--- a/crates/fiber-wasm/src/lib.rs
+++ b/crates/fiber-wasm/src/lib.rs
@@ -222,6 +222,10 @@ pub async fn fiber(
                 .expect("get default funding lock script should be ok");
 
             info!("Starting fiber");
+            if let Err(err) = fiber_config.validate_standalone_watchtower_rpc() {
+                return js_err(err);
+            }
+
             let network_actor = start_network(
                 fiber_config.clone(),
                 chain_client,


### PR DESCRIPTION
## Summary
- reject `standalone_watchtower_rpc_url` at startup because the current watchtower RPC payload exports settlement private keys
- apply the guard to native and WASM startup paths before network actors are started
- add config-level regression coverage for rejecting standalone watchtower RPC while allowing the built-in watchtower config

## Tests
- cargo nextest run -p fnn --features sqlite standalone_watchtower_rpc_url_is_rejected built_in_watchtower_config_is_allowed
- cargo check -p fiber-bin --features sqlite
- cargo check -p fiber-wasm --target wasm32-unknown-unknown
- cargo fmt --all -- --check
- git diff --check
