### PR TITLE
fix: rotate stalled active gossip sync peers

### DIFF
--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -114,6 +114,10 @@ const QUERY_BROADCAST_MESSAGES_TIMEOUT: Duration = Duration::from_secs(20);
 const UPDATE_PEER_FILTER_RETRY_DELAY: Duration = Duration::from_millis(500);
 const DEFERRED_SYNC_CURSOR_RETRY_DELAY: Duration = Duration::from_millis(500);
 #[cfg(test)]
+const MAX_CONSECUTIVE_ACTIVE_SYNC_PENDING_RESULTS: usize = 3;
+#[cfg(not(test))]
+const MAX_CONSECUTIVE_ACTIVE_SYNC_PENDING_RESULTS: usize = 20;
+#[cfg(test)]
 const ACTIVE_SYNC_FAILURE_RETRY_DELAY: Duration = Duration::from_millis(200);
 #[cfg(not(test))]
 const ACTIVE_SYNC_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(10);
@@ -870,6 +874,7 @@ pub struct GossipSyncingActorState<S> {
     peer_state: SyncingPeerState,
     request_id: u64,
     inflight_requests: HashMap<u64, InflightGetBroadcastMessagesRequest>,
+    consecutive_pending_results: usize,
 }
 
 struct InflightGetBroadcastMessagesRequest {
@@ -901,6 +906,7 @@ impl<S> GossipSyncingActorState<S> {
             peer_state: Default::default(),
             inflight_requests: Default::default(),
             request_id: 0,
+            consecutive_pending_results: 0,
         }
     }
 
@@ -1046,8 +1052,31 @@ where
                     ) {
                         Ok(ActiveSyncSaveMessagesResult::Validated(cursor)) => {
                             state.cursor = cursor;
+                            state.consecutive_pending_results = 0;
                         }
                         Ok(ActiveSyncSaveMessagesResult::Pending) => {
+                            state.consecutive_pending_results =
+                                state.consecutive_pending_results.saturating_add(1);
+                            if state.consecutive_pending_results
+                                >= MAX_CONSECUTIVE_ACTIVE_SYNC_PENDING_RESULTS
+                            {
+                                warn!(
+                                    "Aborting active sync with peer {:?} after {} consecutive pending results",
+                                    &state.peer_pubkey, state.consecutive_pending_results
+                                );
+                                state
+                                    .gossip_actor
+                                    .send_message(GossipActorMessage::ActiveSyncingAborted {
+                                        peer: state.peer_pubkey,
+                                        session_id: state.session_id,
+                                        sync_id: state.sync_id,
+                                    })
+                                    .expect("gossip actor alive");
+                                myself.stop(Some(
+                                    "Too many consecutive pending active sync results".to_string(),
+                                ));
+                                return Ok(());
+                            }
                             trace!(
                                 "Deferring active sync cursor advancement for peer {:?}",
                                 &state.peer_pubkey

--- a/crates/fiber-lib/src/fiber/gossip.rs
+++ b/crates/fiber-lib/src/fiber/gossip.rs
@@ -104,6 +104,9 @@ const ACTOR_HANDLE_WARN_THRESHOLD_MS: u64 = 15_000;
 const MIN_NUM_OF_PASSIVE_SYNCING_PEERS: usize = 3;
 
 const NUM_SIMULTANEOUS_GET_REQUESTS: usize = 1;
+#[cfg(test)]
+const GET_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(not(test))]
 const GET_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 // The maximum number of concurrent query tasks to run. We will wait for query previous task to exit
@@ -114,9 +117,9 @@ const QUERY_BROADCAST_MESSAGES_TIMEOUT: Duration = Duration::from_secs(20);
 const UPDATE_PEER_FILTER_RETRY_DELAY: Duration = Duration::from_millis(500);
 const DEFERRED_SYNC_CURSOR_RETRY_DELAY: Duration = Duration::from_millis(500);
 #[cfg(test)]
-const MAX_CONSECUTIVE_ACTIVE_SYNC_PENDING_RESULTS: usize = 3;
+const MAX_CONSECUTIVE_ACTIVE_SYNC_NO_PROGRESS: usize = 3;
 #[cfg(not(test))]
-const MAX_CONSECUTIVE_ACTIVE_SYNC_PENDING_RESULTS: usize = 20;
+const MAX_CONSECUTIVE_ACTIVE_SYNC_NO_PROGRESS: usize = 20;
 #[cfg(test)]
 const ACTIVE_SYNC_FAILURE_RETRY_DELAY: Duration = Duration::from_millis(200);
 #[cfg(not(test))]
@@ -742,11 +745,6 @@ where
     }
 }
 
-#[derive(Debug, Default)]
-struct SyncingPeerState {
-    failed_times: usize,
-}
-
 #[derive(Clone, Debug)]
 struct DelayedGossipMessage {
     target: Pubkey,
@@ -871,10 +869,9 @@ pub struct GossipSyncingActorState<S> {
     // Of course, using different cursor for different peers will waste
     // some bandwidth by requesting the same messages from different peers.
     cursor: Cursor,
-    peer_state: SyncingPeerState,
     request_id: u64,
     inflight_requests: HashMap<u64, InflightGetBroadcastMessagesRequest>,
-    consecutive_pending_results: usize,
+    consecutive_no_progress: usize,
 }
 
 struct InflightGetBroadcastMessagesRequest {
@@ -903,10 +900,9 @@ impl<S> GossipSyncingActorState<S> {
             gossip_actor,
             store,
             cursor,
-            peer_state: Default::default(),
             inflight_requests: Default::default(),
             request_id: 0,
-            consecutive_pending_results: 0,
+            consecutive_no_progress: 0,
         }
     }
 
@@ -918,6 +914,40 @@ impl<S> GossipSyncingActorState<S> {
         let id = self.request_id;
         self.request_id += 1;
         id
+    }
+
+    fn update_cursor_if_advanced(&mut self, cursor: Cursor) -> bool {
+        if cursor <= self.cursor {
+            return false;
+        }
+        self.cursor = cursor;
+        self.consecutive_no_progress = 0;
+        true
+    }
+
+    fn record_no_progress(
+        &mut self,
+        myself: &ActorRef<GossipSyncingActorMessage>,
+        reason: &'static str,
+    ) -> bool {
+        self.consecutive_no_progress = self.consecutive_no_progress.saturating_add(1);
+        if self.consecutive_no_progress < MAX_CONSECUTIVE_ACTIVE_SYNC_NO_PROGRESS {
+            return false;
+        }
+
+        warn!(
+            "Aborting active sync with peer {:?} after {} consecutive no-progress events: {}",
+            &self.peer_pubkey, self.consecutive_no_progress, reason
+        );
+        self.gossip_actor
+            .send_message(GossipActorMessage::ActiveSyncingAborted {
+                peer: self.peer_pubkey,
+                session_id: self.session_id,
+                sync_id: self.sync_id,
+            })
+            .expect("gossip actor alive");
+        myself.stop(Some(format!("Active sync made no progress: {reason}")));
+        true
     }
 }
 
@@ -992,10 +1022,13 @@ where
         );
         match message {
             GossipSyncingActorMessage::RequestTimeout(request_id) => {
-                state.inflight_requests.remove(&request_id);
-                // TODO: When the peer failed for too many times, we should consider disconnecting from the peer.
-                state.peer_state.failed_times += 1;
+                if state.inflight_requests.remove(&request_id).is_none() {
+                    return Ok(());
+                }
                 observe_active_sync_timeout();
+                if state.record_no_progress(&myself, "request timed out") {
+                    return Ok(());
+                }
                 myself
                     .send_message(GossipSyncingActorMessage::NewGetRequest())
                     .expect("gossip syncing actor alive");
@@ -1044,50 +1077,20 @@ where
                         return Ok(());
                     }
 
-                    match call!(
+                    let no_progress_reason = match call!(
                         &state.store.actor,
                         ExtendedGossipMessageStoreMessage::SaveActiveSyncMessages,
                         state.peer_pubkey,
                         messages
                     ) {
                         Ok(ActiveSyncSaveMessagesResult::Validated(cursor)) => {
-                            state.cursor = cursor;
-                            state.consecutive_pending_results = 0;
-                        }
-                        Ok(ActiveSyncSaveMessagesResult::Pending) => {
-                            state.consecutive_pending_results =
-                                state.consecutive_pending_results.saturating_add(1);
-                            if state.consecutive_pending_results
-                                >= MAX_CONSECUTIVE_ACTIVE_SYNC_PENDING_RESULTS
-                            {
-                                warn!(
-                                    "Aborting active sync with peer {:?} after {} consecutive pending results",
-                                    &state.peer_pubkey, state.consecutive_pending_results
-                                );
-                                state
-                                    .gossip_actor
-                                    .send_message(GossipActorMessage::ActiveSyncingAborted {
-                                        peer: state.peer_pubkey,
-                                        session_id: state.session_id,
-                                        sync_id: state.sync_id,
-                                    })
-                                    .expect("gossip actor alive");
-                                myself.stop(Some(
-                                    "Too many consecutive pending active sync results".to_string(),
-                                ));
-                                return Ok(());
+                            if state.update_cursor_if_advanced(cursor) {
+                                None
+                            } else {
+                                Some("validated cursor did not advance")
                             }
-                            trace!(
-                                "Deferring active sync cursor advancement for peer {:?}",
-                                &state.peer_pubkey
-                            );
-                            std::mem::drop(
-                                myself.send_after(DEFERRED_SYNC_CURSOR_RETRY_DELAY, || {
-                                    GossipSyncingActorMessage::NewGetRequest()
-                                }),
-                            );
-                            return Ok(());
                         }
+                        Ok(ActiveSyncSaveMessagesResult::Pending) => Some("messages are pending"),
                         Ok(ActiveSyncSaveMessagesResult::Rejected(violation)) => {
                             warn!(
                                 "Active sync response from peer {:?} rejected: {:?}",
@@ -1127,6 +1130,20 @@ where
                             myself.stop(Some("Failed to save active sync messages".to_string()));
                             return Ok(());
                         }
+                    };
+                    if let Some(reason) = no_progress_reason {
+                        if state.record_no_progress(&myself, reason) {
+                            return Ok(());
+                        }
+                        trace!(
+                            "Deferring active sync cursor advancement for peer {:?}: {}",
+                            &state.peer_pubkey,
+                            reason
+                        );
+                        std::mem::drop(myself.send_after(DEFERRED_SYNC_CURSOR_RETRY_DELAY, || {
+                            GossipSyncingActorMessage::NewGetRequest()
+                        }));
+                        return Ok(());
                     }
                     trace!(
                         "Sending new GetBroadcastMessages request after receiving response: pubkey {:?}",

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -21,7 +21,8 @@ use crate::{
         payment::{SendPaymentCommand, SendPaymentDataExt},
         types::{
             broadcast_message_to_gossip, BroadcastMessageWithTimestamp,
-            BroadcastMessagesFilterResult, FiberMessage, GossipMessage, OpenChannel,
+            BroadcastMessagesFilterResult, FiberMessage, GetBroadcastMessagesResult, GossipMessage,
+            OpenChannel,
         },
         BroadcastMessage, ChannelAnnouncement, ChannelUpdateChannelFlags, Cursor, FeatureVector,
         NetworkActorCommand, NetworkActorEvent, NetworkActorMessage, NodeAnnouncement, Privkey,
@@ -1148,6 +1149,164 @@ async fn test_pending_active_sync_peer_releases_budget_while_connected() {
             .get_latest_node_announcement(&announcement.node_id)
             .is_some(),
         "pending active-sync peer must not keep consuming the active sync budget"
+    );
+}
+
+#[tokio::test]
+async fn test_non_advancing_active_sync_results_do_not_reset_stall_budget() {
+    init_tracing();
+
+    const LARGE_INTERVAL_MS: u64 = 3_600_000;
+    let target_one_active_sync_peer = || {
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.gossip_network_maintenance_interval_ms = Some(LARGE_INTERVAL_MS);
+                config.gossip_network_num_targeted_active_syncing_peers = Some(1);
+            })
+            .build()
+    };
+
+    let mut victim = NetworkNode::new_with_config(target_one_active_sync_peer()).await;
+    let now = now_timestamp_as_millis_u64();
+    let older_announcement = create_node_announcement_message_with_priv_key_and_timestamp(
+        &gen_rand_fiber_private_key(),
+        now.saturating_sub(1_000),
+    );
+    let newer_announcement = create_node_announcement_message_with_priv_key_and_timestamp(
+        &gen_rand_fiber_private_key(),
+        now,
+    );
+    victim
+        .get_store()
+        .save_node_announcement(older_announcement.clone());
+    victim
+        .get_store()
+        .save_node_announcement(newer_announcement.clone());
+
+    let mut stalled_peer = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some("stalled-peer".to_string()))
+            .fiber_config_updater(|config| config.auto_announce_node = Some(false))
+            .build(),
+    )
+    .await;
+    stalled_peer
+        .gossip_actor
+        .as_ref()
+        .expect("gossip actor started")
+        .stop(Some("manually drive active-sync responses".to_string()));
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    victim.connect_to(&mut stalled_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let mut honest_peer = NetworkNode::new_with_node_name("honest-peer").await;
+    let (_, honest_announcement) = gen_rand_node_announcement();
+    honest_peer.send_message_to_gossip_actor(GossipActorMessage::TryBroadcastMessages(vec![
+        BroadcastMessageWithTimestamp::NodeAnnouncement(honest_announcement.clone()),
+    ]));
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    victim.connect_to(&mut honest_peer).await;
+
+    let channel_context = ChannelTestContext::gen().await;
+    let orphan_update = channel_context.create_channel_update_of_node1(
+        ChannelUpdateChannelFlags::empty(),
+        144,
+        0,
+        0,
+        Some(now_timestamp_as_millis_u64()),
+    );
+
+    let mut request_id = 0;
+    victim.mock_received_gossip_message_from_peer(
+        stalled_peer.pubkey,
+        GossipMessage::GetBroadcastMessagesResult(GetBroadcastMessagesResult {
+            id: request_id,
+            messages: vec![BroadcastMessage::NodeAnnouncement(newer_announcement)],
+        }),
+    );
+    request_id += 1;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    for _ in 0..3 {
+        victim.mock_received_gossip_message_from_peer(
+            stalled_peer.pubkey,
+            GossipMessage::GetBroadcastMessagesResult(GetBroadcastMessagesResult {
+                id: request_id,
+                messages: vec![BroadcastMessage::ChannelUpdate(orphan_update.clone())],
+            }),
+        );
+        request_id += 1;
+        tokio::time::sleep(tokio::time::Duration::from_millis(550)).await;
+
+        victim.mock_received_gossip_message_from_peer(
+            stalled_peer.pubkey,
+            GossipMessage::GetBroadcastMessagesResult(GetBroadcastMessagesResult {
+                id: request_id,
+                messages: vec![BroadcastMessage::NodeAnnouncement(
+                    older_announcement.clone(),
+                )],
+            }),
+        );
+        request_id += 1;
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    assert!(
+        victim
+            .get_store()
+            .get_latest_node_announcement(&honest_announcement.node_id)
+            .is_some(),
+        "non-advancing validated responses must not reset the active-sync stall budget"
+    );
+}
+
+#[tokio::test]
+async fn test_timed_out_active_sync_peer_releases_budget_while_connected() {
+    init_tracing();
+
+    const LARGE_INTERVAL_MS: u64 = 3_600_000;
+    let target_one_active_sync_peer = || {
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.gossip_network_maintenance_interval_ms = Some(LARGE_INTERVAL_MS);
+                config.gossip_network_num_targeted_active_syncing_peers = Some(1);
+            })
+            .build()
+    };
+
+    let mut victim = NetworkNode::new_with_config(target_one_active_sync_peer()).await;
+    let mut stalled_peer = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .node_name(Some("stalled-peer".to_string()))
+            .fiber_config_updater(|config| config.auto_announce_node = Some(false))
+            .build(),
+    )
+    .await;
+    stalled_peer
+        .gossip_actor
+        .as_ref()
+        .expect("gossip actor started")
+        .stop(Some("drop active-sync requests".to_string()));
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    victim.connect_to(&mut stalled_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let mut honest_peer = NetworkNode::new_with_node_name("honest-peer").await;
+    let (_, announcement) = gen_rand_node_announcement();
+    honest_peer.send_message_to_gossip_actor(GossipActorMessage::TryBroadcastMessages(vec![
+        BroadcastMessageWithTimestamp::NodeAnnouncement(announcement.clone()),
+    ]));
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    victim.connect_to(&mut honest_peer).await;
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+    assert!(
+        victim
+            .get_store()
+            .get_latest_node_announcement(&announcement.node_id)
+            .is_some(),
+        "timed-out active-sync peer must not keep consuming the active sync budget"
     );
 }
 

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -1098,6 +1098,60 @@ async fn test_rejected_active_sync_peer_releases_budget_while_connected() {
 }
 
 #[tokio::test]
+async fn test_pending_active_sync_peer_releases_budget_while_connected() {
+    init_tracing();
+
+    const LARGE_INTERVAL_MS: u64 = 3_600_000;
+    let target_one_active_sync_peer = || {
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.gossip_network_maintenance_interval_ms = Some(LARGE_INTERVAL_MS);
+                config.gossip_network_num_targeted_active_syncing_peers = Some(1);
+            })
+            .build()
+    };
+
+    let mut victim = NetworkNode::new_with_config(target_one_active_sync_peer()).await;
+    let mut incomplete_peer = NetworkNode::new_with_node_name("incomplete-peer").await;
+    let channel_context = ChannelTestContext::gen().await;
+    let orphan_update = channel_context.create_channel_update_of_node1(
+        ChannelUpdateChannelFlags::empty(),
+        144,
+        0,
+        0,
+        Some(now_timestamp_as_millis_u64()),
+    );
+    incomplete_peer
+        .get_store()
+        .save_channel_update(orphan_update);
+    assert!(incomplete_peer
+        .get_store()
+        .get_latest_channel_announcement(channel_context.channel_outpoint())
+        .is_none());
+
+    victim.connect_to(&mut incomplete_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    let mut honest_peer = NetworkNode::new_with_node_name("honest-peer").await;
+    let (_, announcement) = gen_rand_node_announcement();
+    honest_peer.send_message_to_gossip_actor(GossipActorMessage::TryBroadcastMessages(vec![
+        BroadcastMessageWithTimestamp::NodeAnnouncement(announcement.clone()),
+    ]));
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    victim.connect_to(&mut honest_peer).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    assert!(
+        victim
+            .get_store()
+            .get_latest_node_announcement(&announcement.node_id)
+            .is_some(),
+        "pending active-sync peer must not keep consuming the active sync budget"
+    );
+}
+
+#[tokio::test]
 async fn test_repeated_rejected_active_sync_peer_is_eventually_banned() {
     init_tracing();
 


### PR DESCRIPTION
## Summary

- track consecutive no-progress results during active gossip sync
- require validated cursors to advance monotonically before updating the local cursor or resetting the stall budget
- count pending dependency results, non-advancing validated cursors, and request timeouts through one bounded abort path
- add end-to-end regression coverage for missing dependencies, duplicate-cursor bypasses, and silent peers

## Why

An active sync peer can keep a limited sync slot indefinitely by returning messages whose dependencies are unavailable, replaying already-known messages that do not advance the cursor, or never answering requests. The receiver previously retried the same peer without a bounded no-progress policy.

## Implementation

Only a cursor strictly greater than the current cursor is accepted as progress. Production builds allow 20 consecutive no-progress events; tests use a smaller threshold while exercising the same state transition. Once the threshold is reached, the syncing actor emits the existing `ActiveSyncingAborted` event and stops, allowing normal maintenance to select another peer without banning it.

The production request timeout remains 20 seconds, so a completely silent peer is bounded at approximately 400 seconds before rotation.

## Testing

- `RUST_LOG=off cargo nextest run -p fnn --features rocksdb active_sync` (10 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features rocksdb -p fnn -- -D warnings`
