### PR TITLE
Fix Windows release CRT dependency

### DIFF
--- a/.github/actions/build-release-package/action.yml
+++ b/.github/actions/build-release-package/action.yml
@@ -1,0 +1,92 @@
+name: Build FNN release package
+description: Build, smoke test, and package FNN release binaries.
+
+inputs:
+  os:
+    description: Runner OS label.
+    required: true
+  package-name:
+    description: Output package file name.
+    required: true
+  bin-suffix:
+    description: Binary suffix, such as .exe on Windows.
+    required: false
+    default: ''
+  portable:
+    description: Whether to build with the portable feature.
+    required: false
+    default: 'false'
+  openssl-configure:
+    description: OpenSSL Configure arguments for portable Linux builds.
+    required: false
+    default: ''
+  windows-dependencies:
+    description: 'Windows dependency setup mode: none, minimal, or release.'
+    required: false
+    default: 'none'
+
+outputs:
+  package_name:
+    description: Generated package file name.
+    value: ${{ steps.package.outputs.package_name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Windows release dependencies
+      if: ${{ inputs.windows-dependencies == 'release' }}
+      shell: pwsh
+      run: |
+        iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
+        .\install-scoop.ps1 -RunAsAdmin
+        echo "LIBCLANG_PATH=$($HOME)/scoop/apps/llvm/current/bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        scoop install llvm yasm
+        vcpkg integrate install
+        vcpkg install openssl:x64-windows-static
+
+    - name: Install Windows dependencies
+      if: ${{ inputs.windows-dependencies == 'minimal' }}
+      shell: pwsh
+      run: |
+        vcpkg integrate install
+        vcpkg install openssl:x64-windows-static
+
+    - name: Build Linux portable release binary
+      if: ${{ startsWith(inputs.os, 'ubuntu') && inputs.portable == 'true' }}
+      shell: bash
+      run: bash .github/actions/build-release-package/helpers/build-linux-portable.sh "${{ inputs.openssl-configure }}"
+
+    - name: Build Windows release binary
+      if: ${{ inputs.os == 'windows-2022' }}
+      shell: pwsh
+      env:
+        RUSTFLAGS: -C target-feature=+crt-static
+      run: cargo build --release --locked
+
+    - name: Build portable release binary
+      if: ${{ startsWith(inputs.os, 'macos') && inputs.portable == 'true' }}
+      shell: bash
+      run: cargo build --release --locked --features portable
+
+    - name: Build release binary
+      if: ${{ inputs.os != 'windows-2022' && inputs.portable != 'true' }}
+      shell: bash
+      run: cargo build --release --locked
+
+    - name: Smoke test Windows store open
+      if: ${{ inputs.os == 'windows-2022' }}
+      shell: pwsh
+      run: '& .github/actions/build-release-package/helpers/smoke-test-windows-store.ps1 -Executable target\release\fnn.exe'
+
+    - name: Smoke test release binary
+      if: ${{ inputs.os != 'windows-2022' }}
+      shell: bash
+      run: |
+        target/release/fnn --version
+        target/release/fnn-cli --version
+
+    - name: Package release binary
+      id: package
+      shell: bash
+      run: bash .github/actions/build-release-package/helpers/package-release.sh "${{ inputs.package-name }}" "${{ inputs.bin-suffix }}"

--- a/.github/actions/build-release-package/helpers/build-linux-portable.sh
+++ b/.github/actions/build-release-package/helpers/build-linux-portable.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+openssl_configure=${1:?openssl configure arguments are required}
+read -r -a configure_args <<< "${openssl_configure}"
+
+pwd_dir=$(pwd)
+curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
+tar -xzf openssl-1.1.1s.tar.gz
+pushd openssl-1.1.1s
+./Configure "${configure_args[@]}"
+make
+popd
+
+export OPENSSL_LIB_DIR="${pwd_dir}/openssl-1.1.1s"
+export OPENSSL_INCLUDE_DIR="${pwd_dir}/openssl-1.1.1s/include"
+export OPENSSL_STATIC=1
+cargo build --release --locked --features portable

--- a/.github/actions/build-release-package/helpers/package-release.sh
+++ b/.github/actions/build-release-package/helpers/package-release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pkgname=${1:?package name is required}
+bin_suffix=${2:-}
+
+cp "target/release/fnn${bin_suffix}" "fnn${bin_suffix}"
+cp "target/release/fnn-cli${bin_suffix}" "fnn-cli${bin_suffix}"
+tar czvf "${pkgname}" "fnn${bin_suffix}" "fnn-cli${bin_suffix}" config
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "package_name=${pkgname}" >> "${GITHUB_OUTPUT}"
+fi

--- a/.github/actions/build-release-package/helpers/smoke-test-windows-store.ps1
+++ b/.github/actions/build-release-package/helpers/smoke-test-windows-store.ps1
@@ -1,0 +1,23 @@
+param(
+    [string]$Executable = "target\release\fnn.exe",
+    [string]$Name = "fnn-smoke"
+)
+
+$smokeDir = Join-Path $env:RUNNER_TEMP $Name
+Remove-Item $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path (Join-Path $smokeDir "fiber\store") -Force | Out-Null
+$env:FIBER_SECRET_KEY_PASSWORD = "ci-smoke-test"
+
+$output = & $Executable --check-validate -c config\testnet\config.yml -d $smokeDir 2>&1
+$exitCode = $LASTEXITCODE
+$output | Write-Output
+
+if ($exitCode -eq 0) {
+    exit 0
+}
+
+if ($exitCode -eq 1 -and $output -match "db validate failed") {
+    exit 0
+}
+
+throw "Windows store smoke test failed with exit code $exitCode"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,16 +200,7 @@ jobs:
         if: contains(matrix.os, 'windows')
         run: |
           $profileDir = if ("${{ matrix.profile }}" -eq "release") { "release" } else { "debug" }
-          $smokeDir = Join-Path $env:RUNNER_TEMP "fnn-smoke-${{ matrix.profile }}"
-          Remove-Item $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path (Join-Path $smokeDir "fiber\store") -Force | Out-Null
-          $env:FIBER_SECRET_KEY_PASSWORD = "ci-smoke-test"
-          $output = & "target\$profileDir\fnn.exe" --check-validate -c config\testnet\config.yml -d $smokeDir 2>&1
-          $exitCode = $LASTEXITCODE
-          $output | Write-Output
-          if ($exitCode -eq 0) { exit 0 }
-          if ($exitCode -eq 1 -and $output -match "db validate failed") { exit 0 }
-          throw "Windows store smoke test failed with exit code $exitCode"
+          & .github/actions/build-release-package/helpers/smoke-test-windows-store.ps1 -Executable "target\$profileDir\fnn.exe" -Name "fnn-smoke-${{ matrix.profile }}"
 
   windows-release-test:
     name: Windows release package test
@@ -222,40 +213,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: windows-release-test-${{ runner.os }}
-      - name: Install Dependencies
-        run: |
-          vcpkg integrate install
-          vcpkg install openssl:x64-windows-static
-      - name: Build Windows release binary
-        env:
-          RUSTFLAGS: -C target-feature=+crt-static
-        run: cargo build --release --locked
-      - name: Smoke test Windows store open
-        run: |
-          $smokeDir = Join-Path $env:RUNNER_TEMP "fnn-smoke"
-          Remove-Item $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path (Join-Path $smokeDir "fiber\store") -Force | Out-Null
-          $env:FIBER_SECRET_KEY_PASSWORD = "ci-smoke-test"
-          $output = & target\release\fnn.exe --check-validate -c config\testnet\config.yml -d $smokeDir 2>&1
-          $exitCode = $LASTEXITCODE
-          $output | Write-Output
-          if ($exitCode -eq 0) { exit 0 }
-          if ($exitCode -eq 1 -and $output -match "db validate failed") { exit 0 }
-          throw "Windows store smoke test failed with exit code $exitCode"
-      - name: Package Windows release binary
-        run: |
-          $packageDir = Join-Path $env:RUNNER_TEMP "fnn-windows"
-          Remove-Item $packageDir -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
-          Copy-Item -Path target\release\fnn.exe -Destination $packageDir
-          Copy-Item -Path target\release\fnn-cli.exe -Destination $packageDir
-          Copy-Item -Path config -Destination (Join-Path $packageDir "config") -Recurse
-          tar -czf fnn_pr${{ github.event.pull_request.number }}_x86_64-windows.tar.gz -C $packageDir .
+      - name: Build Windows release package
+        id: package
+        uses: ./.github/actions/build-release-package
+        with:
+          os: windows-2022
+          package-name: fnn_pr${{ github.event.pull_request.number }}_x86_64-windows.tar.gz
+          bin-suffix: .exe
+          windows-dependencies: minimal
       - name: Upload Windows release binary
         uses: actions/upload-artifact@v4
         with:
           name: fnn-pr${{ github.event.pull_request.number }}-x86_64-windows
-          path: fnn_pr${{ github.event.pull_request.number }}_x86_64-windows.tar.gz
+          path: ${{ steps.package.outputs.package_name }}
 
   linux-release-test:
     name: Linux release package test (${{ matrix.pkg_suffix }})
@@ -268,13 +238,17 @@ jobs:
         include:
           - os: ubuntu-22.04
             pkg_suffix: x86_64-linux-portable
+            bin_suffix: ''
             portable: true
             openssl_configure: linux-x86_64 shared
           - os: ubuntu-24.04
             pkg_suffix: x86_64-linux
+            bin_suffix: ''
             portable: false
+            openssl_configure: ''
           - os: ubuntu-22.04-arm
             pkg_suffix: aarch64-linux-portable
+            bin_suffix: ''
             portable: true
             openssl_configure: linux-aarch64 shared
     steps:
@@ -283,38 +257,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: linux-release-test-${{ matrix.pkg_suffix }}
-      - if: ${{ matrix.portable }}
-        name: Build Linux portable release binary
-        run: |
-          export PWD_DIR=$(pwd)
-          curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
-          tar -xzf openssl-1.1.1s.tar.gz
-          cd openssl-1.1.1s
-          ./Configure ${{ matrix.openssl_configure }}
-          make
-          cd ..
-          export OPENSSL_LIB_DIR=${PWD_DIR}/openssl-1.1.1s
-          export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
-          export OPENSSL_STATIC=1
-          cargo build --release --locked --features portable
-      - if: ${{ !matrix.portable }}
-        name: Build Linux release binary
-        run: cargo build --release --locked
-      - name: Smoke test Linux release binary
-        run: |
-          target/release/fnn --version
-          target/release/fnn-cli --version
-      - name: Package Linux release binary
-        run: |
-          pkgname="fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz"
-          cp target/release/fnn fnn
-          cp target/release/fnn-cli fnn-cli
-          tar czvf "${pkgname}" fnn fnn-cli config
+      - name: Build Linux release package
+        id: package
+        uses: ./.github/actions/build-release-package
+        with:
+          os: ${{ matrix.os }}
+          package-name: fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz
+          bin-suffix: ${{ matrix.bin_suffix }}
+          portable: ${{ matrix.portable }}
+          openssl-configure: ${{ matrix.openssl_configure }}
       - name: Upload Linux release binary
         uses: actions/upload-artifact@v4
         with:
           name: fnn-pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}
-          path: fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz
+          path: ${{ steps.package.outputs.package_name }}
 
   macos-release-test:
     name: macOS release package test (${{ matrix.pkg_suffix }})
@@ -327,31 +283,34 @@ jobs:
         include:
           - os: macos-15
             pkg_suffix: aarch64-darwin-portable
+            bin_suffix: ''
+            portable: true
+            openssl_configure: ''
           - os: macos-15-intel
             pkg_suffix: x86_64-darwin-portable
+            bin_suffix: ''
+            portable: true
+            openssl_configure: ''
     steps:
       - uses: actions/checkout@v6
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
         with:
           key: macos-release-test-${{ matrix.pkg_suffix }}
-      - name: Build macOS portable release binary
-        run: cargo build --release --locked --features portable
-      - name: Smoke test macOS release binary
-        run: |
-          target/release/fnn --version
-          target/release/fnn-cli --version
-      - name: Package macOS release binary
-        run: |
-          pkgname="fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz"
-          cp target/release/fnn fnn
-          cp target/release/fnn-cli fnn-cli
-          tar czvf "${pkgname}" fnn fnn-cli config
+      - name: Build macOS release package
+        id: package
+        uses: ./.github/actions/build-release-package
+        with:
+          os: ${{ matrix.os }}
+          package-name: fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz
+          bin-suffix: ${{ matrix.bin_suffix }}
+          portable: ${{ matrix.portable }}
+          openssl-configure: ${{ matrix.openssl_configure }}
       - name: Upload macOS release binary
         uses: actions/upload-artifact@v4
         with:
           name: fnn-pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}
-          path: fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz
+          path: ${{ steps.package.outputs.package_name }}
 
   benchmark:
     name: Benchmark (Non-Gossip)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,9 +191,25 @@ jobs:
         if: contains(matrix.os, 'windows')
         run: |
           vcpkg integrate install
-          vcpkg install openssl:x64-windows-static-md
+          vcpkg install openssl:x64-windows-static
       - name: Build with profile
+        env:
+          RUSTFLAGS: ${{ contains(matrix.os, 'windows') && '-C target-feature=+crt-static' || '' }}
         run: cargo build --locked --verbose --profile ${{ matrix.profile }}
+      - name: Smoke test Windows store open
+        if: contains(matrix.os, 'windows')
+        run: |
+          $profileDir = if ("${{ matrix.profile }}" -eq "release") { "release" } else { "debug" }
+          $smokeDir = Join-Path $env:RUNNER_TEMP "fnn-smoke-${{ matrix.profile }}"
+          Remove-Item $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path (Join-Path $smokeDir "fiber\store") -Force | Out-Null
+          $env:FIBER_SECRET_KEY_PASSWORD = "ci-smoke-test"
+          $output = & "target\$profileDir\fnn.exe" --check-validate -c config\testnet\config.yml -d $smokeDir 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | Write-Output
+          if ($exitCode -eq 0) { exit 0 }
+          if ($exitCode -eq 1 -and $output -match "db validate failed") { exit 0 }
+          throw "Windows store smoke test failed with exit code $exitCode"
 
   benchmark:
     name: Benchmark (Non-Gossip)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,148 @@ jobs:
           if ($exitCode -eq 1 -and $output -match "db validate failed") { exit 0 }
           throw "Windows store smoke test failed with exit code $exitCode"
 
+  windows-release-test:
+    name: Windows release package test
+    runs-on: windows-2022
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.body || '', '#windows-release-test')
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dsherret/rust-toolchain-file@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-release-test-${{ runner.os }}
+      - name: Install Dependencies
+        run: |
+          vcpkg integrate install
+          vcpkg install openssl:x64-windows-static
+      - name: Build Windows release binary
+        env:
+          RUSTFLAGS: -C target-feature=+crt-static
+        run: cargo build --release --locked
+      - name: Smoke test Windows store open
+        run: |
+          $smokeDir = Join-Path $env:RUNNER_TEMP "fnn-smoke"
+          Remove-Item $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path (Join-Path $smokeDir "fiber\store") -Force | Out-Null
+          $env:FIBER_SECRET_KEY_PASSWORD = "ci-smoke-test"
+          $output = & target\release\fnn.exe --check-validate -c config\testnet\config.yml -d $smokeDir 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | Write-Output
+          if ($exitCode -eq 0) { exit 0 }
+          if ($exitCode -eq 1 -and $output -match "db validate failed") { exit 0 }
+          throw "Windows store smoke test failed with exit code $exitCode"
+      - name: Package Windows release binary
+        run: |
+          $packageDir = Join-Path $env:RUNNER_TEMP "fnn-windows"
+          Remove-Item $packageDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
+          Copy-Item -Path target\release\fnn.exe -Destination $packageDir
+          Copy-Item -Path target\release\fnn-cli.exe -Destination $packageDir
+          Copy-Item -Path config -Destination (Join-Path $packageDir "config") -Recurse
+          tar -czf fnn_pr${{ github.event.pull_request.number }}_x86_64-windows.tar.gz -C $packageDir .
+      - name: Upload Windows release binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: fnn-pr${{ github.event.pull_request.number }}-x86_64-windows
+          path: fnn_pr${{ github.event.pull_request.number }}_x86_64-windows.tar.gz
+
+  linux-release-test:
+    name: Linux release package test (${{ matrix.pkg_suffix }})
+    runs-on: ${{ matrix.os }}
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.body || '', '#linux-release-test')
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            pkg_suffix: x86_64-linux-portable
+            portable: true
+            openssl_configure: linux-x86_64 shared
+          - os: ubuntu-24.04
+            pkg_suffix: x86_64-linux
+            portable: false
+          - os: ubuntu-22.04-arm
+            pkg_suffix: aarch64-linux-portable
+            portable: true
+            openssl_configure: linux-aarch64 shared
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dsherret/rust-toolchain-file@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: linux-release-test-${{ matrix.pkg_suffix }}
+      - if: ${{ matrix.portable }}
+        name: Build Linux portable release binary
+        run: |
+          export PWD_DIR=$(pwd)
+          curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
+          tar -xzf openssl-1.1.1s.tar.gz
+          cd openssl-1.1.1s
+          ./Configure ${{ matrix.openssl_configure }}
+          make
+          cd ..
+          export OPENSSL_LIB_DIR=${PWD_DIR}/openssl-1.1.1s
+          export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
+          export OPENSSL_STATIC=1
+          cargo build --release --locked --features portable
+      - if: ${{ !matrix.portable }}
+        name: Build Linux release binary
+        run: cargo build --release --locked
+      - name: Smoke test Linux release binary
+        run: |
+          target/release/fnn --version
+          target/release/fnn-cli --version
+      - name: Package Linux release binary
+        run: |
+          pkgname="fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz"
+          cp target/release/fnn fnn
+          cp target/release/fnn-cli fnn-cli
+          tar czvf "${pkgname}" fnn fnn-cli config
+      - name: Upload Linux release binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: fnn-pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}
+          path: fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz
+
+  macos-release-test:
+    name: macOS release package test (${{ matrix.pkg_suffix }})
+    runs-on: ${{ matrix.os }}
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.body || '', '#macos-release-test')
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            pkg_suffix: aarch64-darwin-portable
+          - os: macos-15-intel
+            pkg_suffix: x86_64-darwin-portable
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dsherret/rust-toolchain-file@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: macos-release-test-${{ matrix.pkg_suffix }}
+      - name: Build macOS portable release binary
+        run: cargo build --release --locked --features portable
+      - name: Smoke test macOS release binary
+        run: |
+          target/release/fnn --version
+          target/release/fnn-cli --version
+      - name: Package macOS release binary
+        run: |
+          pkgname="fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz"
+          cp target/release/fnn fnn
+          cp target/release/fnn-cli fnn-cli
+          tar czvf "${pkgname}" fnn fnn-cli config
+      - name: Upload macOS release binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: fnn-pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}
+          path: fnn_pr${{ github.event.pull_request.number }}-${{ matrix.pkg_suffix }}.tar.gz
+
   benchmark:
     name: Benchmark (Non-Gossip)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         scoop install llvm yasm
         vcpkg integrate install
-        vcpkg install openssl:x64-windows-static-md
+        vcpkg install openssl:x64-windows-static
     - if: matrix.os == 'ubuntu-22.04'
       name: Build linux portable
       run: |
@@ -119,7 +119,22 @@ jobs:
       run: cargo build --release --locked --features portable
     - if: matrix.os == 'windows-2022'
       name: Build windows
+      env:
+        RUSTFLAGS: -C target-feature=+crt-static
       run: cargo build --release --locked
+    - if: matrix.os == 'windows-2022'
+      name: Smoke test windows store open
+      run: |
+        $smokeDir = Join-Path $env:RUNNER_TEMP "fnn-smoke"
+        Remove-Item $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Path (Join-Path $smokeDir "fiber\store") -Force | Out-Null
+        $env:FIBER_SECRET_KEY_PASSWORD = "ci-smoke-test"
+        $output = & target\release\fnn.exe --check-validate -c config\testnet\config.yml -d $smokeDir 2>&1
+        $exitCode = $LASTEXITCODE
+        $output | Write-Output
+        if ($exitCode -eq 0) { exit 0 }
+        if ($exitCode -eq 1 -and $output -match "db validate failed") { exit 0 }
+        throw "Windows store smoke test failed with exit code $exitCode"
     - name: Get the Version
       id: get_version
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,101 +53,52 @@ jobs:
         os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, macos-15, macos-15-intel, windows-2022 ]
         include:
           - os: ubuntu-22.04
-            bin_suffix:
+            bin_suffix: ''
             pkg_suffix: x86_64-linux-portable
+            portable: true
+            openssl_configure: linux-x86_64 shared
           - os: ubuntu-24.04
-            bin_suffix:
+            bin_suffix: ''
             pkg_suffix: x86_64-linux
+            portable: false
+            openssl_configure: ''
           - os: ubuntu-22.04-arm
-            bin_suffix:
+            bin_suffix: ''
             pkg_suffix: aarch64-linux-portable
+            portable: true
+            openssl_configure: linux-aarch64 shared
           - os: macos-15
-            bin_suffix:
+            bin_suffix: ''
             pkg_suffix: aarch64-darwin-portable
+            portable: true
+            openssl_configure: ''
           - os: macos-15-intel
-            bin_suffix:
+            bin_suffix: ''
             pkg_suffix: x86_64-darwin-portable
+            portable: true
+            openssl_configure: ''
           - os: windows-2022
             bin_suffix: .exe
             pkg_suffix: x86_64-windows
+            portable: false
+            openssl_configure: ''
     steps:
     - name: Checkout the Repository
       uses: actions/checkout@v6
-    - if: matrix.os == 'windows-2022'
-      name: Windows Dependencies
-      run: |
-        iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
-        .\install-scoop.ps1 -RunAsAdmin
-        echo "LIBCLANG_PATH=$($HOME)/scoop/apps/llvm/current/bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        scoop install llvm yasm
-        vcpkg integrate install
-        vcpkg install openssl:x64-windows-static
-    - if: matrix.os == 'ubuntu-22.04'
-      name: Build linux portable
-      run: |
-        export PWD_DIR=$(pwd)
-        curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
-        tar -xzf openssl-1.1.1s.tar.gz
-        cd openssl-1.1.1s
-        ./Configure linux-x86_64 shared
-        make
-        cd ..
-        export OPENSSL_LIB_DIR=${PWD_DIR}/openssl-1.1.1s
-        export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
-        export OPENSSL_STATIC=1
-        cargo build --release --locked --features portable
-    - if: matrix.os == 'ubuntu-22.04-arm'
-      name: Build aarch64 linux portable
-      run: |
-        export PWD_DIR=$(pwd)
-        curl -LO https://www.openssl.org/source/openssl-1.1.1s.tar.gz
-        tar -xzf openssl-1.1.1s.tar.gz
-        cd openssl-1.1.1s
-        ./Configure linux-aarch64 shared
-        make
-        cd ..
-        export OPENSSL_LIB_DIR=${PWD_DIR}/openssl-1.1.1s
-        export OPENSSL_INCLUDE_DIR=${PWD_DIR}/openssl-1.1.1s/include
-        export OPENSSL_STATIC=1
-        cargo build --release --locked --features portable
-    - if: matrix.os == 'ubuntu-24.04'
-      name: Build linux
-      run: cargo build --release --locked
-    - if: startsWith(matrix.os, 'macos-15')
-      name: Build macos portable
-      run: cargo build --release --locked --features portable
-    - if: matrix.os == 'windows-2022'
-      name: Build windows
-      env:
-        RUSTFLAGS: -C target-feature=+crt-static
-      run: cargo build --release --locked
-    - if: matrix.os == 'windows-2022'
-      name: Smoke test windows store open
-      run: |
-        $smokeDir = Join-Path $env:RUNNER_TEMP "fnn-smoke"
-        Remove-Item $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
-        New-Item -ItemType Directory -Path (Join-Path $smokeDir "fiber\store") -Force | Out-Null
-        $env:FIBER_SECRET_KEY_PASSWORD = "ci-smoke-test"
-        $output = & target\release\fnn.exe --check-validate -c config\testnet\config.yml -d $smokeDir 2>&1
-        $exitCode = $LASTEXITCODE
-        $output | Write-Output
-        if ($exitCode -eq 0) { exit 0 }
-        if ($exitCode -eq 1 -and $output -match "db validate failed") { exit 0 }
-        throw "Windows store smoke test failed with exit code $exitCode"
     - name: Get the Version
       id: get_version
       shell: bash
       run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
-    - id: get_package
-      name: Package
-      shell: bash
-      run: |
-        pkgname="fnn_${{ steps.get_version.outputs.VERSION }}-${{ matrix.pkg_suffix }}.tar.gz"
-        cp "target/release/fnn${{ matrix.bin_suffix }}" "fnn${{ matrix.bin_suffix }}"
-        cp "target/release/fnn-cli${{ matrix.bin_suffix }}" "fnn-cli${{ matrix.bin_suffix }}"
-        tar czvf "${pkgname}" "fnn${{ matrix.bin_suffix }}" "fnn-cli${{ matrix.bin_suffix }}" "config"
-        echo "PKGNAME=${pkgname}" >> $GITHUB_OUTPUT
+    - id: package
+      name: Build release package
+      uses: ./.github/actions/build-release-package
+      with:
+        os: ${{ matrix.os }}
+        package-name: fnn_${{ steps.get_version.outputs.VERSION }}-${{ matrix.pkg_suffix }}.tar.gz
+        bin-suffix: ${{ matrix.bin_suffix }}
+        portable: ${{ matrix.portable }}
+        openssl-configure: ${{ matrix.openssl_configure }}
+        windows-dependencies: ${{ matrix.os == 'windows-2022' && 'release' || 'none' }}
     - name: Upload Release Asset
       uses: softprops/action-gh-release@v1
       env:
@@ -155,7 +106,7 @@ jobs:
       with:
         draft: true
         files: |
-          ${{ steps.get_package.outputs.PKGNAME }}
+          ${{ steps.package.outputs.package_name }}
   release-docker-build:
     name: Build & Publish Docker Image (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION

Fixes #1344.

## Summary

- Build Windows release binaries with the MSVC CRT statically linked by switching the vcpkg OpenSSL triplet from `x64-windows-static-md` to `x64-windows-static` and setting `RUSTFLAGS=-C target-feature=+crt-static`.
- Mirror the same static-CRT configuration in the Windows CI build so the release path is continuously covered.
- Add a Windows store-open smoke test that runs `fnn.exe --check-validate` against an empty store, catching process crashes before packaging a release.

## Root Cause

The Windows release workflow built on `windows-2022` with `openssl:x64-windows-static-md` and Rust MSVC defaults. That combination statically linked OpenSSL but dynamically linked the MSVC C runtime, so `fnn.exe` depended on a sufficiently new system-wide `MSVCP140.dll` / `VCRUNTIME140.dll`. On machines with older VC++ Redistributable versions, the binary could crash with `0xC0000005` when startup first opened RocksDB.

## Validation

- `rtk git diff --check upstream/develop...HEAD`
- `rtk ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- Local smoke command using `target/debug/fnn --check-validate` against an empty store, confirming the command reaches the database validation path and returns a Rust-level validation error instead of failing before store open.



## Release test triggers

#windows-release-test
