### PR TITLE
Avoid panic on session without remote pubkey

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -4443,7 +4443,10 @@ impl ServiceProtocol for GossipProtocolHandle {
                     ));
             }
             None => {
-                unreachable!("Received message without remote pubkey");
+                debug!(
+                    "Peer disconnected without remote pubkey {:?}",
+                    context.session
+                );
             }
         }
     }
@@ -4463,7 +4466,10 @@ impl ServiceProtocol for GossipProtocolHandle {
                     ));
             }
             None => {
-                unreachable!("Received message without remote pubkey");
+                debug!(
+                    "Received gossip message without remote pubkey {:?}",
+                    context.session
+                );
             }
         }
     }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -6584,7 +6584,10 @@ impl ServiceProtocol for FiberProtocolHandle {
                 );
             }
             None => {
-                unreachable!("Received message without remote pubkey");
+                debug!(
+                    "Peer disconnected without remote pubkey {:?}",
+                    context.session
+                );
             }
         }
     }
@@ -6602,7 +6605,10 @@ impl ServiceProtocol for FiberProtocolHandle {
                 );
             }
             None => {
-                unreachable!("Received message without remote pubkey");
+                debug!(
+                    "Received message without remote pubkey {:?}",
+                    context.session
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace `unreachable!` with `debug!` in Fiber and Gossip protocol `disconnected` / `received` callbacks when session has no remote pubkey
- covers PENDING-0316 and PENDING-0317

## Tests
- cargo fmt --all -- --check
- cargo check -p fnn --features sqlite
- git diff --check