### PR TITLE
fix(cch): make receive_btc creation recoverable

### DIFF
--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -8,6 +8,7 @@ use ractor::{
 };
 use secp256k1::{PublicKey, SecretKey, SECP256K1};
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use tentacle::secio::SecioKeyPair;
@@ -194,6 +195,7 @@ pub struct CchState<S> {
     pub(super) lnd_tracker: ActorRef<LndTrackerMessage>,
     pub(super) scheduler: ActorRef<SchedulerMessage>,
     pub(super) store: S,
+    pending_receive_btc_creation_retries: HashSet<Hash256>,
     /// The CKB network currency this node is configured for.
     pub(super) currency: Currency,
 }
@@ -323,6 +325,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             lnd_tracker,
             scheduler,
             currency: args.currency,
+            pending_receive_btc_creation_retries: HashSet::new(),
         };
 
         Ok(state)
@@ -376,10 +379,15 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
         // A creation intent is persisted before the external LND side effect. Replaying these
         // messages makes a crash between AddHoldInvoice and the final order write recoverable.
         for payment_hash in state.store.get_receive_btc_order_creation_keys_iter() {
-            myself.send_message(CchMessage::ResumeReceiveBTCOrderCreation {
-                payment_hash,
-                retry_count: 0,
-            })?;
+            if state
+                .pending_receive_btc_creation_retries
+                .insert(payment_hash)
+            {
+                myself.send_message(CchMessage::ResumeReceiveBTCOrderCreation {
+                    payment_hash,
+                    retry_count: 0,
+                })?;
+            }
         }
 
         Ok(())
@@ -410,8 +418,38 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 let payment_hash = CkbInvoice::from_str(&receive_btc.fiber_pay_req)
                     .ok()
                     .map(|invoice| *invoice.payment_hash());
-                let result = state.receive_btc(receive_btc).await;
+                let pending_error = match payment_hash {
+                    Some(payment_hash)
+                        if state
+                            .pending_receive_btc_creation_retries
+                            .contains(&payment_hash) =>
+                    {
+                        match state.get_receive_btc_order_creation_or_none(&payment_hash) {
+                            Ok(Some(creation)) => Some(
+                                state
+                                    .ensure_receive_btc_request_matches_creation(
+                                        &receive_btc.fiber_pay_req,
+                                        &creation,
+                                    )
+                                    .err()
+                                    .unwrap_or(CchError::ReceiveBTCOrderCreationInProgress(
+                                        payment_hash,
+                                    )),
+                            ),
+                            Ok(None) => None,
+                            Err(err) => Some(err),
+                        }
+                    }
+                    _ => None,
+                };
+                let result = match pending_error {
+                    Some(err) => Err(err),
+                    None => state.receive_btc(receive_btc).await,
+                };
                 if let Ok((order, true)) = &result {
+                    state
+                        .pending_receive_btc_creation_retries
+                        .remove(&order.payment_hash);
                     // Schedule jobs for new order
                     state.schedule_job_for_non_final_order(order);
                     let actions = ActionDispatcher::on_starting(order);
@@ -424,11 +462,12 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                         if is_retryable_receive_btc_creation_error(err) {
                             schedule_receive_btc_creation_retry(
                                 &myself,
+                                &mut state.pending_receive_btc_creation_retries,
                                 payment_hash,
                                 0,
                                 &err.to_string(),
                             );
-                        } else {
+                        } else if !matches!(err, CchError::ReceiveBTCOrderCreationInProgress(_)) {
                             tracing::error!(
                                 "Permanently failed to complete receive_btc creation {:x}: {}. The durable intent is retained for operator inspection",
                                 payment_hash,
@@ -533,6 +572,9 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 payment_hash,
                 retry_count,
             } => {
+                state
+                    .pending_receive_btc_creation_retries
+                    .remove(&payment_hash);
                 match state.resume_receive_btc_order_creation(payment_hash).await {
                     Ok(Some(order)) => {
                         state.schedule_job_for_non_final_order(&order);
@@ -543,6 +585,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     Err(err) if is_retryable_receive_btc_creation_error(&err) => {
                         schedule_receive_btc_creation_retry(
                             &myself,
+                            &mut state.pending_receive_btc_creation_retries,
                             payment_hash,
                             retry_count,
                             &err.to_string(),
@@ -597,6 +640,19 @@ fn lnd_invoice_mismatch(payment_hash: Hash256, reason: impl Into<String>) -> Cch
     CchError::LndInvoiceMismatch {
         payment_hash,
         reason: reason.into(),
+    }
+}
+
+fn receive_btc_order_creation_is_expired(
+    creation: &CchReceiveBtcOrderCreation,
+    current_time: u64,
+) -> bool {
+    match creation
+        .created_at
+        .checked_add(creation.order_expiry_delta_seconds)
+    {
+        Some(expiry_time) => expiry_time <= current_time,
+        None => true,
     }
 }
 
@@ -1073,17 +1129,38 @@ impl<S: CchOrderStore> CchState<S> {
         creation: CchReceiveBtcOrderCreation,
         preflight_complete: bool,
     ) -> Result<CchOrder, CchError> {
-        let incoming_invoice = match self
+        let (incoming_invoice, initial_status) = match self
             .lnd_invoice_client
             .lookup_invoice(creation.payment_hash)
             .await?
         {
-            Some(invoice) => self.validate_recovered_lnd_invoice(&creation, invoice)?,
+            Some(invoice) => {
+                let initial_status = match invoice.state() {
+                    lnrpc::invoice::InvoiceState::Accepted => CchOrderStatus::IncomingAccepted,
+                    _ => CchOrderStatus::Pending,
+                };
+                (
+                    self.validate_recovered_lnd_invoice(&creation, invoice)?,
+                    initial_status,
+                )
+            }
+            None if receive_btc_order_creation_is_expired(
+                &creation,
+                now_timestamp_as_millis_u64() / 1000,
+            ) =>
+            {
+                return Err(CchError::ReceiveBTCOrderCreationExpired(
+                    creation.payment_hash,
+                ));
+            }
             None => {
                 if !preflight_complete {
                     self.preflight_receive_btc_creation(&creation).await?;
                 }
-                self.create_or_recover_lnd_invoice(&creation).await?
+                (
+                    self.create_or_recover_lnd_invoice(&creation).await?,
+                    CchOrderStatus::Pending,
+                )
             }
         };
 
@@ -1094,7 +1171,7 @@ impl<S: CchOrderStore> CchState<S> {
             incoming_invoice: CchInvoice::Lightning(incoming_invoice),
             outgoing_pay_req: creation.fiber_pay_req.clone(),
             payment_preimage: None,
-            status: CchOrderStatus::Pending,
+            status: initial_status,
             amount_sats: creation.amount_sats,
             fee_sats: creation.fee_sats,
             payment_hash: creation.payment_hash,
@@ -1121,6 +1198,11 @@ impl<S: CchOrderStore> CchState<S> {
         &self,
         creation: &CchReceiveBtcOrderCreation,
     ) -> Result<Bolt11Invoice, CchError> {
+        if receive_btc_order_creation_is_expired(creation, now_timestamp_as_millis_u64() / 1000) {
+            return Err(CchError::ReceiveBTCOrderCreationExpired(
+                creation.payment_hash,
+            ));
+        }
         let fiber_invoice = CkbInvoice::from_str(&creation.fiber_pay_req)?;
         let refreshed_at = now_timestamp_as_millis_u64() / 1000;
         let expiry =
@@ -1374,10 +1456,18 @@ fn is_retryable_receive_btc_creation_error(error: &CchError) -> bool {
 
 fn schedule_receive_btc_creation_retry(
     myself: &ActorRef<CchMessage>,
+    pending_retries: &mut HashSet<Hash256>,
     payment_hash: Hash256,
     retry_count: u32,
     reason: &str,
 ) {
+    if !pending_retries.insert(payment_hash) {
+        tracing::debug!(
+            "receive_btc creation retry for payment hash {:x} is already pending",
+            payment_hash
+        );
+        return;
+    }
     let delay = calculate_retry_delay(retry_count);
     tracing::error!(
         "receive_btc creation for payment hash {:x} failed (retry {}): {}. Retrying in {:?}",

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use lightning_invoice::Bolt11Invoice;
 use lightning_invoice::Currency as LnCurrency;
-use lnd_grpc_tonic_client::{invoicesrpc, Uri};
+use lnd_grpc_tonic_client::{invoicesrpc, lnrpc, Uri};
 use ractor::{
     port::OutputPortSubscriberTrait as _, Actor, ActorProcessingErr, ActorRef, OutputPort,
     RpcReplyPort,
@@ -33,7 +33,9 @@ use crate::invoice::{CkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder};
 use crate::now_timestamp_as_millis_u64;
 use crate::store::store_impl::StoreChange;
 use crate::time::Duration;
-use fiber_types::{AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, HashAlgorithm};
+use fiber_types::{
+    AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation, HashAlgorithm,
+};
 use fiber_types::{Hash256, Privkey};
 
 pub const ACTION_RETRY_BASE_MILLIS: u64 = 1000; // 1 second initial delay
@@ -60,6 +62,59 @@ pub struct ReceiveBTC {
     pub fiber_pay_req: String,
 }
 
+#[async_trait::async_trait]
+pub(crate) trait LndInvoiceClient: Send + Sync {
+    async fn lookup_invoice(
+        &self,
+        payment_hash: Hash256,
+    ) -> Result<Option<lnrpc::Invoice>, CchError>;
+
+    async fn add_hold_invoice(
+        &self,
+        request: invoicesrpc::AddHoldInvoiceRequest,
+    ) -> Result<invoicesrpc::AddHoldInvoiceResp, CchError>;
+}
+
+struct TonicLndInvoiceClient {
+    connection: LndConnectionInfo,
+}
+
+#[async_trait::async_trait]
+impl LndInvoiceClient for TonicLndInvoiceClient {
+    async fn lookup_invoice(
+        &self,
+        payment_hash: Hash256,
+    ) -> Result<Option<lnrpc::Invoice>, CchError> {
+        let mut client = self.connection.create_invoices_client().await?;
+        let request = invoicesrpc::LookupInvoiceMsg {
+            lookup_modifier: invoicesrpc::LookupModifier::Default as i32,
+            invoice_ref: Some(invoicesrpc::lookup_invoice_msg::InvoiceRef::PaymentHash(
+                payment_hash.as_ref().to_vec(),
+            )),
+        };
+        match client.lookup_invoice_v2(request).await {
+            Ok(response) => Ok(Some(response.into_inner())),
+            Err(status) if status.code() == tonic::Code::NotFound => Ok(None),
+            Err(status) => Err(CchError::LndRpcError(format!(
+                "lookup invoice {:x}: {}",
+                payment_hash, status
+            ))),
+        }
+    }
+
+    async fn add_hold_invoice(
+        &self,
+        request: invoicesrpc::AddHoldInvoiceRequest,
+    ) -> Result<invoicesrpc::AddHoldInvoiceResp, CchError> {
+        let mut client = self.connection.create_invoices_client().await?;
+        client
+            .add_hold_invoice(request.clone())
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(|status| CchError::LndRpcError(format!("{}, request: {:?}", status, request)))
+    }
+}
+
 pub enum CchMessage {
     SendBTC(SendBTC, RpcReplyPort<Result<CchOrder, CchError>>),
     ReceiveBTC(ReceiveBTC, RpcReplyPort<Result<CchOrder, CchError>>),
@@ -82,6 +137,12 @@ pub enum CchMessage {
     ExecuteAction {
         payment_hash: Hash256,
         action: CchOrderAction,
+        retry_count: u32,
+    },
+
+    /// Resume a durable `receive_btc` creation left by an interrupted attempt.
+    ResumeReceiveBTCOrderCreation {
+        payment_hash: Hash256,
         retry_count: u32,
     },
 
@@ -120,6 +181,8 @@ pub struct CchArgs<S> {
     /// The CKB network currency this node is configured for.
     /// Used to validate that incoming invoices match the expected network.
     pub currency: Currency,
+    #[cfg(test)]
+    pub(crate) lnd_invoice_client: Option<Arc<dyn LndInvoiceClient>>,
 }
 
 pub struct CchState<S> {
@@ -127,6 +190,7 @@ pub struct CchState<S> {
     pub(super) fiber_agent_ref: CchFiberAgentRef,
     pub(super) node_keypair: Option<(PublicKey, SecretKey)>,
     pub(super) lnd_connection: LndConnectionInfo,
+    lnd_invoice_client: Arc<dyn LndInvoiceClient>,
     pub(super) lnd_tracker: ActorRef<LndTrackerMessage>,
     pub(super) scheduler: ActorRef<SchedulerMessage>,
     pub(super) store: S,
@@ -177,6 +241,16 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             None => None,
         };
         let lnd_connection = LndConnectionInfo::new(lnd_rpc_url, cert, macaroon);
+        #[cfg(test)]
+        let lnd_invoice_client = args.lnd_invoice_client.unwrap_or_else(|| {
+            Arc::new(TonicLndInvoiceClient {
+                connection: lnd_connection.clone(),
+            })
+        });
+        #[cfg(not(test))]
+        let lnd_invoice_client: Arc<dyn LndInvoiceClient> = Arc::new(TonicLndInvoiceClient {
+            connection: lnd_connection.clone(),
+        });
 
         let node_keypair = args.node_keypair.map(|kp| {
             let private_key: Privkey = <[u8; 32]>::try_from(kp.as_ref())
@@ -245,6 +319,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             store: args.store,
             node_keypair,
             lnd_connection,
+            lnd_invoice_client,
             lnd_tracker,
             scheduler,
             currency: args.currency,
@@ -298,6 +373,15 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             }
         }
 
+        // A creation intent is persisted before the external LND side effect. Replaying these
+        // messages makes a crash between AddHoldInvoice and the final order write recoverable.
+        for payment_hash in state.store.get_receive_btc_order_creation_keys_iter() {
+            myself.send_message(CchMessage::ResumeReceiveBTCOrderCreation {
+                payment_hash,
+                retry_count: 0,
+            })?;
+        }
+
         Ok(())
     }
 
@@ -323,16 +407,39 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 Ok(())
             }
             CchMessage::ReceiveBTC(receive_btc, port) => {
+                let payment_hash = CkbInvoice::from_str(&receive_btc.fiber_pay_req)
+                    .ok()
+                    .map(|invoice| *invoice.payment_hash());
                 let result = state.receive_btc(receive_btc).await;
-                if let Ok(order) = &result {
+                if let Ok((order, true)) = &result {
                     // Schedule jobs for new order
                     state.schedule_job_for_non_final_order(order);
                     let actions = ActionDispatcher::on_starting(order);
                     append_actions(myself, order.payment_hash, actions)?;
+                } else if let (Some(payment_hash), Err(err)) = (payment_hash, &result) {
+                    if state
+                        .get_receive_btc_order_creation_or_none(&payment_hash)?
+                        .is_some()
+                    {
+                        if is_retryable_receive_btc_creation_error(err) {
+                            schedule_receive_btc_creation_retry(
+                                &myself,
+                                payment_hash,
+                                0,
+                                &err.to_string(),
+                            );
+                        } else {
+                            tracing::error!(
+                                "Permanently failed to complete receive_btc creation {:x}: {}. The durable intent is retained for operator inspection",
+                                payment_hash,
+                                err
+                            );
+                        }
+                    }
                 }
                 if !port.is_closed() {
                     // ignore error
-                    let _ = port.send(result);
+                    let _ = port.send(result.map(|(order, _)| order));
                 }
                 Ok(())
             }
@@ -422,6 +529,35 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 }
                 Ok(())
             }
+            CchMessage::ResumeReceiveBTCOrderCreation {
+                payment_hash,
+                retry_count,
+            } => {
+                match state.resume_receive_btc_order_creation(payment_hash).await {
+                    Ok(Some(order)) => {
+                        state.schedule_job_for_non_final_order(&order);
+                        let actions = ActionDispatcher::on_starting(&order);
+                        append_actions(myself, order.payment_hash, actions)?;
+                    }
+                    Ok(None) => {}
+                    Err(err) if is_retryable_receive_btc_creation_error(&err) => {
+                        schedule_receive_btc_creation_retry(
+                            &myself,
+                            payment_hash,
+                            retry_count,
+                            &err.to_string(),
+                        );
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            "Permanently failed to resume receive_btc creation {:x}: {}. The durable intent is retained for operator inspection",
+                            payment_hash,
+                            err
+                        );
+                    }
+                }
+                Ok(())
+            }
             #[cfg(test)]
             CchMessage::InsertOrder(order, port) => {
                 let result = state.store.insert_cch_order(order).map_err(Into::into);
@@ -444,6 +580,23 @@ fn expected_ln_currency(currency: Currency) -> LnCurrency {
         Currency::Fibb => LnCurrency::Bitcoin,
         Currency::Fibt => LnCurrency::BitcoinTestnet,
         Currency::Fibd => LnCurrency::Regtest,
+    }
+}
+
+fn receive_btc_total_msat(amount_sats: u128, fee_sats: u128) -> Result<i64, CchError> {
+    i64::try_from(
+        amount_sats
+            .checked_add(fee_sats)
+            .and_then(|sats| sats.checked_mul(1_000))
+            .ok_or(CchError::ReceiveBTCOrderAmountTooLarge)?,
+    )
+    .map_err(|_| CchError::ReceiveBTCOrderAmountTooLarge)
+}
+
+fn lnd_invoice_mismatch(payment_hash: Hash256, reason: impl Into<String>) -> CchError {
+    CchError::LndInvoiceMismatch {
+        payment_hash,
+        reason: reason.into(),
     }
 }
 
@@ -694,10 +847,26 @@ impl<S: CchOrderStore> CchState<S> {
         Ok(remaining_seconds)
     }
 
-    async fn receive_btc(&self, receive_btc: ReceiveBTC) -> Result<CchOrder, CchError> {
+    async fn receive_btc(&self, receive_btc: ReceiveBTC) -> Result<(CchOrder, bool), CchError> {
         // `from_str` requires the invoice to carry a valid signature, so parsing
         // here also guarantees the Fiber invoice is signed.
         let invoice = CkbInvoice::from_str(&receive_btc.fiber_pay_req)?;
+
+        let payment_hash = *invoice.payment_hash();
+        if let Some(order) = self.get_order_or_none(&payment_hash)? {
+            self.ensure_receive_btc_request_matches_order(&receive_btc.fiber_pay_req, &order)?;
+            return Ok((order, false));
+        }
+        if let Some(creation) = self.get_receive_btc_order_creation_or_none(&payment_hash)? {
+            self.ensure_receive_btc_request_matches_creation(
+                &receive_btc.fiber_pay_req,
+                &creation,
+            )?;
+            return self
+                .complete_receive_btc_order_creation(creation, false)
+                .await
+                .map(|order| (order, true));
+        }
 
         // Validate that the CKB invoice currency matches the configured network (#982)
         if invoice.currency != self.currency {
@@ -707,7 +876,6 @@ impl<S: CchOrderStore> CchState<S> {
             });
         }
 
-        let payment_hash = *invoice.payment_hash();
         let amount_sats = invoice.amount().ok_or(CchError::CKBInvoiceMissingAmount)?;
 
         // Validate amount and fee early so we reject overflow/too-large before other checks.
@@ -716,13 +884,7 @@ impl<S: CchOrderStore> CchState<S> {
             .and_then(|v| v.checked_div(1_000_000u128))
             .and_then(|v| v.checked_add(self.config.base_fee_sats as u128))
             .ok_or(CchError::ReceiveBTCOrderAmountTooLarge)?;
-        let total_msat = i64::try_from(
-            amount_sats
-                .checked_add(fee_sats)
-                .and_then(|s| s.checked_mul(1_000u128))
-                .unwrap_or(u128::MAX),
-        )
-        .map_err(|_| CchError::ReceiveBTCOrderAmountTooLarge)?;
+        receive_btc_total_msat(amount_sats, fee_sats)?;
 
         // Validate that outgoing CKB invoice's final TLC is less than half of incoming BTC invoice's final CLTV expiry.
         // This ensures the CCH operator has sufficient time to settle the incoming side before the outgoing side expires.
@@ -794,45 +956,301 @@ impl<S: CchOrderStore> CchState<S> {
             )
             .await?;
 
-        let mut client = self.lnd_connection.create_invoices_client().await?;
-
-        // Preflight and client setup may take long enough for the absolute Fiber invoice expiry
-        // to move materially closer. Refresh it immediately before creating the relative-expiry
-        // LND hold invoice so elapsed setup time is not added to the incoming invoice lifetime.
+        // Preflight can take long enough for the absolute Fiber invoice expiry to move
+        // materially closer. Recheck before persisting the intent: no LND side effect has
+        // happened yet, so an invoice that became too short can still be rejected cleanly.
         let refreshed_at = now_timestamp_as_millis_u64() / 1000;
-        let outgoing_invoice_expiry_delta_seconds =
-            self.remaining_outgoing_invoice_expiry_seconds(&invoice, refreshed_at)?;
+        self.remaining_outgoing_invoice_expiry_seconds(&invoice, refreshed_at)?;
 
-        let req = invoicesrpc::AddHoldInvoiceRequest {
-            hash: payment_hash.as_ref().to_vec(),
-            value_msat: total_msat,
-            expiry: outgoing_invoice_expiry_delta_seconds as i64,
-            cltv_expiry: self.config.btc_final_tlc_expiry_delta_blocks,
-            ..Default::default()
-        };
-        let add_invoice_resp = client
-            .add_hold_invoice(req.clone())
-            .await
-            .map_err(|err| CchError::LndRpcError(format!("{}, request: {:?}", err, req)))?
-            .into_inner();
-        let incoming_invoice = Bolt11Invoice::from_str(&add_invoice_resp.payment_request)?;
-
-        let order = CchOrder {
+        let creation = CchReceiveBtcOrderCreation {
             created_at: order_created_at,
-            expiry_delta_seconds: self.config.order_expiry_delta_seconds,
-            failure_reason: None,
-            incoming_invoice: CchInvoice::Lightning(incoming_invoice),
-            outgoing_pay_req: receive_btc.fiber_pay_req,
-            payment_preimage: None,
-            status: CchOrderStatus::Pending,
+            order_expiry_delta_seconds: self.config.order_expiry_delta_seconds,
+            fiber_pay_req: receive_btc.fiber_pay_req,
+            payment_hash,
             amount_sats,
             fee_sats,
-            payment_hash,
             wrapped_btc_type_script,
+            btc_final_tlc_expiry_delta_blocks: self.config.btc_final_tlc_expiry_delta_blocks,
+            max_outgoing_fee_percentage: self.config.max_outgoing_fee_percentage,
+        };
+        self.store
+            .insert_receive_btc_order_creation(creation.clone())?;
+
+        self.complete_receive_btc_order_creation(creation, true)
+            .await
+            .map(|order| (order, true))
+    }
+
+    fn get_receive_btc_order_creation_or_none(
+        &self,
+        payment_hash: &Hash256,
+    ) -> Result<Option<CchReceiveBtcOrderCreation>, CchError> {
+        match self.store.get_receive_btc_order_creation(payment_hash) {
+            Err(CchStoreError::NotFound(_)) => Ok(None),
+            Err(err) => Err(err.into()),
+            Ok(creation) => Ok(Some(creation)),
+        }
+    }
+
+    fn ensure_receive_btc_request_matches_order(
+        &self,
+        fiber_pay_req: &str,
+        order: &CchOrder,
+    ) -> Result<(), CchError> {
+        if order.outgoing_pay_req == fiber_pay_req
+            && matches!(order.incoming_invoice, CchInvoice::Lightning(_))
+        {
+            Ok(())
+        } else {
+            Err(CchError::ConflictingReceiveBTCRequest(order.payment_hash))
+        }
+    }
+
+    fn ensure_receive_btc_request_matches_creation(
+        &self,
+        fiber_pay_req: &str,
+        creation: &CchReceiveBtcOrderCreation,
+    ) -> Result<(), CchError> {
+        if creation.fiber_pay_req == fiber_pay_req {
+            Ok(())
+        } else {
+            Err(CchError::ConflictingReceiveBTCRequest(
+                creation.payment_hash,
+            ))
+        }
+    }
+
+    async fn resume_receive_btc_order_creation(
+        &self,
+        payment_hash: Hash256,
+    ) -> Result<Option<CchOrder>, CchError> {
+        if self.get_order_or_none(&payment_hash)?.is_some() {
+            // A crash after committing the order but before observing the completed batch is safe:
+            // the order is authoritative and any stale intent can be discarded.
+            self.store.delete_receive_btc_order_creation(&payment_hash);
+            return Ok(None);
+        }
+        let Some(creation) = self.get_receive_btc_order_creation_or_none(&payment_hash)? else {
+            return Ok(None);
+        };
+        self.complete_receive_btc_order_creation(creation, false)
+            .await
+            .map(Some)
+    }
+
+    async fn preflight_receive_btc_creation(
+        &self,
+        creation: &CchReceiveBtcOrderCreation,
+    ) -> Result<(), CchError> {
+        let btc_final_cltv_millis = creation
+            .btc_final_tlc_expiry_delta_blocks
+            .checked_mul(BTC_BLOCK_TIME_MILLIS)
+            .ok_or_else(|| {
+                CchError::ConfigError(format!(
+                    "btc_final_tlc_expiry_delta_blocks ({}) is too large and causes overflow when converting to milliseconds",
+                    creation.btc_final_tlc_expiry_delta_blocks
+                ))
+            })?;
+        let fee_budget_sats = outgoing_fee_budget_from_fee_sats(
+            creation.fee_sats,
+            creation.max_outgoing_fee_percentage,
+        );
+        self.fiber_agent_ref
+            .call_payment_preflight(
+                creation.fiber_pay_req.clone(),
+                (btc_final_cltv_millis / 2).min(MAX_PAYMENT_TLC_EXPIRY_LIMIT),
+                OutgoingFeeLimit {
+                    max_fee_amount: fee_budget_sats,
+                    max_fee_rate: outgoing_max_fee_rate(creation.amount_sats, fee_budget_sats),
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn complete_receive_btc_order_creation(
+        &self,
+        creation: CchReceiveBtcOrderCreation,
+        preflight_complete: bool,
+    ) -> Result<CchOrder, CchError> {
+        let incoming_invoice = match self
+            .lnd_invoice_client
+            .lookup_invoice(creation.payment_hash)
+            .await?
+        {
+            Some(invoice) => self.validate_recovered_lnd_invoice(&creation, invoice)?,
+            None => {
+                if !preflight_complete {
+                    self.preflight_receive_btc_creation(&creation).await?;
+                }
+                self.create_or_recover_lnd_invoice(&creation).await?
+            }
         };
 
-        self.store.insert_cch_order(order.clone())?;
-        Ok(order)
+        let order = CchOrder {
+            created_at: creation.created_at,
+            expiry_delta_seconds: creation.order_expiry_delta_seconds,
+            failure_reason: None,
+            incoming_invoice: CchInvoice::Lightning(incoming_invoice),
+            outgoing_pay_req: creation.fiber_pay_req.clone(),
+            payment_preimage: None,
+            status: CchOrderStatus::Pending,
+            amount_sats: creation.amount_sats,
+            fee_sats: creation.fee_sats,
+            payment_hash: creation.payment_hash,
+            wrapped_btc_type_script: creation.wrapped_btc_type_script,
+        };
+
+        match self
+            .store
+            .complete_receive_btc_order_creation(order.clone())
+        {
+            Ok(()) => Ok(order),
+            Err(CchStoreError::Duplicated(_)) => {
+                let existing = self.store.get_cch_order(&creation.payment_hash)?;
+                self.ensure_receive_btc_request_matches_order(&creation.fiber_pay_req, &existing)?;
+                self.store
+                    .delete_receive_btc_order_creation(&creation.payment_hash);
+                Ok(existing)
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn create_or_recover_lnd_invoice(
+        &self,
+        creation: &CchReceiveBtcOrderCreation,
+    ) -> Result<Bolt11Invoice, CchError> {
+        let fiber_invoice = CkbInvoice::from_str(&creation.fiber_pay_req)?;
+        let refreshed_at = now_timestamp_as_millis_u64() / 1000;
+        let expiry =
+            self.remaining_outgoing_invoice_expiry_seconds(&fiber_invoice, refreshed_at)?;
+        let total_msat = receive_btc_total_msat(creation.amount_sats, creation.fee_sats)?;
+        let request = invoicesrpc::AddHoldInvoiceRequest {
+            hash: creation.payment_hash.as_ref().to_vec(),
+            value_msat: total_msat,
+            expiry: expiry as i64,
+            cltv_expiry: creation.btc_final_tlc_expiry_delta_blocks,
+            ..Default::default()
+        };
+
+        match self
+            .lnd_invoice_client
+            .add_hold_invoice(request.clone())
+            .await
+        {
+            Ok(response) => self.validate_lnd_payment_request(creation, &response.payment_request),
+            Err(add_error) => {
+                // AddHoldInvoice is not transactional with this process. Any transport error is
+                // ambiguous, so reconcile by hash before reporting the original failure.
+                match self
+                    .lnd_invoice_client
+                    .lookup_invoice(creation.payment_hash)
+                    .await
+                {
+                    Ok(Some(invoice)) => self.validate_recovered_lnd_invoice(creation, invoice),
+                    Ok(None) => Err(add_error),
+                    Err(lookup_error) => Err(CchError::LndRpcError(format!(
+                        "{}; reconciliation lookup failed: {}",
+                        add_error, lookup_error
+                    ))),
+                }
+            }
+        }
+    }
+
+    fn validate_recovered_lnd_invoice(
+        &self,
+        creation: &CchReceiveBtcOrderCreation,
+        invoice: lnrpc::Invoice,
+    ) -> Result<Bolt11Invoice, CchError> {
+        let expected_total_msat = receive_btc_total_msat(creation.amount_sats, creation.fee_sats)?;
+        if invoice.r_hash.as_slice() != creation.payment_hash.as_ref() {
+            return Err(lnd_invoice_mismatch(
+                creation.payment_hash,
+                "payment hash differs",
+            ));
+        }
+        if invoice.value_msat != expected_total_msat {
+            return Err(lnd_invoice_mismatch(
+                creation.payment_hash,
+                format!(
+                    "value_msat is {}, expected {}",
+                    invoice.value_msat, expected_total_msat
+                ),
+            ));
+        }
+        if invoice.cltv_expiry != creation.btc_final_tlc_expiry_delta_blocks {
+            return Err(lnd_invoice_mismatch(
+                creation.payment_hash,
+                format!(
+                    "cltv_expiry is {}, expected {}",
+                    invoice.cltv_expiry, creation.btc_final_tlc_expiry_delta_blocks
+                ),
+            ));
+        }
+        if matches!(
+            invoice.state(),
+            lnrpc::invoice::InvoiceState::Canceled | lnrpc::invoice::InvoiceState::Settled
+        ) {
+            return Err(lnd_invoice_mismatch(
+                creation.payment_hash,
+                format!("invoice is already {:?}", invoice.state()),
+            ));
+        }
+        self.validate_lnd_payment_request(creation, &invoice.payment_request)
+    }
+
+    fn validate_lnd_payment_request(
+        &self,
+        creation: &CchReceiveBtcOrderCreation,
+        payment_request: &str,
+    ) -> Result<Bolt11Invoice, CchError> {
+        let invoice = Bolt11Invoice::from_str(payment_request)?;
+        let expected_total_msat = u64::try_from(receive_btc_total_msat(
+            creation.amount_sats,
+            creation.fee_sats,
+        )?)
+        .map_err(|_| CchError::ReceiveBTCOrderAmountTooLarge)?;
+        if Hash256::from(*invoice.payment_hash()) != creation.payment_hash {
+            return Err(lnd_invoice_mismatch(
+                creation.payment_hash,
+                "encoded payment hash differs",
+            ));
+        }
+        if invoice.amount_milli_satoshis() != Some(expected_total_msat) {
+            return Err(lnd_invoice_mismatch(
+                creation.payment_hash,
+                format!(
+                    "encoded amount is {:?}, expected {}",
+                    invoice.amount_milli_satoshis(),
+                    expected_total_msat
+                ),
+            ));
+        }
+        if invoice.min_final_cltv_expiry_delta() != creation.btc_final_tlc_expiry_delta_blocks {
+            return Err(lnd_invoice_mismatch(
+                creation.payment_hash,
+                format!(
+                    "encoded CLTV delta is {}, expected {}",
+                    invoice.min_final_cltv_expiry_delta(),
+                    creation.btc_final_tlc_expiry_delta_blocks
+                ),
+            ));
+        }
+        let fiber_invoice = CkbInvoice::from_str(&creation.fiber_pay_req)?;
+        let expected_currency = expected_ln_currency(fiber_invoice.currency);
+        if invoice.currency() != expected_currency {
+            return Err(lnd_invoice_mismatch(
+                creation.payment_hash,
+                format!(
+                    "encoded currency is {:?}, expected {:?}",
+                    invoice.currency(),
+                    expected_currency
+                ),
+            ));
+        }
+        Ok(invoice)
     }
 
     async fn handle_tracking_event(&self, event: CchTrackingEvent) -> Result<Vec<CchOrderAction>> {
@@ -945,6 +1363,33 @@ fn append_actions(
         })?;
     }
     Ok(())
+}
+
+fn is_retryable_receive_btc_creation_error(error: &CchError) -> bool {
+    matches!(
+        error,
+        CchError::LndChannelError(_) | CchError::LndRpcError(_) | CchError::FiberNodeError(_)
+    )
+}
+
+fn schedule_receive_btc_creation_retry(
+    myself: &ActorRef<CchMessage>,
+    payment_hash: Hash256,
+    retry_count: u32,
+    reason: &str,
+) {
+    let delay = calculate_retry_delay(retry_count);
+    tracing::error!(
+        "receive_btc creation for payment hash {:x} failed (retry {}): {}. Retrying in {:?}",
+        payment_hash,
+        retry_count,
+        reason,
+        delay
+    );
+    myself.send_after(delay, move || CchMessage::ResumeReceiveBTCOrderCreation {
+        payment_hash,
+        retry_count: retry_count.saturating_add(1),
+    });
 }
 
 fn schedule_action_retry(

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -80,6 +80,14 @@ struct TonicLndInvoiceClient {
     connection: LndConnectionInfo,
 }
 
+const LND_NO_INVOICES_CREATED_ERROR: &str = "there are no existing invoices";
+
+fn is_lnd_invoice_not_found(status: &tonic::Status) -> bool {
+    status.code() == tonic::Code::NotFound
+        || (status.code() == tonic::Code::Unknown
+            && status.message() == LND_NO_INVOICES_CREATED_ERROR)
+}
+
 #[async_trait::async_trait]
 impl LndInvoiceClient for TonicLndInvoiceClient {
     async fn lookup_invoice(
@@ -95,7 +103,7 @@ impl LndInvoiceClient for TonicLndInvoiceClient {
         };
         match client.lookup_invoice_v2(request).await {
             Ok(response) => Ok(Some(response.into_inner())),
-            Err(status) if status.code() == tonic::Code::NotFound => Ok(None),
+            Err(status) if is_lnd_invoice_not_found(&status) => Ok(None),
             Err(status) => Err(CchError::LndRpcError(format!(
                 "lookup invoice {:x}: {}",
                 payment_hash, status
@@ -1646,5 +1654,23 @@ pub(crate) fn redacted_store_change_summary(change: &StoreChange) -> RedactedSto
             payment_hash: *payment_hash,
             has_payment_preimage: true,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_lnd_invoice_not_found, LND_NO_INVOICES_CREATED_ERROR};
+
+    #[test]
+    fn test_lnd_invoice_not_found_status_classification() {
+        assert!(is_lnd_invoice_not_found(&tonic::Status::not_found(
+            "unable to locate invoice",
+        )));
+        assert!(is_lnd_invoice_not_found(&tonic::Status::unknown(
+            LND_NO_INVOICES_CREATED_ERROR,
+        )));
+        assert!(!is_lnd_invoice_not_found(&tonic::Status::unknown(
+            "database unavailable",
+        )));
     }
 }

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -83,6 +83,10 @@ pub enum CchError {
     LndRpcError(String),
     #[error("Conflicting receive_btc request for payment hash {0}")]
     ConflictingReceiveBTCRequest(Hash256),
+    #[error("receive_btc order creation for payment hash {0} is already being recovered")]
+    ReceiveBTCOrderCreationInProgress(Hash256),
+    #[error("receive_btc order creation for payment hash {0} has expired")]
+    ReceiveBTCOrderCreationExpired(Hash256),
     #[error("LND invoice for payment hash {payment_hash} does not match the CCH order: {reason}")]
     LndInvoiceMismatch {
         payment_hash: Hash256,

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -81,6 +81,13 @@ pub enum CchError {
     LndChannelError(#[from] lnd_grpc_tonic_client::channel::Error),
     #[error("Lnd RPC error: {0}")]
     LndRpcError(String),
+    #[error("Conflicting receive_btc request for payment hash {0}")]
+    ConflictingReceiveBTCRequest(Hash256),
+    #[error("LND invoice for payment hash {payment_hash} does not match the CCH order: {reason}")]
+    LndInvoiceMismatch {
+        payment_hash: Hash256,
+        reason: String,
+    },
     #[error("Fiber node error: {0}")]
     FiberNodeError(anyhow::Error),
 }

--- a/crates/fiber-lib/src/cch/order/order_store.rs
+++ b/crates/fiber-lib/src/cch/order/order_store.rs
@@ -1,5 +1,5 @@
 use crate::cch::error::CchStoreError;
-use fiber_types::{CchOrder, Hash256};
+use fiber_types::{CchOrder, CchReceiveBtcOrderCreation, Hash256};
 
 pub trait CchOrderStore {
     /// Gets an order from the store.
@@ -20,4 +20,25 @@ pub trait CchOrderStore {
 
     /// Deletes an order from the store.
     fn delete_cch_order(&self, payment_hash: &Hash256);
+
+    /// Gets a durable `receive_btc` creation intent by payment hash.
+    fn get_receive_btc_order_creation(
+        &self,
+        payment_hash: &Hash256,
+    ) -> Result<CchReceiveBtcOrderCreation, CchStoreError>;
+
+    /// Inserts a durable `receive_btc` creation intent.
+    fn insert_receive_btc_order_creation(
+        &self,
+        creation: CchReceiveBtcOrderCreation,
+    ) -> Result<(), CchStoreError>;
+
+    /// Iterates over all durable `receive_btc` creation intent keys.
+    fn get_receive_btc_order_creation_keys_iter(&self) -> impl IntoIterator<Item = Hash256>;
+
+    /// Atomically replaces a durable creation intent with its completed order.
+    fn complete_receive_btc_order_creation(&self, order: CchOrder) -> Result<(), CchStoreError>;
+
+    /// Deletes a durable `receive_btc` creation intent.
+    fn delete_receive_btc_order_creation(&self, payment_hash: &Hash256);
 }

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -11,7 +11,7 @@
 //!   Pending → IncomingAccepted → OutgoingInFlight → OutgoingSuccess → Success
 
 use crate::cch::{
-    actor::{CchActor, CchArgs, CchMessage, BTC_BLOCK_TIME_MILLIS},
+    actor::{CchActor, CchArgs, CchMessage, LndInvoiceClient, BTC_BLOCK_TIME_MILLIS},
     config::{
         DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS, DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS,
     },
@@ -30,9 +30,10 @@ use crate::store::{store_impl::StoreChange, Store};
 use crate::tests::test_utils::{generate_store, TempDir};
 use crate::time::{Duration, SystemTime, UNIX_EPOCH};
 use fiber_types::{
-    AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, Hash256, HashAlgorithm, PaymentHopData,
-    PaymentStatus,
+    AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation, Hash256,
+    HashAlgorithm, PaymentHopData, PaymentStatus,
 };
+use lnd_grpc_tonic_client::{invoicesrpc, lnrpc};
 use ractor::{call, port::OutputPortSubscriberTrait, Actor, ActorRef, OutputPort};
 use secp256k1::{Secp256k1, SecretKey};
 use std::collections::HashMap;
@@ -46,7 +47,13 @@ const BTC_BLOCK_TIME_SECS: u64 = BTC_BLOCK_TIME_MILLIS / 1_000;
 /// Mock order store using an in-memory HashMap for testing
 #[derive(Clone, Default)]
 pub struct MockCchOrderStore {
-    orders: Arc<Mutex<HashMap<Hash256, CchOrder>>>,
+    state: Arc<Mutex<MockCchOrderStoreState>>,
+}
+
+#[derive(Default)]
+struct MockCchOrderStoreState {
+    orders: HashMap<Hash256, CchOrder>,
+    receive_btc_order_creations: HashMap<Hash256, CchReceiveBtcOrderCreation>,
 }
 
 impl MockCchOrderStore {
@@ -57,41 +64,238 @@ impl MockCchOrderStore {
 
 impl CchOrderStore for MockCchOrderStore {
     fn get_cch_order(&self, payment_hash: &Hash256) -> Result<CchOrder, CchStoreError> {
-        self.orders
+        self.state
             .lock()
             .unwrap()
+            .orders
             .get(payment_hash)
             .ok_or(CchStoreError::NotFound(*payment_hash))
             .cloned()
     }
 
     fn insert_cch_order(&self, order: CchOrder) -> Result<(), CchStoreError> {
-        let mut orders = self.orders.lock().unwrap();
+        let mut state = self.state.lock().unwrap();
         let payment_hash = order.payment_hash;
-        match orders.insert(payment_hash, order) {
+        match state.orders.insert(payment_hash, order) {
             Some(_) => Err(CchStoreError::Duplicated(payment_hash)),
             None => Ok(()),
         }
     }
 
     fn update_cch_order(&self, order: CchOrder) {
-        let mut orders = self.orders.lock().unwrap();
-        orders.insert(order.payment_hash, order);
+        let mut state = self.state.lock().unwrap();
+        state.orders.insert(order.payment_hash, order);
     }
 
     fn get_cch_order_keys_iter(&self) -> impl IntoIterator<Item = Hash256> {
-        self.orders
+        self.state
             .lock()
             .unwrap()
+            .orders
             .keys()
             .copied()
             .collect::<Vec<_>>()
     }
 
     fn delete_cch_order(&self, payment_hash: &Hash256) {
-        let mut orders = self.orders.lock().unwrap();
-        orders.remove(payment_hash);
+        let mut state = self.state.lock().unwrap();
+        state.orders.remove(payment_hash);
     }
+
+    fn get_receive_btc_order_creation(
+        &self,
+        payment_hash: &Hash256,
+    ) -> Result<CchReceiveBtcOrderCreation, CchStoreError> {
+        self.state
+            .lock()
+            .unwrap()
+            .receive_btc_order_creations
+            .get(payment_hash)
+            .cloned()
+            .ok_or(CchStoreError::NotFound(*payment_hash))
+    }
+
+    fn insert_receive_btc_order_creation(
+        &self,
+        creation: CchReceiveBtcOrderCreation,
+    ) -> Result<(), CchStoreError> {
+        let mut state = self.state.lock().unwrap();
+        let payment_hash = creation.payment_hash;
+        match state
+            .receive_btc_order_creations
+            .insert(payment_hash, creation)
+        {
+            Some(_) => Err(CchStoreError::Duplicated(payment_hash)),
+            None => Ok(()),
+        }
+    }
+
+    fn get_receive_btc_order_creation_keys_iter(&self) -> impl IntoIterator<Item = Hash256> {
+        self.state
+            .lock()
+            .unwrap()
+            .receive_btc_order_creations
+            .keys()
+            .copied()
+            .collect::<Vec<_>>()
+    }
+
+    fn complete_receive_btc_order_creation(&self, order: CchOrder) -> Result<(), CchStoreError> {
+        let mut state = self.state.lock().unwrap();
+        let payment_hash = order.payment_hash;
+        if state.orders.contains_key(&payment_hash) {
+            return Err(CchStoreError::Duplicated(payment_hash));
+        }
+        state.orders.insert(payment_hash, order);
+        state.receive_btc_order_creations.remove(&payment_hash);
+        Ok(())
+    }
+
+    fn delete_receive_btc_order_creation(&self, payment_hash: &Hash256) {
+        self.state
+            .lock()
+            .unwrap()
+            .receive_btc_order_creations
+            .remove(payment_hash);
+    }
+}
+
+#[derive(Clone, Default)]
+struct MockLndInvoiceClient {
+    state: Arc<Mutex<MockLndInvoiceClientState>>,
+}
+
+#[derive(Default)]
+struct MockLndInvoiceClientState {
+    invoices: HashMap<Hash256, lnrpc::Invoice>,
+    add_calls: usize,
+    lookup_calls: usize,
+    lookup_failures_remaining: usize,
+    add_delay: Duration,
+    fail_before_create: bool,
+    fail_after_create_once: bool,
+}
+
+impl MockLndInvoiceClient {
+    fn add_calls(&self) -> usize {
+        self.state.lock().unwrap().add_calls
+    }
+
+    fn lookup_calls(&self) -> usize {
+        self.state.lock().unwrap().lookup_calls
+    }
+
+    fn set_lookup_failures(&self, count: usize) {
+        self.state.lock().unwrap().lookup_failures_remaining = count;
+    }
+
+    fn insert_invoice(&self, payment_hash: Hash256, invoice: lnrpc::Invoice) {
+        self.state
+            .lock()
+            .unwrap()
+            .invoices
+            .insert(payment_hash, invoice);
+    }
+
+    fn set_add_delay(&self, delay: Duration) {
+        self.state.lock().unwrap().add_delay = delay;
+    }
+
+    fn set_fail_before_create(&self, fail: bool) {
+        self.state.lock().unwrap().fail_before_create = fail;
+    }
+
+    fn set_fail_after_create_once(&self) {
+        self.state.lock().unwrap().fail_after_create_once = true;
+    }
+}
+
+#[async_trait::async_trait]
+impl LndInvoiceClient for MockLndInvoiceClient {
+    async fn lookup_invoice(
+        &self,
+        payment_hash: Hash256,
+    ) -> Result<Option<lnrpc::Invoice>, CchError> {
+        let mut state = self.state.lock().unwrap();
+        state.lookup_calls += 1;
+        if state.lookup_failures_remaining > 0 {
+            state.lookup_failures_remaining -= 1;
+            return Err(CchError::LndRpcError(
+                "mock LookupInvoiceV2 unavailable".to_string(),
+            ));
+        }
+        Ok(state.invoices.get(&payment_hash).cloned())
+    }
+
+    async fn add_hold_invoice(
+        &self,
+        request: invoicesrpc::AddHoldInvoiceRequest,
+    ) -> Result<invoicesrpc::AddHoldInvoiceResp, CchError> {
+        let delay = self.state.lock().unwrap().add_delay;
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+
+        let mut state = self.state.lock().unwrap();
+        state.add_calls += 1;
+        if state.fail_before_create {
+            return Err(CchError::LndRpcError(
+                "mock AddHoldInvoice unavailable".to_string(),
+            ));
+        }
+
+        let payment_hash = Hash256::try_from(request.hash.as_slice()).unwrap();
+        let payment_request = create_mock_lnd_hold_invoice(&request).to_string();
+        state.invoices.insert(
+            payment_hash,
+            lnrpc::Invoice {
+                r_hash: request.hash,
+                value_msat: request.value_msat,
+                payment_request: payment_request.clone(),
+                expiry: request.expiry,
+                cltv_expiry: request.cltv_expiry,
+                state: lnrpc::invoice::InvoiceState::Open as i32,
+                ..Default::default()
+            },
+        );
+
+        if state.fail_after_create_once {
+            state.fail_after_create_once = false;
+            return Err(CchError::LndRpcError(
+                "mock response lost after AddHoldInvoice committed".to_string(),
+            ));
+        }
+
+        Ok(invoicesrpc::AddHoldInvoiceResp {
+            payment_request,
+            ..Default::default()
+        })
+    }
+}
+
+fn create_mock_lnd_hold_invoice(
+    request: &invoicesrpc::AddHoldInvoiceRequest,
+) -> lightning_invoice::Bolt11Invoice {
+    use bitcoin::hashes::Hash as _;
+    use lightning_invoice::{Currency as LnCurrency, InvoiceBuilder as LnInvoiceBuilder};
+
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let private_key = bitcoin::secp256k1::SecretKey::from_slice(&[44u8; 32]).unwrap();
+    let payment_hash = bitcoin::hashes::sha256::Hash::from_slice(&request.hash).unwrap();
+    let duration_since_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+
+    LnInvoiceBuilder::new(LnCurrency::Bitcoin)
+        .description("mock CCH hold invoice".to_string())
+        .payment_hash(payment_hash)
+        .payment_secret(lightning_invoice::PaymentSecret([45u8; 32]))
+        .duration_since_epoch(duration_since_epoch)
+        .min_final_cltv_expiry_delta(request.cltv_expiry)
+        .expiry_time(std::time::Duration::from_secs(request.expiry as u64))
+        .amount_milli_satoshis(request.value_msat as u64)
+        .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &private_key))
+        .unwrap()
 }
 
 /// Helper function to create a test payment hash
@@ -271,6 +475,7 @@ struct TestHarness {
     event_port: Arc<OutputPort<CchTrackingEvent>>,
     /// Shared mock state for tracking sent payments
     mock_state: MockNetworkState,
+    _store: MockCchOrderStore,
 }
 
 struct StoreBackedTestHarness {
@@ -530,6 +735,14 @@ async fn setup_test_harness_with_config_and_store(
     config: CchConfig,
     store: MockCchOrderStore,
 ) -> TestHarness {
+    setup_test_harness_with_config_store_and_lnd(config, store, None).await
+}
+
+async fn setup_test_harness_with_config_store_and_lnd(
+    config: CchConfig,
+    store: MockCchOrderStore,
+    lnd_invoice_client: Option<Arc<dyn LndInvoiceClient>>,
+) -> TestHarness {
     let event_port = Arc::new(OutputPort::<CchTrackingEvent>::default());
 
     let mock_state = MockNetworkState {
@@ -553,8 +766,9 @@ async fn setup_test_harness_with_config_and_store(
         token: CancellationToken::new(),
         network_actor: Some(network_actor),
         node_keypair: Some(crate::fiber::KeyPair::try_from([42u8; 32].as_slice()).unwrap()),
-        store,
+        store: store.clone(),
         currency: Currency::Fibb,
+        lnd_invoice_client,
     };
 
     let (actor_ref, _handle) = Actor::spawn(None, CchActor::default(), args)
@@ -568,6 +782,7 @@ async fn setup_test_harness_with_config_and_store(
         actor: actor_ref,
         event_port,
         mock_state,
+        _store: store,
     }
 }
 
@@ -608,6 +823,7 @@ async fn setup_store_backed_test_harness() -> StoreBackedTestHarness {
         node_keypair: Some(crate::fiber::KeyPair::try_from([42u8; 32].as_slice()).unwrap()),
         store: store.clone(),
         currency: Currency::Fibb,
+        lnd_invoice_client: None,
     };
 
     let (actor_ref, _handle) = Actor::spawn(None, CchActor::default(), args)
@@ -1972,33 +2188,14 @@ async fn test_send_btc_proxy_invoice_includes_fee() {
     );
 }
 
-/// Tests that the receive_btc order correctly calculates fee_sats and total_msat
-/// that would be used for the LND hold invoice.
-///
-/// Note: We cannot directly test the LND hold invoice creation since it requires
-/// an LND server. Instead we verify that the fee calculation and amount validation
-/// pass correctly (the call fails only at LND), confirming the hold invoice would
-/// be created with `value_msat = (amount_sats + fee_sats) * 1000`.
-#[tokio::test]
-async fn test_receive_btc_fee_calculation() {
+fn create_receive_btc_fiber_invoice(
+    payment_hash: Hash256,
+    amount_sats: u128,
+    description: &str,
+) -> CkbInvoice {
     use crate::ckb::contracts::{get_script_by_contract, Contract};
     use crate::invoice::CkbScript;
 
-    let config = CchConfig {
-        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
-        wrapped_btc_type_script_args: "0x".to_string(),
-        min_outgoing_invoice_expiry_delta_seconds: 60,
-        base_fee_sats: 500,
-        fee_rate_per_million_sats: 5_000, // 0.5% proportional fee
-        ..Default::default()
-    };
-    let harness = setup_test_harness_with_config(config).await;
-
-    let (_preimage, payment_hash) = create_valid_preimage_pair(180);
-    let amount_sats: u128 = 200_000;
-
-    // Build a Fiber invoice with the correct UDT type script and SHA256 hash algorithm
-    // to pass all validations before the LND call.
     let wrapped_btc_type_script = get_script_by_contract(Contract::SimpleUDT, &[]);
     let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
     let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
@@ -2014,7 +2211,7 @@ async fn test_receive_btc_fee_calculation() {
                 .as_millis(),
             attrs: vec![
                 Attribute::FinalHtlcMinimumExpiryDelta(12),
-                Attribute::Description("test".to_string()),
+                Attribute::Description(description.to_string()),
                 Attribute::ExpiryTime(Duration::from_secs(3600)),
                 Attribute::PayeePublicKey(public_key),
                 Attribute::UdtScript(CkbScript(wrapped_btc_type_script)),
@@ -2025,44 +2222,419 @@ async fn test_receive_btc_fee_calculation() {
     invoice
         .update_signature(|hash| Secp256k1::new().sign_ecdsa_recoverable(hash, &private_key))
         .unwrap();
+    invoice
+}
 
-    // receive_btc will fail at the LND call, but all prior validations
-    // (amount, fee, UDT script, hash algorithm) should pass.
-    let result = call!(
+/// Tests that the receive_btc order correctly calculates fee_sats and total_msat.
+#[tokio::test]
+async fn test_receive_btc_fee_calculation() {
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        base_fee_sats: 500,
+        fee_rate_per_million_sats: 5_000, // 0.5% proportional fee
+        ..Default::default()
+    };
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    let harness =
+        setup_test_harness_with_config_store_and_lnd(config, MockCchOrderStore::new(), Some(lnd))
+            .await;
+
+    let (_preimage, payment_hash) = create_valid_preimage_pair(180);
+    let amount_sats: u128 = 200_000;
+    let invoice = create_receive_btc_fiber_invoice(payment_hash, amount_sats, "fee test");
+    let order = call!(
         harness.actor,
         CchMessage::ReceiveBTC,
         crate::cch::ReceiveBTC {
             fiber_pay_req: invoice.to_string(),
         }
     )
-    .expect("actor call failed");
-
-    // The call should fail due to LND being unavailable, not due to amount validation.
-    // This confirms the fee calculation and overflow checks passed successfully,
-    // meaning the hold invoice would have been created with the correct total_msat.
-    let err = result.unwrap_err();
+    .expect("actor call failed")
+    .unwrap();
 
     // fee_sats = 200_000 * 5_000 / 1_000_000 + 500 = 1_000 + 500 = 1_500
-    // total_msat = (200_000 + 1_500) * 1_000 = 201_500_000
     let expected_fee: u128 = 1_500;
-    let expected_total_msat: i64 = ((amount_sats + expected_fee) * 1_000) as i64;
-    assert_eq!(expected_total_msat, 201_500_000);
+    assert_eq!(order.fee_sats, expected_fee);
+    let CchInvoice::Lightning(incoming_invoice) = order.incoming_invoice else {
+        panic!("expected Lightning incoming invoice")
+    };
+    assert_eq!(
+        incoming_invoice.amount_milli_satoshis(),
+        Some(((amount_sats + expected_fee) * 1_000) as u64)
+    );
+}
 
-    match err {
-        CchError::LndRpcError(msg) => {
-            assert!(
-                msg.contains(&format!("value_msat: {}", expected_total_msat)),
-                "hold invoice request should contain value_msat={}, got: {}",
-                expected_total_msat,
-                msg
-            );
-        }
-        other => panic!(
-            "expected LND connection error (no LND server), got: {:?}. \
-             If this is an amount error, the fee calculation may be wrong.",
-            other
-        ),
+fn receive_btc_recovery_test_config() -> CchConfig {
+    CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ..Default::default()
     }
+}
+
+fn create_receive_btc_order_creation(
+    config: &CchConfig,
+    payment_hash: Hash256,
+    description: &str,
+) -> CchReceiveBtcOrderCreation {
+    let amount_sats = 100_000u128;
+    let fee_sats = amount_sats * u128::from(config.fee_rate_per_million_sats) / 1_000_000
+        + u128::from(config.base_fee_sats);
+    CchReceiveBtcOrderCreation {
+        created_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        order_expiry_delta_seconds: config.order_expiry_delta_seconds,
+        fiber_pay_req: create_receive_btc_fiber_invoice(payment_hash, amount_sats, description)
+            .to_string(),
+        payment_hash,
+        amount_sats,
+        fee_sats,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        btc_final_tlc_expiry_delta_blocks: config.btc_final_tlc_expiry_delta_blocks,
+        max_outgoing_fee_percentage: config.max_outgoing_fee_percentage,
+    }
+}
+
+async fn wait_for_mock_order(store: &MockCchOrderStore, payment_hash: Hash256) -> CchOrder {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Ok(order) = store.get_cch_order(&payment_hash) {
+            return order;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for recovered CCH order"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn test_receive_btc_rpc_timeout_is_recoverable_by_retry() {
+    let store = MockCchOrderStore::new();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    lnd.set_add_delay(Duration::from_millis(100));
+    let harness = setup_test_harness_with_config_store_and_lnd(
+        receive_btc_recovery_test_config(),
+        store.clone(),
+        Some(lnd.clone()),
+    )
+    .await;
+    let (_, payment_hash) = create_valid_preimage_pair(181);
+    let fiber_pay_req =
+        create_receive_btc_fiber_invoice(payment_hash, 100_000, "timeout retry").to_string();
+
+    let timed_out = harness
+        .actor
+        .call(
+            |reply| {
+                CchMessage::ReceiveBTC(
+                    crate::cch::ReceiveBTC {
+                        fiber_pay_req: fiber_pay_req.clone(),
+                    },
+                    reply,
+                )
+            },
+            Some(Duration::from_millis(10)),
+        )
+        .await;
+    assert!(
+        timed_out
+            .expect("actor message should be sent")
+            .is_timeout(),
+        "the first actor RPC should time out"
+    );
+
+    let created = wait_for_mock_order(&store, payment_hash).await;
+    let retried = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC { fiber_pay_req }
+    )
+    .expect("actor call failed")
+    .unwrap();
+
+    assert_eq!(retried.payment_hash, created.payment_hash);
+    match (&retried.incoming_invoice, &created.incoming_invoice) {
+        (CchInvoice::Lightning(retried), CchInvoice::Lightning(created)) => {
+            assert_eq!(retried.to_string(), created.to_string());
+        }
+        _ => panic!("receive_btc must create Lightning invoices"),
+    }
+    assert_eq!(lnd.add_calls(), 1, "retry must not create another invoice");
+}
+
+#[tokio::test]
+async fn test_receive_btc_recovers_lnd_invoice_after_add_response_is_lost() {
+    let store = MockCchOrderStore::new();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    lnd.set_fail_after_create_once();
+    let harness = setup_test_harness_with_config_store_and_lnd(
+        receive_btc_recovery_test_config(),
+        store.clone(),
+        Some(lnd.clone()),
+    )
+    .await;
+    let (_, payment_hash) = create_valid_preimage_pair(182);
+    let fiber_pay_req =
+        create_receive_btc_fiber_invoice(payment_hash, 100_000, "lost response").to_string();
+
+    let order = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC { fiber_pay_req }
+    )
+    .expect("actor call failed")
+    .unwrap();
+
+    assert_eq!(order.payment_hash, payment_hash);
+    assert_eq!(lnd.add_calls(), 1);
+    assert!(
+        matches!(
+            store.get_receive_btc_order_creation(&payment_hash),
+            Err(CchStoreError::NotFound(_))
+        ),
+        "completing the order must atomically remove its creation intent"
+    );
+}
+
+#[tokio::test]
+async fn test_receive_btc_creation_resumes_after_actor_restart() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    lnd.set_fail_before_create(true);
+    let first = setup_test_harness_with_config_store_and_lnd(
+        config.clone(),
+        store.clone(),
+        Some(lnd.clone()),
+    )
+    .await;
+    let (_, payment_hash) = create_valid_preimage_pair(183);
+    let fiber_pay_req =
+        create_receive_btc_fiber_invoice(payment_hash, 100_000, "restart recovery").to_string();
+
+    let first_result = call!(
+        first.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: fiber_pay_req.clone(),
+        }
+    )
+    .expect("actor call failed");
+    assert!(matches!(first_result, Err(CchError::LndRpcError(_))));
+    assert!(store.get_receive_btc_order_creation(&payment_hash).is_ok());
+
+    first.actor.stop(None);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    lnd.set_fail_before_create(false);
+    let _restarted =
+        setup_test_harness_with_config_store_and_lnd(config, store.clone(), Some(lnd.clone()))
+            .await;
+
+    let order = wait_for_mock_order(&store, payment_hash).await;
+    assert_eq!(order.outgoing_pay_req, fiber_pay_req);
+    assert_eq!(lnd.add_calls(), 2);
+    assert!(
+        matches!(
+            store.get_receive_btc_order_creation(&payment_hash),
+            Err(CchStoreError::NotFound(_))
+        ),
+        "restart recovery must remove the completed creation intent"
+    );
+}
+
+#[tokio::test]
+async fn test_receive_btc_transient_error_retries_without_client_retry() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    lnd.set_lookup_failures(1);
+    let harness =
+        setup_test_harness_with_config_store_and_lnd(config, store.clone(), Some(lnd.clone()))
+            .await;
+    let (_, payment_hash) = create_valid_preimage_pair(185);
+    let fiber_pay_req =
+        create_receive_btc_fiber_invoice(payment_hash, 100_000, "automatic retry").to_string();
+
+    let first_result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC { fiber_pay_req }
+    )
+    .expect("actor call failed");
+    assert!(matches!(first_result, Err(CchError::LndRpcError(_))));
+
+    let order = wait_for_mock_order(&store, payment_hash).await;
+    assert_eq!(order.payment_hash, payment_hash);
+    assert_eq!(lnd.lookup_calls(), 2);
+    assert_eq!(lnd.add_calls(), 1);
+}
+
+#[tokio::test]
+async fn test_receive_btc_startup_recovery_retries_transient_error() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let (_, payment_hash) = create_valid_preimage_pair(186);
+    store
+        .insert_receive_btc_order_creation(create_receive_btc_order_creation(
+            &config,
+            payment_hash,
+            "startup retry",
+        ))
+        .unwrap();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    lnd.set_lookup_failures(1);
+
+    let _harness =
+        setup_test_harness_with_config_store_and_lnd(config, store.clone(), Some(lnd.clone()))
+            .await;
+
+    let order = wait_for_mock_order(&store, payment_hash).await;
+    assert_eq!(order.payment_hash, payment_hash);
+    assert_eq!(lnd.lookup_calls(), 2);
+    assert_eq!(lnd.add_calls(), 1);
+}
+
+#[tokio::test]
+async fn test_receive_btc_startup_recovery_does_not_retry_permanent_mismatch() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let (_, payment_hash) = create_valid_preimage_pair(187);
+    store
+        .insert_receive_btc_order_creation(create_receive_btc_order_creation(
+            &config,
+            payment_hash,
+            "permanent mismatch",
+        ))
+        .unwrap();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    lnd.insert_invoice(
+        payment_hash,
+        lnrpc::Invoice {
+            r_hash: payment_hash.as_ref().to_vec(),
+            value_msat: 1,
+            cltv_expiry: config.btc_final_tlc_expiry_delta_blocks,
+            state: lnrpc::invoice::InvoiceState::Open as i32,
+            ..Default::default()
+        },
+    );
+
+    let _harness =
+        setup_test_harness_with_config_store_and_lnd(config, store.clone(), Some(lnd.clone()))
+            .await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    while lnd.lookup_calls() == 0 {
+        assert!(tokio::time::Instant::now() < deadline);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+    assert_eq!(lnd.lookup_calls(), 1, "permanent errors must not retry");
+    assert!(matches!(
+        store.get_cch_order(&payment_hash),
+        Err(CchStoreError::NotFound(_))
+    ));
+    assert!(store.get_receive_btc_order_creation(&payment_hash).is_ok());
+}
+
+#[tokio::test]
+async fn test_receive_btc_rejects_conflicting_retry_for_same_payment_hash() {
+    let store = MockCchOrderStore::new();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    let harness = setup_test_harness_with_config_store_and_lnd(
+        receive_btc_recovery_test_config(),
+        store,
+        Some(lnd.clone()),
+    )
+    .await;
+    let (_, payment_hash) = create_valid_preimage_pair(184);
+    let first_request =
+        create_receive_btc_fiber_invoice(payment_hash, 100_000, "first request").to_string();
+    let conflicting_request =
+        create_receive_btc_fiber_invoice(payment_hash, 100_000, "conflicting request").to_string();
+
+    call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: first_request,
+        }
+    )
+    .expect("actor call failed")
+    .unwrap();
+    let conflict = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: conflicting_request,
+        }
+    )
+    .expect("actor call failed")
+    .unwrap_err();
+
+    assert!(matches!(
+        conflict,
+        CchError::ConflictingReceiveBTCRequest(hash) if hash == payment_hash
+    ));
+    assert_eq!(lnd.add_calls(), 1);
+}
+
+#[test]
+fn test_store_atomically_completes_receive_btc_order_creation() {
+    let (store, _store_dir) = generate_store();
+    let (_, payment_hash) = create_valid_preimage_pair(184);
+    let fiber_pay_req =
+        create_receive_btc_fiber_invoice(payment_hash, 100_000, "atomic completion").to_string();
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let creation = CchReceiveBtcOrderCreation {
+        created_at,
+        order_expiry_delta_seconds: 3_600,
+        fiber_pay_req: fiber_pay_req.clone(),
+        payment_hash,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        btc_final_tlc_expiry_delta_blocks: DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS,
+        max_outgoing_fee_percentage: 50,
+    };
+    store.insert_receive_btc_order_creation(creation).unwrap();
+
+    let order = CchOrder {
+        created_at,
+        expiry_delta_seconds: 3_600,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: fiber_pay_req,
+        incoming_invoice: CchInvoice::Lightning(create_test_lightning_invoice_with_cltv(
+            payment_hash,
+            DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS,
+        )),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::Pending,
+        failure_reason: None,
+    };
+    store.complete_receive_btc_order_creation(order).unwrap();
+
+    assert_eq!(
+        store.get_cch_order(&payment_hash).unwrap().payment_hash,
+        payment_hash
+    );
+    assert!(matches!(
+        store.get_receive_btc_order_creation(&payment_hash),
+        Err(CchStoreError::NotFound(hash)) if hash == payment_hash
+    ));
 }
 
 // =============================================================================

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -2138,6 +2138,51 @@ async fn test_receive_btc_rechecks_fiber_invoice_expiry_after_preflight() {
     );
 }
 
+#[tokio::test]
+async fn test_receive_btc_rechecks_order_expiry_after_preflight() {
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 1,
+        order_expiry_delta_seconds: 1,
+        ..Default::default()
+    };
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    let harness = setup_test_harness_with_config_store_and_lnd(
+        config,
+        MockCchOrderStore::new(),
+        Some(lnd.clone()),
+    )
+    .await;
+    harness.delay_fiber_payment_preflight(Duration::from_millis(1_100));
+    let (_, payment_hash) = create_valid_preimage_pair(191);
+    let invoice = create_receive_btc_fiber_invoice_at(
+        payment_hash,
+        100_000,
+        "order expires during preflight",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+        None,
+    );
+
+    let result = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: invoice.to_string(),
+        }
+    )
+    .expect("actor call failed");
+
+    assert!(matches!(
+        result,
+        Err(CchError::ReceiveBTCOrderCreationExpired(hash)) if hash == payment_hash
+    ));
+    assert_eq!(lnd.add_calls(), 0);
+}
+
 /// Tests that the send_btc proxy Fiber invoice includes the fee in its amount.
 ///
 /// In the SendBTC flow, the hub creates a Fiber invoice (the proxy invoice) for the
@@ -2193,30 +2238,49 @@ fn create_receive_btc_fiber_invoice(
     amount_sats: u128,
     description: &str,
 ) -> CkbInvoice {
+    create_receive_btc_fiber_invoice_at(
+        payment_hash,
+        amount_sats,
+        description,
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+        Some(Duration::from_secs(3600)),
+    )
+}
+
+fn create_receive_btc_fiber_invoice_at(
+    payment_hash: Hash256,
+    amount_sats: u128,
+    description: &str,
+    timestamp: u128,
+    expiry: Option<Duration>,
+) -> CkbInvoice {
     use crate::ckb::contracts::{get_script_by_contract, Contract};
     use crate::invoice::CkbScript;
 
     let wrapped_btc_type_script = get_script_by_contract(Contract::SimpleUDT, &[]);
     let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
     let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
+    let mut attrs = vec![
+        Attribute::FinalHtlcMinimumExpiryDelta(12),
+        Attribute::Description(description.to_string()),
+        Attribute::PayeePublicKey(public_key),
+        Attribute::UdtScript(CkbScript(wrapped_btc_type_script)),
+        Attribute::HashAlgorithm(HashAlgorithm::Sha256),
+    ];
+    if let Some(expiry) = expiry {
+        attrs.push(Attribute::ExpiryTime(expiry));
+    }
     let mut invoice = CkbInvoice {
         currency: Currency::Fibb,
         amount: Some(amount_sats),
         signature: None,
         data: InvoiceData {
             payment_hash,
-            timestamp: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-            attrs: vec![
-                Attribute::FinalHtlcMinimumExpiryDelta(12),
-                Attribute::Description(description.to_string()),
-                Attribute::ExpiryTime(Duration::from_secs(3600)),
-                Attribute::PayeePublicKey(public_key),
-                Attribute::UdtScript(CkbScript(wrapped_btc_type_script)),
-                Attribute::HashAlgorithm(HashAlgorithm::Sha256),
-            ],
+            timestamp,
+            attrs,
         },
     };
     invoice
@@ -2542,6 +2606,186 @@ async fn test_receive_btc_startup_recovery_does_not_retry_permanent_mismatch() {
         Err(CchStoreError::NotFound(_))
     ));
     assert!(store.get_receive_btc_order_creation(&payment_hash).is_ok());
+}
+
+#[tokio::test]
+async fn test_receive_btc_expired_creation_does_not_create_lnd_invoice() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let (_, payment_hash) = create_valid_preimage_pair(188);
+    let mut creation = create_receive_btc_order_creation(&config, payment_hash, "expired creation");
+    creation.created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .saturating_sub(config.order_expiry_delta_seconds)
+        .saturating_sub(1);
+    creation.fiber_pay_req = create_receive_btc_fiber_invoice_at(
+        payment_hash,
+        creation.amount_sats,
+        "expired creation without Fiber expiry",
+        u128::from(creation.created_at) * 1_000,
+        None,
+    )
+    .to_string();
+    store.insert_receive_btc_order_creation(creation).unwrap();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+
+    let _harness =
+        setup_test_harness_with_config_store_and_lnd(config, store.clone(), Some(lnd.clone()))
+            .await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    while lnd.lookup_calls() == 0 {
+        assert!(tokio::time::Instant::now() < deadline);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+    assert_eq!(lnd.lookup_calls(), 1, "expiry is a permanent failure");
+    assert_eq!(lnd.add_calls(), 0, "expired intent must not reach LND");
+    assert!(matches!(
+        store.get_cch_order(&payment_hash),
+        Err(CchStoreError::NotFound(_))
+    ));
+    assert!(store.get_receive_btc_order_creation(&payment_hash).is_ok());
+}
+
+#[tokio::test]
+async fn test_receive_btc_expired_creation_recovers_accepted_lnd_invoice() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let (_, payment_hash) = create_valid_preimage_pair(190);
+    let mut creation =
+        create_receive_btc_order_creation(&config, payment_hash, "accepted before expiry");
+    creation.created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .saturating_sub(config.order_expiry_delta_seconds)
+        .saturating_sub(1);
+    creation.fiber_pay_req = create_receive_btc_fiber_invoice_at(
+        payment_hash,
+        creation.amount_sats,
+        "accepted before order expiry",
+        u128::from(creation.created_at) * 1_000,
+        None,
+    )
+    .to_string();
+    let request = invoicesrpc::AddHoldInvoiceRequest {
+        hash: payment_hash.as_ref().to_vec(),
+        value_msat: ((creation.amount_sats + creation.fee_sats) * 1_000) as i64,
+        expiry: 86_400,
+        cltv_expiry: creation.btc_final_tlc_expiry_delta_blocks,
+        ..Default::default()
+    };
+    let payment_request = create_mock_lnd_hold_invoice(&request).to_string();
+    store.insert_receive_btc_order_creation(creation).unwrap();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    lnd.insert_invoice(
+        payment_hash,
+        lnrpc::Invoice {
+            r_hash: request.hash,
+            value_msat: request.value_msat,
+            payment_request,
+            expiry: request.expiry,
+            cltv_expiry: request.cltv_expiry,
+            state: lnrpc::invoice::InvoiceState::Accepted as i32,
+            ..Default::default()
+        },
+    );
+
+    let harness = setup_test_harness_with_config_store_and_lnd(config, store, Some(lnd)).await;
+
+    let recovered = wait_for_mock_order(&harness._store, payment_hash).await;
+    assert_ne!(recovered.status, CchOrderStatus::Pending);
+    assert_ne!(recovered.status, CchOrderStatus::Failed);
+    let order = harness
+        .wait_for_order_status(payment_hash, CchOrderStatus::OutgoingInFlight, 1_000)
+        .await;
+    assert_eq!(order.status, CchOrderStatus::OutgoingInFlight);
+    assert!(harness.was_fiber_payment_sent(payment_hash));
+}
+
+#[tokio::test]
+async fn test_receive_btc_client_retries_share_one_recovery_chain() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let lnd = Arc::new(MockLndInvoiceClient::default());
+    lnd.set_lookup_failures(10);
+    let harness =
+        setup_test_harness_with_config_store_and_lnd(config, store, Some(lnd.clone())).await;
+    let (_, payment_hash) = create_valid_preimage_pair(189);
+    let fiber_pay_req =
+        create_receive_btc_fiber_invoice(payment_hash, 100_000, "deduplicated retry").to_string();
+
+    let first_error = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: fiber_pay_req.clone(),
+        }
+    )
+    .expect("actor call failed")
+    .unwrap_err();
+    assert!(matches!(first_error, CchError::LndRpcError(_)));
+
+    for _ in 0..3 {
+        let retry_error = call!(
+            harness.actor,
+            CchMessage::ReceiveBTC,
+            crate::cch::ReceiveBTC {
+                fiber_pay_req: fiber_pay_req.clone(),
+            }
+        )
+        .expect("actor call failed")
+        .unwrap_err();
+        assert!(matches!(
+            retry_error,
+            CchError::ReceiveBTCOrderCreationInProgress(hash) if hash == payment_hash
+        ));
+    }
+    assert_eq!(lnd.lookup_calls(), 1);
+
+    let conflicting_error = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC {
+            fiber_pay_req: create_receive_btc_fiber_invoice(
+                payment_hash,
+                100_000,
+                "conflicting pending retry",
+            )
+            .to_string(),
+        }
+    )
+    .expect("actor call failed")
+    .unwrap_err();
+    assert!(matches!(
+        conflicting_error,
+        CchError::ConflictingReceiveBTCRequest(hash) if hash == payment_hash
+    ));
+    assert_eq!(lnd.lookup_calls(), 1);
+
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    assert_eq!(
+        lnd.lookup_calls(),
+        2,
+        "only the single scheduled recovery may retry LND"
+    );
+
+    let retry_error = call!(
+        harness.actor,
+        CchMessage::ReceiveBTC,
+        crate::cch::ReceiveBTC { fiber_pay_req }
+    )
+    .expect("actor call failed")
+    .unwrap_err();
+    assert!(matches!(
+        retry_error,
+        CchError::ReceiveBTCOrderCreationInProgress(hash) if hash == payment_hash
+    ));
+    assert_eq!(lnd.lookup_calls(), 2);
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/store/.schema.json
+++ b/crates/fiber-lib/src/store/.schema.json
@@ -9,6 +9,7 @@
   "CchInvoice": "89249fa9954b88d5cab734894bbcd0ae6ce1e3b27fe8cb5e7dadab70bbe7b96c",
   "CchOrder": "301b7fbdc941fb6afa8d596e15de1fc66974927fed0af7bf3b67e0e2bd5c931f",
   "CchOrderStatus": "a9b5b58aec4d7830709a505310a6367ff3431de38a27bfde3c56505487470e9c",
+  "CchReceiveBtcOrderCreation": "47b59c3dbcaf9a0c2ce7218fbacaa44cf6a7ceb0c42669a7209a9d02f1bc637e",
   "ChannelActorData": "9fbf0df167319fb30ffa9b94e16b328f5405e354b6f42fb43320ec668324d132",
   "ChannelAnnouncement": "c563d7eae48dbc39b8dedce964b836aece184be176d8687150c0ef5abc2c81db",
   "ChannelBasePublicKeys": "c711ccbe027f8bf52b7123393e447a650b838d327fa1832a28d92e88125317e2",

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -31,13 +31,13 @@ use fiber_store::migration::{
     MigrateConfirmFn, MigrateProgressFn, INIT_DB_VERSION, MIGRATION_VERSION_KEY,
 };
 use fiber_types::schema::*;
-#[cfg(not(target_arch = "wasm32"))]
-use fiber_types::CchOrder;
 use fiber_types::{
     Attempt, AttemptStatus, BroadcastMessage, BroadcastMessageID, ChannelOpenRecord, ChannelState,
     Cursor, Direction, Hash256, PaymentCustomRecords, PaymentSession, PaymentStatus,
     PersistentNetworkActorState, Pubkey, TimedResult, CURSOR_SIZE,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use fiber_types::{CchOrder, CchReceiveBtcOrderCreation};
 #[cfg(feature = "watchtower")]
 use fiber_types::{ChannelData, NodeId, Privkey, RevocationData, SettlementData};
 
@@ -289,6 +289,14 @@ pub fn check_validate<P: AsRef<Path>>(path: P) -> Result<(), String> {
             CCH_ORDER_PREFIX => {
                 check_deserialization::<CchOrder>(&value, "CCH_ORDER_PREFIX", &mut errors);
             }
+            #[cfg(not(target_arch = "wasm32"))]
+            CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX => {
+                check_deserialization::<CchReceiveBtcOrderCreation>(
+                    &value,
+                    "CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX",
+                    &mut errors,
+                );
+            }
             #[cfg(feature = "watchtower")]
             WATCHTOWER_CHANNEL_PREFIX => {
                 check_deserialization::<ChannelData>(
@@ -401,6 +409,8 @@ pub enum KeyValue {
     HoldTlc((Hash256, Hash256, u64), u64),
     #[cfg(not(target_arch = "wasm32"))]
     CchOrder(Hash256, CchOrder),
+    #[cfg(not(target_arch = "wasm32"))]
+    CchReceiveBtcOrderCreation(Hash256, CchReceiveBtcOrderCreation),
     ChannelOpenRecord(Hash256, ChannelOpenRecord),
 }
 
@@ -526,6 +536,12 @@ impl StoreKeyValue for KeyValue {
             KeyValue::CchOrder(payment_hash, _data) => {
                 [&[CCH_ORDER_PREFIX], payment_hash.as_ref()].concat()
             }
+            #[cfg(not(target_arch = "wasm32"))]
+            KeyValue::CchReceiveBtcOrderCreation(payment_hash, _data) => [
+                &[CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX],
+                payment_hash.as_ref(),
+            ]
+            .concat(),
             KeyValue::ChannelOpenRecord(channel_id, _) => {
                 [&[CHANNEL_OPEN_RECORD_PREFIX], channel_id.as_ref()].concat()
             }
@@ -570,6 +586,10 @@ impl StoreKeyValue for KeyValue {
             KeyValue::HoldTlc(_, expired_at) => serialize_to_vec(expired_at, "HoldTlc"),
             #[cfg(not(target_arch = "wasm32"))]
             KeyValue::CchOrder(_, cch_order) => serialize_to_vec(cch_order, "CchOrder"),
+            #[cfg(not(target_arch = "wasm32"))]
+            KeyValue::CchReceiveBtcOrderCreation(_, creation) => {
+                serialize_to_vec(creation, "CchReceiveBtcOrderCreation")
+            }
             KeyValue::ChannelOpenRecord(_, record) => serialize_to_vec(record, "ChannelOpenRecord"),
         }
     }
@@ -1910,6 +1930,78 @@ impl CchOrderStore for Store {
 
     fn delete_cch_order(&self, payment_hash: &Hash256) {
         let key = [&[CCH_ORDER_PREFIX], payment_hash.as_ref()].concat();
+        let mut batch = self.batch();
+        batch.delete(key);
+        batch.commit();
+    }
+
+    fn get_receive_btc_order_creation(
+        &self,
+        payment_hash: &Hash256,
+    ) -> Result<CchReceiveBtcOrderCreation, CchStoreError> {
+        let key = [
+            &[CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX],
+            payment_hash.as_ref(),
+        ]
+        .concat();
+        self.get(key)
+            .map(|value| deserialize_from(&value, "CchReceiveBtcOrderCreation"))
+            .ok_or(CchStoreError::NotFound(*payment_hash))
+    }
+
+    fn insert_receive_btc_order_creation(
+        &self,
+        creation: CchReceiveBtcOrderCreation,
+    ) -> Result<(), CchStoreError> {
+        let key = [
+            &[CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX],
+            creation.payment_hash.as_ref(),
+        ]
+        .concat();
+        if self.get(&key).is_some() {
+            return Err(CchStoreError::Duplicated(creation.payment_hash));
+        }
+        let mut batch = self.batch();
+        let kv = KeyValue::CchReceiveBtcOrderCreation(creation.payment_hash, creation);
+        batch.put(kv.key(), kv.value());
+        batch.commit();
+        Ok(())
+    }
+
+    fn get_receive_btc_order_creation_keys_iter(&self) -> impl IntoIterator<Item = Hash256> {
+        const PREFIX_LEN: usize = 1;
+        const PREFIX: [u8; PREFIX_LEN] = [CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX];
+        self.collect_by_prefix(&PREFIX).into_iter().map(|kv| {
+            Hash256::try_from(&kv.key[PREFIX_LEN..])
+                .expect("CchReceiveBtcOrderCreation key must be Hash256")
+        })
+    }
+
+    fn complete_receive_btc_order_creation(&self, order: CchOrder) -> Result<(), CchStoreError> {
+        let order_key = [&[CCH_ORDER_PREFIX], order.payment_hash.as_ref()].concat();
+        if self.get(&order_key).is_some() {
+            return Err(CchStoreError::Duplicated(order.payment_hash));
+        }
+
+        let creation_key = [
+            &[CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX],
+            order.payment_hash.as_ref(),
+        ]
+        .concat();
+        let mut batch = self.batch();
+        let kv = KeyValue::CchOrder(order.payment_hash, order);
+        batch.put(kv.key(), kv.value());
+        batch.delete(creation_key);
+        batch.commit();
+        Ok(())
+    }
+
+    fn delete_receive_btc_order_creation(&self, payment_hash: &Hash256) {
+        let key = [
+            &[CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX],
+            payment_hash.as_ref(),
+        ]
+        .concat();
         let mut batch = self.batch();
         batch.delete(key);
         batch.commit();

--- a/crates/fiber-types/src/cch.rs
+++ b/crates/fiber-types/src/cch.rs
@@ -93,6 +93,40 @@ pub struct CchOrder {
     pub failure_reason: Option<String>,
 }
 
+/// Durable intent for creating the Lightning incoming invoice of a `receive_btc` order.
+///
+/// The intent is written before calling LND and atomically removed when the final
+/// [`CchOrder`] is persisted. Its payment hash is the idempotency key used to recover
+/// an invoice creation whose RPC result was lost or interrupted by a node restart.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CchReceiveBtcOrderCreation {
+    /// Seconds since epoch when order creation was accepted.
+    #[serde_as(as = "U64Hex")]
+    pub created_at: u64,
+    /// Relative expiry time copied from the CCH configuration at acceptance time.
+    #[serde_as(as = "U64Hex")]
+    pub order_expiry_delta_seconds: u64,
+    /// Original signed Fiber invoice. Exact equality is used to reject conflicting retries.
+    pub fiber_pay_req: String,
+    /// Idempotency key shared by the Fiber invoice, LND invoice, and final CCH order.
+    pub payment_hash: Hash256,
+    /// Outgoing Fiber principal in satoshis.
+    #[serde_as(as = "U128Hex")]
+    pub amount_sats: u128,
+    /// CCH fee in satoshis.
+    #[serde_as(as = "U128Hex")]
+    pub fee_sats: u128,
+    /// Wrapped BTC type script validated when the operation was accepted.
+    pub wrapped_btc_type_script: ckb_jsonrpc_types::Script,
+    /// LND final-hop CLTV delta validated when the operation was accepted.
+    #[serde_as(as = "U64Hex")]
+    pub btc_final_tlc_expiry_delta_blocks: u64,
+    /// Percentage of the collected fee available to the outgoing Fiber payment.
+    #[serde_as(as = "U64Hex")]
+    pub max_outgoing_fee_percentage: u64,
+}
+
 impl CchOrder {
     pub fn is_final(&self) -> bool {
         self.status == CchOrderStatus::Success || self.status == CchOrderStatus::Failed

--- a/crates/fiber-types/src/lib.rs
+++ b/crates/fiber-types/src/lib.rs
@@ -32,7 +32,7 @@ pub mod serde_utils;
 pub mod sample;
 
 #[cfg(feature = "cch")]
-pub use cch::{CchInvoice, CchOrder, CchOrderStatus};
+pub use cch::{CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation};
 pub use channel::*;
 pub use config::*;
 pub use invoice::*;

--- a/crates/fiber-types/src/schema.rs
+++ b/crates/fiber-types/src/schema.rs
@@ -18,6 +18,7 @@
 //! | 224          | Hash256              | ChannelData                 |
 //! | 201          | Hash256              | ChannelOpenRecord           |
 //! | 232          | Payment_hash         | CchOrder                    |
+//! | 233          | Payment_hash         | CchReceiveBtcOrderCreation  |
 //! +--------------+----------------------+-----------------------------+
 
 pub const CHANNEL_ACTOR_STATE_PREFIX: u8 = 0;
@@ -51,3 +52,5 @@ mod watchtower {
 pub use watchtower::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub const CCH_ORDER_PREFIX: u8 = 232;
+#[cfg(not(target_arch = "wasm32"))]
+pub const CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX: u8 = 233;


### PR DESCRIPTION
## Summary

- persist a durable receive_btc creation intent keyed by payment hash before creating the LND hold invoice
- reconcile LND state before creation and after ambiguous AddHoldInvoice failures, then atomically replace the intent with the completed CCH order
- make retries idempotent, reject conflicting requests and mismatched recovered invoices, and resume incomplete creations after restart
- retry transient LND and Fiber recovery failures with exponential backoff while retaining permanent failures for operator inspection

Fixes #1564.

The global LND invoice tracker concurrency limit is intentionally unchanged and remains separate follow-up work.

## Verification

- cargo nextest run -p fnn --features sqlite cch::tests (133 passed)
- cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings
- cargo fmt --all -- --check
- make check-migrate