### PR TITLE
Abort watchtower scan on RPC pagination error

### DIFF
--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -713,7 +713,8 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
                 }
             }
             Err(err) => {
-                error!("Failed to get cells: {:?}", err);
+                error!("Failed to get cells: {:?}, aborting settlement scan", err);
+                break;
             }
         }
     }
@@ -776,7 +777,11 @@ fn scan_watched_settlement_txs<S: WatchtowerStore>(
                 }
             }
             Err(err) => {
-                error!("Failed to get transactions: {:?}", err);
+                error!(
+                    "Failed to get transactions: {:?}, aborting settlement scan",
+                    err
+                );
+                break;
             }
         }
     }


### PR DESCRIPTION
## Summary
- abort watchtower settlement scan pagination loops on CKB RPC errors instead of spinning forever
- apply the fix to both the `get_cells` and `get_transactions` pagination loops

## Tests
- cargo fmt --all -- --check
- cargo check -p fnn --features sqlite
- git diff --check
