### PR TITLE
Cap default shutdown fee to funding fee rate

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -2297,9 +2297,10 @@ where
                 }
             };
 
-            let shutdown_fee_rate = command
-                .fee_rate
-                .unwrap_or(FeeRate::from_u64(state.commitment_fee_rate));
+            let shutdown_fee_rate = command.fee_rate.unwrap_or_else(|| {
+                let capped = u64::min(state.commitment_fee_rate, state.funding_fee_rate);
+                FeeRate::from_u64(capped)
+            });
             let close_script = command
                 .close_script
                 .clone()


### PR DESCRIPTION
## Summary
- cap the default cooperative shutdown fee to `funding_fee_rate` when no explicit fee is provided
- a peer-controlled excessive `commitment_fee_rate` should not dictate the shutdown fee

## Tests
- cargo fmt --all -- --check
- cargo check -p fnn --features sqlite
- git diff --check