### PR TITLE
Reject invalid derived TLC pubkeys

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -58,7 +58,7 @@ use ckb_types::{
     H256,
 };
 use fiber_types::{
-    blake2b_hash_with_salt, derive_tlc_pubkey, is_tlc_key_derivation_safe, AddTlcCommand,
+    blake2b_hash_with_salt, is_tlc_key_derivation_safe, try_derive_tlc_pubkey, AddTlcCommand,
     AppliedFlags, AwaitingChannelReadyFlags, AwaitingTxSignaturesFlags, BasicMppPaymentData,
     ChannelActorData, ChannelAnnouncement, ChannelBasePublicKeys, ChannelConnectivityState,
     ChannelConstraints, ChannelFlags, ChannelOpenRecord, ChannelState, ChannelTlcInfo,
@@ -6760,35 +6760,41 @@ impl ChannelActorState {
     // The offerer who offered this tlc will have the first pubkey, and the receiver
     // will have the second pubkey.
     // This tlc must have valid local_committed_at and remote_committed_at fields.
-    pub fn get_tlc_pubkeys(&self, tlc: &TlcInfo) -> (Pubkey, Pubkey) {
+    pub fn get_tlc_pubkeys(
+        &self,
+        tlc: &TlcInfo,
+    ) -> Result<(Pubkey, Pubkey), ProcessingChannelError> {
         let CommitmentNumbers {
             local: local_commitment_number,
             remote: remote_commitment_number,
         } = tlc.get_commitment_numbers();
-        let local_pubkey = derive_tlc_pubkey(
+        let local_pubkey = try_derive_tlc_pubkey(
             &self.get_local_channel_public_keys().tlc_base_key,
             &self.get_local_commitment_point(remote_commitment_number),
-        );
-        let remote_pubkey = derive_tlc_pubkey(
+        )
+        .map_err(ProcessingChannelError::InvalidParameter)?;
+        let remote_pubkey = try_derive_tlc_pubkey(
             &self.get_remote_channel_public_keys().tlc_base_key,
             &self.get_remote_commitment_point(local_commitment_number),
-        );
-        (local_pubkey, remote_pubkey)
+        )
+        .map_err(ProcessingChannelError::InvalidParameter)?;
+        Ok((local_pubkey, remote_pubkey))
     }
 
-    fn get_tlc_keys(&self, tlc: &TlcInfo) -> (Privkey, Pubkey) {
+    fn get_tlc_keys(&self, tlc: &TlcInfo) -> Result<(Privkey, Pubkey), ProcessingChannelError> {
         let CommitmentNumbers {
             local: local_commitment_number,
             remote: remote_commitment_number,
         } = tlc.get_commitment_numbers();
 
-        (
+        Ok((
             self.signer.derive_tlc_key(remote_commitment_number),
-            derive_tlc_pubkey(
+            try_derive_tlc_pubkey(
                 &self.get_remote_channel_public_keys().tlc_base_key,
                 &self.get_remote_commitment_point(local_commitment_number),
-            ),
-        )
+            )
+            .map_err(ProcessingChannelError::InvalidParameter)?,
+        ))
     }
 
     // We are using tlc base key for settlement keys, since settlement
@@ -6820,12 +6826,15 @@ impl ChannelActorState {
         [a, b].concat()
     }
 
-    fn get_active_tlcs_for_settlement(&self, for_remote: bool) -> Vec<SettlementTlc> {
+    fn get_active_tlcs_for_settlement(
+        &self,
+        for_remote: bool,
+    ) -> Result<Vec<SettlementTlc>, ProcessingChannelError> {
         let tlcs = self.get_active_tlcs(for_remote);
         tlcs.into_iter()
             .map(|tlc| {
-                let (local_key, remote_key) = self.get_tlc_keys(&tlc);
-                SettlementTlc {
+                let (local_key, remote_key) = self.get_tlc_keys(&tlc)?;
+                Ok(SettlementTlc {
                     tlc_id: tlc.tlc_id,
                     hash_algorithm: tlc.hash_algorithm,
                     payment_amount: tlc.amount,
@@ -6833,7 +6842,7 @@ impl ChannelActorState {
                     expiry: tlc.expiry,
                     local_key,
                     remote_key,
-                }
+                })
             })
             .collect()
     }
@@ -8263,11 +8272,10 @@ impl ChannelActorState {
             .update_for_revoke_and_ack(commitment_numbers);
         self.set_waiting_ack(myself, false);
 
-        let tlcs = self.get_active_tlcs_for_settlement(true);
         info!(
             "After RevokeAndAckReceived settlement data for commitment_number: {}, tlcs count: {}, tlc_state: {:?}",
             self.get_local_commitment_number(),
-            tlcs.len(),
+            settlement_data.tlcs.len(),
             self.tlc_state
                 .all_tlcs()
                 .map(|tlc| tlc.status.clone())
@@ -9434,7 +9442,7 @@ impl ChannelActorState {
         Ok(SettlementData {
             local_amount: to_local_value,
             remote_amount: to_remote_value,
-            tlcs: self.get_active_tlcs_for_settlement(for_remote),
+            tlcs: self.get_active_tlcs_for_settlement(for_remote)?,
         })
     }
 

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -54,13 +54,13 @@ use ckb_types::{
     prelude::{AsTransactionBuilder, Builder, Entity, IntoTransactionView, Pack, Unpack},
 };
 use fiber_types::{
-    derive_private_key, derive_tlc_pubkey, is_tlc_key_derivation_safe, AddTlcCommand, AppliedFlags,
-    AwaitingChannelReadyFlags, AwaitingTxSignaturesFlags, ChannelConstraints, ChannelOpeningStatus,
-    ChannelState, CollaboratingFundingTxFlags, HashAlgorithm, InMemorySigner, InboundTlcStatus,
-    NegotiatingFundingFlags, OutboundTlcStatus, PaymentHopData, PaymentStatus, Privkey, RemoveTlc,
-    RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation, RevokeAndAck, ShuttingDownFlags,
-    SigningCommitmentFlags, TLCId, TlcErrPacket, TlcErrorCode, TlcInfo, TlcStatus,
-    NO_SHARED_SECRET,
+    derive_private_key, is_tlc_key_derivation_safe, try_derive_tlc_pubkey, AddTlcCommand,
+    AppliedFlags, AwaitingChannelReadyFlags, AwaitingTxSignaturesFlags, ChannelConstraints,
+    ChannelOpeningStatus, ChannelState, CollaboratingFundingTxFlags, HashAlgorithm, InMemorySigner,
+    InboundTlcStatus, NegotiatingFundingFlags, OutboundTlcStatus, PaymentHopData, PaymentStatus,
+    Privkey, RemoveTlc, RemoveTlcFulfill, RemoveTlcReason, RetryableTlcOperation, RevokeAndAck,
+    ShuttingDownFlags, SigningCommitmentFlags, TLCId, TlcErrPacket, TlcErrorCode, TlcInfo,
+    TlcStatus, NO_SHARED_SECRET,
 };
 use fiber_types::{CloseFlags, FeatureVector};
 use molecule::bytes::BytesMut;
@@ -268,7 +268,8 @@ fn test_derive_private_and_public_tlc_keys() {
     let privkey = Privkey::from(&[1; 32]);
     let per_commitment_point = Privkey::from(&[2; 32]).pubkey();
     let derived_privkey = derive_private_key(&privkey, &per_commitment_point);
-    let derived_pubkey = derive_tlc_pubkey(&privkey.pubkey(), &per_commitment_point);
+    let derived_pubkey =
+        try_derive_tlc_pubkey(&privkey.pubkey(), &per_commitment_point).expect("honest keys");
     assert_eq!(derived_privkey.pubkey(), derived_pubkey);
 }
 
@@ -326,7 +327,7 @@ fn test_try_derive_tlc_pubkey_rejects_malicious_keys() {
 
 #[test]
 fn test_revoke_and_ack_bypass_safe_initial_keys_with_malicious_later_key() {
-    use fiber_types::derive_tlc_pubkey;
+    use fiber_types::try_derive_tlc_pubkey;
     let (malicious_tlc_basepoint, bad_commitment_point) =
         malicious_tlc_basepoint_and_commitment_point();
 
@@ -348,12 +349,9 @@ fn test_revoke_and_ack_bypass_safe_initial_keys_with_malicious_later_key() {
         "malicious next_per_commitment_point in RevokeAndAck should be rejected by the fix"
     );
 
-    let result = std::panic::catch_unwind(|| {
-        let _ = derive_tlc_pubkey(&malicious_tlc_basepoint, &bad_commitment_point);
-    });
     assert!(
-        result.is_err(),
-        "without validation, the malicious next_per_commitment_point would cause a panic"
+        try_derive_tlc_pubkey(&malicious_tlc_basepoint, &bad_commitment_point).is_err(),
+        "without validation, the malicious next_per_commitment_point should be rejected"
     );
 }
 

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -314,17 +314,13 @@ fn test_is_tlc_key_derivation_safe_accepts_honest_keys() {
 }
 
 #[test]
-fn test_malicious_keys_would_have_caused_panic() {
-    use fiber_types::derive_tlc_pubkey;
+fn test_try_derive_tlc_pubkey_rejects_malicious_keys() {
+    use fiber_types::try_derive_tlc_pubkey;
     let (tlc_basepoint, commitment_point) = malicious_tlc_basepoint_and_commitment_point();
 
-    let result = std::panic::catch_unwind(|| {
-        let _ = derive_tlc_pubkey(&tlc_basepoint, &commitment_point);
-    });
-
     assert!(
-        result.is_err(),
-        "malicious TLC basepoint and commitment point should cause a panic in derive_tlc_pubkey"
+        try_derive_tlc_pubkey(&tlc_basepoint, &commitment_point).is_err(),
+        "malicious TLC basepoint and commitment point should be rejected"
     );
 }
 

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -1183,6 +1183,7 @@ pub fn derive_private_key(secret: &Privkey, commitment_point: &Pubkey) -> Privke
 }
 
 /// Derive a public key by tweaking a base key with a commitment point.
+#[deprecated(note = "use `try_derive_public_key` instead to avoid panicking on invalid keys")]
 pub fn derive_public_key(base_key: &Pubkey, commitment_point: &Pubkey) -> Pubkey {
     base_key.tweak(get_tweak_by_commitment_point(commitment_point))
 }
@@ -1196,7 +1197,9 @@ pub fn try_derive_public_key(
 }
 
 /// Derive the TLC public key from a base key and commitment point.
+#[deprecated(note = "use `try_derive_tlc_pubkey` instead to avoid panicking on invalid keys")]
 pub fn derive_tlc_pubkey(base_key: &Pubkey, commitment_point: &Pubkey) -> Pubkey {
+    #[allow(deprecated)]
     derive_public_key(base_key, commitment_point)
 }
 

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -1187,9 +1187,25 @@ pub fn derive_public_key(base_key: &Pubkey, commitment_point: &Pubkey) -> Pubkey
     base_key.tweak(get_tweak_by_commitment_point(commitment_point))
 }
 
+/// Fallibly derive a public key by tweaking a base key with a commitment point.
+pub fn try_derive_public_key(
+    base_key: &Pubkey,
+    commitment_point: &Pubkey,
+) -> Result<Pubkey, String> {
+    base_key.try_tweak(get_tweak_by_commitment_point(commitment_point))
+}
+
 /// Derive the TLC public key from a base key and commitment point.
 pub fn derive_tlc_pubkey(base_key: &Pubkey, commitment_point: &Pubkey) -> Pubkey {
     derive_public_key(base_key, commitment_point)
+}
+
+/// Fallibly derive the TLC public key from a base key and commitment point.
+pub fn try_derive_tlc_pubkey(
+    base_key: &Pubkey,
+    commitment_point: &Pubkey,
+) -> Result<Pubkey, String> {
+    try_derive_public_key(base_key, commitment_point)
 }
 
 /// Check if the TLC key derivation for a given base key and commitment point

--- a/crates/fiber-types/src/primitives.rs
+++ b/crates/fiber-types/src/primitives.rs
@@ -523,4 +523,20 @@ impl Pubkey {
         let point = result.not_inf().expect("valid public key");
         PublicKey::from(point).into()
     }
+
+    /// Fallibly tweak this public key by a scalar.
+    pub fn try_tweak<I: Into<[u8; 32]>>(&self, scalar: I) -> Result<Self, String> {
+        let scalar = scalar.into();
+        let scalar = Scalar::from_slice(&scalar).map_err(|err| {
+            format!(
+                "Value {:?} must be within secp256k1 scalar range: {}",
+                &scalar, err
+            )
+        })?;
+        let result = Point::from(self) + scalar.base_point_mul();
+        let point = result
+            .not_inf()
+            .map_err(|_| "derived public key is point at infinity".to_string())?;
+        Ok(PublicKey::from(point).into())
+    }
 }


### PR DESCRIPTION
## Summary
- add fallible public/TLC key derivation APIs that reject point-at-infinity results
- use fallible TLC public-key derivation when building settlement TLC key material
- update malicious-key regression coverage to assert rejection instead of panic

## Tests
- cargo nextest run -p fnn --features sqlite test_try_derive_tlc_pubkey_rejects_malicious_keys test_derive_private_and_public_tlc_keys test_is_tlc_key_derivation_safe_rejects_malicious_keys test_revoke_and_ack_bypass_safe_initial_keys_with_malicious_later_key
- cargo check -p fnn --features sqlite
- cargo fmt --all -- --check
- git diff --check
