### PR TITLE
Fix intermittent Biscuit authorization failures

### DIFF
--- a/crates/fiber-lib/src/rpc/biscuit.rs
+++ b/crates/fiber-lib/src/rpc/biscuit.rs
@@ -1,15 +1,19 @@
-use anyhow::{anyhow, Context, Result};
-use biscuit_auth::{
-    builder::{Fact, Term},
-    AuthorizerBuilder, Biscuit, PublicKey,
-};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
+    time::Duration,
+};
+
+use anyhow::{anyhow, Context, Result};
+use biscuit_auth::{
+    builder::{Fact, Term},
+    AuthorizerBuilder, AuthorizerLimits, Biscuit, PublicKey,
 };
 
 use crate::now_timestamp_as_millis_u64;
 use fiber_types::NodeId;
+
+const DEFAULT_BISCUIT_AUTH_MAX_TIME: Duration = Duration::from_millis(10);
 
 pub struct AuthRule {
     pub(crate) code: &'static str,
@@ -32,6 +36,10 @@ impl AuthRule {
     /// build rule
     fn build_rule(&self) -> Result<AuthorizerBuilder> {
         let authorizer = AuthorizerBuilder::new()
+            .set_limits(AuthorizerLimits {
+                max_time: DEFAULT_BISCUIT_AUTH_MAX_TIME,
+                ..Default::default()
+            })
             .code(self.code)
             .context("build authorizer code")?;
         Ok(authorizer)
@@ -237,10 +245,7 @@ impl BiscuitAuth {
         }
         // check permission
         let rule = self.get_rule(method)?;
-        if let Err(err) = rule.authorize(&b, time_in_ms) {
-            tracing::debug!("authorize failed: {err}");
-            return Err(err);
-        }
+        rule.authorize(&b, time_in_ms)?;
         Ok((b, rule))
     }
 
@@ -270,7 +275,19 @@ mod tests {
 
     use crate::rpc::biscuit::extract_node_id;
 
-    use super::BiscuitAuth;
+    use super::{AuthRule, BiscuitAuth, DEFAULT_BISCUIT_AUTH_MAX_TIME};
+
+    #[test]
+    fn test_biscuit_auth_uses_ten_millisecond_authorizer_limit() {
+        let rule = AuthRule::new(r#"allow if read("payments");"#);
+        let authorizer = rule.build_rule().unwrap();
+        let limits = authorizer.limits();
+        let default_limits = biscuit_auth::AuthorizerLimits::default();
+
+        assert_eq!(limits.max_time, DEFAULT_BISCUIT_AUTH_MAX_TIME);
+        assert_eq!(limits.max_facts, default_limits.max_facts);
+        assert_eq!(limits.max_iterations, default_limits.max_iterations);
+    }
 
     #[test]
     fn test_biscuit_auth() {

--- a/crates/fiber-lib/src/rpc/biscuit.rs
+++ b/crates/fiber-lib/src/rpc/biscuit.rs
@@ -7,13 +7,24 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use biscuit_auth::{
     builder::{Fact, Term},
-    AuthorizerBuilder, AuthorizerLimits, Biscuit, PublicKey,
+    Authorizer, AuthorizerBuilder, AuthorizerLimits, Biscuit, PublicKey,
 };
 
 use crate::now_timestamp_as_millis_u64;
 use fiber_types::NodeId;
 
 const DEFAULT_BISCUIT_AUTH_MAX_TIME: Duration = Duration::from_millis(10);
+
+fn authorizer_builder() -> AuthorizerBuilder {
+    AuthorizerBuilder::new().set_limits(AuthorizerLimits {
+        max_time: DEFAULT_BISCUIT_AUTH_MAX_TIME,
+        ..Default::default()
+    })
+}
+
+fn build_authorizer(token: &Biscuit) -> Result<Authorizer> {
+    Ok(authorizer_builder().build(token)?)
+}
 
 pub struct AuthRule {
     pub(crate) code: &'static str,
@@ -35,11 +46,7 @@ impl AuthRule {
 
     /// build rule
     fn build_rule(&self) -> Result<AuthorizerBuilder> {
-        let authorizer = AuthorizerBuilder::new()
-            .set_limits(AuthorizerLimits {
-                max_time: DEFAULT_BISCUIT_AUTH_MAX_TIME,
-                ..Default::default()
-            })
+        let authorizer = authorizer_builder()
             .code(self.code)
             .context("build authorizer code")?;
         Ok(authorizer)
@@ -261,7 +268,8 @@ impl BiscuitAuth {
 /// Extract node id from token
 pub fn extract_node_id(token: &Biscuit) -> Result<NodeId> {
     const QUERY: &str = "data($id) <- node($id)";
-    let (id,): (String,) = token.authorizer()?.query_exactly_one(QUERY)?;
+    let mut authorizer = build_authorizer(token)?;
+    let (id,): (String,) = authorizer.query_exactly_one(QUERY)?;
     let node_id = NodeId::from_str(id.as_str())?;
     tracing::warn!("fetch {id:?} {node_id:?}");
     Ok(node_id)
@@ -275,7 +283,7 @@ mod tests {
 
     use crate::rpc::biscuit::extract_node_id;
 
-    use super::{AuthRule, BiscuitAuth, DEFAULT_BISCUIT_AUTH_MAX_TIME};
+    use super::{build_authorizer, AuthRule, BiscuitAuth};
 
     #[test]
     fn test_biscuit_auth_uses_ten_millisecond_authorizer_limit() {
@@ -284,9 +292,19 @@ mod tests {
         let limits = authorizer.limits();
         let default_limits = biscuit_auth::AuthorizerLimits::default();
 
-        assert_eq!(limits.max_time, DEFAULT_BISCUIT_AUTH_MAX_TIME);
+        assert_eq!(limits.max_time, Duration::from_millis(10));
         assert_eq!(limits.max_facts, default_limits.max_facts);
         assert_eq!(limits.max_iterations, default_limits.max_iterations);
+    }
+
+    #[test]
+    fn test_node_id_query_uses_ten_millisecond_authorizer_limit() {
+        let root = KeyPair::new();
+        let token = biscuit!(r#"node("test-node-id");"#).build(&root).unwrap();
+        let authorizer = build_authorizer(&token).unwrap();
+        let limits = authorizer.limits();
+
+        assert_eq!(limits.max_time, Duration::from_millis(10));
     }
 
     #[test]

--- a/crates/fiber-lib/src/rpc/middleware.rs
+++ b/crates/fiber-lib/src/rpc/middleware.rs
@@ -1,14 +1,15 @@
 use std::borrow::Cow;
+use std::future::Future;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Error, Result};
+use biscuit_auth::error::{RunLimit, Token as BiscuitError};
 use hyper::header::AUTHORIZATION;
 use hyper::HeaderMap;
 use jsonrpsee::core::middleware::{Batch, BatchEntry, BatchEntryErr, Notification};
 use jsonrpsee::server::middleware::rpc::RpcServiceT;
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned, Id, Request};
 use jsonrpsee::MethodResponse;
-use std::future::Future;
 
 use crate::rpc::biscuit::extract_node_id;
 use fiber_json_types::RpcContext;
@@ -58,37 +59,20 @@ impl<S> BiscuitAuthMiddleware<S> {
     }
 
     /// Authorize the request
-    fn auth_call(&self, req: &mut Request<'_>) -> bool {
+    fn auth_call(&self, req: &mut Request<'_>) -> Result<()> {
         if self.enable_auth {
-            // extract auth token
-            let token = match self.auth_token() {
-                Ok(token) => token,
-                Err(err) => {
-                    tracing::debug!("failed to get auth token: {err}");
-                    return false;
-                }
-            };
+            let token = self.auth_token()?;
+            let (token, rule) = self.auth.check_permission(&req.method, &token)?;
+            if rule.require_rpc_context {
+                let node_id = extract_node_id(&token)?;
 
-            match self.auth.check_permission(&req.method, &token) {
-                Ok((token, rule)) => {
-                    if rule.require_rpc_context {
-                        let Ok(node_id) = extract_node_id(&token) else {
-                            return false;
-                        };
-
-                        // Inject RpcContext as first param (node_id as String)
-                        let ctx = RpcContext {
-                            node_id: node_id.to_string(),
-                        };
-                        self.inject_rpc_context(req, ctx);
-                    }
-                    return true;
-                }
-                Err(err) => {
-                    tracing::debug!("Failed check_permission #{err:?}");
-                    return false;
-                }
+                // Inject RpcContext as first param (node_id as String)
+                let ctx = RpcContext {
+                    node_id: node_id.to_string(),
+                };
+                self.inject_rpc_context(req, ctx);
             }
+            Ok(())
         } else {
             // local rpc, auth token is none
             match self.auth.get_rule(&req.method) {
@@ -102,28 +86,22 @@ impl<S> BiscuitAuthMiddleware<S> {
                         };
                         self.inject_rpc_context(req, ctx);
                     }
-                    return true;
                 }
                 Err(err) => {
                     tracing::debug!("Failed get_rule #{err:?}");
                     // no auth rule, but allow local rpc to proceed.
-                    return true;
                 }
             }
+            Ok(())
         }
     }
 
     /// Authorize the notification
-    fn auth_notify(&self, notify: &Notification<'_>) -> bool {
-        let token = match self.auth_token() {
-            Ok(token) => token,
-            Err(err) => {
-                tracing::debug!("failed to get auth token: {err}");
-                return false;
-            }
-        };
-        let res = self.auth.check_permission(notify.method_name(), &token);
-        res.is_ok()
+    fn auth_notify(&self, notify: &Notification<'_>) -> Result<()> {
+        let token = self.auth_token()?;
+        self.auth
+            .check_permission(notify.method_name(), &token)
+            .map(|_| ())
     }
 }
 
@@ -147,11 +125,14 @@ where
         mut req: Request<'a>,
     ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
         let this = self.clone();
-        let auth_ok = this.auth_call(&mut req);
+        let auth_error = this
+            .auth_call(&mut req)
+            .err()
+            .map(|err| auth_reject_error(&req.method, &err));
 
         async move {
-            if !auth_ok {
-                return MethodResponse::error(req.id, auth_reject_error());
+            if let Some(err) = auth_error {
+                return MethodResponse::error(req.id, err);
             }
             this.inner.call(req).await
         }
@@ -161,19 +142,21 @@ where
         let entries: Vec<_> = batch
             .into_iter()
             .filter_map(|entry| match entry {
-                Ok(BatchEntry::Call(mut req)) => {
-                    if self.auth_call(&mut req) {
-                        Some(Ok(BatchEntry::Call(req)))
-                    } else {
-                        Some(Err(BatchEntryErr::new(req.id, auth_reject_error())))
+                Ok(BatchEntry::Call(mut req)) => match self.auth_call(&mut req) {
+                    Ok(()) => Some(Ok(BatchEntry::Call(req))),
+                    Err(err) => {
+                        let rpc_error = auth_reject_error(&req.method, &err);
+                        Some(Err(BatchEntryErr::new(req.id, rpc_error)))
                     }
-                }
+                },
                 Ok(BatchEntry::Notification(notif)) => {
                     // ignore permissionless notification
-                    if self.auth_notify(&notif) {
-                        Some(Ok(BatchEntry::Notification(notif)))
-                    } else {
-                        None
+                    match self.auth_notify(&notif) {
+                        Ok(()) => Some(Ok(BatchEntry::Notification(notif))),
+                        Err(err) => {
+                            log_auth_rejection(notif.method_name(), &err);
+                            None
+                        }
                     }
                 }
                 Err(err) => Some(Err(err)),
@@ -188,17 +171,102 @@ where
         n: Notification<'a>,
     ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
         let this = self.clone();
-        let auth_ok = this.auth_notify(&n);
+        let auth_error = this
+            .auth_notify(&n)
+            .err()
+            .map(|err| auth_reject_error(n.method_name(), &err));
 
         async move {
-            if !auth_ok {
-                return MethodResponse::error(Id::Null, auth_reject_error());
+            if let Some(err) = auth_error {
+                return MethodResponse::error(Id::Null, err);
             }
             this.inner.notification(n).await
         }
     }
 }
 
-fn auth_reject_error() -> ErrorObjectOwned {
-    ErrorObject::owned(-32999, "Unauthorized", None::<()>)
+fn auth_reject_message(error: &Error) -> &'static str {
+    match error.downcast_ref::<BiscuitError>() {
+        Some(BiscuitError::RunLimit(RunLimit::Timeout)) => {
+            "Unauthorized: Biscuit authorization timed out"
+        }
+        Some(BiscuitError::RunLimit(RunLimit::TooManyFacts)) => {
+            "Unauthorized: Biscuit authorization generated too many facts"
+        }
+        Some(BiscuitError::RunLimit(RunLimit::TooManyIterations)) => {
+            "Unauthorized: Biscuit authorization exceeded the iteration limit"
+        }
+        Some(BiscuitError::RunLimit(RunLimit::UnexpectedQueryResult(_, _))) => {
+            "Unauthorized: Biscuit authorization returned unexpected query results"
+        }
+        _ => "Unauthorized",
+    }
+}
+
+fn log_auth_rejection(method: &str, error: &Error) {
+    match error.downcast_ref::<BiscuitError>() {
+        Some(BiscuitError::RunLimit(limit)) => {
+            tracing::warn!(
+                rpc_method = method,
+                run_limit = ?limit,
+                "Biscuit authorization failed"
+            );
+        }
+        _ => {
+            tracing::debug!(
+                rpc_method = method,
+                error = %error,
+                "Biscuit authorization failed"
+            );
+        }
+    }
+}
+
+fn auth_reject_error(method: &str, error: &Error) -> ErrorObjectOwned {
+    log_auth_rejection(method, error);
+    ErrorObject::owned(-32999, auth_reject_message(error), None::<()>)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_reject_error_reports_run_limit_reason() {
+        let cases = [
+            (
+                RunLimit::Timeout,
+                "Unauthorized: Biscuit authorization timed out",
+            ),
+            (
+                RunLimit::TooManyFacts,
+                "Unauthorized: Biscuit authorization generated too many facts",
+            ),
+            (
+                RunLimit::TooManyIterations,
+                "Unauthorized: Biscuit authorization exceeded the iteration limit",
+            ),
+            (
+                RunLimit::UnexpectedQueryResult(1, 2),
+                "Unauthorized: Biscuit authorization returned unexpected query results",
+            ),
+        ];
+
+        for (limit, message) in cases {
+            let error = Error::new(BiscuitError::RunLimit(limit));
+            let rpc_error = auth_reject_error("test_method", &error);
+
+            assert_eq!(rpc_error.code(), -32999);
+            assert_eq!(rpc_error.message(), message);
+        }
+    }
+
+    #[test]
+    fn test_auth_reject_error_keeps_generic_unauthorized_message() {
+        let error = anyhow!("missing token");
+        let rpc_error = auth_reject_error("test_method", &error);
+
+        assert_eq!(rpc_error.code(), -32999);
+        assert_eq!(rpc_error.message(), "Unauthorized");
+    }
 }


### PR DESCRIPTION
## Summary

- raise the Biscuit authorizer execution-time limit from the library default of 1 ms to a fixed 10 ms
- apply the limit to `AuthorizerBuilder` before building the authorizer so the Datalog run phase uses it
- preserve authorization errors through the RPC middleware and expose concrete Datalog run-limit causes in RPC responses and structured logs

## Root cause

`biscuit-auth 6.0.0` defaults `max_time` to 1 ms. FNN previously built each authorizer with that default, so valid tokens could intermittently hit `RunLimit::Timeout` when the process was under modest load.

The middleware then reduced every authorization failure to a boolean and returned the same `-32999 Unauthorized` response, hiding whether the Datalog engine timed out, generated too many facts, exceeded its iteration limit, or returned unexpected query results.

This change keeps the existing RPC error code and generic response for ordinary authorization failures. Datalog run-limit failures now include their specific cause. It does not add configuration or retryability metadata.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run -p fnn --features rocksdb 'rpc::biscuit::tests'`
- `cargo nextest run -p fnn --features rocksdb test_auth_reject_error`
- `cargo nextest run -p fnn --features rocksdb test_rpc_auth`
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo clippy -p fiber-wasm -p fiber-wasm-db-worker -p fiber-wasm-db-common --target wasm32-unknown-unknown -- -D warnings`

Fixes #1559
