### PR TITLE
fix: initialize channel state backup flag in tests

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -10085,6 +10085,7 @@ mod tests {
             ephemeral_config: ChannelEphemeralConfig::default(),
             funding_abort_detail: None,
             private_key: None,
+            needs_backup: false,
         }
     }
 

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -11196,6 +11196,7 @@ mod udt_funding_cell_capacity_tests {
             ephemeral_config: Default::default(),
             private_key: None,
             funding_abort_detail: None,
+            needs_backup: false,
         }
     }
 


### PR DESCRIPTION
## Summary
- Initialize the runtime-only `needs_backup` flag in two test `ChannelActorState` fixtures.
- Fix CI compile failures in test, clippy, and channel restart stress jobs after the backup/restore PR.

## Test Plan
- [x] `cargo test --no-run --message-format short`
- [x] `cargo test --no-run --message-format short --package fnn --lib --features rocksdb`
- [x] `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- [x] `cargo fmt --all -- --check`