### PR TITLE
Coalesce duplicate CCH LND invoice trackers

### DIFF
--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -19,8 +19,8 @@ use crate::cch::cch_fiber_agent::{CchFiberAgentActor, CchFiberAgentHttpBackend, 
 use crate::cch::order::CchOrderStateMachine;
 use crate::cch::scheduler::{CchOrderSchedulerActor, SchedulerArgs, SchedulerMessage};
 use crate::cch::trackers::{
-    CchTrackingEvent, LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage,
-    RedactedCchTrackingEvent,
+    CchTrackingEvent, InvoiceTrackingReservationResult, LndConnectionInfo, LndTrackerActor,
+    LndTrackerArgs, LndTrackerMessage, RedactedCchTrackingEvent, MAX_TRACKED_INVOICES,
 };
 use crate::cch::{CchConfig, CchError, CchOrderStore, CchStoreError};
 use crate::ckb::contracts::{get_script_by_contract, Contract};
@@ -766,37 +766,69 @@ impl<S: CchOrderStore> CchState<S> {
             return Err(CchError::CKBInvoiceIncompatibleHashAlgorithm);
         }
 
-        let mut client = self.lnd_connection.create_invoices_client().await?;
-        let req = invoicesrpc::AddHoldInvoiceRequest {
-            hash: payment_hash.as_ref().to_vec(),
-            value_msat: total_msat,
-            expiry: outgoing_invoice_expiry_delta_seconds as i64,
-            cltv_expiry: self.config.btc_final_tlc_expiry_delta_blocks,
-            ..Default::default()
-        };
-        let add_invoice_resp = client
-            .add_hold_invoice(req.clone())
-            .await
-            .map_err(|err| CchError::LndRpcError(format!("{}, request: {:?}", err, req)))?
-            .into_inner();
-        let incoming_invoice = Bolt11Invoice::from_str(&add_invoice_resp.payment_request)?;
+        let reservation = ractor::call!(self.lnd_tracker, |reply| {
+            LndTrackerMessage::ReserveInvoiceTracking(payment_hash, reply)
+        })
+        .map_err(|err| CchError::LndInvoiceTrackerError(err.to_string()))?;
+        match reservation {
+            InvoiceTrackingReservationResult::Reserved => {}
+            InvoiceTrackingReservationResult::AlreadyTracked => {
+                return Err(CchError::LndInvoiceAlreadyTracked(payment_hash));
+            }
+            InvoiceTrackingReservationResult::CapacityExceeded => {
+                return Err(CchError::LndInvoiceTrackerCapacityExceeded(
+                    MAX_TRACKED_INVOICES,
+                ));
+            }
+        }
 
-        let order = CchOrder {
-            created_at: order_created_at,
-            expiry_delta_seconds: self.config.order_expiry_delta_seconds,
-            failure_reason: None,
-            incoming_invoice: CchInvoice::Lightning(incoming_invoice),
-            outgoing_pay_req: receive_btc.fiber_pay_req,
-            payment_preimage: None,
-            status: CchOrderStatus::Pending,
-            amount_sats,
-            fee_sats,
-            payment_hash,
-            wrapped_btc_type_script,
-        };
+        let result = async {
+            let mut client = self.lnd_connection.create_invoices_client().await?;
+            let req = invoicesrpc::AddHoldInvoiceRequest {
+                hash: payment_hash.as_ref().to_vec(),
+                value_msat: total_msat,
+                expiry: outgoing_invoice_expiry_delta_seconds as i64,
+                cltv_expiry: self.config.btc_final_tlc_expiry_delta_blocks,
+                ..Default::default()
+            };
+            let add_invoice_resp = client
+                .add_hold_invoice(req.clone())
+                .await
+                .map_err(|err| CchError::LndRpcError(format!("{}, request: {:?}", err, req)))?
+                .into_inner();
+            let incoming_invoice = Bolt11Invoice::from_str(&add_invoice_resp.payment_request)?;
 
-        self.store.insert_cch_order(order.clone())?;
-        Ok(order)
+            let order = CchOrder {
+                created_at: order_created_at,
+                expiry_delta_seconds: self.config.order_expiry_delta_seconds,
+                failure_reason: None,
+                incoming_invoice: CchInvoice::Lightning(incoming_invoice),
+                outgoing_pay_req: receive_btc.fiber_pay_req,
+                payment_preimage: None,
+                status: CchOrderStatus::Pending,
+                amount_sats,
+                fee_sats,
+                payment_hash,
+                wrapped_btc_type_script,
+            };
+
+            self.store.insert_cch_order(order.clone())?;
+            Ok(order)
+        };
+        let result = result.await;
+        if result.is_err() {
+            if let Err(err) = self
+                .lnd_tracker
+                .send_message(LndTrackerMessage::StopTracking(payment_hash))
+            {
+                tracing::warn!(
+                    "Failed to release invoice tracker reservation for {:x}: {}",
+                    payment_hash,
+                    err
+                );
+            }
+        }
+        result
     }
 
     async fn handle_tracking_event(&self, event: CchTrackingEvent) -> Result<Vec<CchOrderAction>> {

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -81,6 +81,12 @@ pub enum CchError {
     LndChannelError(#[from] lnd_grpc_tonic_client::channel::Error),
     #[error("Lnd RPC error: {0}")]
     LndRpcError(String),
+    #[error("LND invoice {0} is already being tracked")]
+    LndInvoiceAlreadyTracked(Hash256),
+    #[error("LND invoice tracker capacity exceeded (maximum {0})")]
+    LndInvoiceTrackerCapacityExceeded(usize),
+    #[error("LND invoice tracker error: {0}")]
+    LndInvoiceTrackerError(String),
     #[error("Fiber node error: {0}")]
     FiberNodeError(anyhow::Error),
 }

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -1858,13 +1858,15 @@ async fn test_receive_btc_fee_calculation() {
         .update_signature(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
         .unwrap();
 
+    let fiber_pay_req = invoice.to_string();
+
     // receive_btc will fail at the LND call, but all prior validations
     // (amount, fee, UDT script, hash algorithm) should pass.
     let result = call!(
         harness.actor,
         CchMessage::ReceiveBTC,
         crate::cch::ReceiveBTC {
-            fiber_pay_req: invoice.to_string(),
+            fiber_pay_req: fiber_pay_req.clone(),
         }
     )
     .expect("actor call failed");
@@ -1895,6 +1897,24 @@ async fn test_receive_btc_fee_calculation() {
             other
         ),
     }
+
+    // A failed LND invoice creation must release its reservation. Retrying the
+    // same request should reach LND again instead of being rejected as tracked.
+    let retry_err = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC { fiber_pay_req }
+    )
+    .expect("actor call failed")
+    .unwrap_err();
+    assert!(
+        matches!(
+            &retry_err,
+            CchError::LndRpcError(_) | CchError::LndChannelError(_)
+        ),
+        "failed LND invoice creation should release its tracker reservation, got: {:?}",
+        retry_err
+    );
 }
 
 // =============================================================================

--- a/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
@@ -60,6 +60,7 @@ struct TestStateSnapshot {
     invoice_queue_len: usize,
     active_invoice_trackers: usize,
     reserved_invoice_trackers: usize,
+    stopping_invoice_trackers: usize,
     tracked_invoices: usize,
 }
 
@@ -76,6 +77,7 @@ async fn get_state(actor_ref: &ActorRef<LndTrackerMessage>) -> TestStateSnapshot
         invoice_queue_len: state.invoice_queue_len,
         active_invoice_trackers: state.active_invoice_trackers,
         reserved_invoice_trackers: state.reserved_invoice_trackers,
+        stopping_invoice_trackers: state.stopping_invoice_trackers,
         tracked_invoices: state.tracked_invoices,
     }
 }
@@ -167,6 +169,40 @@ async fn test_tracking_commits_invoice_tracking_reservation() {
 }
 
 #[tokio::test]
+async fn test_stopping_active_tracker_remains_capacity_accounted() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let active_payment_hash = test_payment_hash(0);
+
+    assert_eq!(
+        reserve_invoice_tracking(&actor_ref, active_payment_hash).await,
+        InvoiceTrackingReservationResult::Reserved
+    );
+    actor_ref
+        .cast(LndTrackerMessage::TrackInvoice(active_payment_hash))
+        .expect("Failed to send TrackInvoice");
+    for value in 1..MAX_TRACKED_INVOICES {
+        assert_eq!(
+            reserve_invoice_tracking(&actor_ref, test_payment_hash(value as u8)).await,
+            InvoiceTrackingReservationResult::Reserved
+        );
+    }
+
+    actor_ref
+        .cast(LndTrackerMessage::StopTracking(active_payment_hash))
+        .expect("Failed to send StopTracking");
+    assert_eq!(
+        reserve_invoice_tracking(&actor_ref, test_payment_hash(MAX_TRACKED_INVOICES as u8)).await,
+        InvoiceTrackingReservationResult::CapacityExceeded
+    );
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.active_invoice_trackers, 1);
+    assert_eq!(state.stopping_invoice_trackers, 1);
+    assert_eq!(state.reserved_invoice_trackers, MAX_TRACKED_INVOICES - 1);
+    assert_eq!(state.tracked_invoices, MAX_TRACKED_INVOICES);
+}
+
+#[tokio::test]
 async fn test_retracking_before_stopped_tracker_completes_does_not_duplicate_tracker() {
     let (actor_ref, _handle) = create_test_actor().await;
     let payment_hash = test_payment_hash(1);
@@ -178,9 +214,21 @@ async fn test_retracking_before_stopped_tracker_completes_does_not_duplicate_tra
     actor_ref
         .cast(LndTrackerMessage::StopTracking(payment_hash))
         .expect("Failed to send StopTracking");
+
+    let stopping_state = get_state(&actor_ref).await;
+    assert_eq!(stopping_state.active_invoice_trackers, 1);
+    assert_eq!(stopping_state.stopping_invoice_trackers, 1);
+    assert_eq!(stopping_state.tracked_invoices, 1);
+
     actor_ref
         .cast(LndTrackerMessage::TrackInvoice(payment_hash))
         .expect("Failed to send TrackInvoice");
+
+    let resumed_state = get_state(&actor_ref).await;
+    assert_eq!(resumed_state.active_invoice_trackers, 1);
+    assert_eq!(resumed_state.stopping_invoice_trackers, 0);
+    assert_eq!(resumed_state.tracked_invoices, 1);
+
     actor_ref
         .cast(LndTrackerMessage::InvoiceTrackerCompleted {
             payment_hash,

--- a/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
@@ -13,12 +13,12 @@ fn create_test_args() -> LndTrackerArgs {
     let port = Arc::new(OutputPort::default());
     let tracker = TaskTracker::new();
     let token = CancellationToken::new();
-    let lnd_connection = LndConnectionInfo {
+    let lnd_connection = LndConnectionInfo::new(
         // Tracker will keep running because this URI is unreachable
-        uri: "https://localhost:10009".parse().unwrap(),
-        cert: None,
-        macaroon: None,
-    };
+        "https://localhost:10009".parse().unwrap(),
+        None,
+        None,
+    );
 
     LndTrackerArgs {
         port,
@@ -169,7 +169,7 @@ async fn test_tracking_commits_invoice_tracking_reservation() {
 }
 
 #[tokio::test]
-async fn test_stopping_active_tracker_remains_capacity_accounted() {
+async fn test_stopping_active_tracker_releases_capacity_after_task_exit() {
     let (actor_ref, _handle) = create_test_actor().await;
     let active_payment_hash = test_payment_hash(0);
 
@@ -190,16 +190,18 @@ async fn test_stopping_active_tracker_remains_capacity_accounted() {
     actor_ref
         .cast(LndTrackerMessage::StopTracking(active_payment_hash))
         .expect("Failed to send StopTracking");
-    assert_eq!(
-        reserve_invoice_tracking(&actor_ref, test_payment_hash(MAX_TRACKED_INVOICES as u8)).await,
-        InvoiceTrackingReservationResult::CapacityExceeded
-    );
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     let state = get_state(&actor_ref).await;
-    assert_eq!(state.active_invoice_trackers, 1);
-    assert_eq!(state.stopping_invoice_trackers, 1);
+    assert_eq!(state.active_invoice_trackers, 0);
+    assert_eq!(state.stopping_invoice_trackers, 0);
     assert_eq!(state.reserved_invoice_trackers, MAX_TRACKED_INVOICES - 1);
-    assert_eq!(state.tracked_invoices, MAX_TRACKED_INVOICES);
+    assert_eq!(state.tracked_invoices, MAX_TRACKED_INVOICES - 1);
+
+    assert_eq!(
+        reserve_invoice_tracking(&actor_ref, test_payment_hash(MAX_TRACKED_INVOICES as u8)).await,
+        InvoiceTrackingReservationResult::Reserved
+    );
 }
 
 #[tokio::test]
@@ -214,27 +216,9 @@ async fn test_retracking_before_stopped_tracker_completes_does_not_duplicate_tra
     actor_ref
         .cast(LndTrackerMessage::StopTracking(payment_hash))
         .expect("Failed to send StopTracking");
-
-    let stopping_state = get_state(&actor_ref).await;
-    assert_eq!(stopping_state.active_invoice_trackers, 1);
-    assert_eq!(stopping_state.stopping_invoice_trackers, 1);
-    assert_eq!(stopping_state.tracked_invoices, 1);
-
     actor_ref
         .cast(LndTrackerMessage::TrackInvoice(payment_hash))
         .expect("Failed to send TrackInvoice");
-
-    let resumed_state = get_state(&actor_ref).await;
-    assert_eq!(resumed_state.active_invoice_trackers, 1);
-    assert_eq!(resumed_state.stopping_invoice_trackers, 0);
-    assert_eq!(resumed_state.tracked_invoices, 1);
-
-    actor_ref
-        .cast(LndTrackerMessage::InvoiceTrackerCompleted {
-            payment_hash,
-            completed_successfully: false,
-        })
-        .expect("Failed to send completion");
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     let state = get_state(&actor_ref).await;
@@ -281,14 +265,13 @@ async fn test_completion_decrements_counter() {
     assert_eq!(final_state.active_invoice_trackers, 0);
 }
 
-// Test completion triggers queue processing for waiting invoices
+// All globally admitted invoices start immediately instead of waiting behind five long-lived slots.
 #[tokio::test]
-async fn test_completion_triggers_queue_processing() {
+async fn test_all_admitted_invoices_start_tracking() {
     let (actor_ref, _handle) = create_test_actor().await;
 
-    // Add 6 invoices to queue
-    for i in 0..6 {
-        let payment_hash = test_payment_hash(i);
+    for i in 0..MAX_TRACKED_INVOICES {
+        let payment_hash = test_payment_hash(i as u8);
         actor_ref
             .cast(LndTrackerMessage::TrackInvoice(payment_hash))
             .expect("Failed to send TrackInvoice");
@@ -296,8 +279,7 @@ async fn test_completion_triggers_queue_processing() {
 
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
-    // Verify invoices are queued
-    let state_before = actor_ref
+    let state = actor_ref
         .call(
             LndTrackerMessage::GetState,
             Some(RactorDuration::from_millis(1000)),
@@ -306,14 +288,26 @@ async fn test_completion_triggers_queue_processing() {
         .expect("Failed to get state")
         .expect("Failed to get state");
 
-    assert_eq!(
-        state_before.invoice_queue_len, 1,
-        "Should have 1 invoice in queue"
-    );
-    assert_eq!(
-        state_before.active_invoice_trackers, 5,
-        "Should have 5 active invoice trackers"
-    );
+    assert_eq!(state.invoice_queue_len, 0);
+    assert_eq!(state.active_invoice_trackers, MAX_TRACKED_INVOICES);
+}
+
+// Persisted orders from before the admission limit may exceed it. Restore them without opening
+// more than MAX_TRACKED_INVOICES concurrent subscriptions.
+#[tokio::test]
+async fn test_restored_invoices_above_global_limit_are_queued() {
+    let (actor_ref, _handle) = create_test_actor().await;
+
+    for i in 0..=MAX_TRACKED_INVOICES {
+        actor_ref
+            .cast(LndTrackerMessage::TrackInvoice(test_payment_hash(i as u8)))
+            .expect("Failed to send TrackInvoice");
+    }
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state_before = get_state(&actor_ref).await;
+    assert_eq!(state_before.invoice_queue_len, 1);
+    assert_eq!(state_before.active_invoice_trackers, MAX_TRACKED_INVOICES);
 
     let completed_hash = test_payment_hash(1);
     actor_ref
@@ -325,29 +319,14 @@ async fn test_completion_triggers_queue_processing() {
 
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
-    // Verify actor is still responsive
-    let state_after = actor_ref
-        .call(
-            LndTrackerMessage::GetState,
-            Some(RactorDuration::from_millis(1000)),
-        )
-        .await
-        .expect("Failed to get state")
-        .expect("Failed to get state");
-
-    assert_eq!(
-        state_after.invoice_queue_len, 0,
-        "Should have 0 invoices in queue"
-    );
-    assert_eq!(
-        state_after.active_invoice_trackers, 5,
-        "Should have 5 active invoice trackers"
-    );
+    let state_after = get_state(&actor_ref).await;
+    assert_eq!(state_after.invoice_queue_len, 0);
+    assert_eq!(state_after.active_invoice_trackers, MAX_TRACKED_INVOICES);
 }
 
-// Test timeout re-queues active invoices to end of queue
+// An unexpected tracker exit restarts without releasing the invoice's admission.
 #[tokio::test]
-async fn test_timeout_requeues_active_invoices() {
+async fn test_failed_tracker_restarts() {
     let (actor_ref, _handle) = create_test_actor().await;
     let payment_hash = test_payment_hash(1);
 

--- a/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
@@ -180,3 +180,62 @@ async fn test_timeout_requeues_active_invoices() {
     assert_eq!(final_state.invoice_queue_len, 0);
     assert_eq!(final_state.active_invoice_trackers, 1);
 }
+
+#[tokio::test]
+async fn test_duplicate_tracking_requests_are_coalesced() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(2);
+
+    for _ in 0..6 {
+        actor_ref
+            .cast(LndTrackerMessage::TrackInvoice(payment_hash))
+            .expect("Failed to send TrackInvoice");
+    }
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Failed to get state")
+        .expect("Failed to get state");
+
+    assert_eq!(state.invoice_queue_len, 0);
+    assert_eq!(state.active_invoice_trackers, 1);
+}
+
+#[tokio::test]
+async fn test_stopped_tracker_is_not_requeued_after_failure() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(3);
+
+    actor_ref
+        .cast(LndTrackerMessage::TrackInvoice(payment_hash))
+        .expect("Failed to send TrackInvoice");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    actor_ref
+        .cast(LndTrackerMessage::StopTracking(payment_hash))
+        .expect("Failed to send StopTracking");
+    actor_ref
+        .cast(LndTrackerMessage::InvoiceTrackerCompleted {
+            payment_hash,
+            completed_successfully: false,
+        })
+        .expect("Failed to send completion");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Failed to get state")
+        .expect("Failed to get state");
+
+    assert_eq!(state.invoice_queue_len, 0);
+    assert_eq!(state.active_invoice_trackers, 0);
+}

--- a/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/lnd_trackers_tests.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::cch::trackers::{LndConnectionInfo, LndTrackerActor, LndTrackerArgs, LndTrackerMessage};
+use crate::cch::trackers::{
+    InvoiceTrackingReservationResult, LndConnectionInfo, LndTrackerActor, LndTrackerArgs,
+    LndTrackerMessage, MAX_TRACKED_INVOICES,
+};
 use fiber_types::Hash256;
 use ractor::{concurrency::Duration as RactorDuration, Actor, ActorRef, OutputPort};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -41,6 +44,156 @@ async fn create_test_actor() -> (ActorRef<LndTrackerMessage>, tokio::task::JoinH
         .expect("Failed to spawn test actor");
 
     (actor_ref, actor_handle)
+}
+
+async fn reserve_invoice_tracking(
+    actor_ref: &ActorRef<LndTrackerMessage>,
+    payment_hash: Hash256,
+) -> InvoiceTrackingReservationResult {
+    ractor::call!(actor_ref, |reply| {
+        LndTrackerMessage::ReserveInvoiceTracking(payment_hash, reply)
+    })
+    .expect("Failed to reserve invoice tracking")
+}
+
+struct TestStateSnapshot {
+    invoice_queue_len: usize,
+    active_invoice_trackers: usize,
+    reserved_invoice_trackers: usize,
+    tracked_invoices: usize,
+}
+
+async fn get_state(actor_ref: &ActorRef<LndTrackerMessage>) -> TestStateSnapshot {
+    let state = actor_ref
+        .call(
+            LndTrackerMessage::GetState,
+            Some(RactorDuration::from_millis(1000)),
+        )
+        .await
+        .expect("Failed to get state")
+        .expect("Failed to get state");
+    TestStateSnapshot {
+        invoice_queue_len: state.invoice_queue_len,
+        active_invoice_trackers: state.active_invoice_trackers,
+        reserved_invoice_trackers: state.reserved_invoice_trackers,
+        tracked_invoices: state.tracked_invoices,
+    }
+}
+
+#[tokio::test]
+async fn test_invoice_tracking_reservation_enforces_global_limit() {
+    let (actor_ref, _handle) = create_test_actor().await;
+
+    for value in 0..MAX_TRACKED_INVOICES {
+        assert_eq!(
+            reserve_invoice_tracking(&actor_ref, test_payment_hash(value as u8)).await,
+            InvoiceTrackingReservationResult::Reserved
+        );
+    }
+    assert_eq!(
+        reserve_invoice_tracking(&actor_ref, test_payment_hash(MAX_TRACKED_INVOICES as u8)).await,
+        InvoiceTrackingReservationResult::CapacityExceeded
+    );
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.reserved_invoice_trackers, MAX_TRACKED_INVOICES);
+    assert_eq!(state.tracked_invoices, MAX_TRACKED_INVOICES);
+    assert_eq!(state.invoice_queue_len, 0);
+    assert_eq!(state.active_invoice_trackers, 0);
+}
+
+#[tokio::test]
+async fn test_duplicate_invoice_tracking_reservation_is_coalesced() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(1);
+
+    assert_eq!(
+        reserve_invoice_tracking(&actor_ref, payment_hash).await,
+        InvoiceTrackingReservationResult::Reserved
+    );
+    assert_eq!(
+        reserve_invoice_tracking(&actor_ref, payment_hash).await,
+        InvoiceTrackingReservationResult::AlreadyTracked
+    );
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.reserved_invoice_trackers, 1);
+    assert_eq!(state.tracked_invoices, 1);
+}
+
+#[tokio::test]
+async fn test_stopping_reservation_releases_global_capacity() {
+    let (actor_ref, _handle) = create_test_actor().await;
+
+    for value in 0..MAX_TRACKED_INVOICES {
+        assert_eq!(
+            reserve_invoice_tracking(&actor_ref, test_payment_hash(value as u8)).await,
+            InvoiceTrackingReservationResult::Reserved
+        );
+    }
+
+    actor_ref
+        .cast(LndTrackerMessage::StopTracking(test_payment_hash(0)))
+        .expect("Failed to send StopTracking");
+    assert_eq!(
+        reserve_invoice_tracking(&actor_ref, test_payment_hash(MAX_TRACKED_INVOICES as u8)).await,
+        InvoiceTrackingReservationResult::Reserved
+    );
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.reserved_invoice_trackers, MAX_TRACKED_INVOICES);
+    assert_eq!(state.tracked_invoices, MAX_TRACKED_INVOICES);
+}
+
+#[tokio::test]
+async fn test_tracking_commits_invoice_tracking_reservation() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(1);
+
+    assert_eq!(
+        reserve_invoice_tracking(&actor_ref, payment_hash).await,
+        InvoiceTrackingReservationResult::Reserved
+    );
+    actor_ref
+        .cast(LndTrackerMessage::TrackInvoice(payment_hash))
+        .expect("Failed to send TrackInvoice");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.reserved_invoice_trackers, 0);
+    assert_eq!(state.tracked_invoices, 1);
+    assert_eq!(state.invoice_queue_len, 0);
+    assert_eq!(state.active_invoice_trackers, 1);
+}
+
+#[tokio::test]
+async fn test_retracking_before_stopped_tracker_completes_does_not_duplicate_tracker() {
+    let (actor_ref, _handle) = create_test_actor().await;
+    let payment_hash = test_payment_hash(1);
+
+    actor_ref
+        .cast(LndTrackerMessage::TrackInvoice(payment_hash))
+        .expect("Failed to send TrackInvoice");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    actor_ref
+        .cast(LndTrackerMessage::StopTracking(payment_hash))
+        .expect("Failed to send StopTracking");
+    actor_ref
+        .cast(LndTrackerMessage::TrackInvoice(payment_hash))
+        .expect("Failed to send TrackInvoice");
+    actor_ref
+        .cast(LndTrackerMessage::InvoiceTrackerCompleted {
+            payment_hash,
+            completed_successfully: false,
+        })
+        .expect("Failed to send completion");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let state = get_state(&actor_ref).await;
+    assert_eq!(state.reserved_invoice_trackers, 0);
+    assert_eq!(state.tracked_invoices, 1);
+    assert_eq!(state.invoice_queue_len, 0);
+    assert_eq!(state.active_invoice_trackers, 1);
 }
 
 // Test completion decrements active_invoice_trackers counter

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -26,7 +26,12 @@
 //! 2. Re-queue if failed
 //! 3. Dequeue invoices from the queue and start tracking
 
-use std::{collections::VecDeque, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::{HashSet, VecDeque},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{anyhow, Result};
 use futures::StreamExt as _;
@@ -134,6 +139,8 @@ pub struct LndTrackerState {
     tracker: TaskTracker,
     /// Queue of payment hashes waiting to be tracked
     invoice_queue: VecDeque<Hash256>,
+    /// Payment hashes that are queued or currently being tracked.
+    tracked_invoices: HashSet<Hash256>,
     /// Number of currently active invoice trackers
     active_invoice_trackers: usize,
 }
@@ -214,6 +221,7 @@ impl Actor for LndTrackerActor {
             token: args.token.clone(),
             tracker: args.tracker.clone(),
             invoice_queue: VecDeque::new(),
+            tracked_invoices: HashSet::new(),
             active_invoice_trackers: 0,
         };
 
@@ -239,12 +247,16 @@ impl Actor for LndTrackerActor {
     ) -> Result<(), ActorProcessingErr> {
         let res = match message {
             LndTrackerMessage::TrackInvoice(payment_hash) => {
-                state.invoice_queue.push_back(payment_hash);
-                state.process_invoice_queue(myself).await?;
+                if state.tracked_invoices.insert(payment_hash) {
+                    state.invoice_queue.push_back(payment_hash);
+                    state.process_invoice_queue(myself).await?;
+                } else {
+                    tracing::debug!("Invoice {:x} is already being tracked", payment_hash);
+                }
                 Ok(())
             }
             LndTrackerMessage::StopTracking(payment_hash) => {
-                // Remove from queue if present
+                state.tracked_invoices.remove(&payment_hash);
                 state.invoice_queue.retain(|&hash| hash != payment_hash);
                 tracing::debug!("Stopped tracking invoice {:x}", payment_hash);
                 Ok(())
@@ -261,8 +273,9 @@ impl Actor for LndTrackerActor {
                     MAX_CONCURRENT_INVOICE_TRACKERS
                 );
                 state.active_invoice_trackers = state.active_invoice_trackers.saturating_sub(1);
-                // Re-queue failed tracker
-                if !completed_successfully {
+                if completed_successfully {
+                    state.tracked_invoices.remove(&payment_hash);
+                } else if state.tracked_invoices.contains(&payment_hash) {
                     state.invoice_queue.push_back(payment_hash);
                 }
 

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -39,7 +39,7 @@ use lnd_grpc_tonic_client::{
     create_invoices_client, create_router_client, invoicesrpc, lnrpc, routerrpc, InvoicesClient,
     RouterClient, Uri,
 };
-use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, OutputPort};
+use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, OutputPort, RpcReplyPort};
 use tokio::{select, time::sleep};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
@@ -48,6 +48,7 @@ use fiber_types::payment::PaymentStatus as FiberPaymentStatus;
 use fiber_types::Hash256;
 
 const MAX_CONCURRENT_INVOICE_TRACKERS: usize = 5;
+pub(crate) const MAX_TRACKED_INVOICES: usize = 100;
 const INVOICE_TRACKING_TIMEOUT: Duration = Duration::from_secs(5 * 60); // 5 minutes
 
 /// LND connection information
@@ -95,6 +96,9 @@ impl LndConnectionInfo {
 /// Message types for the LndTrackerActor
 #[derive(Debug)]
 pub enum LndTrackerMessage {
+    /// Reserve global capacity before creating an externally payable LND invoice.
+    ReserveInvoiceTracking(Hash256, RpcReplyPort<InvoiceTrackingReservationResult>),
+
     /// Track a new invoice
     TrackInvoice(Hash256),
 
@@ -115,12 +119,21 @@ pub enum LndTrackerMessage {
     GetState(ractor::RpcReplyPort<StateSnapshot>),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvoiceTrackingReservationResult {
+    Reserved,
+    AlreadyTracked,
+    CapacityExceeded,
+}
+
 /// Snapshot of actor state (for testing)
 #[cfg(test)]
 #[derive(Debug, Clone)]
 pub struct StateSnapshot {
     pub invoice_queue_len: usize,
     pub active_invoice_trackers: usize,
+    pub reserved_invoice_trackers: usize,
+    pub tracked_invoices: usize,
 }
 
 /// Arguments for starting the LndTrackerActor
@@ -139,10 +152,14 @@ pub struct LndTrackerState {
     tracker: TaskTracker,
     /// Queue of payment hashes waiting to be tracked
     invoice_queue: VecDeque<Hash256>,
-    /// Payment hashes that are queued or currently being tracked.
+    /// Payment hashes that are reserved, queued, active, or stopping.
     tracked_invoices: HashSet<Hash256>,
-    /// Number of currently active invoice trackers
-    active_invoice_trackers: usize,
+    /// Reservations made before the corresponding LND invoice and CCH order are created.
+    reserved_invoices: HashSet<Hash256>,
+    /// Payment hashes with a currently running tracker task.
+    active_invoices: HashSet<Hash256>,
+    /// Active trackers asked to stop; they remain capacity-accounted until completion.
+    stopped_invoices: HashSet<Hash256>,
 }
 
 /// Ractor Actor to track LND payments and invoices
@@ -222,7 +239,9 @@ impl Actor for LndTrackerActor {
             tracker: args.tracker.clone(),
             invoice_queue: VecDeque::new(),
             tracked_invoices: HashSet::new(),
-            active_invoice_trackers: 0,
+            reserved_invoices: HashSet::new(),
+            active_invoices: HashSet::new(),
+            stopped_invoices: HashSet::new(),
         };
 
         // Start payment tracker in background
@@ -246,8 +265,41 @@ impl Actor for LndTrackerActor {
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         let res = match message {
+            LndTrackerMessage::ReserveInvoiceTracking(payment_hash, reply_port) => {
+                let result = if state.tracked_invoices.contains(&payment_hash) {
+                    InvoiceTrackingReservationResult::AlreadyTracked
+                } else if state.tracked_invoices.len() >= MAX_TRACKED_INVOICES {
+                    InvoiceTrackingReservationResult::CapacityExceeded
+                } else {
+                    state.tracked_invoices.insert(payment_hash);
+                    state.reserved_invoices.insert(payment_hash);
+                    InvoiceTrackingReservationResult::Reserved
+                };
+                let _ = reply_port.send(result);
+                Ok(())
+            }
             LndTrackerMessage::TrackInvoice(payment_hash) => {
-                if state.tracked_invoices.insert(payment_hash) {
+                if state.reserved_invoices.remove(&payment_hash) {
+                    state.invoice_queue.push_back(payment_hash);
+                    state.process_invoice_queue(myself).await?;
+                } else if state.stopped_invoices.remove(&payment_hash)
+                    && state.active_invoices.contains(&payment_hash)
+                {
+                    tracing::debug!(
+                        "Resumed tracking invoice {:x} before its active tracker stopped",
+                        payment_hash
+                    );
+                } else if state.tracked_invoices.insert(payment_hash) {
+                    if state.tracked_invoices.len() > MAX_TRACKED_INVOICES {
+                        // Existing persisted orders must still be restored after an upgrade even
+                        // if they predate the admission limit. New orders reserve capacity before
+                        // creating their LND invoice and cannot take this path.
+                        tracing::warn!(
+                            "Restoring invoice tracker {:x} above the global limit of {}",
+                            payment_hash,
+                            MAX_TRACKED_INVOICES
+                        );
+                    }
                     state.invoice_queue.push_back(payment_hash);
                     state.process_invoice_queue(myself).await?;
                 } else {
@@ -256,8 +308,14 @@ impl Actor for LndTrackerActor {
                 Ok(())
             }
             LndTrackerMessage::StopTracking(payment_hash) => {
-                state.tracked_invoices.remove(&payment_hash);
+                state.reserved_invoices.remove(&payment_hash);
                 state.invoice_queue.retain(|&hash| hash != payment_hash);
+                if state.active_invoices.contains(&payment_hash) {
+                    state.stopped_invoices.insert(payment_hash);
+                } else {
+                    state.stopped_invoices.remove(&payment_hash);
+                    state.tracked_invoices.remove(&payment_hash);
+                }
                 tracing::debug!("Stopped tracking invoice {:x}", payment_hash);
                 Ok(())
             }
@@ -269,11 +327,18 @@ impl Actor for LndTrackerActor {
                     "Processing completion for payment_hash={}, success={}, active={}/{}",
                     payment_hash,
                     completed_successfully,
-                    state.active_invoice_trackers,
+                    state.active_invoices.len(),
                     MAX_CONCURRENT_INVOICE_TRACKERS
                 );
-                state.active_invoice_trackers = state.active_invoice_trackers.saturating_sub(1);
-                if completed_successfully {
+                if !state.active_invoices.remove(&payment_hash) {
+                    tracing::warn!(
+                        "Ignoring stale completion for inactive invoice tracker {:x}",
+                        payment_hash
+                    );
+                    return Ok(());
+                }
+
+                if state.stopped_invoices.remove(&payment_hash) || completed_successfully {
                     state.tracked_invoices.remove(&payment_hash);
                 } else if state.tracked_invoices.contains(&payment_hash) {
                     state.invoice_queue.push_back(payment_hash);
@@ -289,7 +354,9 @@ impl Actor for LndTrackerActor {
             LndTrackerMessage::GetState(reply_port) => {
                 let snapshot = StateSnapshot {
                     invoice_queue_len: state.invoice_queue.len(),
-                    active_invoice_trackers: state.active_invoice_trackers,
+                    active_invoice_trackers: state.active_invoices.len(),
+                    reserved_invoice_trackers: state.reserved_invoices.len(),
+                    tracked_invoices: state.tracked_invoices.len(),
                 };
                 let _ = reply_port.send(snapshot);
                 Ok(())
@@ -302,7 +369,7 @@ impl Actor for LndTrackerActor {
             metrics::gauge!(crate::metrics::CCH_LND_TRACKER_INVOICE_QUEUE_LEN)
                 .set(state.invoice_queue.len() as f64);
             metrics::gauge!(crate::metrics::CCH_LND_TRACKER_ACTIVE_INVOICE_TRACKERS)
-                .set(state.active_invoice_trackers as f64);
+                .set(state.active_invoices.len() as f64);
         }
 
         res
@@ -315,11 +382,17 @@ impl LndTrackerState {
         myself: ActorRef<LndTrackerMessage>,
     ) -> Result<(), ActorProcessingErr> {
         // Process invoices from queue
-        while self.active_invoice_trackers < MAX_CONCURRENT_INVOICE_TRACKERS {
+        while self.active_invoices.len() < MAX_CONCURRENT_INVOICE_TRACKERS {
             let Some(payment_hash) = self.invoice_queue.pop_front() else {
                 break;
             };
-            self.active_invoice_trackers += 1;
+            if !self.active_invoices.insert(payment_hash) {
+                tracing::warn!(
+                    "Skipping duplicate queued invoice tracker {:x}",
+                    payment_hash
+                );
+                continue;
+            }
 
             let tracker = InvoiceTracker {
                 port: self.port.clone(),
@@ -353,7 +426,7 @@ impl LndTrackerState {
             tracing::debug!(
                 "Started invoice tracker for payment_hash={}, active={}/{}",
                 payment_hash,
-                self.active_invoice_trackers,
+                self.active_invoices.len(),
                 MAX_CONCURRENT_INVOICE_TRACKERS
             );
         }

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -5,10 +5,10 @@
 //!
 //! ## Key Features
 //!
-//! - **Concurrent Tracking**: Tracks up to 5 invoices simultaneously to avoid overwhelming LND.
-//! - **Queue Management**: Maintains FIFO queue for pending invoice tracking requests.
-//! - **Timeout**: Re-queues active invoices after 5 minutes to prevent indefinite blocking.
-//! - **Completion Handling**: Properly cleans up when tracker tasks complete, timeout or fail.
+//! - **Bounded Tracking**: Tracks every admitted invoice, up to the global invoice limit.
+//! - **Connection Reuse**: Multiplexes invoice subscriptions over one shared LND client.
+//! - **Reconnect Protection**: Bounds concurrent subscription attempts and adds retry jitter.
+//! - **Completion Handling**: Properly cleans up when tracker tasks complete, stop, or fail.
 //!
 //! ## Architecture
 //!
@@ -16,18 +16,12 @@
 //! - `TrackInvoice(Hash256)`: Adds invoice to tracking queue
 //! - `InvoiceTrackerCompleted{...}`: Sent by spawned tracker tasks when they finish
 //!
-//! When a tracker task completes (successfully or with error), it ALWAYS sends
-//! `InvoiceTrackerCompleted` back to the actor. The actor maintains two data structures:
-//! - `invoice_queue`: VecDeque of pending invoice hashes
-//! - `active_invoice_trackers`: Number of active invoice trackers
-//!
-//! When completion message arrives:
-//! 1. Decrement `active_invoice_trackers` counter
-//! 2. Re-queue if failed
-//! 3. Dequeue invoices from the queue and start tracking
+//! The queue is only needed when restoring more persisted orders than the current global
+//! admission limit. Newly created orders reserve global capacity before their LND invoice is
+//! created, so every newly admitted invoice starts tracking immediately.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -40,16 +34,21 @@ use lnd_grpc_tonic_client::{
     RouterClient, Uri,
 };
 use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, OutputPort, RpcReplyPort};
-use tokio::{select, time::sleep};
+use tokio::{
+    sync::Semaphore,
+    time::{sleep, timeout},
+};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 use crate::{cch::trackers::CchTrackingEvent, invoice::CkbInvoiceStatus};
 use fiber_types::payment::PaymentStatus as FiberPaymentStatus;
 use fiber_types::Hash256;
 
-const MAX_CONCURRENT_INVOICE_TRACKERS: usize = 5;
 pub(crate) const MAX_TRACKED_INVOICES: usize = 100;
-const INVOICE_TRACKING_TIMEOUT: Duration = Duration::from_secs(5 * 60); // 5 minutes
+const MAX_CONCURRENT_SUBSCRIBE_ATTEMPTS: usize = 10;
+const SUBSCRIBE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
+const INVOICE_TRACKER_RETRY_DELAY: Duration = Duration::from_secs(15);
+const INVOICE_TRACKER_RETRY_JITTER: Duration = Duration::from_secs(15);
 
 /// LND connection information
 ///
@@ -156,13 +155,19 @@ pub struct LndTrackerArgs {
 /// State for the LndTrackerActor
 pub struct LndTrackerState {
     port: Arc<OutputPort<CchTrackingEvent>>,
-    lnd_connection: LndConnectionInfo,
+    invoices_client: InvoicesClient,
     token: CancellationToken,
     tracker: TaskTracker,
     /// Queue of payment hashes waiting to be tracked
     invoice_queue: VecDeque<Hash256>,
     /// State of every admitted invoice tracker. The map size is the global capacity usage.
     invoice_trackers: HashMap<Hash256, InvoiceTrackingState>,
+    /// Cancellation token for each active or stopping invoice tracker.
+    active_invoice_tracker_tokens: HashMap<Hash256, CancellationToken>,
+    /// Invoices requested again while their previous tracker is stopping.
+    restart_stopping_invoices: HashSet<Hash256>,
+    /// Limits only subscription establishment. Permits are released once streams are established.
+    subscribe_attempts: Arc<Semaphore>,
 }
 
 /// Ractor Actor to track LND payments and invoices
@@ -176,9 +181,9 @@ pub struct LndTrackerState {
 ///
 /// ## Invoice Tracking
 /// - Supports tracking individual invoices via `LndTrackerMessage::TrackInvoice`
-/// - Implements concurrency control: maximum 5 concurrent invoice connections
-/// - Track invoices with a 5-minute timeout and automatically retry them later
-/// - Queues additional invoices when concurrency limit is reached
+/// - Tracks all invoices admitted by the global invoice limit
+/// - Multiplexes subscriptions over a shared LND HTTP/2 client
+/// - Limits concurrent subscription attempts to protect LND during startup and reconnects
 ///
 /// ## Example Usage
 ///
@@ -191,11 +196,11 @@ pub struct LndTrackerState {
 /// let port = Arc::new(OutputPort::<CchTrackingEvent>::default());
 ///
 /// // Create connection info
-/// let lnd_connection = LndConnectionInfo {
-///     uri: "https://localhost:10009".parse().unwrap(),
-///     cert: Some(cert_bytes),
-///     macaroon: Some(macaroon_bytes),
-/// };
+/// let lnd_connection = LndConnectionInfo::new(
+///     "https://localhost:10009".parse().unwrap(),
+///     Some(cert_bytes),
+///     Some(macaroon_bytes),
+/// );
 ///
 /// // Start the actor
 /// let args = LndTrackerArgs {
@@ -235,13 +240,17 @@ impl Actor for LndTrackerActor {
         _myself: ActorRef<Self::Msg>,
         args: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
+        let invoices_client = args.lnd_connection.create_invoices_client().await?;
         let state = LndTrackerState {
             port: args.port.clone(),
-            lnd_connection: args.lnd_connection.clone(),
+            invoices_client,
             token: args.token.clone(),
             tracker: args.tracker.clone(),
             invoice_queue: VecDeque::new(),
             invoice_trackers: HashMap::new(),
+            active_invoice_tracker_tokens: HashMap::new(),
+            restart_stopping_invoices: HashSet::new(),
+            subscribe_attempts: Arc::new(Semaphore::new(MAX_CONCURRENT_SUBSCRIBE_ATTEMPTS)),
         };
 
         // Start payment tracker in background
@@ -286,10 +295,10 @@ impl Actor for LndTrackerActor {
                         state.invoice_queue.push_back(payment_hash);
                         true
                     }
-                    Some(tracker_state @ InvoiceTrackingState::Stopping) => {
-                        *tracker_state = InvoiceTrackingState::Active;
+                    Some(InvoiceTrackingState::Stopping) => {
+                        state.restart_stopping_invoices.insert(payment_hash);
                         tracing::debug!(
-                            "Resumed tracking invoice {:x} before its active tracker stopped",
+                            "Will restart invoice tracker {:x} after its previous task stops",
                             payment_hash
                         );
                         false
@@ -324,11 +333,17 @@ impl Actor for LndTrackerActor {
             LndTrackerMessage::StopTracking(payment_hash) => {
                 match state.invoice_trackers.get(&payment_hash).copied() {
                     Some(InvoiceTrackingState::Active) => {
+                        if let Some(token) = state.active_invoice_tracker_tokens.get(&payment_hash)
+                        {
+                            token.cancel();
+                        }
                         state
                             .invoice_trackers
                             .insert(payment_hash, InvoiceTrackingState::Stopping);
                     }
-                    Some(InvoiceTrackingState::Stopping) => {}
+                    Some(InvoiceTrackingState::Stopping) => {
+                        state.restart_stopping_invoices.remove(&payment_hash);
+                    }
                     Some(InvoiceTrackingState::Reserved | InvoiceTrackingState::Queued) => {
                         state.invoice_trackers.remove(&payment_hash);
                         state.invoice_queue.retain(|&hash| hash != payment_hash);
@@ -347,16 +362,28 @@ impl Actor for LndTrackerActor {
                     payment_hash,
                     completed_successfully,
                     state.active_invoice_trackers(),
-                    MAX_CONCURRENT_INVOICE_TRACKERS
+                    MAX_TRACKED_INVOICES
                 );
+                state.active_invoice_tracker_tokens.remove(&payment_hash);
                 match state.invoice_trackers.get(&payment_hash).copied() {
-                    Some(InvoiceTrackingState::Active) if !completed_successfully => {
+                    Some(InvoiceTrackingState::Active)
+                        if !completed_successfully && !state.token.is_cancelled() =>
+                    {
+                        state
+                            .invoice_trackers
+                            .insert(payment_hash, InvoiceTrackingState::Queued);
+                        state.invoice_queue.push_back(payment_hash);
+                    }
+                    Some(InvoiceTrackingState::Stopping)
+                        if state.restart_stopping_invoices.remove(&payment_hash) =>
+                    {
                         state
                             .invoice_trackers
                             .insert(payment_hash, InvoiceTrackingState::Queued);
                         state.invoice_queue.push_back(payment_hash);
                     }
                     Some(InvoiceTrackingState::Active | InvoiceTrackingState::Stopping) => {
+                        state.restart_stopping_invoices.remove(&payment_hash);
                         state.invoice_trackers.remove(&payment_hash);
                     }
                     Some(InvoiceTrackingState::Reserved | InvoiceTrackingState::Queued) | None => {
@@ -428,8 +455,10 @@ impl LndTrackerState {
         &mut self,
         myself: ActorRef<LndTrackerMessage>,
     ) -> Result<(), ActorProcessingErr> {
-        // Process invoices from queue
-        while self.active_invoice_trackers() < MAX_CONCURRENT_INVOICE_TRACKERS {
+        // New orders are globally admitted before invoice creation, so they start immediately.
+        // The bound is still enforced here because an upgrade can restore more persisted orders
+        // than the current admission limit.
+        while self.active_invoice_trackers() < MAX_TRACKED_INVOICES {
             let Some(payment_hash) = self.invoice_queue.pop_front() else {
                 break;
             };
@@ -446,10 +475,14 @@ impl LndTrackerState {
                 }
             }
 
+            let token = self.token.child_token();
+            self.active_invoice_tracker_tokens
+                .insert(payment_hash, token.clone());
             let tracker = InvoiceTracker {
                 port: self.port.clone(),
-                lnd_connection: self.lnd_connection.clone(),
-                token: self.token.clone(),
+                invoices_client: self.invoices_client.clone(),
+                token,
+                subscribe_attempts: self.subscribe_attempts.clone(),
                 payment_hash,
             };
 
@@ -458,28 +491,20 @@ impl LndTrackerState {
             // - Even on error, the tracker has quit, so we must clean up
             let myself_clone = myself.clone();
             self.tracker.spawn(async move {
-                select! {
-                    _ = sleep(INVOICE_TRACKING_TIMEOUT) => {
-                        let _ = tracker;
-                        myself_clone.cast(LndTrackerMessage::InvoiceTrackerCompleted {
-                            payment_hash,
-                            completed_successfully: false,
-                        }).expect("cast LndTrackerMessage");
-                    }
-                    completed_successfully = tracker.run() => {
-                        myself_clone.cast(LndTrackerMessage::InvoiceTrackerCompleted {
-                            payment_hash,
-                            completed_successfully,
-                        }).expect("cast LndTrackerMessage");
-                    }
-                }
+                let completed_successfully = tracker.run().await;
+                myself_clone
+                    .cast(LndTrackerMessage::InvoiceTrackerCompleted {
+                        payment_hash,
+                        completed_successfully,
+                    })
+                    .expect("cast LndTrackerMessage");
             });
 
             tracing::debug!(
                 "Started invoice tracker for payment_hash={}, active={}/{}",
                 payment_hash,
                 self.active_invoice_trackers(),
-                MAX_CONCURRENT_INVOICE_TRACKERS
+                MAX_TRACKED_INVOICES
             );
         }
 
@@ -550,8 +575,9 @@ impl PaymentTracker {
 struct InvoiceTracker {
     port: Arc<OutputPort<CchTrackingEvent>>,
     payment_hash: Hash256,
-    lnd_connection: LndConnectionInfo,
+    invoices_client: InvoicesClient,
     token: CancellationToken,
+    subscribe_attempts: Arc<Semaphore>,
 }
 
 impl InvoiceTracker {
@@ -564,12 +590,14 @@ impl InvoiceTracker {
 
     async fn run_loop(&self) {
         while let Err(err) = self.run_once().await {
+            let retry_delay = invoice_tracker_retry_delay();
             tracing::error!(
-                "Error tracking LND invoice {}, retry 15 seconds later: {:?}",
+                "Error tracking LND invoice {}, retry {:?} later: {:?}",
                 self.payment_hash,
+                retry_delay,
                 err
             );
-            sleep(Duration::from_secs(15)).await;
+            sleep(retry_delay).await;
         }
         tracing::debug!(
             "InvoiceTracker completed successfully for payment_hash={}",
@@ -578,13 +606,22 @@ impl InvoiceTracker {
     }
 
     async fn run_once(&self) -> Result<()> {
-        let mut client = self.lnd_connection.create_invoices_client().await?;
-        let mut stream = client
-            .subscribe_single_invoice(invoicesrpc::SubscribeSingleInvoiceRequest {
+        let permit = self
+            .subscribe_attempts
+            .acquire()
+            .await
+            .map_err(|_| anyhow!("invoice subscription limiter closed"))?;
+        let mut client = self.invoices_client.clone();
+        let response = timeout(
+            SUBSCRIBE_ATTEMPT_TIMEOUT,
+            client.subscribe_single_invoice(invoicesrpc::SubscribeSingleInvoiceRequest {
                 r_hash: self.payment_hash.into(),
-            })
-            .await?
-            .into_inner();
+            }),
+        )
+        .await
+        .map_err(|_| anyhow!("invoice subscription attempt timed out"))??;
+        drop(permit);
+        let mut stream = response.into_inner();
 
         loop {
             match stream.next().await {
@@ -620,6 +657,12 @@ impl InvoiceTracker {
             }
         ))
     }
+}
+
+fn invoice_tracker_retry_delay() -> Duration {
+    let jitter_millis = INVOICE_TRACKER_RETRY_JITTER.as_millis() as u64;
+    let jitter = Duration::from_millis(rand::random::<u64>() % (jitter_millis + 1));
+    INVOICE_TRACKER_RETRY_DELAY + jitter
 }
 
 /// LND represents missing payment preimage using all zeros hash before success.

--- a/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
+++ b/crates/fiber-lib/src/cch/trackers/lnd_trackers.rs
@@ -27,7 +27,7 @@
 //! 3. Dequeue invoices from the queue and start tracking
 
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -126,6 +126,14 @@ pub enum InvoiceTrackingReservationResult {
     CapacityExceeded,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InvoiceTrackingState {
+    Reserved,
+    Queued,
+    Active,
+    Stopping,
+}
+
 /// Snapshot of actor state (for testing)
 #[cfg(test)]
 #[derive(Debug, Clone)]
@@ -133,6 +141,7 @@ pub struct StateSnapshot {
     pub invoice_queue_len: usize,
     pub active_invoice_trackers: usize,
     pub reserved_invoice_trackers: usize,
+    pub stopping_invoice_trackers: usize,
     pub tracked_invoices: usize,
 }
 
@@ -152,14 +161,8 @@ pub struct LndTrackerState {
     tracker: TaskTracker,
     /// Queue of payment hashes waiting to be tracked
     invoice_queue: VecDeque<Hash256>,
-    /// Payment hashes that are reserved, queued, active, or stopping.
-    tracked_invoices: HashSet<Hash256>,
-    /// Reservations made before the corresponding LND invoice and CCH order are created.
-    reserved_invoices: HashSet<Hash256>,
-    /// Payment hashes with a currently running tracker task.
-    active_invoices: HashSet<Hash256>,
-    /// Active trackers asked to stop; they remain capacity-accounted until completion.
-    stopped_invoices: HashSet<Hash256>,
+    /// State of every admitted invoice tracker. The map size is the global capacity usage.
+    invoice_trackers: HashMap<Hash256, InvoiceTrackingState>,
 }
 
 /// Ractor Actor to track LND payments and invoices
@@ -238,10 +241,7 @@ impl Actor for LndTrackerActor {
             token: args.token.clone(),
             tracker: args.tracker.clone(),
             invoice_queue: VecDeque::new(),
-            tracked_invoices: HashSet::new(),
-            reserved_invoices: HashSet::new(),
-            active_invoices: HashSet::new(),
-            stopped_invoices: HashSet::new(),
+            invoice_trackers: HashMap::new(),
         };
 
         // Start payment tracker in background
@@ -266,55 +266,74 @@ impl Actor for LndTrackerActor {
     ) -> Result<(), ActorProcessingErr> {
         let res = match message {
             LndTrackerMessage::ReserveInvoiceTracking(payment_hash, reply_port) => {
-                let result = if state.tracked_invoices.contains(&payment_hash) {
+                let result = if state.invoice_trackers.contains_key(&payment_hash) {
                     InvoiceTrackingReservationResult::AlreadyTracked
-                } else if state.tracked_invoices.len() >= MAX_TRACKED_INVOICES {
+                } else if state.invoice_trackers.len() >= MAX_TRACKED_INVOICES {
                     InvoiceTrackingReservationResult::CapacityExceeded
                 } else {
-                    state.tracked_invoices.insert(payment_hash);
-                    state.reserved_invoices.insert(payment_hash);
+                    state
+                        .invoice_trackers
+                        .insert(payment_hash, InvoiceTrackingState::Reserved);
                     InvoiceTrackingReservationResult::Reserved
                 };
                 let _ = reply_port.send(result);
                 Ok(())
             }
             LndTrackerMessage::TrackInvoice(payment_hash) => {
-                if state.reserved_invoices.remove(&payment_hash) {
-                    state.invoice_queue.push_back(payment_hash);
-                    state.process_invoice_queue(myself).await?;
-                } else if state.stopped_invoices.remove(&payment_hash)
-                    && state.active_invoices.contains(&payment_hash)
-                {
-                    tracing::debug!(
-                        "Resumed tracking invoice {:x} before its active tracker stopped",
-                        payment_hash
-                    );
-                } else if state.tracked_invoices.insert(payment_hash) {
-                    if state.tracked_invoices.len() > MAX_TRACKED_INVOICES {
-                        // Existing persisted orders must still be restored after an upgrade even
-                        // if they predate the admission limit. New orders reserve capacity before
-                        // creating their LND invoice and cannot take this path.
-                        tracing::warn!(
-                            "Restoring invoice tracker {:x} above the global limit of {}",
-                            payment_hash,
-                            MAX_TRACKED_INVOICES
-                        );
+                let should_process_queue = match state.invoice_trackers.get_mut(&payment_hash) {
+                    Some(tracker_state @ InvoiceTrackingState::Reserved) => {
+                        *tracker_state = InvoiceTrackingState::Queued;
+                        state.invoice_queue.push_back(payment_hash);
+                        true
                     }
-                    state.invoice_queue.push_back(payment_hash);
+                    Some(tracker_state @ InvoiceTrackingState::Stopping) => {
+                        *tracker_state = InvoiceTrackingState::Active;
+                        tracing::debug!(
+                            "Resumed tracking invoice {:x} before its active tracker stopped",
+                            payment_hash
+                        );
+                        false
+                    }
+                    Some(_) => {
+                        tracing::debug!("Invoice {:x} is already being tracked", payment_hash);
+                        false
+                    }
+                    None => {
+                        state
+                            .invoice_trackers
+                            .insert(payment_hash, InvoiceTrackingState::Queued);
+                        if state.invoice_trackers.len() > MAX_TRACKED_INVOICES {
+                            // Existing persisted orders must still be restored after an upgrade even
+                            // if they predate the admission limit. New orders reserve capacity before
+                            // creating their LND invoice and cannot take this path.
+                            tracing::warn!(
+                                "Restoring invoice tracker {:x} above the global limit of {}",
+                                payment_hash,
+                                MAX_TRACKED_INVOICES
+                            );
+                        }
+                        state.invoice_queue.push_back(payment_hash);
+                        true
+                    }
+                };
+                if should_process_queue {
                     state.process_invoice_queue(myself).await?;
-                } else {
-                    tracing::debug!("Invoice {:x} is already being tracked", payment_hash);
                 }
                 Ok(())
             }
             LndTrackerMessage::StopTracking(payment_hash) => {
-                state.reserved_invoices.remove(&payment_hash);
-                state.invoice_queue.retain(|&hash| hash != payment_hash);
-                if state.active_invoices.contains(&payment_hash) {
-                    state.stopped_invoices.insert(payment_hash);
-                } else {
-                    state.stopped_invoices.remove(&payment_hash);
-                    state.tracked_invoices.remove(&payment_hash);
+                match state.invoice_trackers.get(&payment_hash).copied() {
+                    Some(InvoiceTrackingState::Active) => {
+                        state
+                            .invoice_trackers
+                            .insert(payment_hash, InvoiceTrackingState::Stopping);
+                    }
+                    Some(InvoiceTrackingState::Stopping) => {}
+                    Some(InvoiceTrackingState::Reserved | InvoiceTrackingState::Queued) => {
+                        state.invoice_trackers.remove(&payment_hash);
+                        state.invoice_queue.retain(|&hash| hash != payment_hash);
+                    }
+                    None => {}
                 }
                 tracing::debug!("Stopped tracking invoice {:x}", payment_hash);
                 Ok(())
@@ -327,21 +346,26 @@ impl Actor for LndTrackerActor {
                     "Processing completion for payment_hash={}, success={}, active={}/{}",
                     payment_hash,
                     completed_successfully,
-                    state.active_invoices.len(),
+                    state.active_invoice_trackers(),
                     MAX_CONCURRENT_INVOICE_TRACKERS
                 );
-                if !state.active_invoices.remove(&payment_hash) {
-                    tracing::warn!(
-                        "Ignoring stale completion for inactive invoice tracker {:x}",
-                        payment_hash
-                    );
-                    return Ok(());
-                }
-
-                if state.stopped_invoices.remove(&payment_hash) || completed_successfully {
-                    state.tracked_invoices.remove(&payment_hash);
-                } else if state.tracked_invoices.contains(&payment_hash) {
-                    state.invoice_queue.push_back(payment_hash);
+                match state.invoice_trackers.get(&payment_hash).copied() {
+                    Some(InvoiceTrackingState::Active) if !completed_successfully => {
+                        state
+                            .invoice_trackers
+                            .insert(payment_hash, InvoiceTrackingState::Queued);
+                        state.invoice_queue.push_back(payment_hash);
+                    }
+                    Some(InvoiceTrackingState::Active | InvoiceTrackingState::Stopping) => {
+                        state.invoice_trackers.remove(&payment_hash);
+                    }
+                    Some(InvoiceTrackingState::Reserved | InvoiceTrackingState::Queued) | None => {
+                        tracing::warn!(
+                            "Ignoring stale completion for inactive invoice tracker {:x}",
+                            payment_hash
+                        );
+                        return Ok(());
+                    }
                 }
 
                 // Now that a slot is free, we can start tracking more invoices from the queue
@@ -354,9 +378,12 @@ impl Actor for LndTrackerActor {
             LndTrackerMessage::GetState(reply_port) => {
                 let snapshot = StateSnapshot {
                     invoice_queue_len: state.invoice_queue.len(),
-                    active_invoice_trackers: state.active_invoices.len(),
-                    reserved_invoice_trackers: state.reserved_invoices.len(),
-                    tracked_invoices: state.tracked_invoices.len(),
+                    active_invoice_trackers: state.active_invoice_trackers(),
+                    reserved_invoice_trackers: state
+                        .count_invoice_trackers(InvoiceTrackingState::Reserved),
+                    stopping_invoice_trackers: state
+                        .count_invoice_trackers(InvoiceTrackingState::Stopping),
+                    tracked_invoices: state.invoice_trackers.len(),
                 };
                 let _ = reply_port.send(snapshot);
                 Ok(())
@@ -369,7 +396,7 @@ impl Actor for LndTrackerActor {
             metrics::gauge!(crate::metrics::CCH_LND_TRACKER_INVOICE_QUEUE_LEN)
                 .set(state.invoice_queue.len() as f64);
             metrics::gauge!(crate::metrics::CCH_LND_TRACKER_ACTIVE_INVOICE_TRACKERS)
-                .set(state.active_invoices.len() as f64);
+                .set(state.active_invoice_trackers() as f64);
         }
 
         res
@@ -377,21 +404,46 @@ impl Actor for LndTrackerActor {
 }
 
 impl LndTrackerState {
+    #[cfg(test)]
+    fn count_invoice_trackers(&self, expected_state: InvoiceTrackingState) -> usize {
+        self.invoice_trackers
+            .values()
+            .filter(|&&state| state == expected_state)
+            .count()
+    }
+
+    fn active_invoice_trackers(&self) -> usize {
+        self.invoice_trackers
+            .values()
+            .filter(|&&state| {
+                matches!(
+                    state,
+                    InvoiceTrackingState::Active | InvoiceTrackingState::Stopping
+                )
+            })
+            .count()
+    }
+
     async fn process_invoice_queue(
         &mut self,
         myself: ActorRef<LndTrackerMessage>,
     ) -> Result<(), ActorProcessingErr> {
         // Process invoices from queue
-        while self.active_invoices.len() < MAX_CONCURRENT_INVOICE_TRACKERS {
+        while self.active_invoice_trackers() < MAX_CONCURRENT_INVOICE_TRACKERS {
             let Some(payment_hash) = self.invoice_queue.pop_front() else {
                 break;
             };
-            if !self.active_invoices.insert(payment_hash) {
-                tracing::warn!(
-                    "Skipping duplicate queued invoice tracker {:x}",
-                    payment_hash
-                );
-                continue;
+            match self.invoice_trackers.get_mut(&payment_hash) {
+                Some(tracker_state @ InvoiceTrackingState::Queued) => {
+                    *tracker_state = InvoiceTrackingState::Active;
+                }
+                _ => {
+                    tracing::warn!(
+                        "Skipping invoice {:x} that is queued with an invalid state",
+                        payment_hash
+                    );
+                    continue;
+                }
             }
 
             let tracker = InvoiceTracker {
@@ -426,7 +478,7 @@ impl LndTrackerState {
             tracing::debug!(
                 "Started invoice tracker for payment_hash={}, active={}/{}",
                 payment_hash,
-                self.active_invoices.len(),
+                self.active_invoice_trackers(),
                 MAX_CONCURRENT_INVOICE_TRACKERS
             );
         }

--- a/crates/fiber-lib/src/cch/trackers/mod.rs
+++ b/crates/fiber-lib/src/cch/trackers/mod.rs
@@ -2,7 +2,8 @@ mod event;
 pub use event::{CchTrackingEvent, RedactedCchTrackingEvent};
 
 mod lnd_trackers;
+pub(crate) use lnd_trackers::MAX_TRACKED_INVOICES;
 pub use lnd_trackers::{
-    map_lnd_payment_changed_event, LndConnectionInfo, LndTrackerActor, LndTrackerArgs,
-    LndTrackerMessage,
+    map_lnd_payment_changed_event, InvoiceTrackingReservationResult, LndConnectionInfo,
+    LndTrackerActor, LndTrackerArgs, LndTrackerMessage,
 };


### PR DESCRIPTION
## Summary

- coalesce repeated tracking requests for the same invoice and model the tracker lifecycle explicitly
- reserve global tracker capacity before creating an externally payable LND hold invoice
- remove the five-active-tracker bottleneck so every admitted invoice is monitored immediately
- reuse one LND invoices client while bounding subscription establishment concurrency, time, and retry bursts
- cancel stopped trackers promptly and avoid duplicate trackers during stop/retrack races

## Motivation

The previous tracker limited `SubscribeSingleInvoice` to five active streams and rotated them through a FIFO every five minutes. Five invoices that stayed `OPEN` could therefore occupy all observation slots and delay updates for every other CCH order.

Repeated `TrackInvoice` messages could also enqueue or start multiple tasks for the same payment hash. That duplicate work consumed tracker slots and could grow the queue without adding coverage.

Tracker capacity should bound node resource use without making five long-lived invoices a global observation bottleneck.

## Design

### Admission and lifecycle

- New orders reserve tracker capacity before `AddHoldInvoice` makes an invoice externally payable.
- The global limit is 100 tracked invoice hashes across `Reserved`, `Queued`, `Active`, and `Stopping` states.
- Duplicate payment hashes are coalesced, and new orders are rejected before invoice creation when capacity is exhausted.
- If invoice creation or persistence fails, the reservation is released.
- All newly admitted invoices start tracking immediately; there is no five-stream limit or five-minute rotation.
- On startup, legacy non-final orders above the current limit are restored into a FIFO, with at most 100 active subscriptions at once.

### LND subscription protection

This remains an event-driven `SubscribeSingleInvoice` design, not polling.

- Invoice trackers clone one shared tonic `InvoicesClient`, allowing the underlying HTTP/2 channel to be reused.
- At most 10 `SubscribeSingleInvoice` establishment attempts run concurrently. The permit is released once the stream is established.
- Each establishment attempt has a 15-second timeout.
- Failed or closed streams retry after a randomized 15-30 second delay to avoid synchronized reconnect storms.
- Each active tracker has its own cancellation token, so `StopTracking` terminates the stream instead of waiting for a remote update.
- A retrack request received while the previous task is stopping is deferred until that task exits, preventing duplicate subscriptions.

## Security boundary

This change bounds tracker and LND connection-establishment resource use and prevents five orphan invoices from monopolizing observation capacity. A malicious principal can still attempt to fill all 100 global order slots with valid non-final orders. Fair admission against that attack requires per-principal, gateway, API-key, Biscuit, or IP rate limiting at the request boundary; the tracker only sees payment hashes and cannot attribute them to an attacker.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run -p fnn --features sqlite -E 'test(/cch::tests::lnd_trackers_tests::/)'` (12 passed)
- `cargo nextest run -p fnn --features sqlite -E 'test(/cch::tests::/)'` (134 passed)
- `cargo clippy --all-targets --features sqlite -p fnn -- -D warnings`
- `git diff --check`
