### PR TITLE
Add release-safe payment diagnostics RPC

### DIFF
--- a/crates/fiber-json-types/src/convert.rs
+++ b/crates/fiber-json-types/src/convert.rs
@@ -405,6 +405,18 @@ impl From<fiber_types::SessionRoute> for JsonSessionRoute {
     }
 }
 
+impl From<fiber_types::AttemptStatus> for crate::payment::PaymentAttemptStatus {
+    fn from(status: fiber_types::AttemptStatus) -> Self {
+        match status {
+            fiber_types::AttemptStatus::Created => Self::Created,
+            fiber_types::AttemptStatus::Inflight => Self::Inflight,
+            fiber_types::AttemptStatus::Retrying => Self::Retrying,
+            fiber_types::AttemptStatus::Success => Self::Success,
+            fiber_types::AttemptStatus::Failed => Self::Failed,
+        }
+    }
+}
+
 // ─── RouterHop Conversions ──────────────────────────────────────────────────
 
 impl From<fiber_types::RouterHop> for crate::payment::RouterHop {

--- a/crates/fiber-json-types/src/payment.rs
+++ b/crates/fiber-json-types/src/payment.rs
@@ -93,6 +93,70 @@ pub struct GetPaymentCommandResult {
     pub routers: Vec<SessionRoute>,
 }
 
+/// The status of one concrete payment attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum PaymentAttemptStatus {
+    Created,
+    Inflight,
+    Retrying,
+    Success,
+    Failed,
+}
+
+/// Redacted, read-only evidence for one payment attempt.
+///
+/// This type intentionally excludes the session key, preimage, invoice, custom records,
+/// route hop payloads, and onion data held by the internal payment attempt.
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct PaymentAttemptDiagnostic {
+    #[serde_as(as = "U64Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub attempt_id: u64,
+    pub status: PaymentAttemptStatus,
+    #[serde_as(as = "U32Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub retry_count: u32,
+    #[serde_as(as = "U32Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub retry_limit: u32,
+    #[serde_as(as = "U64Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub created_at: u64,
+    #[serde_as(as = "U64Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub last_updated_at: u64,
+    #[serde_as(as = "U128Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub receiver_amount: u128,
+    #[serde_as(as = "U128Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub fee: u128,
+    pub failed_error: Option<String>,
+    pub route: SessionRoute,
+}
+
+/// Release-safe payment diagnostics for operators and observability clients.
+///
+/// Unlike the debug-only route field on `get_payment`, this response is available in release
+/// builds. It exposes only redacted failure and route evidence.
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct GetPaymentDiagnosticsResult {
+    pub payment_hash: Hash256,
+    pub status: PaymentStatus,
+    #[serde_as(as = "U64Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub created_at: u64,
+    #[serde_as(as = "U64Hex")]
+    #[schemars(schema_with = "schema_as_uint_hex")]
+    pub last_updated_at: u64,
+    /// Stable Fiber TLC error code name when the failure supplied one.
+    pub failed_error_code: Option<String>,
+    pub failed_error: Option<String>,
+    pub attempts: Vec<PaymentAttemptDiagnostic>,
+}
+
 /// Parameters for listing payments.
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Default, JsonSchema)]
@@ -397,4 +461,39 @@ pub struct SendPaymentWithRouterParams {
     /// it's useful for the sender to double check the payment before sending it to the network,
     /// default is false
     pub dry_run: Option<bool>,
+}
+
+#[cfg(test)]
+mod diagnostic_tests {
+    use super::{PaymentAttemptDiagnostic, PaymentAttemptStatus, SessionRoute};
+
+    #[test]
+    fn payment_attempt_diagnostic_serialization_has_no_secret_fields() {
+        let diagnostic = PaymentAttemptDiagnostic {
+            attempt_id: 7,
+            status: PaymentAttemptStatus::Failed,
+            retry_count: 2,
+            retry_limit: 3,
+            created_at: 10,
+            last_updated_at: 20,
+            receiver_amount: 1_000,
+            fee: 5,
+            failed_error: Some("route unavailable".to_owned()),
+            route: SessionRoute::default(),
+        };
+
+        let value = serde_json::to_value(diagnostic).unwrap();
+        for forbidden in [
+            "session_key",
+            "preimage",
+            "invoice",
+            "custom_records",
+            "route_hops",
+            "onion",
+        ] {
+            assert!(value.get(forbidden).is_none(), "leaked {forbidden}");
+        }
+        assert_eq!(value["attempt_id"], "0x7");
+        assert_eq!(value["status"], "Failed");
+    }
 }

--- a/crates/fiber-lib/src/rpc/biscuit.rs
+++ b/crates/fiber-lib/src/rpc/biscuit.rs
@@ -119,6 +119,7 @@ fn build_rules() -> HashMap<&'static str, AuthRule> {
     // payment
     b.rule("send_payment", r#"allow if write("payments");"#);
     b.rule("get_payment", r#"allow if read("payments");"#);
+    b.rule("get_payment_diagnostics", r#"allow if read("payments");"#);
     b.rule("list_payments", r#"allow if read("payments");"#);
     b.rule("build_router", r#"allow if read("payments");"#);
     b.rule("send_payment_with_router", r#"allow if write("payments");"#);
@@ -294,11 +295,37 @@ mod tests {
         assert!(auth.check_permission("send_payment", &token,).is_ok());
         // write permission do not implies read
         assert!(auth.check_permission("get_payment", &token).is_err());
+        assert!(auth
+            .check_permission("get_payment_diagnostics", &token)
+            .is_err());
         assert!(auth.check_permission("list_peers", &token).is_ok());
         assert!(auth.check_permission("connect_peer", &token).is_err());
 
         // if not match any rule, it should be denied
         assert!(auth.check_permission("unknown", &token).is_err());
+    }
+
+    #[test]
+    fn test_payment_diagnostics_requires_read_payments() {
+        let root = KeyPair::new();
+        let auth = BiscuitAuth::from_pubkey(root.public().to_string()).unwrap();
+        let read_token = biscuit!(r#"read("payments");"#)
+            .build(&root)
+            .unwrap()
+            .to_base64()
+            .unwrap();
+        let write_token = biscuit!(r#"write("payments");"#)
+            .build(&root)
+            .unwrap()
+            .to_base64()
+            .unwrap();
+
+        assert!(auth
+            .check_permission("get_payment_diagnostics", &read_token)
+            .is_ok());
+        assert!(auth
+            .check_permission("get_payment_diagnostics", &write_token)
+            .is_err());
     }
 
     #[test]

--- a/crates/fiber-lib/src/rpc/payment.rs
+++ b/crates/fiber-lib/src/rpc/payment.rs
@@ -5,7 +5,7 @@ use crate::fiber::{
     channel::ChannelActorStateStore, payment::SendPaymentCommand, NetworkActorCommand,
     NetworkActorMessage,
 };
-use crate::rpc::utils::RpcResultExt;
+use crate::rpc::utils::{rpc_error, RpcResultExt};
 use crate::{handle_actor_call, log_and_error};
 #[cfg(debug_assertions)]
 use fiber_json_types::SessionRoute as JsonSessionRoute;
@@ -21,8 +21,9 @@ use ractor::{call, ActorRef};
 
 pub use fiber_json_types::{
     BuildPaymentRouterResult, BuildRouterParams, GetPaymentCommandParams, GetPaymentCommandResult,
-    HopHint, ListPaymentsParams, ListPaymentsResult, PaymentCustomRecords,
-    SendPaymentCommandParams, SendPaymentWithRouterParams,
+    GetPaymentDiagnosticsResult, HopHint, ListPaymentsParams, ListPaymentsResult,
+    PaymentAttemptDiagnostic, PaymentCustomRecords, SendPaymentCommandParams,
+    SendPaymentWithRouterParams,
 };
 
 /// RPC module for channel management.
@@ -42,6 +43,13 @@ trait PaymentRpc {
         &self,
         params: GetPaymentCommandParams,
     ) -> Result<GetPaymentCommandResult, ErrorObjectOwned>;
+
+    /// Retrieves redacted payment attempts and routes in both debug and release builds.
+    #[method(name = "get_payment_diagnostics")]
+    async fn get_payment_diagnostics(
+        &self,
+        params: GetPaymentCommandParams,
+    ) -> Result<GetPaymentDiagnosticsResult, ErrorObjectOwned>;
 
     /// Builds a router with a list of pubkeys and required channels.
     #[method(name = "build_router")]
@@ -77,6 +85,29 @@ trait PaymentRpc {
     ) -> Result<ListPaymentsResult, ErrorObjectOwned>;
 }
 
+#[cfg(test)]
+mod diagnostic_tests {
+    use super::redact_payment_failure;
+
+    #[test]
+    fn diagnostic_failure_text_is_bounded_and_sensitive_detail_is_redacted() {
+        assert_eq!(
+            redact_payment_failure(&Some("route unavailable".to_owned())).as_deref(),
+            Some("route unavailable")
+        );
+        assert_eq!(
+            redact_payment_failure(&Some("invoice=fibt...".to_owned())).as_deref(),
+            Some("[redacted sensitive payment failure detail]")
+        );
+        assert_eq!(
+            redact_payment_failure(&Some("x".repeat(600)))
+                .unwrap()
+                .len(),
+            512
+        );
+    }
+}
+
 pub struct PaymentRpcServerImpl<S> {
     actor: ActorRef<NetworkActorMessage>,
     store: S,
@@ -107,6 +138,13 @@ where
         params: GetPaymentCommandParams,
     ) -> Result<GetPaymentCommandResult, ErrorObjectOwned> {
         self.get_payment(params).await
+    }
+
+    async fn get_payment_diagnostics(
+        &self,
+        params: GetPaymentCommandParams,
+    ) -> Result<GetPaymentDiagnosticsResult, ErrorObjectOwned> {
+        self.get_payment_diagnostics(params).await
     }
 
     /// Builds a router with a list of pubkeys and required channels.
@@ -160,6 +198,28 @@ fn send_payment_response_to_json(
             .map(JsonSessionRoute::from)
             .collect(),
     }
+}
+
+fn redact_payment_failure(error: &Option<String>) -> Option<String> {
+    error.as_ref().map(|message| {
+        let normalized = message.to_ascii_lowercase();
+        if [
+            "invoice",
+            "preimage",
+            "session_key",
+            "session key",
+            "custom_records",
+            "custom records",
+            "onion payload",
+        ]
+        .iter()
+        .any(|needle| normalized.contains(needle))
+        {
+            return "[redacted sensitive payment failure detail]".to_owned();
+        }
+
+        message.chars().take(512).collect()
+    })
 }
 
 impl<S> PaymentRpcServerImpl<S>
@@ -242,6 +302,47 @@ where
         };
         handle_actor_call!(self.actor, message, params)
             .map(|response| send_payment_response_to_json(&response))
+    }
+
+    pub async fn get_payment_diagnostics(
+        &self,
+        params: GetPaymentCommandParams,
+    ) -> Result<GetPaymentDiagnosticsResult, ErrorObjectOwned> {
+        let payment_hash = params.payment_hash.into();
+        let session = self
+            .store
+            .get_payment_session(payment_hash)
+            .ok_or_else(|| rpc_error(format!("Payment session not found: {payment_hash:?}")))?;
+
+        let attempts = session
+            .attempts()
+            .map(|attempt| {
+                let first_amount = attempt.route.nodes.first().map_or(0, |node| node.amount);
+                let receiver_amount = attempt.route.receiver_amount();
+                PaymentAttemptDiagnostic {
+                    attempt_id: attempt.id,
+                    status: attempt.status.into(),
+                    retry_count: attempt.tried_times,
+                    retry_limit: attempt.try_limit,
+                    created_at: attempt.created_at,
+                    last_updated_at: attempt.last_updated_at,
+                    receiver_amount,
+                    fee: first_amount.saturating_sub(receiver_amount),
+                    failed_error: redact_payment_failure(&attempt.last_error),
+                    route: attempt.route.clone().into(),
+                }
+            })
+            .collect();
+
+        Ok(GetPaymentDiagnosticsResult {
+            payment_hash: session.payment_hash().into(),
+            status: session.status.into(),
+            created_at: session.created_at,
+            last_updated_at: session.last_updated_at,
+            failed_error_code: session.last_error_code.map(|code| code.as_ref().to_owned()),
+            failed_error: redact_payment_failure(&session.last_error),
+            attempts,
+        })
     }
 
     pub async fn build_router(


### PR DESCRIPTION
## Summary

Adds a read-only `get_payment_diagnostics` JSON-RPC method for operator tooling and payment incident analysis.

The existing `get_payment` route list is debug-only. This additive method reads persisted payment sessions and exposes redacted attempt evidence in release builds:

- payment status, timestamps, and structured TLC error code;
- attempt ID, status, retry count/limit, and timestamps;
- receiver amount, fee, and attempted route nodes/channel outpoints.

It deliberately omits session keys, preimages, invoices, custom records, route-hop payloads, and onion data. Failure text is bounded and redacts sensitive-field indicators.

## Authorization

The method requires `read("payments")`. A write-only payments Biscuit is rejected.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p fnn --features sqlite`
- `cargo check -p fnn --release --features sqlite`
- JSON serialization regression test for forbidden secret fields
- Biscuit read/write authorization regression test
- failure-text redaction and length-bound regression test
- release binary exercised against a real RocksDB-backed three-node Fiber testnet environment; retained failed and successful multi-hop attempt routes were returned without secret fields

This is additive and existing clients remain compatible.