### PR TITLE
[Draft] Split channel state into immutable/mutable data

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -10085,6 +10085,7 @@ mod tests {
             ephemeral_config: ChannelEphemeralConfig::default(),
             funding_abort_detail: None,
             private_key: None,
+            needs_backup: false,
         }
     }
 

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -11196,6 +11196,7 @@ mod udt_funding_cell_capacity_tests {
             ephemeral_config: Default::default(),
             private_key: None,
             funding_abort_detail: None,
+            needs_backup: false,
         }
     }
 

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -30,6 +30,7 @@ use fiber_store::db_migrate::DbMigrate;
 use fiber_store::migration::{
     MigrateConfirmFn, MigrateProgressFn, INIT_DB_VERSION, MIGRATION_VERSION_KEY,
 };
+use fiber_types::channel::ChannelImmutableData;
 use fiber_types::schema::*;
 #[cfg(not(target_arch = "wasm32"))]
 use fiber_types::CchOrder;
@@ -747,8 +748,43 @@ impl ChannelActorStateStore for Store {
             let kv = KeyValue::OutPointChannelId(outpoint, state.id);
             batch.put(kv.key(), kv.value());
         }
+
+        // Extract immutable data before state is consumed by KeyValue.
+        let immutable = ChannelImmutableData {
+            local_pubkey: state.local_pubkey,
+            remote_pubkey: state.remote_pubkey,
+            id: state.id,
+            funding_tx: state.funding_tx.clone(),
+            funding_tx_confirmed_at: state.funding_tx_confirmed_at.clone(),
+            funding_udt_type_script: state.funding_udt_type_script.clone(),
+            is_acceptor: state.is_acceptor,
+            is_one_way: state.is_one_way,
+            local_reserved_ckb_amount: state.local_reserved_ckb_amount,
+            remote_reserved_ckb_amount: state.remote_reserved_ckb_amount,
+            commitment_fee_rate: state.commitment_fee_rate,
+            commitment_delay_epoch: state.commitment_delay_epoch,
+            funding_fee_rate: state.funding_fee_rate,
+            signer: state.signer.clone(),
+            local_channel_public_keys: state.local_channel_public_keys.clone(),
+            local_constraints: state.local_constraints.clone(),
+            remote_constraints: state.remote_constraints.clone(),
+            remote_shutdown_script: state.remote_shutdown_script.clone(),
+            local_shutdown_script: state.local_shutdown_script.clone(),
+            created_at: state.created_at,
+        };
+
         let kv = KeyValue::ChannelActorState(state.id, state);
         batch.put(kv.key(), kv.value());
+
+        // Write immutable data under a separate prefix for future optimization.
+        let immutable_key = [&[CHANNEL_IMMUTABLE_DATA_PREFIX], immutable.id.as_ref()].concat();
+        if self.get(&immutable_key).is_none() {
+            batch.put(
+                immutable_key,
+                serialize_to_vec(&immutable, "ChannelImmutableData"),
+            );
+        }
+
         batch.commit();
     }
 
@@ -766,8 +802,41 @@ impl ChannelActorStateStore for Store {
             let kv = KeyValue::OutPointChannelId(outpoint, state.id);
             batch.put(kv.key(), kv.value());
         }
+
+        // Extract immutable data before state is consumed by KeyValue.
+        let immutable = ChannelImmutableData {
+            local_pubkey: state.local_pubkey,
+            remote_pubkey: state.remote_pubkey,
+            id: state.id,
+            funding_tx: state.funding_tx.clone(),
+            funding_tx_confirmed_at: state.funding_tx_confirmed_at.clone(),
+            funding_udt_type_script: state.funding_udt_type_script.clone(),
+            is_acceptor: state.is_acceptor,
+            is_one_way: state.is_one_way,
+            local_reserved_ckb_amount: state.local_reserved_ckb_amount,
+            remote_reserved_ckb_amount: state.remote_reserved_ckb_amount,
+            commitment_fee_rate: state.commitment_fee_rate,
+            commitment_delay_epoch: state.commitment_delay_epoch,
+            funding_fee_rate: state.funding_fee_rate,
+            signer: state.signer.clone(),
+            local_channel_public_keys: state.local_channel_public_keys.clone(),
+            local_constraints: state.local_constraints.clone(),
+            remote_constraints: state.remote_constraints.clone(),
+            remote_shutdown_script: state.remote_shutdown_script.clone(),
+            local_shutdown_script: state.local_shutdown_script.clone(),
+            created_at: state.created_at,
+        };
+
         let kv = KeyValue::ChannelActorState(state.id, state);
         batch.put(kv.key(), kv.value());
+
+        let immutable_key = [&[CHANNEL_IMMUTABLE_DATA_PREFIX], channel_id.as_ref()].concat();
+        if self.get(&immutable_key).is_none() {
+            batch.put(
+                immutable_key,
+                serialize_to_vec(&immutable, "ChannelImmutableData"),
+            );
+        }
 
         let key = [&[PENDING_COMMIT_DIFF_PREFIX], channel_id.as_ref()].concat();
         batch.put(key, serialize_to_vec(diff, "CommitDiff"));

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -1463,6 +1463,36 @@ impl PendingNotifySettleTlc {
     }
 }
 
+/// Immutable channel parameters set during channel opening and never changed.
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ChannelImmutableData {
+    pub local_pubkey: Pubkey,
+    pub remote_pubkey: Pubkey,
+    pub id: Hash256,
+    #[serde_as(as = "Option<EntityHex>")]
+    pub funding_tx: Option<Transaction>,
+    pub funding_tx_confirmed_at: Option<(H256, u32, u64)>,
+    #[serde_as(as = "Option<EntityHex>")]
+    pub funding_udt_type_script: Option<Script>,
+    pub is_acceptor: bool,
+    pub is_one_way: bool,
+    pub local_reserved_ckb_amount: u64,
+    pub remote_reserved_ckb_amount: u64,
+    pub commitment_fee_rate: u64,
+    pub commitment_delay_epoch: u64,
+    pub funding_fee_rate: u64,
+    pub signer: InMemorySigner,
+    pub local_channel_public_keys: ChannelBasePublicKeys,
+    pub local_constraints: ChannelConstraints,
+    pub remote_constraints: ChannelConstraints,
+    #[serde_as(as = "Option<EntityHex>")]
+    pub remote_shutdown_script: Option<Script>,
+    #[serde_as(as = "EntityHex")]
+    pub local_shutdown_script: Script,
+    pub created_at: SystemTime,
+}
+
 /// The core serializable state of a channel actor.
 ///
 /// This struct contains all the persistable fields of a channel.

--- a/crates/fiber-types/src/schema.rs
+++ b/crates/fiber-types/src/schema.rs
@@ -40,6 +40,7 @@ pub const ATTEMPT_CHANNEL_INDEX_PREFIX: u8 = 196;
 pub const HOLD_TLC_PREFIX: u8 = 197;
 // A shared prefix for watchtower and channel store
 pub const WATCHTOWER_TLC_SETTLED_PREFIX: u8 = 200;
+pub const CHANNEL_IMMUTABLE_DATA_PREFIX: u8 = 208;
 pub const CHANNEL_OPEN_RECORD_PREFIX: u8 = 201;
 #[cfg(feature = "watchtower")]
 mod watchtower {


### PR DESCRIPTION
## Summary
This is a draft PR showing the direction for reducing serialization overhead in ChannelActorState.

### Changes
- Added `ChannelImmutableData` struct in `fiber-types` containing fields that never change after channel opening (pubkeys, fee rates, constraints, etc.)
- Added `CHANNEL_IMMUTABLE_DATA_PREFIX = 208` in store schema
- Modified `insert_channel_actor_state` and `insert_channel_actor_state_with_pending_commit_diff` to write immutable data under a separate prefix on first write only

### Next steps (not in this draft)
- Skip serializing immutable fields in the main `ChannelActorData` key
- Use the separate immutable key when reading channel state
- Add migration for existing records

### Why
Each `insert_channel_actor_state` call serializes ~immutable fields every time state changes, wasting serialization/IO overhead. By storing them once under a separate prefix, these fields can be skipped on subsequent writes.