### PR TITLE
Avoid panic on short payment route

### DIFF
--- a/crates/fiber-lib/src/fiber/history.rs
+++ b/crates/fiber-lib/src/fiber/history.rs
@@ -271,7 +271,10 @@ impl InternalResult {
     ) -> bool {
         let mut need_retry = true;
         let len = nodes.len();
-        assert!(len >= 2);
+        if len < 2 {
+            error!("record_payment_fail_with_index called with fewer than 2 route nodes (len={}), ignoring", len);
+            return false;
+        }
         let error_code = tlc_err.error_code;
         error!(
             "Payment failed at node index {}: len: {:?} error_code: {:?} error_node={:?} error_channel={:?} route={:?}",

--- a/crates/fiber-lib/src/fiber/tests/history.rs
+++ b/crates/fiber-lib/src/fiber/tests/history.rs
@@ -1464,3 +1464,25 @@ fn test_history_can_not_send_with_time() {
     let res = history.cannot_send(90, before, 100);
     assert_eq!(res, 100);
 }
+
+#[test]
+fn record_payment_fail_with_index_does_not_panic_on_empty_route() {
+    let mut result = InternalResult::default();
+    let nodes: Vec<SessionRouteNode> = vec![];
+    let tlc_err = TlcErr::new(TlcErrorCode::TemporaryChannelFailure);
+    let need_retry = result.record_payment_fail(&nodes, tlc_err);
+    assert!(!need_retry);
+}
+
+#[test]
+fn record_payment_fail_with_index_does_not_panic_on_single_node_route() {
+    let mut result = InternalResult::default();
+    let nodes = vec![SessionRouteNode {
+        pubkey: gen_rand_fiber_public_key(),
+        amount: 100,
+        channel_outpoint: gen_rand_channel_outpoint(),
+    }];
+    let tlc_err = TlcErr::new(TlcErrorCode::TemporaryChannelFailure);
+    let need_retry = result.record_payment_fail(&nodes, tlc_err);
+    assert!(!need_retry);
+}


### PR DESCRIPTION
## Summary
- replace `assert!(len >= 2)` with graceful early return in payment failure recording
- add regression coverage for empty and single-node routes

## Tests
- cargo nextest run -p fnn --features sqlite record_payment_fail_with_index_does_not_panic
- cargo fmt --all -- --check
- cargo check -p fnn --features sqlite
