### PR TITLE
fix(cch): stop retrying permanent LND send errors

### DIFF
--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -134,7 +134,20 @@ impl ActionExecutor for SendLightningOutgoingPaymentExecutor {
         );
 
         let mut client = self.lnd_connection.create_router_client().await?;
-        let mut stream = client.send_payment_v2(req).await?.into_inner();
+        let mut stream = match client.send_payment_v2(req).await {
+            Ok(response) => response.into_inner(),
+            Err(err) => {
+                tracing::debug!(
+                    "SendLightningOutgoingPaymentExecutor initial response error code={} message={}",
+                    err.code(),
+                    err.message()
+                );
+                let event = Self::event_for_payment_error(self.payment_hash, &err)?;
+                self.cch_actor_ref
+                    .send_message(CchMessage::TrackingEvent(event))?;
+                return Ok(());
+            }
+        };
         // Wait for the first message then quit
         let payment_result_opt = stream.next().await;
         match &payment_result_opt {
@@ -159,32 +172,7 @@ impl ActionExecutor for SendLightningOutgoingPaymentExecutor {
         }
         let event = match payment_result_opt {
             Some(Ok(payment)) => map_lnd_payment_changed_event(payment)?,
-            Some(Err(err)) if err.code() == tonic::Code::AlreadyExists => {
-                CchTrackingEvent::PaymentChanged {
-                    payment_hash: self.payment_hash,
-                    payment_preimage: None,
-                    status: PaymentStatus::Inflight,
-                    failure_reason: None,
-                }
-            }
-            Some(Err(err)) => {
-                let failure_reason =
-                    format!("SendLightningOutgoingPaymentExecutor failure: {:?}", err);
-                if Self::is_permanent_error(&err) {
-                    CchTrackingEvent::PaymentChanged {
-                        payment_hash: self.payment_hash,
-                        payment_preimage: None,
-                        status: PaymentStatus::Failed,
-                        failure_reason: Some(failure_reason),
-                    }
-                } else {
-                    tracing::warn!(
-                        "SendLightningOutgoingPaymentExecutor transient error, will retry. code: {}, error: {}",
-                        err.code(), err.message()
-                    );
-                    return Err(anyhow!(failure_reason));
-                }
-            }
+            Some(Err(err)) => Self::event_for_payment_error(self.payment_hash, &err)?,
             None => {
                 return Err(anyhow!(
                     "SendLightningOutgoingPaymentExecutor failed to get payment result because stream is closed"
@@ -198,6 +186,36 @@ impl ActionExecutor for SendLightningOutgoingPaymentExecutor {
 }
 
 impl SendLightningOutgoingPaymentExecutor {
+    fn event_for_payment_error(
+        payment_hash: Hash256,
+        status: &tonic::Status,
+    ) -> Result<CchTrackingEvent> {
+        if status.code() == tonic::Code::AlreadyExists {
+            return Ok(CchTrackingEvent::PaymentChanged {
+                payment_hash,
+                payment_preimage: None,
+                status: PaymentStatus::Inflight,
+                failure_reason: None,
+            });
+        }
+
+        let failure_reason = format!("SendLightningOutgoingPaymentExecutor failure: {:?}", status);
+        if Self::is_permanent_error(status) {
+            Ok(CchTrackingEvent::PaymentChanged {
+                payment_hash,
+                payment_preimage: None,
+                status: PaymentStatus::Failed,
+                failure_reason: Some(failure_reason),
+            })
+        } else {
+            tracing::warn!(
+                "SendLightningOutgoingPaymentExecutor transient error, will retry. code: {}, error: {}",
+                status.code(), status.message()
+            );
+            Err(anyhow!(failure_reason))
+        }
+    }
+
     fn is_permanent_error(status: &tonic::Status) -> bool {
         // Check for explicit invalid argument errors
         if matches!(status.code(), tonic::Code::InvalidArgument) {
@@ -396,5 +414,78 @@ impl SendOutgoingPaymentDispatcher {
                 }))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lnd_permanent_payment_error_returns_failed_event() {
+        let payment_hash = Hash256::from([42; 32]);
+        let error = tonic::Status::unknown("self-payments not allowed");
+
+        let event =
+            SendLightningOutgoingPaymentExecutor::event_for_payment_error(payment_hash, &error)
+                .expect("permanent errors should be converted into tracking events");
+
+        match event {
+            CchTrackingEvent::PaymentChanged {
+                payment_hash: event_payment_hash,
+                payment_preimage,
+                status,
+                failure_reason,
+            } => {
+                assert_eq!(event_payment_hash, payment_hash);
+                assert_eq!(payment_preimage, None);
+                assert_eq!(status, PaymentStatus::Failed);
+                assert!(failure_reason
+                    .expect("failed payment should include a reason")
+                    .contains("self-payments not allowed"));
+            }
+            CchTrackingEvent::InvoiceChanged { .. } => {
+                panic!("payment errors should not produce invoice events")
+            }
+        }
+    }
+
+    #[test]
+    fn test_lnd_already_exists_payment_error_returns_inflight_event() {
+        let payment_hash = Hash256::from([43; 32]);
+        let error = tonic::Status::already_exists("payment is in flight");
+
+        let event =
+            SendLightningOutgoingPaymentExecutor::event_for_payment_error(payment_hash, &error)
+                .expect("already-existing payments should be tracked rather than retried");
+
+        match event {
+            CchTrackingEvent::PaymentChanged {
+                payment_hash: event_payment_hash,
+                payment_preimage,
+                status,
+                failure_reason,
+            } => {
+                assert_eq!(event_payment_hash, payment_hash);
+                assert_eq!(payment_preimage, None);
+                assert_eq!(status, PaymentStatus::Inflight);
+                assert_eq!(failure_reason, None);
+            }
+            CchTrackingEvent::InvoiceChanged { .. } => {
+                panic!("payment errors should not produce invoice events")
+            }
+        }
+    }
+
+    #[test]
+    fn test_lnd_transient_payment_error_remains_retryable() {
+        let payment_hash = Hash256::from([44; 32]);
+        let error = tonic::Status::unavailable("lnd is unavailable");
+
+        let result =
+            SendLightningOutgoingPaymentExecutor::event_for_payment_error(payment_hash, &error);
+
+        let error = result.expect_err("transient errors should be returned for actor retry");
+        assert!(error.to_string().contains("lnd is unavailable"));
     }
 }


### PR DESCRIPTION
## Summary

- classify errors returned by `SendPaymentV2` before the response stream is created
- reuse the same LND payment error mapping for initial RPC errors and stream item errors
- preserve retries for transient errors and the existing `AlreadyExists` inflight behavior
- add regression tests for permanent, transient, and already-existing payment errors

## Root cause

The permanent-error classifier was only applied to errors returned by `stream.next()`. Errors returned directly by `send_payment_v2(req).await` were propagated with `?`, so the CCH actor treated permanent LND policy errors such as `self-payments not allowed` as transient failures and retried them indefinitely.

The initial RPC result now goes through the same mapping as stream errors:

- `AlreadyExists` produces an `Inflight` tracking event
- known permanent errors produce a `Failed` tracking event and persist the failure reason
- transient errors are returned to the actor for retry

## Validation

- `cargo nextest run --no-fail-fast` (1174 passed, 8 skipped)
- all 128 CCH tests
- `cargo check --locked`
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #1488
