### PR TITLE
Reconstruct commitment tx on demand instead of persisting

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -7815,7 +7815,6 @@ impl ChannelActorState {
             }
         }
         self.commit_remote_nonce(commitment_signed.next_commitment_nonce);
-        self.latest_commitment_transaction = Some(commitment_tx.data());
         Ok(true)
     }
 
@@ -7971,17 +7970,6 @@ impl ChannelActorState {
         match self.state {
             ChannelState::AwaitingChannelReady(flags) => {
                 if flags.contains(AwaitingChannelReadyFlags::CHANNEL_READY) {
-                    // Defense-in-depth: refuse to advertise readiness if we never received the
-                    // peer's CommitmentSigned (which is what populates
-                    // latest_commitment_transaction). Without this, get_latest_commitment_transaction
-                    // would panic on force-close. See GHSA-x6rw-txsignatures-verification.
-                    if self.latest_commitment_transaction.is_none() {
-                        error!(
-                            "Refusing to advance to ChannelReady for channel {:?}: latest_commitment_transaction is not set; the peer likely skipped sending CommitmentSigned",
-                            self.get_id()
-                        );
-                        return;
-                    }
                     if !self.is_public() {
                         self.on_new_channel_ready(myself);
                     } else {
@@ -9487,16 +9475,8 @@ impl ChannelActorState {
     pub async fn get_latest_commitment_transaction(
         &self,
     ) -> Result<TransactionView, ProcessingChannelError> {
-        let tx = self
-            .latest_commitment_transaction
-            .clone()
-            .expect("latest_commitment_transaction should exist");
-        let cell_deps = get_cell_deps(vec![Contract::FundingLock], &self.funding_udt_type_script)
-            .await
-            .map_err(|e| ProcessingChannelError::InternalError(e.to_string()))?;
-        let raw_tx = tx.raw().as_builder().cell_deps(cell_deps).build();
-        let tx = tx.as_builder().raw(raw_tx).build();
-        Ok(tx.into_view())
+        let (commitment_tx, _) = self.build_commitment_tx_and_settlement_data(false)?;
+        Ok(commitment_tx)
     }
 
     /// Verify the partial signature from the peer and create a complete transaction

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -9476,7 +9476,17 @@ impl ChannelActorState {
         &self,
     ) -> Result<TransactionView, ProcessingChannelError> {
         let (commitment_tx, _) = self.build_commitment_tx_and_settlement_data(false)?;
-        Ok(commitment_tx)
+        let cell_deps = get_cell_deps(vec![Contract::FundingLock], &self.funding_udt_type_script)
+            .await
+            .map_err(|e| ProcessingChannelError::InternalError(e.to_string()))?;
+        let raw_tx = commitment_tx
+            .data()
+            .raw()
+            .as_builder()
+            .cell_deps(cell_deps)
+            .build();
+        let tx = commitment_tx.data().as_builder().raw(raw_tx).build();
+        Ok(tx.into_view())
     }
 
     /// Verify the partial signature from the peer and create a complete transaction

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -10604,10 +10604,6 @@ async fn test_tx_signatures_after_channel_ready_rejected() {
         .funding_tx
         .as_ref()
         .map(|tx| tx.as_slice().to_vec());
-    let latest_commitment_bytes_before = state_before
-        .latest_commitment_transaction
-        .as_ref()
-        .map(|tx| tx.as_slice().to_vec());
 
     node_a
         .network_actor
@@ -10635,14 +10631,6 @@ async fn test_tx_signatures_after_channel_ready_rejected() {
     assert_eq!(
         funding_tx_bytes_after, funding_tx_bytes_before,
         "funding_tx must not be mutated by a stale peer TxSignatures"
-    );
-    let latest_commitment_bytes_after = state_after
-        .latest_commitment_transaction
-        .as_ref()
-        .map(|tx| tx.as_slice().to_vec());
-    assert_eq!(
-        latest_commitment_bytes_after, latest_commitment_bytes_before,
-        "latest_commitment_transaction must be unchanged by a stale peer TxSignatures"
     );
 }
 

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -1560,8 +1560,10 @@ pub struct ChannelActorData {
     #[serde_as(as = "Option<PubNonceAsBytes>")]
     pub remote_revocation_nonce_for_next: Option<PubNonce>,
 
-    /// The latest commitment transaction we're holding,
-    /// it can be broadcasted to blockchain by us to force close the channel.
+    /// The latest commitment transaction we're holding.
+    /// This field is no longer persisted; the transaction is reconstructed from
+    /// state on demand via `build_commitment_tx_and_settlement_data`.
+    #[serde(default)]
     #[serde_as(as = "Option<EntityHex>")]
     pub latest_commitment_transaction: Option<Transaction>,
 


### PR DESCRIPTION
## Summary
- remove persisted storage of `latest_commitment_transaction` from `ChannelActorData`
- reconstruct commitment transaction from state fields on demand during force-close via `build_commitment_tx_and_settlement_data`
- field kept with `#[serde(default)]` for backward compat with old persisted data

## Why
The commitment transaction is fully determined by state fields already persisted (funding outpoint, commitment numbers, TLCs, settlement amounts, delay epoch, pubkeys). Storing it redundantly costs `~500B per channel` and incurs deserialization overhead that slows down unrelated state reads (e.g., preimage cleanup scanning TLCs across channels).

## Tests
- cargo check -p fnn --features sqlite
- cargo nextest run -p fnn --features sqlite test_tx_signatures_after_channel_ready_rejected
- cargo fmt --all -- --check
- git diff --check