### PR TITLE
Apply the default final TLC expiry delta to invoices

### DIFF
--- a/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
+++ b/crates/fiber-lib/src/cch/actions/send_outgoing_payment.rs
@@ -236,16 +236,13 @@ impl SendOutgoingPaymentDispatcher {
     /// The other half is reserved for the CCH to settle the incoming payment
     /// after receiving the preimage.
     ///
-    /// The final expiry delta is extracted from the stored incoming invoice when
-    /// available, so that persisted orders use the actual inbound HTLC/TLC terms
-    /// even if the config has changed since order creation. Falls back to the
-    /// current config values when the invoice does not carry the setting.
+    /// The final expiry delta is extracted from the stored incoming invoice, so
+    /// persisted orders use the actual inbound HTLC/TLC terms even if the config
+    /// has changed since order creation. Fiber invoices that omit the attribute
+    /// use the protocol default.
     ///
     /// Returns `None` if there is insufficient time remaining.
-    fn compute_max_outgoing_expiry_seconds<S: CchOrderStore>(
-        state: &CchState<S>,
-        order: &CchOrder,
-    ) -> Option<u64> {
+    fn compute_max_outgoing_expiry_seconds(order: &CchOrder) -> Option<u64> {
         let now = now_timestamp_as_millis_u64() / 1000;
         let elapsed = now.saturating_sub(order.created_at);
 
@@ -258,9 +255,7 @@ impl SendOutgoingPaymentDispatcher {
         let incoming_expiry_seconds = match &order.incoming_invoice {
             CchInvoice::Fiber(inv) => {
                 // CkbInvoice stores the delta in milliseconds; convert to seconds.
-                inv.final_tlc_minimum_expiry_delta()
-                    .map(|ms| ms / 1000)
-                    .unwrap_or(state.config.ckb_final_tlc_expiry_delta_seconds)
+                inv.final_tlc_minimum_expiry_delta_or_default() / 1000
             }
             CchInvoice::Lightning(inv) => {
                 // Bolt11Invoice stores the delta in blocks; convert to seconds.
@@ -315,8 +310,7 @@ impl SendOutgoingPaymentDispatcher {
                 // Outgoing is CKB Fiber: parse the CKB invoice's final_tlc_minimum_expiry_delta
                 CkbInvoice::from_str(&order.outgoing_pay_req)
                     .ok()
-                    .and_then(|inv| inv.final_tlc_minimum_expiry_delta().copied())
-                    .map(|millis| millis / 1000)
+                    .map(|inv| inv.final_tlc_minimum_expiry_delta_or_default() / 1000)
                     .unwrap_or(0)
             }
         };
@@ -355,7 +349,7 @@ impl SendOutgoingPaymentDispatcher {
         // Check the remaining incoming time and compute the max outgoing route expiry.
         // This ensures the CCH has enough time to settle the incoming payment
         // even in the worst case where the outgoing payment settles at the last moment.
-        let max_outgoing_seconds = Self::compute_max_outgoing_expiry_seconds(state, order);
+        let max_outgoing_seconds = Self::compute_max_outgoing_expiry_seconds(order);
         let max_outgoing_seconds =
             Self::check_expiry_or_fail(cch_actor_ref, order, max_outgoing_seconds)?;
 

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -692,10 +692,7 @@ impl<S: CchOrderStore> CchState<S> {
         // Validate that outgoing CKB invoice's final TLC is less than half of incoming BTC invoice's final CLTV expiry.
         // This ensures the CCH operator has sufficient time to settle the incoming side before the outgoing side expires.
         // CKB uses milliseconds, BTC uses blocks (~10 min each).
-        let ckb_final_tlc_millis = invoice
-            .final_tlc_minimum_expiry_delta()
-            .copied()
-            .unwrap_or(0);
+        let ckb_final_tlc_millis = invoice.final_tlc_minimum_expiry_delta_or_default();
         let btc_final_cltv_millis = self
             .config
             .btc_final_tlc_expiry_delta_blocks

--- a/crates/fiber-lib/src/cch/cch_fiber_agent.rs
+++ b/crates/fiber-lib/src/cch/cch_fiber_agent.rs
@@ -120,7 +120,7 @@ impl CchFiberAgentHttpBackend {
             payment_hash: Some((*invoice.payment_hash()).into()),
             hash_algorithm: invoice.hash_algorithm().copied().map(Into::into),
             expiry: invoice.expiry_time().map(|duration| duration.as_secs()),
-            final_expiry_delta: invoice.final_tlc_minimum_expiry_delta().copied(),
+            final_expiry_delta: Some(invoice.final_tlc_minimum_expiry_delta_or_default()),
             udt_type_script: invoice
                 .udt_type_script()
                 .map(|script| script.clone().into()),

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -1929,13 +1929,24 @@ fn create_test_lightning_invoice_with_cltv(
         .expect("build lightning invoice")
 }
 
-/// Create a test Fiber invoice with a custom final_tlc_minimum_expiry_delta (in milliseconds).
-fn create_test_fiber_invoice_with_expiry(
+/// Create a test Fiber invoice with an optional final TLC minimum expiry delta.
+fn create_test_fiber_invoice_with_optional_expiry(
     payment_hash: Hash256,
-    final_tlc_expiry_delta_ms: u64,
+    final_tlc_expiry_delta_ms: Option<u64>,
 ) -> CkbInvoice {
     let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
     let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
+
+    let mut attrs = vec![
+        Attribute::Description("test".to_string()),
+        Attribute::ExpiryTime(Duration::from_secs(3600)),
+        Attribute::PayeePublicKey(public_key),
+    ];
+    if let Some(final_tlc_expiry_delta_ms) = final_tlc_expiry_delta_ms {
+        attrs.push(Attribute::FinalHtlcMinimumExpiryDelta(
+            final_tlc_expiry_delta_ms,
+        ));
+    }
 
     let mut invoice = CkbInvoice {
         currency: Currency::Fibb,
@@ -1947,18 +1958,58 @@ fn create_test_fiber_invoice_with_expiry(
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_millis(),
-            attrs: vec![
-                Attribute::FinalHtlcMinimumExpiryDelta(final_tlc_expiry_delta_ms),
-                Attribute::Description("test".to_string()),
-                Attribute::ExpiryTime(Duration::from_secs(3600)),
-                Attribute::PayeePublicKey(public_key),
-            ],
+            attrs,
         },
     };
     invoice
         .update_signature(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
         .unwrap();
     invoice
+}
+
+/// Create a test Fiber invoice with a custom final TLC minimum expiry delta.
+fn create_test_fiber_invoice_with_expiry(
+    payment_hash: Hash256,
+    final_tlc_expiry_delta_ms: u64,
+) -> CkbInvoice {
+    create_test_fiber_invoice_with_optional_expiry(payment_hash, Some(final_tlc_expiry_delta_ms))
+}
+
+/// Create a test Fiber invoice without a final TLC minimum expiry delta attribute.
+fn create_test_fiber_invoice_without_expiry(payment_hash: Hash256) -> CkbInvoice {
+    create_test_fiber_invoice_with_optional_expiry(payment_hash, None)
+}
+
+/// An omitted final TLC expiry delta still represents the protocol default of 24 hours.
+/// The ReceiveBTC static safety check must reject it when the configured incoming BTC
+/// CLTV only leaves a 12-hour outgoing budget.
+#[tokio::test]
+async fn test_receive_btc_applies_protocol_default_to_missing_fiber_expiry_delta() {
+    let (_, payment_hash) = create_valid_preimage_pair(253);
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        // 144 blocks is 24 hours; only half (12 hours) is available outgoing.
+        btc_final_tlc_expiry_delta_blocks: 144,
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config(config).await;
+    let invoice = create_test_fiber_invoice_without_expiry(payment_hash);
+
+    let result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::actor::ReceiveBTC {
+            fiber_pay_req: invoice.to_string(),
+        }
+    )
+    .expect("actor call failed");
+
+    assert!(matches!(
+        result,
+        Err(CchError::CKBInvoiceFinalTlcExpiryDeltaTooLarge)
+    ));
 }
 
 /// Tests that a SendBTC order fails when the incoming CKB TLC does not have enough
@@ -2107,6 +2158,107 @@ async fn test_receive_btc_fails_insufficient_expiry_delta() {
         reason.contains("Insufficient HTLC expiry delta"),
         "Expected expiry delta failure message, got: {}",
         reason,
+    );
+}
+
+/// A missing outgoing Fiber expiry attribute means 24 hours, not zero. With a
+/// 36-hour incoming Lightning budget, only 18 hours are safe for the outgoing route.
+#[tokio::test]
+async fn test_receive_btc_order_fails_when_omitted_outgoing_expiry_exceeds_budget() {
+    let (_, payment_hash) = create_valid_preimage_pair(254);
+    let store = MockCchOrderStore::new();
+    let incoming_lightning_invoice =
+        create_test_lightning_invoice_with_cltv(payment_hash, 36 * 60 * 60 / BTC_BLOCK_TIME_SECS);
+    let outgoing_fiber_invoice = create_test_fiber_invoice_without_expiry(payment_hash);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let order = CchOrder {
+        created_at: now,
+        expiry_delta_seconds: 200_000,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: outgoing_fiber_invoice.to_string(),
+        incoming_invoice: CchInvoice::Lightning(incoming_lightning_invoice),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::IncomingAccepted,
+        failure_reason: None,
+    };
+
+    store.insert_cch_order(order).unwrap();
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config_and_store(config, store).await;
+
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::Failed, 2000)
+        .await;
+    assert!(
+        order
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("Insufficient HTLC expiry delta")),
+        "expected expiry delta failure, got {:?}",
+        order.failure_reason
+    );
+}
+
+/// Persisted incoming Fiber invoices without an expiry attribute guarantee 24 hours,
+/// even when the current CCH config has a longer default. Only 12 hours are therefore
+/// available for the outgoing route, which cannot fit an 18-hour Lightning CLTV.
+#[tokio::test]
+async fn test_send_btc_order_uses_protocol_default_for_omitted_incoming_expiry() {
+    let (_, payment_hash) = create_valid_preimage_pair(255);
+    let store = MockCchOrderStore::new();
+    let incoming_fiber_invoice = create_test_fiber_invoice_without_expiry(payment_hash);
+    let outgoing_lightning_invoice =
+        create_test_lightning_invoice_with_cltv(payment_hash, 18 * 60 * 60 / BTC_BLOCK_TIME_SECS);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let order = CchOrder {
+        created_at: now,
+        expiry_delta_seconds: 200_000,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: outgoing_lightning_invoice.to_string(),
+        incoming_invoice: CchInvoice::Fiber(incoming_fiber_invoice),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::IncomingAccepted,
+        failure_reason: None,
+    };
+
+    store.insert_cch_order(order).unwrap();
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        // The old fallback used this 60-hour value and incorrectly allowed the order.
+        ckb_final_tlc_expiry_delta_seconds: 60 * 60 * 60,
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config_and_store(config, store).await;
+
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::Failed, 2000)
+        .await;
+    assert!(
+        order
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("Insufficient HTLC expiry delta")),
+        "expected expiry delta failure, got {:?}",
+        order.failure_reason
     );
 }
 

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -10,6 +10,7 @@ use clap_serde_derive::{
     ClapSerde,
 };
 use fiber_types::protocol::AnnouncedNodeName;
+pub use fiber_types::DEFAULT_FINAL_TLC_EXPIRY_DELTA;
 #[cfg(not(any(test, feature = "bench")))]
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -38,9 +39,6 @@ pub const DEFAULT_COMMITMENT_DELAY_EPOCHS: u64 = 1;
 
 /// The expiry delta to forward a tlc, in milliseconds, default to 4 hours.
 pub const DEFAULT_TLC_EXPIRY_DELTA: u64 = 4 * 60 * 60 * 1000;
-
-/// The final hop expiry delta for a tlc, in milliseconds, default to 24 hours.
-pub const DEFAULT_FINAL_TLC_EXPIRY_DELTA: u64 = 24 * 60 * 60 * 1000; // 24 hours
 
 /// 4 hours for each epoch
 #[cfg(not(debug_assertions))]

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -449,11 +449,21 @@ impl SendPaymentDataExt for SendPaymentData {
         };
 
         // check htlc expiry delta and limit are both valid if it is set
-        let final_tlc_expiry_delta = invoice
-            .as_ref()
-            .and_then(|i| i.final_tlc_minimum_expiry_delta().copied())
-            .or(command.final_tlc_expiry_delta)
-            .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA);
+        let final_tlc_expiry_delta = match invoice.as_ref() {
+            Some(invoice) => match invoice.final_tlc_minimum_expiry_delta().copied() {
+                Some(delta) => delta,
+                None => {
+                    let protocol_default = invoice.final_tlc_minimum_expiry_delta_or_default();
+                    command
+                        .final_tlc_expiry_delta
+                        .unwrap_or(protocol_default)
+                        .max(protocol_default)
+                }
+            },
+            None => command
+                .final_tlc_expiry_delta
+                .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA),
+        };
 
         let tlc_expiry_limit = command
             .tlc_expiry_limit

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -449,11 +449,27 @@ impl SendPaymentDataExt for SendPaymentData {
         };
 
         // check htlc expiry delta and limit are both valid if it is set
-        let final_tlc_expiry_delta = invoice
-            .as_ref()
-            .and_then(|invoice| invoice.final_tlc_minimum_expiry_delta().copied())
-            .or(command.final_tlc_expiry_delta)
-            .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA);
+        let final_tlc_expiry_delta = match invoice.as_ref() {
+            Some(invoice) => match invoice.final_tlc_minimum_expiry_delta().copied() {
+                Some(delta) => delta,
+                None => {
+                    let minimum_delta = invoice.final_tlc_minimum_expiry_delta_or_default();
+                    match command.final_tlc_expiry_delta {
+                        Some(delta) if delta < minimum_delta => {
+                            return Err(format!(
+                                "final_tlc_expiry_delta is below the invoice minimum: {} < {}",
+                                delta, minimum_delta
+                            ));
+                        }
+                        Some(delta) => delta,
+                        None => minimum_delta,
+                    }
+                }
+            },
+            None => command
+                .final_tlc_expiry_delta
+                .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA),
+        };
 
         let tlc_expiry_limit = command
             .tlc_expiry_limit

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -449,21 +449,11 @@ impl SendPaymentDataExt for SendPaymentData {
         };
 
         // check htlc expiry delta and limit are both valid if it is set
-        let final_tlc_expiry_delta = match invoice.as_ref() {
-            Some(invoice) => match invoice.final_tlc_minimum_expiry_delta().copied() {
-                Some(delta) => delta,
-                None => {
-                    let protocol_default = invoice.final_tlc_minimum_expiry_delta_or_default();
-                    command
-                        .final_tlc_expiry_delta
-                        .unwrap_or(protocol_default)
-                        .max(protocol_default)
-                }
-            },
-            None => command
-                .final_tlc_expiry_delta
-                .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA),
-        };
+        let final_tlc_expiry_delta = invoice
+            .as_ref()
+            .and_then(|invoice| invoice.final_tlc_minimum_expiry_delta().copied())
+            .or(command.final_tlc_expiry_delta)
+            .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA);
 
         let tlc_expiry_limit = command
             .tlc_expiry_limit

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -100,6 +100,7 @@ fn create_mock_pending_add_tlc_command(
             .payment_hash(payment_hash)
             .hash_algorithm(hash_algorithm)
             .payee_pub_key(target.pubkey.into())
+            .final_expiry_delta(0)
             .build()
             .expect("build mock pending invoice");
         target.insert_invoice(invoice, None);

--- a/crates/fiber-lib/src/fiber/tests/mpp.rs
+++ b/crates/fiber-lib/src/fiber/tests/mpp.rs
@@ -22,8 +22,8 @@ use crate::{
     now_timestamp_as_millis_u64,
     rpc::invoice::NewInvoiceParams,
     test_utils::{
-        create_n_nodes_network, establish_channel_between_nodes, init_tracing, ChannelParameters,
-        NetworkNode, MIN_RESERVED_CKB,
+        create_n_nodes_network, establish_channel_between_nodes, init_tracing, wait_until_timeout,
+        ChannelParameters, NetworkNode, MIN_RESERVED_CKB,
     },
     NetworkServiceEvent, HUGE_CKB_AMOUNT,
 };
@@ -509,6 +509,8 @@ async fn test_mpp_tlc_set() {
 
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
+    let tlc_expiry =
+        now_timestamp_as_millis_u64() + DEFAULT_FINAL_TLC_EXPIRY_DELTA + DEFAULT_TLC_EXPIRY_DELTA;
 
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 20000000000);
@@ -516,7 +518,7 @@ async fn test_mpp_tlc_set() {
     let hops_infos = vec![
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: tlc_expiry,
             next_hop: Some(target_pubkey),
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
@@ -524,7 +526,7 @@ async fn test_mpp_tlc_set() {
         },
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: tlc_expiry,
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
             ..Default::default()
@@ -548,7 +550,7 @@ async fn test_mpp_tlc_set() {
                         amount: 10000000000,
                         hash_algorithm,
                         payment_hash,
-                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                        expiry: tlc_expiry,
                         onion_packet: packet.next.clone(),
                         shared_secret: packet.shared_secret,
                         is_trampoline_hop: false,
@@ -572,7 +574,7 @@ async fn test_mpp_tlc_set() {
                         amount: 10000000000,
                         hash_algorithm,
                         payment_hash,
-                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                        expiry: tlc_expiry,
                         onion_packet: packet.next.clone(),
                         shared_secret: packet.shared_secret,
                         is_trampoline_hop: false,
@@ -590,19 +592,19 @@ async fn test_mpp_tlc_set() {
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
 
     // wait tlc 1 is removed
-    while source_node
-        .get_tlc(channels[0], TLCId::Offered(add_tlc_result_1.tlc_id))
-        .is_some()
-    {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    }
+    wait_until_timeout(30_000, || {
+        source_node
+            .get_tlc(channels[0], TLCId::Offered(add_tlc_result_1.tlc_id))
+            .is_none()
+    })
+    .await;
     // wait tlc 2 is removed
-    while source_node
-        .get_tlc(channels[1], TLCId::Offered(add_tlc_result_2.tlc_id))
-        .is_some()
-    {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    }
+    wait_until_timeout(30_000, || {
+        source_node
+            .get_tlc(channels[1], TLCId::Offered(add_tlc_result_2.tlc_id))
+            .is_none()
+    })
+    .await;
 
     let node_0_balance = source_node.get_local_balance_from_channel(channels[0]);
     let node_1_balance = node_1.get_local_balance_from_channel(channels[0]);
@@ -781,6 +783,8 @@ async fn test_mpp_tlc_set_with_only_1_tlc() {
 
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
+    let tlc_expiry =
+        now_timestamp_as_millis_u64() + DEFAULT_FINAL_TLC_EXPIRY_DELTA + DEFAULT_TLC_EXPIRY_DELTA;
 
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 10000000000);
@@ -788,7 +792,7 @@ async fn test_mpp_tlc_set_with_only_1_tlc() {
     let hops_infos = vec![
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: tlc_expiry,
             next_hop: Some(target_pubkey),
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
@@ -796,7 +800,7 @@ async fn test_mpp_tlc_set_with_only_1_tlc() {
         },
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: tlc_expiry,
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
             ..Default::default()
@@ -820,7 +824,7 @@ async fn test_mpp_tlc_set_with_only_1_tlc() {
                         amount: 10000000000,
                         hash_algorithm,
                         payment_hash,
-                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                        expiry: tlc_expiry,
                         onion_packet: packet.next.clone(),
                         shared_secret: packet.shared_secret,
                         is_trampoline_hop: false,
@@ -838,12 +842,12 @@ async fn test_mpp_tlc_set_with_only_1_tlc() {
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
 
     // wait tlc 1 is removed
-    while source_node
-        .get_tlc(channels[0], TLCId::Offered(add_tlc_result_1.tlc_id))
-        .is_some()
-    {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    }
+    wait_until_timeout(30_000, || {
+        source_node
+            .get_tlc(channels[0], TLCId::Offered(add_tlc_result_1.tlc_id))
+            .is_none()
+    })
+    .await;
 
     let node_0_balance = source_node.get_local_balance_from_channel(channels[0]);
     let node_1_balance = node_1.get_local_balance_from_channel(channels[0]);
@@ -1460,6 +1464,8 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
 
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
+    let tlc_expiry =
+        now_timestamp_as_millis_u64() + DEFAULT_FINAL_TLC_EXPIRY_DELTA + DEFAULT_TLC_EXPIRY_DELTA;
 
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 30000000000);
@@ -1467,7 +1473,7 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
     let hops_infos = vec![
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: tlc_expiry,
             next_hop: Some(target_pubkey),
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
@@ -1475,7 +1481,7 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
         },
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: tlc_expiry,
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
             ..Default::default()
@@ -1499,7 +1505,7 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
                         amount: 10000000000,
                         hash_algorithm,
                         payment_hash,
-                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                        expiry: tlc_expiry,
                         onion_packet: packet.next.clone(),
                         shared_secret: packet.shared_secret,
                         is_trampoline_hop: false,
@@ -1515,9 +1521,10 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
     .expect("tlc");
 
     // wait until tlc is hold
-    while node_1.store.get_payment_hold_tlcs(payment_hash).is_empty() {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    }
+    wait_until_timeout(30_000, || {
+        !node_1.store.get_payment_hold_tlcs(payment_hash).is_empty()
+    })
+    .await;
 
     let add_tlc_result_2 = ractor::call!(source_node.network_actor, |rpc_reply| {
         NetworkActorMessage::Command(NetworkActorCommand::ControlFiberChannel(
@@ -1528,7 +1535,7 @@ async fn test_mpp_tlc_set_timeout_1_of_2() {
                         amount: 10000000000,
                         hash_algorithm,
                         payment_hash,
-                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                        expiry: tlc_expiry,
                         onion_packet: packet.next.clone(),
                         shared_secret: packet.shared_secret,
                         is_trampoline_hop: false,
@@ -1671,6 +1678,8 @@ async fn test_mpp_tlc_set_timeout() {
 
     let payment_hash = *ckb_invoice.payment_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
+    let tlc_expiry =
+        now_timestamp_as_millis_u64() + DEFAULT_FINAL_TLC_EXPIRY_DELTA + DEFAULT_TLC_EXPIRY_DELTA;
 
     let mut custom_records = PaymentCustomRecords::default();
     let record = BasicMppPaymentData::new(payment_secret, 20000000000);
@@ -1678,7 +1687,7 @@ async fn test_mpp_tlc_set_timeout() {
     let hops_infos = vec![
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: tlc_expiry,
             next_hop: Some(target_pubkey),
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
@@ -1686,7 +1695,7 @@ async fn test_mpp_tlc_set_timeout() {
         },
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: tlc_expiry,
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
             ..Default::default()
@@ -1710,7 +1719,7 @@ async fn test_mpp_tlc_set_timeout() {
                         amount: 10000000000,
                         hash_algorithm,
                         payment_hash,
-                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                        expiry: tlc_expiry,
                         onion_packet: packet.next.clone(),
                         shared_secret: packet.shared_secret,
                         is_trampoline_hop: false,
@@ -1726,9 +1735,10 @@ async fn test_mpp_tlc_set_timeout() {
     .expect("tlc");
 
     // wait until tlc is hold
-    while node_1.store.get_payment_hold_tlcs(payment_hash).is_empty() {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    }
+    wait_until_timeout(30_000, || {
+        !node_1.store.get_payment_hold_tlcs(payment_hash).is_empty()
+    })
+    .await;
 
     // timeout hold tlc
     for hold_tlc in node_1.store.get_payment_hold_tlcs(payment_hash) {
@@ -1765,7 +1775,7 @@ async fn test_mpp_tlc_set_timeout() {
                         amount: 10000000000,
                         hash_algorithm,
                         payment_hash,
-                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                        expiry: tlc_expiry,
                         onion_packet: packet.next.clone(),
                         shared_secret: packet.shared_secret,
                         is_trampoline_hop: false,

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -1864,18 +1864,30 @@ fn test_send_payment_validate_invoice() {
     let result = SendPaymentData::new(send_command);
     assert!(result.is_ok());
 
-    // invoice with invalid final_tlc_expiry_delta
+    // An invoice without an explicit final TLC delta still requires the 24-hour
+    // protocol default, so a shorter command value cannot reduce it.
     let send_command = SendPaymentCommand {
-        final_tlc_expiry_delta: Some(11),
+        final_tlc_expiry_delta: Some(12 * 60 * 60 * 1000),
         invoice: Some(invoice_encoded.clone()),
         ..Default::default()
     };
 
-    let result = SendPaymentData::new(send_command);
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .contains("invalid final_tlc_expiry_delta"));
+    let payment_data = SendPaymentData::new(send_command).unwrap();
+    assert_eq!(
+        payment_data.final_tlc_expiry_delta,
+        crate::fiber::config::DEFAULT_FINAL_TLC_EXPIRY_DELTA
+    );
+
+    // Callers may still request a longer final-hop delta.
+    let longer_delta = 48 * 60 * 60 * 1000;
+    let send_command = SendPaymentCommand {
+        final_tlc_expiry_delta: Some(longer_delta),
+        invoice: Some(invoice_encoded.clone()),
+        ..Default::default()
+    };
+
+    let payment_data = SendPaymentData::new(send_command).unwrap();
+    assert_eq!(payment_data.final_tlc_expiry_delta, longer_delta);
 
     // invoice with invalid final_tlc_expiry_delta
     let invoice = InvoiceBuilder::new(Currency::Fibb)

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -1864,19 +1864,17 @@ fn test_send_payment_validate_invoice() {
     let result = SendPaymentData::new(send_command);
     assert!(result.is_ok());
 
-    // An invoice without an explicit final TLC delta still requires the 24-hour
-    // protocol default, so a shorter command value cannot reduce it.
+    // When the invoice does not specify a final TLC delta, an explicit command
+    // value takes precedence over the 24-hour local default.
+    let shorter_delta = 12 * 60 * 60 * 1000;
     let send_command = SendPaymentCommand {
-        final_tlc_expiry_delta: Some(12 * 60 * 60 * 1000),
+        final_tlc_expiry_delta: Some(shorter_delta),
         invoice: Some(invoice_encoded.clone()),
         ..Default::default()
     };
 
     let payment_data = SendPaymentData::new(send_command).unwrap();
-    assert_eq!(
-        payment_data.final_tlc_expiry_delta,
-        crate::fiber::config::DEFAULT_FINAL_TLC_EXPIRY_DELTA
-    );
+    assert_eq!(payment_data.final_tlc_expiry_delta, shorter_delta);
 
     // Callers may still request a longer final-hop delta.
     let longer_delta = 48 * 60 * 60 * 1000;

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -1865,7 +1865,7 @@ fn test_send_payment_validate_invoice() {
     assert!(result.is_ok());
 
     // When the invoice does not specify a final TLC delta, an explicit command
-    // value takes precedence over the 24-hour local default.
+    // value below the effective 24-hour minimum must be rejected before sending.
     let shorter_delta = 12 * 60 * 60 * 1000;
     let send_command = SendPaymentCommand {
         final_tlc_expiry_delta: Some(shorter_delta),
@@ -1873,8 +1873,8 @@ fn test_send_payment_validate_invoice() {
         ..Default::default()
     };
 
-    let payment_data = SendPaymentData::new(send_command).unwrap();
-    assert_eq!(payment_data.final_tlc_expiry_delta, shorter_delta);
+    let err = SendPaymentData::new(send_command).unwrap_err();
+    assert!(err.contains("final_tlc_expiry_delta is below the invoice minimum"));
 
     // Callers may still request a longer final-hop delta.
     let longer_delta = 48 * 60 * 60 * 1000;

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -5673,6 +5673,7 @@ async fn test_shutdown_with_pending_tlc() {
         .payment_hash(payment_hash)
         .hash_algorithm(hash_algorithm)
         .payee_pub_key(nodes[1].pubkey.into())
+        .final_expiry_delta(0)
         .build()
         .expect("build pending invoice");
     nodes[1].insert_invoice(invoice, None);
@@ -5827,6 +5828,7 @@ async fn test_payment_onion_invoice_udt_type_script_mismatch_fails() {
         .hash_algorithm(HashAlgorithm::CkbHash)
         .udt_type_script(invoice_udt_script)
         .payee_pub_key(target_pubkey.into())
+        .final_expiry_delta(0)
         .build()
         .expect("build invoice");
     node_b.insert_invoice(invoice.clone(), Some(preimage));

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -7524,7 +7524,9 @@ async fn test_payment_with_payment_data_record() {
     let hops_infos = vec![
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: now_timestamp_as_millis_u64()
+                + DEFAULT_FINAL_TLC_EXPIRY_DELTA
+                + DEFAULT_TLC_EXPIRY_DELTA,
             next_hop: Some(target_pubkey),
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
@@ -7532,7 +7534,9 @@ async fn test_payment_with_payment_data_record() {
         },
         PaymentHopData {
             amount: 10000000000,
-            expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+            expiry: now_timestamp_as_millis_u64()
+                + DEFAULT_FINAL_TLC_EXPIRY_DELTA
+                + DEFAULT_TLC_EXPIRY_DELTA,
             hash_algorithm,
             custom_records: Some(custom_records.clone()),
             ..Default::default()
@@ -7556,7 +7560,9 @@ async fn test_payment_with_payment_data_record() {
                         amount: 10000000000,
                         hash_algorithm,
                         payment_hash,
-                        expiry: now_timestamp_as_millis_u64() + DEFAULT_TLC_EXPIRY_DELTA,
+                        expiry: now_timestamp_as_millis_u64()
+                            + DEFAULT_FINAL_TLC_EXPIRY_DELTA
+                            + DEFAULT_TLC_EXPIRY_DELTA,
                         onion_packet: packet.next.clone(),
                         shared_secret: packet.shared_secret,
                         is_trampoline_hop: false,
@@ -7574,12 +7580,12 @@ async fn test_payment_with_payment_data_record() {
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
 
     // wait tlc 1 is removed
-    while source_node
-        .get_tlc(channels[0], TLCId::Offered(add_tlc_result_1.tlc_id))
-        .is_some()
-    {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    }
+    wait_until_timeout(30_000, || {
+        source_node
+            .get_tlc(channels[0], TLCId::Offered(add_tlc_result_1.tlc_id))
+            .is_none()
+    })
+    .await;
 
     let node_0_balance = source_node.get_local_balance_from_channel(channels[0]);
     let node_1_balance = node_1.get_local_balance_from_channel(channels[0]);

--- a/crates/fiber-types/src/invoice.rs
+++ b/crates/fiber-types/src/invoice.rs
@@ -153,6 +153,9 @@ pub const MAX_DESCRIPTION_LENGTH: usize = 639;
 /// addresses and future attributes while bounding compressed-input expansion.
 pub const MAX_INVOICE_DATA_LENGTH: usize = 16 * 1024;
 
+/// Default final-hop TLC expiry delta when an invoice does not specify one.
+pub const DEFAULT_FINAL_TLC_EXPIRY_DELTA: u64 = 24 * 60 * 60 * 1000;
+
 /// Encodes bytes and returns the compressed form.
 /// This is used for encoding the invoice data, to make the final Invoice encoded address shorter.
 pub(crate) fn ar_encompress(data: &[u8]) -> IoResult<Vec<u8>> {
@@ -557,7 +560,10 @@ pub enum Attribute {
     /// This attribute is deprecated since v0.6.0. The final TLC timeout, in milliseconds.
     #[serde(with = "U64Hex")]
     FinalHtlcTimeout(u64),
-    /// The final TLC minimum expiry delta, in milliseconds. Default is 160 minutes.
+    /// The final TLC minimum expiry delta, in milliseconds.
+    ///
+    /// When omitted, the protocol default is 24 hours. Invoices created through
+    /// the node RPC normally contain an explicit value, defaulting to 160 minutes.
     #[serde(with = "U64Hex")]
     FinalHtlcMinimumExpiryDelta(u64),
     /// The expiry time of the invoice, in seconds.
@@ -858,8 +864,8 @@ impl CkbInvoice {
         let required_expiry = now
             + (self
                 .final_tlc_minimum_expiry_delta()
-                .cloned()
-                .unwrap_or_default() as u128);
+                .copied()
+                .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA) as u128);
         (tlc_expiry as u128) < required_expiry
     }
 
@@ -875,6 +881,29 @@ impl CkbInvoice {
         self.signature = Some(InvoiceSignature(signature));
         self.check_signature()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invoice_without_final_expiry_delta_uses_protocol_default() {
+        let now = crate::now_timestamp_as_millis_u64();
+        let invoice = CkbInvoice {
+            currency: Currency::Fibd,
+            amount: Some(1_000),
+            signature: None,
+            data: InvoiceData {
+                timestamp: now.into(),
+                payment_hash: Hash256::default(),
+                attrs: Vec::new(),
+            },
+        };
+
+        assert!(invoice.is_tlc_expire_too_soon(now + 12 * 60 * 60 * 1_000));
+        assert!(!invoice.is_tlc_expire_too_soon(now + 48 * 60 * 60 * 1_000));
     }
 }
 

--- a/crates/fiber-types/src/invoice.rs
+++ b/crates/fiber-types/src/invoice.rs
@@ -787,6 +787,16 @@ impl CkbInvoice {
             .next()
     }
 
+    /// Returns the effective final TLC minimum expiry delta.
+    ///
+    /// Uses [`DEFAULT_FINAL_TLC_EXPIRY_DELTA`] when the invoice omits the
+    /// corresponding attribute.
+    pub fn final_tlc_minimum_expiry_delta_or_default(&self) -> u64 {
+        self.final_tlc_minimum_expiry_delta()
+            .copied()
+            .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA)
+    }
+
     /// Returns the fallback address if set in the invoice attributes.
     pub fn fallback_address(&self) -> Option<&String> {
         self.data
@@ -861,11 +871,7 @@ impl CkbInvoice {
             .elapsed()
             .expect("Duration since unix epoch")
             .as_millis();
-        let required_expiry = now
-            + (self
-                .final_tlc_minimum_expiry_delta()
-                .copied()
-                .unwrap_or(DEFAULT_FINAL_TLC_EXPIRY_DELTA) as u128);
+        let required_expiry = now + u128::from(self.final_tlc_minimum_expiry_delta_or_default());
         (tlc_expiry as u128) < required_expiry
     }
 
@@ -902,8 +908,23 @@ mod tests {
             },
         };
 
+        assert_eq!(
+            invoice.final_tlc_minimum_expiry_delta_or_default(),
+            DEFAULT_FINAL_TLC_EXPIRY_DELTA
+        );
         assert!(invoice.is_tlc_expire_too_soon(now + 12 * 60 * 60 * 1_000));
         assert!(!invoice.is_tlc_expire_too_soon(now + 48 * 60 * 60 * 1_000));
+
+        let explicit_delta = 36 * 60 * 60 * 1_000;
+        let mut invoice_with_explicit_delta = invoice;
+        invoice_with_explicit_delta
+            .data
+            .attrs
+            .push(Attribute::FinalHtlcMinimumExpiryDelta(explicit_delta));
+        assert_eq!(
+            invoice_with_explicit_delta.final_tlc_minimum_expiry_delta_or_default(),
+            explicit_delta
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- define the default final-hop TLC expiry delta in `fiber-types`
- apply the 24-hour default when an invoice omits `FinalHtlcMinimumExpiryDelta`
- re-export the shared constant from the node configuration module
- add regression coverage for invoices without an explicit final expiry delta

## Motivation

The invoice expiry check previously treated a missing final-hop expiry delta as zero. As a result, an invoice without the optional attribute could accept a final TLC with no protocol-default safety margin. Applying the shared default keeps omitted attributes consistent with the expected 24-hour final-hop expiry requirement.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run -p fiber-types invoice_without_final_expiry_delta_uses_protocol_default`
- `cargo clippy -p fiber-types --lib -- -D warnings`
- `cargo clippy --all-targets --features sqlite -p fnn -- -D warnings`
