### PR TITLE
Require funding signature acknowledgement

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -189,7 +189,7 @@ pub struct TlcNotification {
 #[derive(Debug, AsRefStr)]
 pub enum ChannelCommand {
     TxCollaborationCommand(TxCollaborationCommand),
-    FundingTxSigned(Transaction),
+    FundingTxSigned(Transaction, RpcReplyPort<Result<(), String>>),
     CommitmentSigned(Option<RpcReplyPort<Result<(), String>>>),
     AddTlc(AddTlcCommand, RpcReplyPort<Result<AddTlcResponse, TlcErr>>),
     RemoveTlc(RemoveTlcCommand, RpcReplyPort<ProcessingChannelResult>),
@@ -213,7 +213,7 @@ impl Display for ChannelCommand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ChannelCommand::TxCollaborationCommand(_) => write!(f, "TxCollaborationCommand"),
-            ChannelCommand::FundingTxSigned(_) => write!(f, "FundingTxSigned"),
+            ChannelCommand::FundingTxSigned(_, _) => write!(f, "FundingTxSigned"),
             ChannelCommand::CommitmentSigned(_) => write!(f, "CommitmentSigned"),
             ChannelCommand::AddTlc(_, _) => write!(f, "AddTlc"),
             ChannelCommand::RemoveTlc(_, _) => write!(f, "RemoveTlc"),
@@ -237,6 +237,7 @@ impl ChannelCommand {
     pub fn rpc_reply_port(self) -> Option<RpcReplyPort<Result<(), String>>> {
         match self {
             ChannelCommand::CommitmentSigned(Some(port)) => Some(port),
+            ChannelCommand::FundingTxSigned(_, port) => Some(port),
             ChannelCommand::Shutdown(_, port) => Some(port),
             ChannelCommand::Update(_, port) => Some(port),
             _ => None,
@@ -2758,24 +2759,10 @@ where
             ChannelCommand::TxCollaborationCommand(tx_collaboration_command) => {
                 self.handle_tx_collaboration_command(state, tx_collaboration_command)
             }
-            ChannelCommand::FundingTxSigned(tx) => {
-                match state.state {
-                    ChannelState::AwaitingTxSignatures(flags) => {
-                        let flags = flags | AwaitingTxSignaturesFlags::OUR_TX_SIGNATURES_SENT;
-                        state.funding_tx = Some(tx);
-                        state.update_state(ChannelState::AwaitingTxSignatures(flags));
-                    }
-                    ChannelState::AwaitingChannelReady(_)
-                        if state.ephemeral_config.external_funding.enabled
-                            && state.ephemeral_config.external_funding.signed_submitted =>
-                    {
-                        state.funding_tx = Some(tx);
-                    }
-                    _ => {
-                        error!("Invalid state. Expect channel state to be AwaitingTxSignatures, but got {:?}", state.state);
-                    }
-                }
-                Ok(())
+            ChannelCommand::FundingTxSigned(tx, reply) => {
+                let result = state.apply_funding_tx_signed(tx);
+                let _ = reply.send(result.clone().map_err(|err| err.to_string()));
+                result
             }
             ChannelCommand::CommitmentSigned(rpc_reply) => {
                 let result = self.handle_commitment_signed_command(myself, state).await;
@@ -4891,6 +4878,28 @@ enum TlcUpdateAction {
 
 // Constructors for the channel actor state.
 impl ChannelActorState {
+    pub(crate) fn apply_funding_tx_signed(&mut self, tx: Transaction) -> ProcessingChannelResult {
+        match self.state {
+            ChannelState::AwaitingTxSignatures(flags) => {
+                let flags = flags | AwaitingTxSignaturesFlags::OUR_TX_SIGNATURES_SENT;
+                self.funding_tx = Some(tx);
+                self.update_state(ChannelState::AwaitingTxSignatures(flags));
+                Ok(())
+            }
+            ChannelState::AwaitingChannelReady(_)
+                if self.ephemeral_config.external_funding.enabled
+                    && self.ephemeral_config.external_funding.signed_submitted =>
+            {
+                self.funding_tx = Some(tx);
+                Ok(())
+            }
+            _ => Err(ProcessingChannelError::InvalidState(format!(
+                "Expected channel state to accept FundingTxSigned, got {:?}",
+                self.state
+            ))),
+        }
+    }
+
     pub fn network(&self) -> ActorRef<NetworkActorMessage> {
         self.network
             .as_ref()

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -52,7 +52,7 @@ use super::channel::{
     ChannelActorStateStore, ChannelCommand, ChannelCommandWithId, ChannelEvent,
     ChannelInitializationParameter, ChannelOpenRecordStore, OpenChannelParameter,
     ProcessingChannelError, ProcessingChannelResult, RemoveTlcCommand, StopReason,
-    DEFAULT_MAX_TLC_VALUE_IN_FLIGHT,
+    DEFAULT_MAX_TLC_VALUE_IN_FLIGHT, PEER_CHANNEL_RESPONSE_TIMEOUT,
 };
 use super::gossip::{
     get_latest_startup_broadcast_message_cursor, GossipActorMessage, GossipMessageStore,
@@ -3906,6 +3906,39 @@ where
         let funding_tx = signed_funding_tx.take().expect("take tx");
         let witnesses = funding_tx.witnesses();
 
+        let Some(channel_actor) = state.channels.get(&channel_id).cloned() else {
+            debug!(
+                "Skipping signed funding tx for channel {:?}: channel actor no longer exists",
+                channel_id
+            );
+            return Ok(());
+        };
+
+        match call_t!(
+            channel_actor,
+            |reply| ChannelActorMessage::Command(ChannelCommand::FundingTxSigned(
+                funding_tx.data(),
+                reply,
+            )),
+            PEER_CHANNEL_RESPONSE_TIMEOUT
+        ) {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                warn!(
+                    "Discarding signed funding tx for channel {:?}: channel rejected FundingTxSigned: {}",
+                    channel_id, err
+                );
+                return Ok(());
+            }
+            Err(err) => {
+                warn!(
+                    "Discarding signed funding tx for channel {:?}: failed to acknowledge FundingTxSigned: {}",
+                    channel_id, err
+                );
+                return Ok(());
+            }
+        }
+
         if has_partial_witnesses {
             let outpoint = funding_tx
                 .output_pts_iter()
@@ -3939,19 +3972,6 @@ where
         state
             .trace_tx(tx_hash, InFlightCkbTxKind::Funding(channel_id))
             .await?;
-
-        if let Err(err) = state
-            .send_command_to_channel(
-                channel_id,
-                ChannelCommand::FundingTxSigned(funding_tx.data()),
-            )
-            .await
-        {
-            error!(
-                "Failed to update signed funding tx {:?}: {}",
-                channel_id, err
-            );
-        }
 
         myself
             .send_message(NetworkActorMessage::new_command(

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -11226,6 +11226,17 @@ mod udt_funding_cell_capacity_tests {
     }
 
     #[test]
+    fn funding_tx_signed_rejects_invalid_state() {
+        let mut state = minimal_udt_channel_state();
+        state.core.state = ChannelState::Closed(CloseFlags::FUNDING_ABORTED);
+
+        let result = state.apply_funding_tx_signed(Transaction::default());
+
+        assert!(result.is_err());
+        assert!(state.funding_tx.is_none());
+    }
+
+    #[test]
     fn udt_funding_tx_is_final_when_capacity_matches_total_reserved() {
         let state = minimal_udt_channel_state();
         let total = LOCAL_RESERVED_SHANNONS + REMOTE_RESERVED_SHANNONS;


### PR DESCRIPTION
## Summary
- require ChannelActor to acknowledge `FundingTxSigned` before NetworkActor traces, broadcasts, or sends peer `TxSignatures`
- reject `FundingTxSigned` in invalid channel states instead of logging and succeeding
- add regression coverage that an aborted channel state rejects signed funding transactions

## Tests
- cargo nextest run -p fnn --features sqlite funding_tx_signed_rejects_invalid_state test_abort_funding_on_sign_funding_tx_failure test_abort_funding_on_committing_funding_tx_on_chain
- cargo check -p fnn --features sqlite
- cargo fmt --all -- --check
- git diff --check
