### PR TITLE
fix: recover CCH LND payments after restart

### DIFF
--- a/crates/fiber-lib/src/cch/actions/mod.rs
+++ b/crates/fiber-lib/src/cch/actions/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod backend_dispatchers;
 pub(crate) mod send_outgoing_payment;
 pub(crate) mod settle_incoming_invoice;
 pub(crate) mod track_incoming_invoice;
-mod track_outgoing_payment;
+pub(crate) mod track_outgoing_payment;
 use fiber_types::{CchOrder, CchOrderStatus};
 use send_outgoing_payment::SendOutgoingPaymentDispatcher;
 use settle_incoming_invoice::SettleIncomingInvoiceDispatcher;

--- a/crates/fiber-lib/src/cch/actions/track_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/track_outgoing_payment.rs
@@ -1,18 +1,55 @@
-use fiber_types::CchOrder;
+use anyhow::Result;
+use fiber_types::{CchOrder, CchOrderStatus, Hash256};
 use ractor::ActorRef;
 
-use crate::cch::{actions::ActionExecutor, actor::CchState, CchMessage, CchOrderStore};
+use crate::cch::{
+    actions::{
+        backend_dispatchers::{dispatch_payment_handler, PaymentHandlerType},
+        ActionExecutor,
+    },
+    actor::CchState,
+    trackers::LndTrackerMessage,
+    CchMessage, CchOrderStore,
+};
 
 pub struct TrackOutgoingPaymentDispatcher;
 
+struct TrackLightningOutgoingPaymentExecutor {
+    payment_hash: Hash256,
+    lnd_tracker_ref: ActorRef<LndTrackerMessage>,
+}
+
+#[async_trait::async_trait]
+impl ActionExecutor for TrackLightningOutgoingPaymentExecutor {
+    async fn execute(self: Box<Self>) -> Result<()> {
+        self.lnd_tracker_ref
+            .send_message(LndTrackerMessage::TrackPayment(self.payment_hash))?;
+        Ok(())
+    }
+}
+
 impl TrackOutgoingPaymentDispatcher {
+    pub fn should_dispatch(order: &CchOrder) -> bool {
+        matches!(
+            order.status,
+            CchOrderStatus::IncomingAccepted | CchOrderStatus::OutgoingInFlight
+        ) && dispatch_payment_handler(order) == PaymentHandlerType::Lightning
+    }
+
     pub fn dispatch<S: CchOrderStore>(
-        _state: &CchState<S>,
+        state: &CchState<S>,
         _cch_actor_ref: &ActorRef<CchMessage>,
-        _order: &CchOrder,
+        order: &CchOrder,
         _retry_count: u32,
     ) -> Option<Box<dyn ActionExecutor>> {
-        // `CchActor` will track all fiber payments, so there's nothing to do here to track a single payment.
-        None
+        if !Self::should_dispatch(order) {
+            // `CchActor` already tracks all Fiber payments through store changes.
+            return None;
+        }
+
+        Some(Box::new(TrackLightningOutgoingPaymentExecutor {
+            payment_hash: order.payment_hash,
+            lnd_tracker_ref: state.lnd_tracker.clone(),
+        }))
     }
 }

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -20,7 +20,7 @@ use crate::cch::order::CchOrderStateMachine;
 use crate::cch::scheduler::{CchOrderSchedulerActor, SchedulerArgs, SchedulerMessage};
 use crate::cch::trackers::{
     CchTrackingEvent, LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage,
-    RedactedCchTrackingEvent,
+    PaymentTrackingReservationResult, RedactedCchTrackingEvent, MAX_TRACKED_PAYMENTS,
 };
 use crate::cch::{CchConfig, CchError, CchOrderStore, CchStoreError};
 use crate::ckb::contracts::{get_script_by_contract, Contract};
@@ -276,6 +276,16 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 state.schedule_job_for_final_order(&order);
                 tracing::info!("Marked expired order {:x} as Failed", payment_hash);
                 continue;
+            }
+
+            if matches!(&order.incoming_invoice, CchInvoice::Fiber(_)) {
+                // Restore reservations before dispatching payment tracking. Orders created before
+                // the admission limit remain recoverable even when they exceed the new limit.
+                state
+                    .lnd_tracker
+                    .send_message(LndTrackerMessage::RestorePaymentTracking(
+                        order.payment_hash,
+                    ))?;
             }
 
             // Schedule expiry job for non-final orders
@@ -645,24 +655,49 @@ impl<S: CchOrderStore> CchState<S> {
             invoice_builder.build()
         }?;
 
-        let invoice = self.fiber_agent_ref.call_add_invoice(invoice).await?;
+        let reservation = ractor::call!(self.lnd_tracker, |reply| {
+            LndTrackerMessage::ReservePaymentTracking(payment_hash, reply)
+        })
+        .map_err(|err| CchError::LndPaymentTrackerError(err.to_string()))?;
+        match reservation {
+            PaymentTrackingReservationResult::Reserved => {}
+            PaymentTrackingReservationResult::AlreadyTracked => {
+                return Err(CchError::LndPaymentAlreadyTracked(payment_hash));
+            }
+            PaymentTrackingReservationResult::CapacityExceeded => {
+                return Err(CchError::LndPaymentTrackerCapacityExceeded(
+                    MAX_TRACKED_PAYMENTS,
+                ));
+            }
+        }
 
-        let order = CchOrder {
-            amount_sats: invoice_amount_sats,
-            created_at: order_created_at,
-            expiry_delta_seconds: self.config.order_expiry_delta_seconds,
-            failure_reason: None,
-            incoming_invoice: CchInvoice::Fiber(invoice),
-            outgoing_pay_req: send_btc.btc_pay_req,
-            payment_preimage: None,
-            status: CchOrderStatus::Pending,
-            fee_sats,
-            payment_hash,
-            wrapped_btc_type_script,
+        let result = async {
+            let invoice = self.fiber_agent_ref.call_add_invoice(invoice).await?;
+
+            let order = CchOrder {
+                amount_sats: invoice_amount_sats,
+                created_at: order_created_at,
+                expiry_delta_seconds: self.config.order_expiry_delta_seconds,
+                failure_reason: None,
+                incoming_invoice: CchInvoice::Fiber(invoice),
+                outgoing_pay_req: send_btc.btc_pay_req,
+                payment_preimage: None,
+                status: CchOrderStatus::Pending,
+                fee_sats,
+                payment_hash,
+                wrapped_btc_type_script,
+            };
+
+            self.store.insert_cch_order(order.clone())?;
+            Ok(order)
         };
-
-        self.store.insert_cch_order(order.clone())?;
-        Ok(order)
+        let result = result.await;
+        if result.is_err() {
+            let _ = self
+                .lnd_tracker
+                .send_message(LndTrackerMessage::StopTrackingPayment(payment_hash));
+        }
+        result
     }
 
     async fn receive_btc(&self, receive_btc: ReceiveBTC) -> Result<CchOrder, CchError> {

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -501,6 +501,12 @@ impl<S: CchOrderStore> CchState<S> {
 
     fn schedule_job_on_entering(&self, order: &CchOrder) {
         if order.is_final() {
+            // A final order no longer needs its dedicated LND payment stream. This
+            // also covers terminal transitions triggered by the incoming invoice
+            // or another tracker before the per-payment stream completes.
+            let _ = self
+                .lnd_tracker
+                .send_message(LndTrackerMessage::StopTrackingPayment(order.payment_hash));
             self.schedule_job_for_final_order(order);
         } else {
             self.schedule_job_for_non_final_order(order);

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -81,6 +81,12 @@ pub enum CchError {
     LndChannelError(#[from] lnd_grpc_tonic_client::channel::Error),
     #[error("Lnd RPC error: {0}")]
     LndRpcError(String),
+    #[error("LND payment tracker error: {0}")]
+    LndPaymentTrackerError(String),
+    #[error("LND payment is already tracked: {0}")]
+    LndPaymentAlreadyTracked(Hash256),
+    #[error("LND payment tracker capacity exceeded (maximum {0})")]
+    LndPaymentTrackerCapacityExceeded(usize),
     #[error("Fiber node error: {0}")]
     FiberNodeError(anyhow::Error),
 }

--- a/crates/fiber-lib/src/cch/scheduler.rs
+++ b/crates/fiber-lib/src/cch/scheduler.rs
@@ -290,6 +290,9 @@ impl<S: CchOrderStore> SchedulerState<S> {
         order.status = CchOrderStatus::Failed;
         order.failure_reason = Some("Order expired".to_string());
         self.store.update_cch_order(order);
+        let _ = self
+            .lnd_tracker
+            .send_message(LndTrackerMessage::StopTrackingPayment(payment_hash));
         tracing::info!("Expired order {:x}", payment_hash);
 
         // Schedule prune job for this expired order
@@ -324,6 +327,9 @@ impl<S: CchOrderStore> SchedulerState<S> {
         let _ = self
             .lnd_tracker
             .send_message(LndTrackerMessage::StopTracking(payment_hash));
+        let _ = self
+            .lnd_tracker
+            .send_message(LndTrackerMessage::StopTrackingPayment(payment_hash));
 
         // Delete order from store
         self.store.delete_cch_order(&payment_hash);

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -16,7 +16,7 @@ use crate::cch::{
         DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS, DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS,
     },
     order::CchOrderStore,
-    trackers::CchTrackingEvent,
+    trackers::{CchTrackingEvent, MAX_TRACKED_PAYMENTS},
     CchConfig, CchError, CchStoreError,
 };
 use crate::fiber::{
@@ -25,7 +25,9 @@ use crate::fiber::{
     payment::{PaymentSessionExt, SendPaymentCommand, SendPaymentDataBuilder},
     NetworkActorCommand, NetworkActorMessage,
 };
-use crate::invoice::{Attribute, CkbInvoice, CkbInvoiceStatus, Currency, InvoiceData};
+use crate::invoice::{
+    Attribute, CkbInvoice, CkbInvoiceStatus, Currency, InvoiceData, InvoiceError,
+};
 use crate::store::{store_impl::StoreChange, Store};
 use crate::tests::test_utils::{generate_store, TempDir};
 use crate::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -37,7 +39,10 @@ use ractor::{call, port::OutputPortSubscriberTrait, Actor, ActorRef, OutputPort}
 use secp256k1::{Secp256k1, SecretKey};
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 /// Bitcoin block interval in seconds (see [`BTC_BLOCK_TIME_MILLIS`] in `cch::actor`).
@@ -132,6 +137,8 @@ struct MockNetworkState {
     sent_fiber_payment_fees: Arc<Mutex<std::collections::HashMap<Hash256, Option<u128>>>>,
     /// Status returned by mocked outgoing Fiber SendPayment.
     send_payment_status: Arc<Mutex<PaymentStatus>>,
+    /// Makes mocked Fiber invoice creation fail after payment tracking was reserved.
+    fail_add_invoice: Arc<AtomicBool>,
 }
 
 /// Mock network actor that handles commands from action executors
@@ -160,8 +167,11 @@ impl Actor for MockNetworkActor {
         match message {
             NetworkActorMessage::Command(cmd) => match cmd {
                 NetworkActorCommand::AddInvoice(_invoice, _opt_hash, reply) => {
-                    // Accept all invoices
-                    let _ = reply.send(Ok(()));
+                    if state.fail_add_invoice.load(Ordering::SeqCst) {
+                        let _ = reply.send(Err(InvoiceError::InvoiceAlreadyExists));
+                    } else {
+                        let _ = reply.send(Ok(()));
+                    }
                 }
                 NetworkActorCommand::SendPayment(cmd, reply) => {
                     // Extract payment hash from invoice
@@ -383,8 +393,15 @@ impl TestHarness {
     /// Create a SendBTC order via CchMessage
     /// Returns both the order and the preimage that hashes to its payment hash
     async fn create_send_btc_order_with_preimage(&self) -> Result<(CchOrder, Hash256), CchError> {
+        self.create_send_btc_order_with_seed(200).await
+    }
+
+    async fn create_send_btc_order_with_seed(
+        &self,
+        seed: u8,
+    ) -> Result<(CchOrder, Hash256), CchError> {
         // Generate a valid preimage/payment hash pair first
-        let (preimage, payment_hash) = create_valid_preimage_pair(200);
+        let (preimage, payment_hash) = create_valid_preimage_pair(seed);
         let lightning_invoice = create_test_lightning_invoice_with_payment_hash(payment_hash);
         let btc_pay_req = lightning_invoice.to_string();
 
@@ -399,6 +416,12 @@ impl TestHarness {
         .expect("actor call failed")?;
 
         Ok((order, preimage))
+    }
+
+    fn set_add_invoice_failure(&self, fail: bool) {
+        self.mock_state
+            .fail_add_invoice
+            .store(fail, Ordering::SeqCst);
     }
 
     /// Insert an order directly into the database (for testing without LND)
@@ -496,6 +519,7 @@ async fn setup_test_harness_with_config_and_store(
         sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
         sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
         send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
+        fail_add_invoice: Arc::new(AtomicBool::new(false)),
     };
 
     let (network_actor, _) = Actor::spawn(None, MockNetworkActor, mock_state.clone())
@@ -541,6 +565,7 @@ async fn setup_store_backed_test_harness() -> StoreBackedTestHarness {
         sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
         sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
         send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
+        fail_add_invoice: Arc::new(AtomicBool::new(false)),
     };
 
     let (network_actor, _) = Actor::spawn(None, MockNetworkActor, mock_state.clone())
@@ -661,9 +686,99 @@ fn create_test_fiber_invoice_with_amount(payment_hash: Hash256, amount: u128) ->
     invoice
 }
 
+fn insert_pending_send_btc_orders(store: &MockCchOrderStore, count: usize) {
+    let current_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_secs();
+    for value in 0..count {
+        let payment_hash = test_payment_hash(value as u8);
+        store
+            .insert_cch_order(CchOrder {
+                created_at: current_time,
+                expiry_delta_seconds: 3600,
+                wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+                outgoing_pay_req: "restored send_btc order".to_string(),
+                incoming_invoice: CchInvoice::Fiber(create_test_fiber_invoice(payment_hash)),
+                payment_hash,
+                payment_preimage: None,
+                amount_sats: 100_000,
+                fee_sats: 1_000,
+                status: CchOrderStatus::Pending,
+                failure_reason: None,
+            })
+            .expect("insert pending send_btc order");
+    }
+}
+
 // =============================================================================
 // SendBTC Happy Path Test
 // =============================================================================
+
+#[tokio::test]
+async fn test_send_btc_rejects_when_payment_tracking_capacity_is_full() {
+    let store = MockCchOrderStore::new();
+    insert_pending_send_btc_orders(&store, MAX_TRACKED_PAYMENTS);
+    let harness = setup_test_harness_with_store(store).await;
+
+    let error = harness
+        .create_send_btc_order_with_seed(200)
+        .await
+        .expect_err("send_btc must reject orders above payment tracking capacity");
+    assert!(matches!(
+        error,
+        CchError::LndPaymentTrackerCapacityExceeded(MAX_TRACKED_PAYMENTS)
+    ));
+}
+
+#[tokio::test]
+async fn test_send_btc_releases_reservation_when_invoice_creation_fails() {
+    let store = MockCchOrderStore::new();
+    insert_pending_send_btc_orders(&store, MAX_TRACKED_PAYMENTS - 1);
+    let harness = setup_test_harness_with_store(store).await;
+
+    harness.set_add_invoice_failure(true);
+    harness
+        .create_send_btc_order_with_seed(200)
+        .await
+        .expect_err("mocked invoice creation must fail");
+
+    harness.set_add_invoice_failure(false);
+    harness
+        .create_send_btc_order_with_seed(201)
+        .await
+        .expect("failed invoice creation must release payment tracking capacity");
+}
+
+#[tokio::test]
+async fn test_final_send_btc_order_releases_payment_tracking_capacity() {
+    let store = MockCchOrderStore::new();
+    insert_pending_send_btc_orders(&store, MAX_TRACKED_PAYMENTS - 1);
+    let harness = setup_test_harness_with_store(store).await;
+
+    let (order, _) = harness
+        .create_send_btc_order_with_seed(200)
+        .await
+        .expect("last available payment tracking slot");
+    harness
+        .create_send_btc_order_with_seed(201)
+        .await
+        .expect_err("capacity must be full before the order becomes final");
+
+    harness.event_port.send(CchTrackingEvent::InvoiceChanged {
+        payment_hash: order.payment_hash,
+        status: CkbInvoiceStatus::Expired,
+        failure_reason: Some("test expiry".to_string()),
+    });
+    harness
+        .wait_for_order_status(order.payment_hash, CchOrderStatus::Failed, 1000)
+        .await;
+
+    harness
+        .create_send_btc_order_with_seed(201)
+        .await
+        .expect("final order must release payment tracking capacity");
+}
 
 /// Tests the complete happy path for a SendBTC order.
 ///

--- a/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
@@ -7,6 +7,7 @@ use crate::cch::actions::{
     send_outgoing_payment::SendOutgoingPaymentDispatcher,
     settle_incoming_invoice::SettleIncomingInvoiceDispatcher,
     track_incoming_invoice::TrackIncomingInvoiceDispatcher,
+    track_outgoing_payment::TrackOutgoingPaymentDispatcher,
     ActionDispatcher, CchOrderAction,
 };
 use fiber_types::{CchInvoice, CchOrder, CchOrderStatus, Hash256};
@@ -293,6 +294,22 @@ fn test_track_incoming_invoice_should_not_dispatch_when_success() {
 fn test_track_incoming_invoice_should_not_dispatch_when_failed() {
     let order = create_order_with_lightning_invoice(CchOrderStatus::Failed);
     assert!(!TrackIncomingInvoiceDispatcher::should_dispatch(&order));
+}
+
+// =============================================================================
+// TrackOutgoingPaymentDispatcher::should_dispatch tests
+// =============================================================================
+
+#[test]
+fn test_track_outgoing_payment_dispatches_for_lightning_payment() {
+    let order = create_order_with_fiber_invoice(CchOrderStatus::OutgoingInFlight);
+    assert!(TrackOutgoingPaymentDispatcher::should_dispatch(&order));
+}
+
+#[test]
+fn test_track_outgoing_payment_does_not_dispatch_for_fiber_payment() {
+    let order = create_order_with_lightning_invoice(CchOrderStatus::OutgoingInFlight);
+    assert!(!TrackOutgoingPaymentDispatcher::should_dispatch(&order));
 }
 
 // =============================================================================

--- a/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
@@ -180,3 +180,63 @@ async fn test_timeout_requeues_active_invoices() {
     assert_eq!(final_state.invoice_queue_len, 0);
     assert_eq!(final_state.active_invoice_trackers, 1);
 }
+
+#[tokio::test]
+async fn test_duplicate_payment_tracking_is_idempotent() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(7);
+
+    actor_ref
+        .cast(LndTrackerMessage::TrackPayment(payment_hash))
+        .expect("Failed to send first TrackPayment");
+    actor_ref
+        .cast(LndTrackerMessage::TrackPayment(payment_hash))
+        .expect("Failed to send duplicate TrackPayment");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Failed to get state")
+        .expect("Failed to get state");
+    assert_eq!(state.active_payment_trackers, 1);
+}
+
+#[tokio::test]
+async fn test_payment_tracker_completion_and_cancellation_cleanup_state() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let completed_hash = test_payment_hash(8);
+    let cancelled_hash = test_payment_hash(9);
+
+    actor_ref
+        .cast(LndTrackerMessage::TrackPayment(completed_hash))
+        .expect("Failed to track completed payment");
+    actor_ref
+        .cast(LndTrackerMessage::TrackPayment(cancelled_hash))
+        .expect("Failed to track cancelled payment");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    actor_ref
+        .cast(LndTrackerMessage::PaymentTrackerCompleted {
+            payment_hash: completed_hash,
+            tracker_id: 0,
+        })
+        .expect("Failed to complete payment tracker");
+    actor_ref
+        .cast(LndTrackerMessage::StopTrackingPayment(cancelled_hash))
+        .expect("Failed to cancel payment tracker");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Failed to get state")
+        .expect("Failed to get state");
+    assert_eq!(state.active_payment_trackers, 0);
+}

--- a/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::cch::trackers::{LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage};
+use crate::cch::trackers::{
+    LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage,
+    PaymentTrackingReservationResult, MAX_TRACKED_PAYMENTS,
+};
 use fiber_types::Hash256;
 use ractor::{concurrency::Duration as RactorDuration, Actor, ActorRef, OutputPort};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -41,6 +44,104 @@ async fn create_test_actor() -> (ActorRef<LndTrackerMessage>, tokio::task::JoinH
         .expect("Failed to spawn test actor");
 
     (actor_ref, actor_handle)
+}
+
+async fn reserve_payment_tracking(
+    actor_ref: &ActorRef<LndTrackerMessage>,
+    payment_hash: Hash256,
+) -> PaymentTrackingReservationResult {
+    ractor::call!(actor_ref, |reply| {
+        LndTrackerMessage::ReservePaymentTracking(payment_hash, reply)
+    })
+    .expect("Failed to reserve payment tracking")
+}
+
+struct TestStateSnapshot {
+    payment_queue_len: usize,
+    active_payment_trackers: usize,
+    reserved_payment_trackers: usize,
+    tracked_payment_count: usize,
+}
+
+async fn get_state(actor_ref: &ActorRef<LndTrackerMessage>) -> TestStateSnapshot {
+    let state = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Failed to get state")
+        .expect("Failed to get state");
+    TestStateSnapshot {
+        payment_queue_len: state.payment_queue_len,
+        active_payment_trackers: state.active_payment_trackers,
+        reserved_payment_trackers: state.reserved_payment_trackers,
+        tracked_payment_count: state.tracked_payment_count,
+    }
+}
+
+#[tokio::test]
+async fn test_payment_tracking_reservation_enforces_global_limit() {
+    let (actor_ref, _handle) = create_test_actor().await;
+
+    for value in 0..MAX_TRACKED_PAYMENTS {
+        assert_eq!(
+            reserve_payment_tracking(&actor_ref, test_payment_hash(value as u8)).await,
+            PaymentTrackingReservationResult::Reserved
+        );
+    }
+    assert_eq!(
+        reserve_payment_tracking(&actor_ref, test_payment_hash(MAX_TRACKED_PAYMENTS as u8)).await,
+        PaymentTrackingReservationResult::CapacityExceeded
+    );
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.reserved_payment_trackers, MAX_TRACKED_PAYMENTS);
+    assert_eq!(state.tracked_payment_count, MAX_TRACKED_PAYMENTS);
+    assert_eq!(state.active_payment_trackers, 0);
+}
+
+#[tokio::test]
+async fn test_duplicate_payment_tracking_reservation_is_coalesced() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(1);
+
+    assert_eq!(
+        reserve_payment_tracking(&actor_ref, payment_hash).await,
+        PaymentTrackingReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_payment_tracking(&actor_ref, payment_hash).await,
+        PaymentTrackingReservationResult::AlreadyTracked
+    );
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.reserved_payment_trackers, 1);
+    assert_eq!(state.tracked_payment_count, 1);
+}
+
+#[tokio::test]
+async fn test_stopping_payment_reservation_releases_global_capacity() {
+    let (actor_ref, _handle) = create_test_actor().await;
+
+    for value in 0..MAX_TRACKED_PAYMENTS {
+        assert_eq!(
+            reserve_payment_tracking(&actor_ref, test_payment_hash(value as u8)).await,
+            PaymentTrackingReservationResult::Reserved
+        );
+    }
+
+    actor_ref
+        .cast(LndTrackerMessage::StopTrackingPayment(test_payment_hash(0)))
+        .expect("Failed to stop payment tracking");
+    assert_eq!(
+        reserve_payment_tracking(&actor_ref, test_payment_hash(MAX_TRACKED_PAYMENTS as u8)).await,
+        PaymentTrackingReservationResult::Reserved
+    );
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.reserved_payment_trackers, MAX_TRACKED_PAYMENTS);
+    assert_eq!(state.tracked_payment_count, MAX_TRACKED_PAYMENTS);
 }
 
 // Test completion decrements active_invoice_trackers counter
@@ -186,6 +287,10 @@ async fn test_duplicate_payment_tracking_is_idempotent() {
     let (actor_ref, _handle) = create_test_actor().await;
     let payment_hash = test_payment_hash(7);
 
+    assert_eq!(
+        reserve_payment_tracking(&actor_ref, payment_hash).await,
+        PaymentTrackingReservationResult::Reserved
+    );
     actor_ref
         .cast(LndTrackerMessage::TrackPayment(payment_hash))
         .expect("Failed to send first TrackPayment");
@@ -203,6 +308,42 @@ async fn test_duplicate_payment_tracking_is_idempotent() {
         .expect("Failed to get state")
         .expect("Failed to get state");
     assert_eq!(state.active_payment_trackers, 1);
+    assert_eq!(state.reserved_payment_trackers, 0);
+    assert_eq!(state.tracked_payment_count, 1);
+}
+
+#[tokio::test]
+async fn test_restored_payments_above_global_limit_are_queued() {
+    let (actor_ref, _handle) = create_test_actor().await;
+
+    for value in 0..=MAX_TRACKED_PAYMENTS {
+        let payment_hash = test_payment_hash(value as u8);
+        actor_ref
+            .cast(LndTrackerMessage::RestorePaymentTracking(payment_hash))
+            .expect("Failed to restore payment tracking");
+        actor_ref
+            .cast(LndTrackerMessage::TrackPayment(payment_hash))
+            .expect("Failed to track restored payment");
+    }
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state_before = get_state(&actor_ref).await;
+    assert_eq!(state_before.active_payment_trackers, MAX_TRACKED_PAYMENTS);
+    assert_eq!(state_before.payment_queue_len, 1);
+    assert_eq!(state_before.tracked_payment_count, MAX_TRACKED_PAYMENTS + 1);
+
+    actor_ref
+        .cast(LndTrackerMessage::PaymentTrackerCompleted {
+            payment_hash: test_payment_hash(0),
+            tracker_id: 0,
+        })
+        .expect("Failed to complete payment tracker");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state_after = get_state(&actor_ref).await;
+    assert_eq!(state_after.active_payment_trackers, MAX_TRACKED_PAYMENTS);
+    assert_eq!(state_after.payment_queue_len, 0);
+    assert_eq!(state_after.tracked_payment_count, MAX_TRACKED_PAYMENTS);
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -12,20 +12,23 @@
 //!
 //! ## Architecture
 //!
-//! The actor uses a message-passing model with two main message types:
+//! Tracking requests are submitted through these message types:
 //! - `TrackInvoice(Hash256)`: Adds invoice to tracking queue
 //! - `TrackPayment(Hash256)`: Starts an idempotent per-payment tracker
-//! - `InvoiceTrackerCompleted{...}`: Sent by spawned tracker tasks when they finish
 //!
-//! When a tracker task completes (successfully or with error), it ALWAYS sends
-//! `InvoiceTrackerCompleted` back to the actor. The actor maintains two data structures:
+//! Spawned tasks send completion messages back to the actor for lifecycle cleanup.
+//!
+//! When an invoice tracker task completes (successfully or with error), it ALWAYS sends
+//! `InvoiceTrackerCompleted` back to the actor. Invoice scheduling uses two data structures:
 //! - `invoice_queue`: VecDeque of pending invoice hashes
 //! - `active_invoice_trackers`: Number of active invoice trackers
 //!
-//! When completion message arrives:
+//! When an invoice completion message arrives:
 //! 1. Decrement `active_invoice_trackers` counter
 //! 2. Re-queue if failed
 //! 3. Dequeue invoices from the queue and start tracking
+//!
+//! Active payment trackers are keyed by payment hash and removed when their task completes.
 
 use std::{
     collections::{HashMap, VecDeque},
@@ -171,7 +174,8 @@ struct ActivePaymentTracker {
 /// It provides the following features:
 ///
 /// ## Payment Tracking
-/// - Automatically tracks all LND payments in the background
+/// - Tracks explicitly requested outgoing payments by payment hash
+/// - Deduplicates active trackers and reconnects until LND reports a terminal status
 /// - Sends `CchTrackingEvent::PaymentChanged` events to the output port
 ///
 /// ## Invoice Tracking
@@ -236,27 +240,15 @@ impl Actor for LndTrackerActor {
         args: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
         let state = LndTrackerState {
-            port: args.port.clone(),
-            lnd_connection: args.lnd_connection.clone(),
-            token: args.token.clone(),
-            tracker: args.tracker.clone(),
+            port: args.port,
+            lnd_connection: args.lnd_connection,
+            token: args.token,
+            tracker: args.tracker,
             invoice_queue: VecDeque::new(),
             active_invoice_trackers: 0,
             active_payment_trackers: HashMap::new(),
             next_payment_tracker_id: 0,
         };
-
-        // Keep the global tracker as a fast notification path. Per-payment trackers
-        // provide the reliable reconnect/restart recovery path for active orders.
-        let payment_tracker = AllPaymentsTracker {
-            port: args.port,
-            lnd_connection: args.lnd_connection,
-            token: args.token,
-        };
-
-        args.tracker.spawn(async move {
-            payment_tracker.run().await;
-        });
 
         Ok(state)
     }
@@ -465,68 +457,9 @@ impl LndTrackerState {
     }
 }
 
-/// Internal struct for tracking payments
-struct AllPaymentsTracker {
-    port: Arc<OutputPort<CchTrackingEvent>>,
-    lnd_connection: LndConnectionInfo,
-    token: CancellationToken,
-}
-
-impl AllPaymentsTracker {
-    async fn run(self) {
-        let token = self.token.clone();
-        let fut = self.run_loop();
-        token.run_until_cancelled(fut).await;
-    }
-
-    async fn run_loop(self) {
-        tracing::debug!("PaymentTracker: will connect {}", self.lnd_connection.uri);
-
-        while let Err(err) = self.run_once().await {
-            tracing::error!(
-                "Error tracking LND payments, retry 15 seconds later: {:?}",
-                err
-            );
-            sleep(Duration::from_secs(15)).await;
-        }
-    }
-
-    async fn run_once(&self) -> Result<()> {
-        let mut client = self.lnd_connection.create_router_client().await?;
-        let mut stream = client
-            .track_payments(routerrpc::TrackPaymentsRequest {
-                no_inflight_updates: true,
-            })
-            .await?
-            .into_inner();
-
-        loop {
-            match stream.next().await {
-                Some(Ok(payment)) => self.on_payment(payment).await?,
-                Some(Err(err)) => return Err(err.into()),
-                None => return Err(anyhow!("unexpected closed stream")),
-            }
-        }
-    }
-
-    async fn on_payment(&self, payment: lnrpc::Payment) -> Result<()> {
-        let payment_hash = payment.payment_hash.clone();
-        let status = payment.status();
-        let has_payment_preimage = !is_payment_preimage_empty(&payment.payment_preimage, status);
-        tracing::debug!(
-            "payment changed payment_hash={} status={:?} has_payment_preimage={}",
-            payment_hash,
-            status,
-            has_payment_preimage
-        );
-        self.port.send(map_lnd_payment_changed_event(payment)?);
-        Ok(())
-    }
-}
-
-/// Tracks one outgoing payment by hash. Unlike `TrackPayments`, `TrackPaymentV2`
-/// returns the current state of the requested payment after every reconnect,
-/// including a terminal state reached while CCH or LND was unavailable.
+/// Tracks one outgoing payment by hash. `TrackPaymentV2` returns the current state
+/// of the requested payment after every reconnect, including a terminal state
+/// reached while CCH or LND was unavailable.
 struct PaymentTracker {
     port: Arc<OutputPort<CchTrackingEvent>>,
     payment_hash: Hash256,

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -14,6 +14,7 @@
 //!
 //! The actor uses a message-passing model with two main message types:
 //! - `TrackInvoice(Hash256)`: Adds invoice to tracking queue
+//! - `TrackPayment(Hash256)`: Starts an idempotent per-payment tracker
 //! - `InvoiceTrackerCompleted{...}`: Sent by spawned tracker tasks when they finish
 //!
 //! When a tracker task completes (successfully or with error), it ALWAYS sends
@@ -26,7 +27,12 @@
 //! 2. Re-queue if failed
 //! 3. Dequeue invoices from the queue and start tracking
 
-use std::{collections::VecDeque, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, VecDeque},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{anyhow, Result};
 use futures::StreamExt as _;
@@ -93,8 +99,14 @@ pub enum LndTrackerMessage {
     /// Track a new invoice
     TrackInvoice(Hash256),
 
+    /// Track an outgoing payment by hash until LND reports a terminal status.
+    TrackPayment(Hash256),
+
     /// Stop tracking an invoice (remove from queue if not yet being tracked)
     StopTracking(Hash256),
+
+    /// Stop tracking an outgoing payment.
+    StopTrackingPayment(Hash256),
 
     /// Notification that an invoice tracker task has completed
     ///
@@ -103,6 +115,12 @@ pub enum LndTrackerMessage {
     InvoiceTrackerCompleted {
         payment_hash: Hash256,
         completed_successfully: bool,
+    },
+
+    /// Notification that a per-payment tracker task has terminated.
+    PaymentTrackerCompleted {
+        payment_hash: Hash256,
+        tracker_id: u64,
     },
 
     /// Get current state snapshot (for testing)
@@ -116,6 +134,7 @@ pub enum LndTrackerMessage {
 pub struct StateSnapshot {
     pub invoice_queue_len: usize,
     pub active_invoice_trackers: usize,
+    pub active_payment_trackers: usize,
 }
 
 /// Arguments for starting the LndTrackerActor
@@ -136,6 +155,14 @@ pub struct LndTrackerState {
     invoice_queue: VecDeque<Hash256>,
     /// Number of currently active invoice trackers
     active_invoice_trackers: usize,
+    /// Active per-payment trackers keyed by payment hash for idempotent dispatch.
+    active_payment_trackers: HashMap<Hash256, ActivePaymentTracker>,
+    next_payment_tracker_id: u64,
+}
+
+struct ActivePaymentTracker {
+    tracker_id: u64,
+    token: CancellationToken,
 }
 
 /// Ractor Actor to track LND payments and invoices
@@ -215,10 +242,13 @@ impl Actor for LndTrackerActor {
             tracker: args.tracker.clone(),
             invoice_queue: VecDeque::new(),
             active_invoice_trackers: 0,
+            active_payment_trackers: HashMap::new(),
+            next_payment_tracker_id: 0,
         };
 
-        // Start payment tracker in background
-        let payment_tracker = PaymentTracker {
+        // Keep the global tracker as a fast notification path. Per-payment trackers
+        // provide the reliable reconnect/restart recovery path for active orders.
+        let payment_tracker = AllPaymentsTracker {
             port: args.port,
             lnd_connection: args.lnd_connection,
             token: args.token,
@@ -243,10 +273,18 @@ impl Actor for LndTrackerActor {
                 state.process_invoice_queue(myself).await?;
                 Ok(())
             }
+            LndTrackerMessage::TrackPayment(payment_hash) => {
+                state.start_payment_tracker(myself, payment_hash);
+                Ok(())
+            }
             LndTrackerMessage::StopTracking(payment_hash) => {
                 // Remove from queue if present
                 state.invoice_queue.retain(|&hash| hash != payment_hash);
                 tracing::debug!("Stopped tracking invoice {:x}", payment_hash);
+                Ok(())
+            }
+            LndTrackerMessage::StopTrackingPayment(payment_hash) => {
+                state.stop_payment_tracker(&payment_hash);
                 Ok(())
             }
             LndTrackerMessage::InvoiceTrackerCompleted {
@@ -271,12 +309,20 @@ impl Actor for LndTrackerActor {
 
                 Ok(())
             }
+            LndTrackerMessage::PaymentTrackerCompleted {
+                payment_hash,
+                tracker_id,
+            } => {
+                state.complete_payment_tracker(&payment_hash, tracker_id);
+                Ok(())
+            }
 
             #[cfg(test)]
             LndTrackerMessage::GetState(reply_port) => {
                 let snapshot = StateSnapshot {
                     invoice_queue_len: state.invoice_queue.len(),
                     active_invoice_trackers: state.active_invoice_trackers,
+                    active_payment_trackers: state.active_payment_trackers.len(),
                 };
                 let _ = reply_port.send(snapshot);
                 Ok(())
@@ -297,6 +343,76 @@ impl Actor for LndTrackerActor {
 }
 
 impl LndTrackerState {
+    fn start_payment_tracker(
+        &mut self,
+        myself: ActorRef<LndTrackerMessage>,
+        payment_hash: Hash256,
+    ) {
+        if self.active_payment_trackers.contains_key(&payment_hash) {
+            tracing::debug!(
+                "Outgoing payment tracker already active for payment_hash={}",
+                payment_hash
+            );
+            return;
+        }
+
+        let tracker_id = self.next_payment_tracker_id;
+        self.next_payment_tracker_id = self.next_payment_tracker_id.wrapping_add(1);
+        let token = self.token.child_token();
+        self.active_payment_trackers.insert(
+            payment_hash,
+            ActivePaymentTracker {
+                tracker_id,
+                token: token.clone(),
+            },
+        );
+
+        let tracker = PaymentTracker {
+            port: self.port.clone(),
+            payment_hash,
+            lnd_connection: self.lnd_connection.clone(),
+            token,
+        };
+        self.tracker.spawn(async move {
+            tracker.run().await;
+            let _ = myself.send_message(LndTrackerMessage::PaymentTrackerCompleted {
+                payment_hash,
+                tracker_id,
+            });
+        });
+        tracing::debug!(
+            "Started outgoing payment tracker for payment_hash={} tracker_id={}",
+            payment_hash,
+            tracker_id
+        );
+    }
+
+    fn stop_payment_tracker(&mut self, payment_hash: &Hash256) {
+        if let Some(active_tracker) = self.active_payment_trackers.remove(payment_hash) {
+            active_tracker.token.cancel();
+            tracing::debug!(
+                "Stopped outgoing payment tracker for payment_hash={} tracker_id={}",
+                payment_hash,
+                active_tracker.tracker_id
+            );
+        }
+    }
+
+    fn complete_payment_tracker(&mut self, payment_hash: &Hash256, tracker_id: u64) {
+        let is_current_tracker = self
+            .active_payment_trackers
+            .get(payment_hash)
+            .is_some_and(|tracker| tracker.tracker_id == tracker_id);
+        if is_current_tracker {
+            self.active_payment_trackers.remove(payment_hash);
+            tracing::debug!(
+                "Completed outgoing payment tracker for payment_hash={} tracker_id={}",
+                payment_hash,
+                tracker_id
+            );
+        }
+    }
+
     async fn process_invoice_queue(
         &mut self,
         myself: ActorRef<LndTrackerMessage>,
@@ -350,13 +466,13 @@ impl LndTrackerState {
 }
 
 /// Internal struct for tracking payments
-struct PaymentTracker {
+struct AllPaymentsTracker {
     port: Arc<OutputPort<CchTrackingEvent>>,
     lnd_connection: LndConnectionInfo,
     token: CancellationToken,
 }
 
-impl PaymentTracker {
+impl AllPaymentsTracker {
     async fn run(self) {
         let token = self.token.clone();
         let fut = self.run_loop();
@@ -406,6 +522,82 @@ impl PaymentTracker {
         self.port.send(map_lnd_payment_changed_event(payment)?);
         Ok(())
     }
+}
+
+/// Tracks one outgoing payment by hash. Unlike `TrackPayments`, `TrackPaymentV2`
+/// returns the current state of the requested payment after every reconnect,
+/// including a terminal state reached while CCH or LND was unavailable.
+struct PaymentTracker {
+    port: Arc<OutputPort<CchTrackingEvent>>,
+    payment_hash: Hash256,
+    lnd_connection: LndConnectionInfo,
+    token: CancellationToken,
+}
+
+impl PaymentTracker {
+    async fn run(self) {
+        let token = self.token.clone();
+        let fut = self.run_loop();
+        token.run_until_cancelled(fut).await;
+    }
+
+    async fn run_loop(&self) {
+        while let Err(err) = self.run_once().await {
+            tracing::error!(
+                "Error tracking outgoing LND payment {}, retry 15 seconds later: {:?}",
+                self.payment_hash,
+                err
+            );
+            sleep(Duration::from_secs(15)).await;
+        }
+        tracing::debug!(
+            "Outgoing payment tracker completed for payment_hash={}",
+            self.payment_hash
+        );
+    }
+
+    async fn run_once(&self) -> Result<()> {
+        let mut client = self.lnd_connection.create_router_client().await?;
+        let mut stream = client
+            .track_payment_v2(track_payment_request(self.payment_hash))
+            .await?
+            .into_inner();
+
+        loop {
+            match stream.next().await {
+                Some(Ok(payment)) => {
+                    if self.on_payment(payment).await? {
+                        return Ok(());
+                    }
+                }
+                Some(Err(err)) => return Err(err.into()),
+                None => return Err(anyhow!("unexpected closed stream")),
+            }
+        }
+    }
+
+    /// Emits every update and returns true once the payment is terminal.
+    async fn on_payment(&self, payment: lnrpc::Payment) -> Result<bool> {
+        let status = payment.status();
+        let is_terminal = is_lnd_payment_terminal(status);
+        let event = map_lnd_payment_changed_event(payment)?;
+        self.port.send(event);
+        Ok(is_terminal)
+    }
+}
+
+fn track_payment_request(payment_hash: Hash256) -> routerrpc::TrackPaymentRequest {
+    routerrpc::TrackPaymentRequest {
+        payment_hash: payment_hash.into(),
+        no_inflight_updates: false,
+    }
+}
+
+fn is_lnd_payment_terminal(status: lnrpc::payment::PaymentStatus) -> bool {
+    matches!(
+        status,
+        lnrpc::payment::PaymentStatus::Succeeded | lnrpc::payment::PaymentStatus::Failed
+    )
 }
 
 /// Internal struct for tracking individual invoices
@@ -604,5 +796,50 @@ mod tests {
             }
             CchTrackingEvent::InvoiceChanged { .. } => panic!("expected payment event"),
         }
+    }
+
+    #[test]
+    fn test_track_payment_request_targets_one_hash_and_streams_inflight_updates() {
+        let payment_hash = Hash256::from_str(PAYMENT_HASH).expect("payment hash should parse");
+        let request = track_payment_request(payment_hash);
+
+        assert_eq!(request.payment_hash, payment_hash.as_ref());
+        assert!(!request.no_inflight_updates);
+    }
+
+    #[tokio::test]
+    async fn test_payment_tracker_stops_on_current_terminal_state() {
+        let tracker = PaymentTracker {
+            port: Arc::new(OutputPort::default()),
+            payment_hash: Hash256::from_str(PAYMENT_HASH).expect("payment hash should parse"),
+            lnd_connection: LndConnectionInfo {
+                uri: "https://localhost:10009".parse().unwrap(),
+                cert: None,
+                macaroon: None,
+            },
+            token: CancellationToken::new(),
+        };
+
+        assert!(tracker
+            .on_payment(lnd_payment(
+                lnrpc::payment::PaymentStatus::Succeeded,
+                ZERO_PREIMAGE,
+            ))
+            .await
+            .expect("successful payment should map"));
+        assert!(tracker
+            .on_payment(lnd_payment(
+                lnrpc::payment::PaymentStatus::Failed,
+                ZERO_PREIMAGE,
+            ))
+            .await
+            .expect("failed payment should map"));
+        assert!(!tracker
+            .on_payment(lnd_payment(
+                lnrpc::payment::PaymentStatus::InFlight,
+                ZERO_PREIMAGE,
+            ))
+            .await
+            .expect("in-flight payment should map"));
     }
 }

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -14,6 +14,7 @@
 //!
 //! Tracking requests are submitted through these message types:
 //! - `TrackInvoice(Hash256)`: Adds invoice to tracking queue
+//! - `ReservePaymentTracking(Hash256)`: Reserves capacity before a `send_btc` order is exposed
 //! - `TrackPayment(Hash256)`: Starts an idempotent per-payment tracker
 //!
 //! Spawned tasks send completion messages back to the actor for lifecycle cleanup.
@@ -28,7 +29,9 @@
 //! 2. Re-queue if failed
 //! 3. Dequeue invoices from the queue and start tracking
 //!
-//! Active payment trackers are keyed by payment hash and removed when their task completes.
+//! Payment tracking capacity is reserved before creating an externally payable Fiber invoice.
+//! Restored orders may exceed the admission limit, but only the bounded number of trackers are
+//! started concurrently.
 
 use std::{
     collections::{HashMap, VecDeque},
@@ -53,6 +56,7 @@ use fiber_types::Hash256;
 
 const MAX_CONCURRENT_INVOICE_TRACKERS: usize = 5;
 const INVOICE_TRACKING_TIMEOUT: Duration = Duration::from_secs(5 * 60); // 5 minutes
+pub(crate) const MAX_TRACKED_PAYMENTS: usize = 100;
 
 /// LND connection information
 ///
@@ -102,6 +106,15 @@ pub enum LndTrackerMessage {
     /// Track a new invoice
     TrackInvoice(Hash256),
 
+    /// Reserve global capacity before creating an externally payable Fiber invoice for `send_btc`.
+    ReservePaymentTracking(
+        Hash256,
+        ractor::RpcReplyPort<PaymentTrackingReservationResult>,
+    ),
+
+    /// Restore capacity for a persisted payment-tracking order created before admission control.
+    RestorePaymentTracking(Hash256),
+
     /// Track an outgoing payment by hash until LND reports a terminal status.
     TrackPayment(Hash256),
 
@@ -131,13 +144,23 @@ pub enum LndTrackerMessage {
     GetState(ractor::RpcReplyPort<StateSnapshot>),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaymentTrackingReservationResult {
+    Reserved,
+    AlreadyTracked,
+    CapacityExceeded,
+}
+
 /// Snapshot of actor state (for testing)
 #[cfg(test)]
 #[derive(Debug, Clone)]
 pub struct StateSnapshot {
     pub invoice_queue_len: usize,
     pub active_invoice_trackers: usize,
+    pub payment_queue_len: usize,
     pub active_payment_trackers: usize,
+    pub reserved_payment_trackers: usize,
+    pub tracked_payment_count: usize,
 }
 
 /// Arguments for starting the LndTrackerActor
@@ -158,14 +181,22 @@ pub struct LndTrackerState {
     invoice_queue: VecDeque<Hash256>,
     /// Number of currently active invoice trackers
     active_invoice_trackers: usize,
-    /// Active per-payment trackers keyed by payment hash for idempotent dispatch.
-    active_payment_trackers: HashMap<Hash256, ActivePaymentTracker>,
+    /// Payment hashes waiting for a bounded tracking slot.
+    payment_queue: VecDeque<Hash256>,
+    /// State of every admitted or restored outgoing Lightning payment.
+    payment_trackers: HashMap<Hash256, PaymentTrackingState>,
     next_payment_tracker_id: u64,
 }
 
 struct ActivePaymentTracker {
     tracker_id: u64,
     token: CancellationToken,
+}
+
+enum PaymentTrackingState {
+    Reserved,
+    Queued,
+    Active(ActivePaymentTracker),
 }
 
 /// Ractor Actor to track LND payments and invoices
@@ -175,6 +206,8 @@ struct ActivePaymentTracker {
 ///
 /// ## Payment Tracking
 /// - Tracks explicitly requested outgoing payments by payment hash
+/// - Reserves capacity before admitting new `send_btc` orders
+/// - Bounds concurrently active trackers while preserving persisted-order recovery
 /// - Deduplicates active trackers and reconnects until LND reports a terminal status
 /// - Sends `CchTrackingEvent::PaymentChanged` events to the output port
 ///
@@ -246,7 +279,8 @@ impl Actor for LndTrackerActor {
             tracker: args.tracker,
             invoice_queue: VecDeque::new(),
             active_invoice_trackers: 0,
-            active_payment_trackers: HashMap::new(),
+            payment_queue: VecDeque::new(),
+            payment_trackers: HashMap::new(),
             next_payment_tracker_id: 0,
         };
 
@@ -265,8 +299,17 @@ impl Actor for LndTrackerActor {
                 state.process_invoice_queue(myself).await?;
                 Ok(())
             }
+            LndTrackerMessage::ReservePaymentTracking(payment_hash, reply_port) => {
+                let result = state.reserve_payment_tracking(payment_hash);
+                let _ = reply_port.send(result);
+                Ok(())
+            }
+            LndTrackerMessage::RestorePaymentTracking(payment_hash) => {
+                state.restore_payment_tracking(payment_hash);
+                Ok(())
+            }
             LndTrackerMessage::TrackPayment(payment_hash) => {
-                state.start_payment_tracker(myself, payment_hash);
+                state.queue_payment_tracker(myself, payment_hash);
                 Ok(())
             }
             LndTrackerMessage::StopTracking(payment_hash) => {
@@ -276,7 +319,7 @@ impl Actor for LndTrackerActor {
                 Ok(())
             }
             LndTrackerMessage::StopTrackingPayment(payment_hash) => {
-                state.stop_payment_tracker(&payment_hash);
+                state.stop_payment_tracker(payment_hash);
                 Ok(())
             }
             LndTrackerMessage::InvoiceTrackerCompleted {
@@ -305,7 +348,7 @@ impl Actor for LndTrackerActor {
                 payment_hash,
                 tracker_id,
             } => {
-                state.complete_payment_tracker(&payment_hash, tracker_id);
+                state.complete_payment_tracker(myself, payment_hash, tracker_id);
                 Ok(())
             }
 
@@ -314,7 +357,10 @@ impl Actor for LndTrackerActor {
                 let snapshot = StateSnapshot {
                     invoice_queue_len: state.invoice_queue.len(),
                     active_invoice_trackers: state.active_invoice_trackers,
-                    active_payment_trackers: state.active_payment_trackers.len(),
+                    payment_queue_len: state.payment_queue.len(),
+                    active_payment_trackers: state.active_payment_tracker_count(),
+                    reserved_payment_trackers: state.reserved_payment_tracker_count(),
+                    tracked_payment_count: state.payment_trackers.len(),
                 };
                 let _ = reply_port.send(snapshot);
                 Ok(())
@@ -335,74 +381,182 @@ impl Actor for LndTrackerActor {
 }
 
 impl LndTrackerState {
-    fn start_payment_tracker(
+    fn reserve_payment_tracking(
+        &mut self,
+        payment_hash: Hash256,
+    ) -> PaymentTrackingReservationResult {
+        if self.payment_trackers.contains_key(&payment_hash) {
+            return PaymentTrackingReservationResult::AlreadyTracked;
+        }
+        if self.payment_trackers.len() >= MAX_TRACKED_PAYMENTS {
+            return PaymentTrackingReservationResult::CapacityExceeded;
+        }
+        self.payment_trackers
+            .insert(payment_hash, PaymentTrackingState::Reserved);
+        PaymentTrackingReservationResult::Reserved
+    }
+
+    fn restore_payment_tracking(&mut self, payment_hash: Hash256) {
+        if self.payment_trackers.contains_key(&payment_hash) {
+            return;
+        }
+        self.payment_trackers
+            .insert(payment_hash, PaymentTrackingState::Reserved);
+        if self.payment_trackers.len() > MAX_TRACKED_PAYMENTS {
+            tracing::warn!(
+                "Restored outgoing payment tracker {} above the global limit of {}",
+                payment_hash,
+                MAX_TRACKED_PAYMENTS
+            );
+        }
+    }
+
+    fn queue_payment_tracker(
         &mut self,
         myself: ActorRef<LndTrackerMessage>,
         payment_hash: Hash256,
     ) {
-        if self.active_payment_trackers.contains_key(&payment_hash) {
+        match self.payment_trackers.get_mut(&payment_hash) {
+            Some(PaymentTrackingState::Reserved) => {
+                self.payment_trackers
+                    .insert(payment_hash, PaymentTrackingState::Queued);
+                self.payment_queue.push_back(payment_hash);
+            }
+            Some(PaymentTrackingState::Queued) | Some(PaymentTrackingState::Active(_)) => {
+                tracing::debug!(
+                    "Outgoing payment tracker already queued or active for payment_hash={}",
+                    payment_hash
+                );
+                return;
+            }
+            None => {
+                // Persisted orders created before admission control must still recover.
+                self.payment_trackers
+                    .insert(payment_hash, PaymentTrackingState::Queued);
+                if self.payment_trackers.len() > MAX_TRACKED_PAYMENTS {
+                    tracing::warn!(
+                        "Restoring outgoing payment tracker {} above the global limit of {}",
+                        payment_hash,
+                        MAX_TRACKED_PAYMENTS
+                    );
+                }
+                self.payment_queue.push_back(payment_hash);
+            }
+        }
+
+        self.process_payment_queue(myself);
+    }
+
+    fn process_payment_queue(&mut self, myself: ActorRef<LndTrackerMessage>) {
+        while self.active_payment_tracker_count() < MAX_TRACKED_PAYMENTS {
+            let Some(payment_hash) = self.payment_queue.pop_front() else {
+                break;
+            };
+            if !matches!(
+                self.payment_trackers.get(&payment_hash),
+                Some(PaymentTrackingState::Queued)
+            ) {
+                continue;
+            }
+
+            let tracker_id = self.next_payment_tracker_id;
+            self.next_payment_tracker_id = self.next_payment_tracker_id.wrapping_add(1);
+            let token = self.token.child_token();
+            self.payment_trackers.insert(
+                payment_hash,
+                PaymentTrackingState::Active(ActivePaymentTracker {
+                    tracker_id,
+                    token: token.clone(),
+                }),
+            );
+
+            let tracker = PaymentTracker {
+                port: self.port.clone(),
+                payment_hash,
+                lnd_connection: self.lnd_connection.clone(),
+                token,
+            };
+            let myself = myself.clone();
+            self.tracker.spawn(async move {
+                tracker.run().await;
+                let _ = myself.send_message(LndTrackerMessage::PaymentTrackerCompleted {
+                    payment_hash,
+                    tracker_id,
+                });
+            });
             tracing::debug!(
-                "Outgoing payment tracker already active for payment_hash={}",
+                "Started outgoing payment tracker for payment_hash={} tracker_id={} active={}/{}",
+                payment_hash,
+                tracker_id,
+                self.active_payment_tracker_count(),
+                MAX_TRACKED_PAYMENTS
+            );
+        }
+    }
+
+    fn stop_payment_tracker(&mut self, payment_hash: Hash256) {
+        let remove_immediately = match self.payment_trackers.get_mut(&payment_hash) {
+            Some(PaymentTrackingState::Reserved | PaymentTrackingState::Queued) => true,
+            Some(PaymentTrackingState::Active(active_tracker)) => {
+                active_tracker.token.cancel();
+                tracing::debug!(
+                    "Stopping outgoing payment tracker for payment_hash={} tracker_id={}",
+                    payment_hash,
+                    active_tracker.tracker_id
+                );
+                false
+            }
+            None => false,
+        };
+        if remove_immediately {
+            self.payment_trackers.remove(&payment_hash);
+            self.payment_queue.retain(|hash| *hash != payment_hash);
+            tracing::debug!(
+                "Released outgoing payment tracking reservation for payment_hash={}",
                 payment_hash
             );
-            return;
-        }
-
-        let tracker_id = self.next_payment_tracker_id;
-        self.next_payment_tracker_id = self.next_payment_tracker_id.wrapping_add(1);
-        let token = self.token.child_token();
-        self.active_payment_trackers.insert(
-            payment_hash,
-            ActivePaymentTracker {
-                tracker_id,
-                token: token.clone(),
-            },
-        );
-
-        let tracker = PaymentTracker {
-            port: self.port.clone(),
-            payment_hash,
-            lnd_connection: self.lnd_connection.clone(),
-            token,
-        };
-        self.tracker.spawn(async move {
-            tracker.run().await;
-            let _ = myself.send_message(LndTrackerMessage::PaymentTrackerCompleted {
-                payment_hash,
-                tracker_id,
-            });
-        });
-        tracing::debug!(
-            "Started outgoing payment tracker for payment_hash={} tracker_id={}",
-            payment_hash,
-            tracker_id
-        );
-    }
-
-    fn stop_payment_tracker(&mut self, payment_hash: &Hash256) {
-        if let Some(active_tracker) = self.active_payment_trackers.remove(payment_hash) {
-            active_tracker.token.cancel();
-            tracing::debug!(
-                "Stopped outgoing payment tracker for payment_hash={} tracker_id={}",
-                payment_hash,
-                active_tracker.tracker_id
-            );
         }
     }
 
-    fn complete_payment_tracker(&mut self, payment_hash: &Hash256, tracker_id: u64) {
+    fn complete_payment_tracker(
+        &mut self,
+        myself: ActorRef<LndTrackerMessage>,
+        payment_hash: Hash256,
+        tracker_id: u64,
+    ) {
         let is_current_tracker = self
-            .active_payment_trackers
-            .get(payment_hash)
-            .is_some_and(|tracker| tracker.tracker_id == tracker_id);
+            .payment_trackers
+            .get(&payment_hash)
+            .is_some_and(|state| {
+                matches!(
+                    state,
+                    PaymentTrackingState::Active(tracker) if tracker.tracker_id == tracker_id
+                )
+            });
         if is_current_tracker {
-            self.active_payment_trackers.remove(payment_hash);
+            self.payment_trackers.remove(&payment_hash);
             tracing::debug!(
                 "Completed outgoing payment tracker for payment_hash={} tracker_id={}",
                 payment_hash,
                 tracker_id
             );
+            self.process_payment_queue(myself);
         }
+    }
+
+    fn active_payment_tracker_count(&self) -> usize {
+        self.payment_trackers
+            .values()
+            .filter(|state| matches!(state, PaymentTrackingState::Active(_)))
+            .count()
+    }
+
+    #[cfg(test)]
+    fn reserved_payment_tracker_count(&self) -> usize {
+        self.payment_trackers
+            .values()
+            .filter(|state| matches!(state, PaymentTrackingState::Reserved))
+            .count()
     }
 
     async fn process_invoice_queue(

--- a/crates/fiber-lib/src/cch/trackers/mod.rs
+++ b/crates/fiber-lib/src/cch/trackers/mod.rs
@@ -2,7 +2,8 @@ mod event;
 pub use event::{CchTrackingEvent, RedactedCchTrackingEvent};
 
 mod lnd_trackers;
+pub(crate) use lnd_trackers::MAX_TRACKED_PAYMENTS;
 pub use lnd_trackers::{
     map_lnd_payment_changed_event, LndConnectionInfo, LndTrackerActor, LndTrackerArgs,
-    LndTrackerMessage,
+    LndTrackerMessage, PaymentTrackingReservationResult,
 };


### PR DESCRIPTION
## Summary

- track each active outgoing Lightning payment by payment hash with `TrackPaymentV2`
- retry the per-payment stream after LND or connection failures
- deduplicate active trackers and clean them up on terminal payment or order states
- remove the redundant global `TrackPayments` stream

Fixes #1501 #1497 .

## Problem

CCH previously relied on LND's global `TrackPayments` stream after the first
`SendPaymentV2` update. If LND restarted while a payment was in flight and the
payment reached a terminal state before CCH reconnected, the new global stream
did not reliably replay that terminal update. The CCH order could therefore
remain in `OutgoingInFlight`, without the preimage needed to settle the incoming
Fiber payment.

## Solution

Outgoing Lightning orders now start an idempotent per-payment tracker using
`TrackPaymentV2(payment_hash)`. This RPC returns the requested payment's current
state after reconnecting, including a terminal state reached while LND or CCH
was unavailable.

The tracker:

- emits every payment update through the existing CCH tracking event path
- retries transient connection and stream failures
- exits after `Succeeded` or `Failed`
- uses per-tracker IDs so a stale completion cannot remove a newer tracker
- is cancelled when the CCH order reaches a final state

The former global `TrackPayments` stream is removed because every active CCH
outgoing Lightning payment now has an explicit per-hash tracker. Outgoing Fiber
payments continue to use the existing store-change tracking path. Persisted
active orders resume per-payment tracking through the existing startup action
scheduling.

## Testing

- TDD regression test added before the implementation
- focused dispatcher suite — 39 passed
- focused LND tracker suite — 9 passed
- `cargo nextest run -p fnn -p fiber-bin cch::` — 131 passed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `git diff --check`

A live LND restart E2E was not run as part of this change; reconnect request
formation, deduplication, terminal handling, cancellation, and lifecycle cleanup
are covered by focused tests.
