### PR TITLE
Preflight CCH Fiber payments before creating LND invoices

### DIFF
--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -28,11 +28,15 @@ const BTC_PAYMENT_TIMEOUT_SECONDS: i32 = 60;
 /// charged on the incoming/order leg. This enforces the invariant that the total outgoing route
 /// fee never exceeds the fee the operator collected. `max_outgoing_fee_percentage` is validated
 /// to be within `1..=100` at startup, so the multiplication only ever shrinks `fee_sats`.
+pub(crate) fn outgoing_fee_budget_from_fee_sats(
+    fee_sats: u128,
+    max_outgoing_fee_percentage: u64,
+) -> u128 {
+    fee_sats.saturating_mul(max_outgoing_fee_percentage as u128) / 100
+}
+
 pub(crate) fn outgoing_fee_budget_sats(order: &CchOrder, max_outgoing_fee_percentage: u64) -> u128 {
-    order
-        .fee_sats
-        .saturating_mul(max_outgoing_fee_percentage as u128)
-        / 100
+    outgoing_fee_budget_from_fee_sats(order.fee_sats, max_outgoing_fee_percentage)
 }
 
 /// Compute the `max_fee_rate` (proportional, over `MAX_FEE_RATE_DENOMINATOR`) that corresponds to

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -14,6 +14,9 @@ use tentacle::secio::SecioKeyPair;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
+use crate::cch::actions::send_outgoing_payment::{
+    outgoing_fee_budget_from_fee_sats, outgoing_max_fee_rate,
+};
 use crate::cch::actions::{ActionDispatcher, CchOrderAction};
 use crate::cch::cch_fiber_agent::{CchFiberAgentActor, CchFiberAgentHttpBackend, CchFiberAgentRef};
 use crate::cch::order::CchOrderStateMachine;
@@ -22,8 +25,9 @@ use crate::cch::trackers::{
     CchTrackingEvent, LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage,
     RedactedCchTrackingEvent,
 };
-use crate::cch::{CchConfig, CchError, CchOrderStore, CchStoreError};
+use crate::cch::{CchConfig, CchError, CchOrderStore, CchStoreError, OutgoingFeeLimit};
 use crate::ckb::contracts::{get_script_by_contract, Contract};
+use crate::fiber::config::MAX_PAYMENT_TLC_EXPIRY_LIMIT;
 use crate::fiber::NetworkActorMessage;
 use crate::invoice::{CkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder};
 use crate::now_timestamp_as_millis_u64;
@@ -765,6 +769,22 @@ impl<S: CchOrderStore> CchState<S> {
         if hash_algorithm != HashAlgorithm::Sha256 {
             return Err(CchError::CKBInvoiceIncompatibleHashAlgorithm);
         }
+
+        // Do not create externally payable BTC-side state for an invoice Fiber cannot currently
+        // route. The actual payment is still attempted only after the hold invoice is accepted;
+        // this dry run is a side-effect-free snapshot that rejects already-invalid orders early.
+        let fee_budget_sats =
+            outgoing_fee_budget_from_fee_sats(fee_sats, self.config.max_outgoing_fee_percentage);
+        self.fiber_agent_ref
+            .call_payment_preflight(
+                receive_btc.fiber_pay_req.clone(),
+                (btc_final_cltv_millis / 2).min(MAX_PAYMENT_TLC_EXPIRY_LIMIT),
+                OutgoingFeeLimit {
+                    max_fee_amount: fee_budget_sats,
+                    max_fee_rate: outgoing_max_fee_rate(amount_sats, fee_budget_sats),
+                },
+            )
+            .await?;
 
         let mut client = self.lnd_connection.create_invoices_client().await?;
         let req = invoicesrpc::AddHoldInvoiceRequest {

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -663,6 +663,37 @@ impl<S: CchOrderStore> CchState<S> {
         Ok(order)
     }
 
+    fn remaining_outgoing_invoice_expiry_seconds(
+        &self,
+        invoice: &CkbInvoice,
+        current_time_seconds: u64,
+    ) -> Result<u64, CchError> {
+        let remaining_seconds = match invoice.expiry_time() {
+            Some(expiry) => invoice
+                .data
+                .timestamp
+                .checked_add(expiry.as_millis())
+                .and_then(|expiry_at| {
+                    u64::try_from(expiry_at / 1000)
+                        .unwrap_or(u64::MAX)
+                        .checked_sub(current_time_seconds)
+                })
+                .ok_or(CchError::OutgoingInvoiceExpiryTooShort)?,
+            // CKB invoices have no default expiry, so use twice the configured minimum when the
+            // outgoing invoice does not set one explicitly.
+            None => self
+                .config
+                .min_outgoing_invoice_expiry_delta_seconds
+                .checked_mul(2)
+                .ok_or(CchError::OutgoingInvoiceExpiryTooShort)?,
+        };
+
+        if remaining_seconds < self.config.min_outgoing_invoice_expiry_delta_seconds {
+            return Err(CchError::OutgoingInvoiceExpiryTooShort);
+        }
+        Ok(remaining_seconds)
+    }
+
     async fn receive_btc(&self, receive_btc: ReceiveBTC) -> Result<CchOrder, CchError> {
         // `from_str` requires the invoice to carry a valid signature, so parsing
         // here also guarantees the Fiber invoice is signed.
@@ -723,30 +754,7 @@ impl<S: CchOrderStore> CchState<S> {
             });
         }
 
-        // Convert timestamp + expiry_time to the expiry time relative to `duration_since`.
-        let outgoing_invoice_expiry_delta_seconds = match invoice.expiry_time() {
-            Some(expiry) => invoice
-                .data
-                .timestamp
-                .checked_add(expiry.as_millis())
-                .and_then(|expiry_at| {
-                    u64::try_from(expiry_at / 1000)
-                        .unwrap_or(u64::MAX)
-                        .checked_sub(order_created_at)
-                })
-                .ok_or(CchError::OutgoingInvoiceExpiryTooShort)?,
-            // CKB invoice has no default expiry, use minimal * 2 to create the invoice
-            None => self
-                .config
-                .min_outgoing_invoice_expiry_delta_seconds
-                .checked_mul(2)
-                .ok_or(CchError::OutgoingInvoiceExpiryTooShort)?,
-        };
-        if outgoing_invoice_expiry_delta_seconds
-            < self.config.min_outgoing_invoice_expiry_delta_seconds
-        {
-            return Err(CchError::OutgoingInvoiceExpiryTooShort);
-        }
+        self.remaining_outgoing_invoice_expiry_seconds(&invoice, order_created_at)?;
 
         // Verify wrapped_btc_type_script matches invoice UDT type script
         let wrapped_btc_type_script = self.resolve_wrapped_btc_type_script()?;
@@ -787,6 +795,14 @@ impl<S: CchOrderStore> CchState<S> {
             .await?;
 
         let mut client = self.lnd_connection.create_invoices_client().await?;
+
+        // Preflight and client setup may take long enough for the absolute Fiber invoice expiry
+        // to move materially closer. Refresh it immediately before creating the relative-expiry
+        // LND hold invoice so elapsed setup time is not added to the incoming invoice lifetime.
+        let refreshed_at = now_timestamp_as_millis_u64() / 1000;
+        let outgoing_invoice_expiry_delta_seconds =
+            self.remaining_outgoing_invoice_expiry_seconds(&invoice, refreshed_at)?;
+
         let req = invoicesrpc::AddHoldInvoiceRequest {
             hash: payment_hash.as_ref().to_vec(),
             value_msat: total_msat,

--- a/crates/fiber-lib/src/cch/cch_fiber_agent.rs
+++ b/crates/fiber-lib/src/cch/cch_fiber_agent.rs
@@ -44,6 +44,13 @@ pub enum CchFiberAgentMessage {
         Option<u64>,
         RpcReplyPort<Result<PaymentStatus>>,
     ),
+    PreflightPayment(
+        String,
+        Option<u64>,
+        Option<u128>,
+        Option<u64>,
+        RpcReplyPort<Result<PaymentStatus>>,
+    ),
     SettleInvoice(Hash256, Hash256, RpcReplyPort<Result<()>>),
 }
 
@@ -96,6 +103,24 @@ impl Actor for CchFiberAgentActor {
                     .await;
                 let _ = port.send(result);
             }
+            CchFiberAgentMessage::PreflightPayment(
+                pay_req,
+                tlc_expiry_limit,
+                max_fee_amount,
+                max_fee_rate,
+                port,
+            ) => {
+                let result = state
+                    .send_payment_with_dry_run(
+                        pay_req,
+                        tlc_expiry_limit,
+                        max_fee_amount,
+                        max_fee_rate,
+                        true,
+                    )
+                    .await;
+                let _ = port.send(result);
+            }
             CchFiberAgentMessage::SettleInvoice(payment_hash, payment_preimage, port) => {
                 let result = state.settle_invoice(payment_hash, payment_preimage).await;
                 let _ = port.send(result);
@@ -145,6 +170,24 @@ impl CchFiberAgentHttpBackend {
         max_fee_amount: Option<u128>,
         max_fee_rate: Option<u64>,
     ) -> Result<PaymentStatus> {
+        self.send_payment_with_dry_run(
+            pay_req,
+            tlc_expiry_limit,
+            max_fee_amount,
+            max_fee_rate,
+            false,
+        )
+        .await
+    }
+
+    async fn send_payment_with_dry_run(
+        &self,
+        pay_req: String,
+        tlc_expiry_limit: Option<u64>,
+        max_fee_amount: Option<u128>,
+        max_fee_rate: Option<u64>,
+        dry_run: bool,
+    ) -> Result<PaymentStatus> {
         let payment_params = SendPaymentCommandParams {
             target_pubkey: None,
             amount: None,
@@ -162,7 +205,7 @@ impl CchFiberAgentHttpBackend {
             allow_self_payment: None,
             custom_records: None,
             hop_hints: None,
-            dry_run: None,
+            dry_run: Some(dry_run),
         };
         let response = self
             .client
@@ -304,6 +347,52 @@ impl CchFiberAgentRef {
                 CchFiberAgentMessage::AddInvoice(invoice.clone(), port)
             })
             .map_err(to_fiber_err)?
+            .map_err(CchError::FiberNodeError),
+        }
+    }
+
+    /// Verify that Fiber can currently build a route for an outgoing payment without creating a
+    /// payment session or sending a TLC.
+    pub async fn call_payment_preflight(
+        &self,
+        outgoing_pay_req: String,
+        tlc_expiry_limit: u64,
+        fee_limit: OutgoingFeeLimit,
+    ) -> Result<(), CchError> {
+        let tlc_limit = Some(tlc_expiry_limit);
+        let max_fee = Some(fee_limit.max_fee_amount);
+        let max_fee_rate = Some(fee_limit.max_fee_rate);
+        match self {
+            Self::InProcess(network_actor) => {
+                let msg = move |tx| {
+                    NetworkActorMessage::Command(NetworkActorCommand::SendPayment(
+                        SendPaymentCommand {
+                            invoice: Some(outgoing_pay_req.clone()),
+                            tlc_expiry_limit: tlc_limit,
+                            max_fee_amount: max_fee,
+                            max_fee_rate,
+                            dry_run: true,
+                            ..Default::default()
+                        },
+                        tx,
+                    ))
+                };
+                call!(network_actor, msg)
+                    .map_err(to_fiber_err)?
+                    .map_err(to_fiber_err)?;
+                Ok(())
+            }
+            Self::Rpc(rpc_actor) => call!(rpc_actor, |port| {
+                CchFiberAgentMessage::PreflightPayment(
+                    outgoing_pay_req,
+                    tlc_limit,
+                    max_fee,
+                    max_fee_rate,
+                    port,
+                )
+            })
+            .map_err(to_fiber_err)?
+            .map(|_| ())
             .map_err(CchError::FiberNodeError),
         }
     }

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -132,6 +132,8 @@ struct MockNetworkState {
     preflighted_fiber_payments: Arc<Mutex<std::collections::HashSet<Hash256>>>,
     /// Optional error returned by dry-run Fiber payments.
     fiber_preflight_error: Arc<Mutex<Option<String>>>,
+    /// Artificial delay before returning a dry-run Fiber payment response.
+    fiber_preflight_delay: Arc<Mutex<Duration>>,
     /// Tracks the `max_fee_amount` of each outgoing Fiber SendPayment, keyed by payment hash.
     sent_fiber_payment_fees: Arc<Mutex<std::collections::HashMap<Hash256, Option<u128>>>>,
     /// Status returned by mocked outgoing Fiber SendPayment.
@@ -177,6 +179,8 @@ impl Actor for MockNetworkActor {
                             .lock()
                             .unwrap()
                             .insert(payment_hash);
+                        let delay = *state.fiber_preflight_delay.lock().unwrap();
+                        tokio::time::sleep(delay).await;
                         if let Some(error) = state.fiber_preflight_error.lock().unwrap().clone() {
                             let _ = reply.send(Err(error));
                             return Ok(());
@@ -348,6 +352,10 @@ impl TestHarness {
 
     fn fail_fiber_payment_preflight(&self, error: impl Into<String>) {
         *self.mock_state.fiber_preflight_error.lock().unwrap() = Some(error.into());
+    }
+
+    fn delay_fiber_payment_preflight(&self, delay: Duration) {
+        *self.mock_state.fiber_preflight_delay.lock().unwrap() = delay;
     }
 
     fn was_fiber_payment_preflighted(&self, payment_hash: Hash256) -> bool {
@@ -530,6 +538,7 @@ async fn setup_test_harness_with_config_and_store(
         sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
         preflighted_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
         fiber_preflight_error: Arc::new(Mutex::new(None)),
+        fiber_preflight_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
         sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
         send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
     };
@@ -577,6 +586,7 @@ async fn setup_store_backed_test_harness() -> StoreBackedTestHarness {
         sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
         preflighted_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
         fiber_preflight_error: Arc::new(Mutex::new(None)),
+        fiber_preflight_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
         sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
         send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
     };
@@ -1846,6 +1856,69 @@ async fn test_receive_btc_preflights_fiber_sendability_before_lnd() {
     assert!(
         harness.was_fiber_payment_preflighted(payment_hash),
         "receive_btc must dry-run the outgoing Fiber payment"
+    );
+}
+
+/// A Fiber invoice that becomes too short-lived during preflight must be rejected before CCH
+/// creates an LND hold invoice with a longer relative expiry.
+#[tokio::test]
+async fn test_receive_btc_rechecks_fiber_invoice_expiry_after_preflight() {
+    use crate::ckb::contracts::{get_script_by_contract, Contract};
+    use crate::invoice::CkbScript;
+
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 1,
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config(config).await;
+    harness.delay_fiber_payment_preflight(Duration::from_millis(2_100));
+
+    let (_preimage, payment_hash) = create_valid_preimage_pair(173);
+    let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
+    let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
+    let mut invoice = CkbInvoice {
+        currency: Currency::Fibb,
+        amount: Some(100_000),
+        signature: None,
+        data: InvoiceData {
+            payment_hash,
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+            attrs: vec![
+                Attribute::FinalHtlcMinimumExpiryDelta(12),
+                Attribute::Description("short-lived invoice".to_string()),
+                Attribute::ExpiryTime(Duration::from_secs(2)),
+                Attribute::PayeePublicKey(public_key),
+                Attribute::UdtScript(CkbScript(get_script_by_contract(Contract::SimpleUDT, &[]))),
+                Attribute::HashAlgorithm(HashAlgorithm::Sha256),
+            ],
+        },
+    };
+    invoice
+        .update_signature(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
+        .unwrap();
+
+    let result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: invoice.to_string(),
+        }
+    )
+    .expect("actor call failed");
+
+    assert!(
+        harness.was_fiber_payment_preflighted(payment_hash),
+        "receive_btc must complete preflight before rechecking expiry"
+    );
+    assert!(
+        matches!(result, Err(CchError::OutgoingInvoiceExpiryTooShort)),
+        "invoice that expires during preflight must be rejected, got: {:?}",
+        result
     );
 }
 

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -128,6 +128,10 @@ struct MockNetworkState {
     event_port: Arc<OutputPort<CchTrackingEvent>>,
     /// Tracks payment hashes for which SendPayment was called (outgoing Fiber payments)
     sent_fiber_payments: Arc<Mutex<std::collections::HashSet<Hash256>>>,
+    /// Tracks payment hashes for which a dry-run Fiber payment was requested.
+    preflighted_fiber_payments: Arc<Mutex<std::collections::HashSet<Hash256>>>,
+    /// Optional error returned by dry-run Fiber payments.
+    fiber_preflight_error: Arc<Mutex<Option<String>>>,
     /// Tracks the `max_fee_amount` of each outgoing Fiber SendPayment, keyed by payment hash.
     sent_fiber_payment_fees: Arc<Mutex<std::collections::HashMap<Hash256, Option<u128>>>>,
     /// Status returned by mocked outgoing Fiber SendPayment.
@@ -167,20 +171,38 @@ impl Actor for MockNetworkActor {
                     // Extract payment hash from invoice
                     let payment_hash = extract_payment_hash_from_command(&cmd);
 
-                    // Track that this payment was sent
-                    state
-                        .sent_fiber_payments
-                        .lock()
-                        .unwrap()
-                        .insert(payment_hash);
-                    state
-                        .sent_fiber_payment_fees
-                        .lock()
-                        .unwrap()
-                        .insert(payment_hash, cmd.max_fee_amount);
+                    if cmd.dry_run {
+                        state
+                            .preflighted_fiber_payments
+                            .lock()
+                            .unwrap()
+                            .insert(payment_hash);
+                        if let Some(error) = state.fiber_preflight_error.lock().unwrap().clone() {
+                            let _ = reply.send(Err(error));
+                            return Ok(());
+                        }
+                    }
+
+                    if !cmd.dry_run {
+                        // Track that this payment was sent
+                        state
+                            .sent_fiber_payments
+                            .lock()
+                            .unwrap()
+                            .insert(payment_hash);
+                        state
+                            .sent_fiber_payment_fees
+                            .lock()
+                            .unwrap()
+                            .insert(payment_hash, cmd.max_fee_amount);
+                    }
 
                     // Return success response - the executor will create CchTrackingEvent
-                    let status = *state.send_payment_status.lock().unwrap();
+                    let status = if cmd.dry_run {
+                        PaymentStatus::Created
+                    } else {
+                        *state.send_payment_status.lock().unwrap()
+                    };
                     let response = SendPaymentResponse {
                         payment_hash,
                         status,
@@ -322,6 +344,18 @@ impl TestHarness {
 
     fn set_send_payment_status(&self, status: PaymentStatus) {
         *self.mock_state.send_payment_status.lock().unwrap() = status;
+    }
+
+    fn fail_fiber_payment_preflight(&self, error: impl Into<String>) {
+        *self.mock_state.fiber_preflight_error.lock().unwrap() = Some(error.into());
+    }
+
+    fn was_fiber_payment_preflighted(&self, payment_hash: Hash256) -> bool {
+        self.mock_state
+            .preflighted_fiber_payments
+            .lock()
+            .unwrap()
+            .contains(&payment_hash)
     }
 
     fn simulate_fiber_attempt_status(&self, payment_hash: Hash256, attempt_status: AttemptStatus) {
@@ -494,6 +528,8 @@ async fn setup_test_harness_with_config_and_store(
         cch_actor: Arc::new(Mutex::new(None)),
         event_port: event_port.clone(),
         sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
+        preflighted_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
+        fiber_preflight_error: Arc::new(Mutex::new(None)),
         sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
         send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
     };
@@ -539,6 +575,8 @@ async fn setup_store_backed_test_harness() -> StoreBackedTestHarness {
         cch_actor: Arc::new(Mutex::new(None)),
         event_port: event_port.clone(),
         sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
+        preflighted_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
+        fiber_preflight_error: Arc::new(Mutex::new(None)),
         sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
         send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
     };
@@ -1751,6 +1789,63 @@ async fn test_receive_btc_amount_overflow_u128() {
         matches!(err, CchError::ReceiveBTCOrderAmountTooLarge),
         "expected ReceiveBTCOrderAmountTooLarge, got: {:?}",
         err
+    );
+}
+
+/// An unroutable Fiber invoice must be rejected before CCH creates an LND hold invoice.
+#[tokio::test]
+async fn test_receive_btc_preflights_fiber_sendability_before_lnd() {
+    use crate::ckb::contracts::{get_script_by_contract, Contract};
+    use crate::invoice::CkbScript;
+
+    let harness = setup_test_harness().await;
+    harness.fail_fiber_payment_preflight("Failed to build route, no path found");
+
+    let (_preimage, payment_hash) = create_valid_preimage_pair(172);
+    let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
+    let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
+    let mut invoice = CkbInvoice {
+        currency: Currency::Fibb,
+        amount: Some(100_000),
+        signature: None,
+        data: InvoiceData {
+            payment_hash,
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+            attrs: vec![
+                Attribute::FinalHtlcMinimumExpiryDelta(12),
+                Attribute::Description("unroutable invoice".to_string()),
+                Attribute::ExpiryTime(Duration::from_secs(3600)),
+                Attribute::PayeePublicKey(public_key),
+                Attribute::UdtScript(CkbScript(get_script_by_contract(Contract::SimpleUDT, &[]))),
+                Attribute::HashAlgorithm(HashAlgorithm::Sha256),
+            ],
+        },
+    };
+    invoice
+        .update_signature(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
+        .unwrap();
+
+    let result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: invoice.to_string(),
+        }
+    )
+    .expect("actor call failed");
+
+    let error = result.expect_err("unroutable Fiber invoice must be rejected");
+    assert!(
+        matches!(error, CchError::FiberNodeError(_)),
+        "sendability failure must be returned before contacting LND, got: {:?}",
+        error
+    );
+    assert!(
+        harness.was_fiber_payment_preflighted(payment_hash),
+        "receive_btc must dry-run the outgoing Fiber payment"
     );
 }
 


### PR DESCRIPTION
## Summary

- run a side-effect-free Fiber payment preflight before creating an LND hold invoice in the CCH receive-BTC flow
- apply the same fee and TLC expiry limits to the preflight and the eventual outgoing payment
- support preflight requests through both in-process and RPC-backed Fiber agents
- add regression coverage for rejecting unroutable Fiber invoices before contacting LND

## Motivation

CCH previously created an externally payable LND hold invoice before checking whether the outgoing Fiber invoice was currently routable. When route construction failed, the BTC-side payment could already be accepted even though the order could not complete. The new dry-run check rejects these requests before creating payable LND state and does not create a Fiber payment session or send a TLC.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run -p fnn --features sqlite test_receive_btc_preflights_fiber_sendability_before_lnd`
- `cargo clippy --all-targets --features sqlite -p fnn -- -D warnings`
