### PR TITLE
fix: handle ChannelReady replay on reconnect

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -70,7 +70,7 @@ use fiber_types::{
     PrevTlcInfo, Privkey, Pubkey, PublicChannelInfo, RemoveTlcFulfill, RemoveTlcReason,
     RetryableTlcOperation, RevocationData, RevokeAndAck, SettlementData, SettlementTlc,
     ShutdownInfo, ShuttingDownFlags, SigningCommitmentFlags, TLCId, TlcErr, TlcErrPacket,
-    TlcErrorCode, TlcInfo, TlcStatus, NO_SHARED_SECRET,
+    TlcErrorCode, TlcInfo, TlcStatus, INITIAL_COMMITMENT_NUMBER, NO_SHARED_SECRET,
 };
 pub use fiber_types::{
     CommitDiff, CommitmentSignedTemplate, ReplayOrderHint, TlcReplayUpdate,
@@ -874,6 +874,7 @@ where
             }
             FiberChannelMessage::ChannelReady(_channel_ready) => {
                 let flags = match state.state {
+                    ChannelState::ChannelReady => return Ok(()),
                     ChannelState::AwaitingTxSignatures(flags)
                         if flags.contains(AwaitingTxSignaturesFlags::TX_SIGNATURES_SENT) =>
                     {
@@ -8389,6 +8390,49 @@ impl ChannelActorState {
         Ok(())
     }
 
+    /// Returns whether reconnect is in the initial `ChannelReady` replay window.
+    ///
+    /// The funding commitment exchange leaves both counters at the first post-initial value,
+    /// while entering `ChannelReady` advances them once more. Requiring the persisted funding
+    /// confirmation and no pending commitment/TLC work keeps this one-step gap from being
+    /// confused with a later channel update. The confirmation is historical local evidence;
+    /// this check does not query the chain again during reestablishment.
+    fn should_replay_channel_ready_on_reestablish(
+        &mut self,
+        myself: &ActorRef<ChannelActorMessage>,
+        reestablish_channel: &ReestablishChannel,
+    ) -> bool {
+        let funding_commitment_number = INITIAL_COMMITMENT_NUMBER + 1;
+        let channel_ready_commitment_number = funding_commitment_number + 1;
+
+        let should_relay_channel_ready = matches!(self.state, ChannelState::ChannelReady)
+            && self.funding_tx_confirmed_at.is_some()
+            && self.get_local_commitment_number() == channel_ready_commitment_number
+            && self.get_remote_commitment_number() == channel_ready_commitment_number
+            && reestablish_channel.local_commitment_number == funding_commitment_number
+            && reestablish_channel.remote_commitment_number == funding_commitment_number
+            && !self.tlc_state.waiting_ack
+            && self.tlc_state.all_tlcs().next().is_none();
+
+        if should_relay_channel_ready {
+            self.on_reestablished_channel_ready(myself);
+            let network = self.network();
+            network
+                .send_message(NetworkActorMessage::new_command(
+                    NetworkActorCommand::SendFiberMessage(FiberMessageWithTarget::new(
+                        self.get_remote_pubkey(),
+                        FiberMessage::channel_ready(ChannelReady {
+                            channel_id: self.get_id(),
+                        }),
+                    )),
+                ))
+                .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+            debug_event!(network, "Replayed ChannelReady after reestablishment");
+            return true;
+        }
+        false
+    }
+
     async fn handle_reestablish_channel_message(
         &mut self,
         myself: &ActorRef<ChannelActorMessage>,
@@ -8542,6 +8586,10 @@ impl ChannelActorState {
                     return Err(ProcessingChannelError::InvalidParameter(
                         "reestablish channel message with invalid commitment numbers".to_string(),
                     ));
+                }
+
+                if self.should_replay_channel_ready_on_reestablish(myself, reestablish_channel) {
+                    return Ok(());
                 }
 
                 if my_local_commitment_number == peer_remote_commitment_number

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -5895,6 +5895,14 @@ async fn test_connect_to_peers_with_mutual_channel_on_restart_1() {
             true,
         )
         .await;
+    let unexpected_channel_ready_replay =
+        vec!["Replayed ChannelReady after reestablishment".to_string()];
+    node_a
+        .add_unexpected_events(unexpected_channel_ready_replay.clone())
+        .await;
+    node_b
+        .add_unexpected_events(unexpected_channel_ready_replay)
+        .await;
 
     node_a.restart().await;
 
@@ -5975,6 +5983,121 @@ async fn test_reestablished_channel_ready_notification_is_not_delayed() {
         .await;
     assert!(node_a.get_triggered_unexpected_events().await.is_empty());
     assert!(node_b.get_triggered_unexpected_events().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_reconnect_resolves_awaiting_channel_ready_when_peer_is_already_ready() {
+    init_tracing();
+
+    let (mut node_a, mut node_b, channel_id) =
+        create_nodes_with_established_channel(100000000000, 100000000000, false).await;
+    node_a
+        .add_unexpected_events(vec![
+            "received ChannelReady message, but we're not ready for ChannelReady".to_string(),
+        ])
+        .await;
+
+    let mut node_b_state = node_b.get_channel_actor_state(channel_id);
+    node_b_state.state =
+        ChannelState::AwaitingChannelReady(AwaitingChannelReadyFlags::OUR_CHANNEL_READY);
+    node_b_state.commitment_numbers.local = node_b_state
+        .commitment_numbers
+        .local
+        .checked_sub(1)
+        .expect("established channel has an initial local commitment");
+    node_b_state.commitment_numbers.remote = node_b_state
+        .commitment_numbers
+        .remote
+        .checked_sub(1)
+        .expect("established channel has an initial remote commitment");
+    node_b
+        .update_channel_actor_state(
+            node_b_state,
+            Some(ReloadParams {
+                notify_changes: false,
+            }),
+        )
+        .await;
+
+    assert!(matches!(
+        node_a.get_channel_actor_state(channel_id).state,
+        ChannelState::ChannelReady
+    ));
+    assert!(matches!(
+        node_b.get_channel_actor_state(channel_id).state,
+        ChannelState::AwaitingChannelReady(flags)
+            if flags.contains(AwaitingChannelReadyFlags::OUR_CHANNEL_READY)
+                && !flags.contains(AwaitingChannelReadyFlags::THEIR_CHANNEL_READY)
+    ));
+    let node_a_state = node_a.get_channel_actor_state(channel_id);
+    let node_b_state = node_b.get_channel_actor_state(channel_id);
+    assert_eq!(
+        node_a_state.commitment_numbers.local,
+        node_b_state.commitment_numbers.remote + 1
+    );
+    assert_eq!(
+        node_a_state.commitment_numbers.remote,
+        node_b_state.commitment_numbers.local + 1
+    );
+
+    node_a
+        .network_actor
+        .send_message(NetworkActorMessage::new_command(
+            NetworkActorCommand::DisconnectPeer(
+                node_b.pubkey,
+                PeerDisconnectReason::Requested,
+                None,
+            ),
+        ))
+        .expect("node_a alive");
+
+    node_a
+        .expect_event(|event| {
+            matches!(
+                event,
+                NetworkServiceEvent::PeerDisConnected(pubkey, _) if pubkey == &node_b.pubkey
+            )
+        })
+        .await;
+    node_b
+        .expect_event(|event| {
+            matches!(
+                event,
+                NetworkServiceEvent::PeerDisConnected(pubkey, _) if pubkey == &node_a.pubkey
+            )
+        })
+        .await;
+
+    node_a.connect_to_nonblocking(&node_b).await;
+    node_a
+        .expect_event(|event| {
+            matches!(
+                event,
+                NetworkServiceEvent::PeerConnected(pubkey, _) if pubkey == &node_b.pubkey
+            )
+        })
+        .await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let mut final_state = node_b.get_channel_actor_state(channel_id).state;
+    while tokio::time::Instant::now() < deadline {
+        final_state = node_b.get_channel_actor_state(channel_id).state;
+        if matches!(final_state, ChannelState::ChannelReady) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        matches!(final_state, ChannelState::ChannelReady),
+        "node_b stayed in {:?} after peers disconnected and reconnected; missing peer ChannelReady was not recovered",
+        final_state,
+    );
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        node_a.get_triggered_unexpected_events().await.is_empty(),
+        "replayed ChannelReady should be handled idempotently"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #1544.

## Summary

Recover channels that remain in `AwaitingChannelReady` when the peer's
`ChannelReady` message was lost before a disconnect.

This PR:

- treats a duplicate `ChannelReady` received by an already-ready channel as an
  idempotent no-op;
- replays the local `ChannelReady` only when the peer's commitment numbers
  identify the initial ready-handshake gap;
- requires a persisted local funding confirmation and no pending commitment or
  TLC work before taking the replay path;
- verifies that normal ready-channel reconnections do not replay
  `ChannelReady`.


## Background

A channel may reach the following state if one `ChannelReady` message is lost:

| Node | State | Commitment numbers |
| --- | --- | --- |
| A | `ChannelReady` | `2/2` |
| B | `AwaitingChannelReady(OUR_CHANNEL_READY)` | `1/1` |

Both nodes have observed the funding transaction confirmation and sent their
own `ChannelReady`. B's message reached A, allowing A to enter
`ChannelReady`, but A's message did not reach B.

When the peers reconnect, B resends its `ChannelReady`. Previously, A rejected
that duplicate because it was already in `ChannelReady`, while A did not replay
its own `ChannelReady`. B therefore remained stuck.