### PR TITLE
test: add start_for_test method for RootActor

### DIFF
--- a/crates/fiber-lib/src/actors.rs
+++ b/crates/fiber-lib/src/actors.rs
@@ -1,4 +1,6 @@
 use ractor::{Actor, ActorProcessingErr, ActorRef, SupervisionEvent};
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{debug, error};
 
@@ -11,19 +13,35 @@ pub struct RootActor;
 
 pub type RootActorMessage = String;
 
+#[cfg(test)]
+static NEXT_TEST_ROOT_ACTOR_ID: AtomicU64 = AtomicU64::new(0);
+
 impl RootActor {
     pub async fn start(
         tracker: TaskTracker,
         token: CancellationToken,
     ) -> ActorRef<RootActorMessage> {
-        Actor::spawn(
-            Some("root actor".to_string()),
-            RootActor {},
-            (tracker, token),
-        )
-        .await
-        .expect("start root actor")
-        .0
+        Self::start_named(Some("root actor".to_string()), tracker, token).await
+    }
+
+    async fn start_named(
+        name: Option<String>,
+        tracker: TaskTracker,
+        token: CancellationToken,
+    ) -> ActorRef<RootActorMessage> {
+        Actor::spawn(name, RootActor {}, (tracker, token))
+            .await
+            .expect("start root actor")
+            .0
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn start_for_test(
+        tracker: TaskTracker,
+        token: CancellationToken,
+    ) -> ActorRef<RootActorMessage> {
+        let id = NEXT_TEST_ROOT_ACTOR_ID.fetch_add(1, Ordering::Relaxed);
+        Self::start_named(Some(format!("test root actor {id}")), tracker, token).await
     }
 }
 
@@ -119,7 +137,7 @@ mod tests {
 
     #[tokio::test]
     async fn root_actor_does_not_panic_when_linked_child_fails() {
-        let root = RootActor::start(TaskTracker::new(), CancellationToken::new()).await;
+        let root = RootActor::start_for_test(TaskTracker::new(), CancellationToken::new()).await;
         let (child, _) = Actor::spawn_linked(
             Some("panicking child".to_string()),
             PanickingActor,

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -1550,7 +1550,7 @@ mod store_actor_tests {
         let temp_dir = tempdir().unwrap();
 
         let (tracker, token) = (new_tokio_task_tracker(), new_tokio_cancellation_token());
-        let root_actor = RootActor::start(tracker, token).await;
+        let root_actor = RootActor::start_for_test(tracker, token).await;
 
         let args = StoreActorInitializationParameter {
             store: mock_store,
@@ -1588,7 +1588,7 @@ mod store_actor_tests {
         };
         let temp_dir = tempdir().unwrap();
         let (tracker, token) = (new_tokio_task_tracker(), new_tokio_cancellation_token());
-        let root_actor = RootActor::start(tracker, token).await;
+        let root_actor = RootActor::start_for_test(tracker, token).await;
 
         let (store_actor, _) = ractor::Actor::spawn_linked(
             None,


### PR DESCRIPTION
Coverage testing is failing with root actor name conflicted:

https://github.com/nervosnetwork/fiber/actions/runs/28865446635/job/85629479945