### PR TITLE
Bind on-chain settlement proofs to exact TLC identities

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -18,7 +18,7 @@ use crate::fiber::onchain_tlc_reconcile::{
     collect_onchain_confirmed_payer_tlcs, collect_onchain_fulfilled_tlcs,
     collect_onchain_received_timeout_settled_tlcs, collect_onchain_timeout_settled_tlcs,
     has_unresolved_onchain_tlcs, onchain_fulfilled_preimage, OnChainConfirmedPayerTlc,
-    OnChainTimeoutTlcRole, OnChainTlcSettlement,
+    OnChainTimeoutTlcRole, StoredOnChainTlcSettlement,
 };
 use crate::fiber::types::{BroadcastMessageWithTimestamp, TxSignatures};
 use crate::store::actor::StoreActorMessage;
@@ -10187,18 +10187,13 @@ pub trait ChannelActorStateStore {
     fn remove_payment_hold_tlc(&self, payment_hash: &Hash256, channel_id: &Hash256, tlc_id: u64);
     fn get_payment_hold_tlcs(&self, payment_hash: Hash256) -> Vec<HoldTlc>;
     fn get_node_hold_tlcs(&self) -> HashMap<Hash256, Vec<HoldTlc>>;
-    /// Returns the channel-scoped confirmed on-chain settlement proof for this TLC.
+    /// Returns an exact settlement proof for this TLC, or a legacy prefix-keyed record.
     fn get_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
         tlc_id: TLCId,
-    ) -> Option<OnChainTlcSettlement>;
-    /// Returns a prefix-keyed settlement record written by an older version.
-    fn get_legacy_onchain_tlc_settlement(
-        &self,
-        channel_id: &Hash256,
         payment_hash: &Hash256,
-    ) -> Option<crate::fiber::onchain_tlc_reconcile::LegacyOnChainTlcSettlement>;
+    ) -> Option<StoredOnChainTlcSettlement>;
 
     /// Store a pending CommitDiff for channel reestablishment
     fn store_pending_commit_diff(&self, channel_id: &Hash256, diff: &CommitDiff);

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -10191,8 +10191,14 @@ pub trait ChannelActorStateStore {
     fn get_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
-        payment_hash: &Hash256,
+        tlc_id: TLCId,
     ) -> Option<OnChainTlcSettlement>;
+    /// Returns a prefix-keyed settlement record written by an older version.
+    fn get_legacy_onchain_tlc_settlement(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<crate::fiber::onchain_tlc_reconcile::LegacyOnChainTlcSettlement>;
 
     /// Store a pending CommitDiff for channel reestablishment
     fn store_pending_commit_diff(&self, channel_id: &Hash256, diff: &CommitDiff);

--- a/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
@@ -39,6 +39,16 @@ pub struct LegacyOnChainTlcSettlement {
     pub tlc_index: Option<u8>,
 }
 
+/// A settlement record decoded from either the exact current key format or the legacy
+/// payment-hash-prefix key format.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StoredOnChainTlcSettlement {
+    /// An exact record keyed by `(channel_id, TLCId)`.
+    Exact(OnChainTlcSettlement),
+    /// A prefix-keyed record written by an older version.
+    Legacy(LegacyOnChainTlcSettlement),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OnChainTlcResolution {
     Unknown,
@@ -102,49 +112,55 @@ pub(crate) fn resolve_onchain_tlc(
     payment_hash: Hash256,
     hash_algorithm: HashAlgorithm,
 ) -> OnChainTlcResolution {
-    if let Some(settlement) = store.get_onchain_tlc_settlement(channel_id, tlc_id) {
-        if settlement.payment_hash != payment_hash || settlement.hash_algorithm != hash_algorithm {
+    let Some(settlement) = store.get_onchain_tlc_settlement(channel_id, tlc_id, &payment_hash)
+    else {
+        return OnChainTlcResolution::Unknown;
+    };
+    match settlement {
+        StoredOnChainTlcSettlement::Exact(settlement) => {
+            if settlement.payment_hash != payment_hash
+                || settlement.hash_algorithm != hash_algorithm
+            {
+                warn!(
+                    "Ignoring mismatched on-chain settlement identity for channel {:?} tlc {:?} tx {:?}: stored hash {:?}/{:?}, expected {:?}/{:?}",
+                    channel_id,
+                    tlc_id,
+                    settlement.tx_hash,
+                    settlement.payment_hash,
+                    settlement.hash_algorithm,
+                    payment_hash,
+                    hash_algorithm
+                );
+                return OnChainTlcResolution::Unknown;
+            }
+            let Some(preimage) = settlement.preimage else {
+                return OnChainTlcResolution::SettledWithoutPreimage;
+            };
+            let discovered_payment_hash: Hash256 = hash_algorithm.hash(preimage).into();
+            if discovered_payment_hash == payment_hash {
+                return OnChainTlcResolution::Fulfilled(preimage);
+            }
             warn!(
-                "Ignoring mismatched on-chain settlement identity for channel {:?} tlc {:?} tx {:?}: stored hash {:?}/{:?}, expected {:?}/{:?}",
-                channel_id,
-                tlc_id,
-                settlement.tx_hash,
-                settlement.payment_hash,
-                settlement.hash_algorithm,
-                payment_hash,
-                hash_algorithm
+                "Ignoring invalid on-chain preimage for channel {:?} tlc {:?} tx {:?}: derived hash {:?}, expected {:?}",
+                channel_id, tlc_id, settlement.tx_hash, discovered_payment_hash, payment_hash
             );
-            return OnChainTlcResolution::Unknown;
+            OnChainTlcResolution::Unknown
         }
-        let Some(preimage) = settlement.preimage else {
-            return OnChainTlcResolution::SettledWithoutPreimage;
-        };
-        let discovered_payment_hash: Hash256 = hash_algorithm.hash(preimage).into();
-        if discovered_payment_hash == payment_hash {
-            return OnChainTlcResolution::Fulfilled(preimage);
+        StoredOnChainTlcSettlement::Legacy(legacy) => {
+            let Some(preimage) = legacy.preimage else {
+                return OnChainTlcResolution::Unknown;
+            };
+            let discovered_payment_hash: Hash256 = hash_algorithm.hash(preimage).into();
+            if discovered_payment_hash == payment_hash {
+                return OnChainTlcResolution::Fulfilled(preimage);
+            }
+            warn!(
+                "Ignoring legacy prefix-keyed settlement for channel {:?} tlc {:?} tx {:?}: preimage hash {:?}, expected {:?}",
+                channel_id, tlc_id, legacy.tx_hash, discovered_payment_hash, payment_hash
+            );
+            OnChainTlcResolution::Unknown
         }
-        warn!(
-            "Ignoring invalid on-chain preimage for channel {:?} tlc {:?} tx {:?}: derived hash {:?}, expected {:?}",
-            channel_id, tlc_id, settlement.tx_hash, discovered_payment_hash, payment_hash
-        );
-        return OnChainTlcResolution::Unknown;
     }
-
-    let Some(legacy) = store.get_legacy_onchain_tlc_settlement(channel_id, &payment_hash) else {
-        return OnChainTlcResolution::Unknown;
-    };
-    let Some(preimage) = legacy.preimage else {
-        return OnChainTlcResolution::Unknown;
-    };
-    let discovered_payment_hash: Hash256 = hash_algorithm.hash(preimage).into();
-    if discovered_payment_hash == payment_hash {
-        return OnChainTlcResolution::Fulfilled(preimage);
-    }
-    warn!(
-        "Ignoring legacy prefix-keyed settlement for channel {:?} tlc {:?} tx {:?}: preimage hash {:?}, expected {:?}",
-        channel_id, tlc_id, legacy.tx_hash, discovered_payment_hash, payment_hash
-    );
-    OnChainTlcResolution::Unknown
 }
 
 pub(crate) fn onchain_fulfilled_preimage(

--- a/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
@@ -1,10 +1,7 @@
 //! On-chain identity invariant: a settlement witness only exposes a 20-byte payment-hash
-//! prefix and an unlock index, so on-chain resolution maps to TLCs via
-//! `(channel_id, payment_hash[0..20])`. Fulfillment with a preimage is additionally
-//! validated against the full 32-byte payment hash; timeout/no-preimage resolution is
-//! only sound while a channel has at most one pending TLC per prefix.
-
-use std::collections::{HashMap, HashSet};
+//! prefix and an unlock index. The watchtower must resolve that index against the immutable
+//! settlement snapshot committed by the force-closed commitment transaction before persisting
+//! a settlement proof for an exact local TLC id and full 32-byte payment hash.
 
 use crate::fiber::channel::{ChannelActorState, ChannelActorStateStore};
 use fiber_types::{
@@ -15,12 +12,30 @@ use tracing::warn;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OnChainTlcSettlement {
+    /// The full payment hash from the commitment's immutable settlement snapshot.
+    pub payment_hash: Hash256,
+    /// The hash algorithm committed for this TLC.
+    pub hash_algorithm: HashAlgorithm,
     /// Preimage revealed by the settlement witness, when the TLC was claimed with one.
     pub preimage: Option<Hash256>,
-    /// The settlement transaction that consumed this TLC's output. `None` for legacy
-    /// empty-value markers that carry no audit evidence.
+    /// The settlement transaction that consumed this TLC's output.
+    pub tx_hash: Hash256,
+    /// The pending-HTLC index inside that settlement witness.
+    pub tlc_index: u8,
+}
+
+/// Prefix-keyed settlement records written by older versions.
+///
+/// These records are retained for database compatibility. A matching preimage can still safely
+/// prove fulfillment after validating the complete hash, but a no-preimage record cannot prove
+/// which TLC sharing the prefix was consumed.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LegacyOnChainTlcSettlement {
+    /// Preimage observed in the old prefix-keyed settlement record.
+    pub preimage: Option<Hash256>,
+    /// Settlement transaction hash when recorded by a newer legacy writer.
     pub tx_hash: Option<Hash256>,
-    /// The pending-HTLC index inside the settlement witness. `None` for legacy markers.
+    /// Witness index when recorded by a newer legacy writer.
     pub tlc_index: Option<u8>,
 }
 
@@ -87,27 +102,49 @@ pub(crate) fn resolve_onchain_tlc(
     payment_hash: Hash256,
     hash_algorithm: HashAlgorithm,
 ) -> OnChainTlcResolution {
-    let Some(settlement) = store.get_onchain_tlc_settlement(channel_id, &payment_hash) else {
+    if let Some(settlement) = store.get_onchain_tlc_settlement(channel_id, tlc_id) {
+        if settlement.payment_hash != payment_hash || settlement.hash_algorithm != hash_algorithm {
+            warn!(
+                "Ignoring mismatched on-chain settlement identity for channel {:?} tlc {:?} tx {:?}: stored hash {:?}/{:?}, expected {:?}/{:?}",
+                channel_id,
+                tlc_id,
+                settlement.tx_hash,
+                settlement.payment_hash,
+                settlement.hash_algorithm,
+                payment_hash,
+                hash_algorithm
+            );
+            return OnChainTlcResolution::Unknown;
+        }
+        let Some(preimage) = settlement.preimage else {
+            return OnChainTlcResolution::SettledWithoutPreimage;
+        };
+        let discovered_payment_hash: Hash256 = hash_algorithm.hash(preimage).into();
+        if discovered_payment_hash == payment_hash {
+            return OnChainTlcResolution::Fulfilled(preimage);
+        }
+        warn!(
+            "Ignoring invalid on-chain preimage for channel {:?} tlc {:?} tx {:?}: derived hash {:?}, expected {:?}",
+            channel_id, tlc_id, settlement.tx_hash, discovered_payment_hash, payment_hash
+        );
+        return OnChainTlcResolution::Unknown;
+    }
+
+    let Some(legacy) = store.get_legacy_onchain_tlc_settlement(channel_id, &payment_hash) else {
         return OnChainTlcResolution::Unknown;
     };
-
-    let Some(preimage) = settlement.preimage else {
-        return OnChainTlcResolution::SettledWithoutPreimage;
+    let Some(preimage) = legacy.preimage else {
+        return OnChainTlcResolution::Unknown;
     };
-
     let discovered_payment_hash: Hash256 = hash_algorithm.hash(preimage).into();
     if discovered_payment_hash == payment_hash {
         return OnChainTlcResolution::Fulfilled(preimage);
     }
-
-    // The channel-scoped settlement record proves the TLC output was consumed on-chain.
-    // If the stored preimage does not validate against the full hash, do not fulfill
-    // upstream, but still finalize this local TLC as settled without a usable preimage.
     warn!(
-        "On-chain settlement record for channel {:?} tlc {:?} tx {:?} has preimage hash {:?}, expected {:?}; treating as settled without preimage",
-        channel_id, tlc_id, settlement.tx_hash, discovered_payment_hash, payment_hash
+        "Ignoring legacy prefix-keyed settlement for channel {:?} tlc {:?} tx {:?}: preimage hash {:?}, expected {:?}",
+        channel_id, tlc_id, legacy.tx_hash, discovered_payment_hash, payment_hash
     );
-    OnChainTlcResolution::SettledWithoutPreimage
+    OnChainTlcResolution::Unknown
 }
 
 pub(crate) fn onchain_fulfilled_preimage(
@@ -200,15 +237,11 @@ pub(crate) fn collect_onchain_timeout_settled_tlcs(
     expect_expiry: u64,
 ) -> Vec<OnChainTimeoutSettledTlc> {
     let channel_id = state.get_id();
-    let non_unique_prefixes = non_unique_onchain_settlement_prefixes(state);
     state
         .tlc_state
         .get_expired_offered_tlcs(expect_expiry)
         .filter(|tlc| tlc.removed_reason.is_none())
         .filter_map(|tlc| {
-            if has_non_unique_onchain_settlement_key(&channel_id, &non_unique_prefixes, tlc) {
-                return None;
-            }
             if !matches!(
                 resolve_onchain_tlc(
                     &channel_id,
@@ -249,17 +282,13 @@ pub(crate) fn collect_onchain_received_timeout_settled_tlcs(
     store: &impl ChannelActorStateStore,
 ) -> Vec<OnChainReceivedTimeoutSettledTlc> {
     let channel_id = state.get_id();
-    let non_unique_prefixes = non_unique_onchain_settlement_prefixes(state);
     state
         .tlc_state
         .received_tlcs
         .tlcs
         .iter()
         .filter(|tlc| can_reconcile_onchain_fulfillment(tlc))
-        .filter_map(|tlc| {
-            if has_non_unique_onchain_settlement_key(&channel_id, &non_unique_prefixes, tlc) {
-                return None;
-            }
+        .filter(|tlc| {
             matches!(
                 resolve_onchain_tlc(
                     &channel_id,
@@ -270,12 +299,12 @@ pub(crate) fn collect_onchain_received_timeout_settled_tlcs(
                 ),
                 OnChainTlcResolution::SettledWithoutPreimage
             )
-            .then(|| {
-                let TLCId::Received(tlc_id) = tlc.tlc_id else {
-                    unreachable!("received TLC list contains only received TLCs");
-                };
-                OnChainReceivedTimeoutSettledTlc { tlc_id }
-            })
+        })
+        .map(|tlc| {
+            let TLCId::Received(tlc_id) = tlc.tlc_id else {
+                unreachable!("received TLC list contains only received TLCs");
+            };
+            OnChainReceivedTimeoutSettledTlc { tlc_id }
         })
         .collect()
 }
@@ -300,56 +329,4 @@ pub(crate) fn can_reconcile_onchain_fulfillment(tlc: &TlcInfo) -> bool {
             InboundTlcStatus::AnnounceWaitAck | InboundTlcStatus::Committed
         )
     }
-}
-
-/// Returns payment-hash prefixes whose current on-chain settlement key is shared by more than one
-/// reconcilable TLC on this channel.
-///
-/// Settlement records are currently looked up by `(channel_id, payment_hash[0..20])`, not by full
-/// payment hash or witness TLC index. When multiple pending TLCs share that lookup key, the record
-/// cannot be safely attributed to exactly one local TLC.
-pub(crate) fn non_unique_onchain_settlement_prefixes(
-    state: &ChannelActorState,
-) -> HashSet<[u8; 20]> {
-    let mut counts_by_prefix: HashMap<[u8; 20], u32> = HashMap::new();
-    for tlc in state
-        .tlc_state
-        .all_tlcs()
-        .filter(|tlc| can_reconcile_onchain_fulfillment(tlc))
-    {
-        *counts_by_prefix
-            .entry(payment_hash_prefix(&tlc.payment_hash))
-            .or_default() += 1;
-    }
-    counts_by_prefix
-        .into_iter()
-        .filter_map(|(prefix, count)| (count > 1).then_some(prefix))
-        .collect()
-}
-
-pub(crate) fn payment_hash_prefix(payment_hash: &Hash256) -> [u8; 20] {
-    payment_hash.as_ref()[0..20]
-        .try_into()
-        .expect("payment hash prefix")
-}
-
-/// Returns true when this TLC's current settlement lookup key is not unique within the channel.
-///
-/// No-preimage callers skip such TLCs because applying a prefix-keyed settlement record could
-/// otherwise mutate the wrong TLC, relay the wrong upstream remove, or complete the wrong
-/// payment/invoice state.
-pub(crate) fn has_non_unique_onchain_settlement_key(
-    channel_id: &Hash256,
-    non_unique_prefixes: &HashSet<[u8; 20]>,
-    tlc: &TlcInfo,
-) -> bool {
-    let prefix = payment_hash_prefix(&tlc.payment_hash);
-    if non_unique_prefixes.contains(&prefix) {
-        warn!(
-            "Skipping on-chain reconciliation for channel {:?} tlc {:?}: on-chain settlement key is shared by multiple pending TLCs",
-            channel_id, tlc.tlc_id
-        );
-        return true;
-    }
-    false
 }

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -3631,6 +3631,7 @@ async fn test_closed_channel_restores_after_restart_mid_settlement() {
         .await;
 
     node_1.store.insert_onchain_tlc_settlement(
+        &fiber_types::NodeId::local(),
         &channels[1],
         TLCId::Offered(downstream_tlc.id()),
         OnChainTlcSettlement {

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -3630,16 +3630,15 @@ async fn test_closed_channel_restores_after_restart_mid_settlement() {
         )
         .await;
 
-    let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
-        .try_into()
-        .expect("20-byte payment hash prefix");
     node_1.store.insert_onchain_tlc_settlement(
         &channels[1],
-        payment_hash_prefix,
+        TLCId::Offered(downstream_tlc.id()),
         OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
             preimage: None,
-            tx_hash: Some(gen_rand_sha256_hash()),
-            tlc_index: Some(0),
+            tx_hash: gen_rand_sha256_hash(),
+            tlc_index: 0,
         },
     );
 

--- a/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
@@ -1,7 +1,7 @@
 use crate::fiber::onchain_tlc_reconcile::{
     collect_onchain_fulfilled_tlcs, collect_onchain_received_timeout_settled_tlcs,
     collect_onchain_timeout_settled_tlcs, has_unresolved_onchain_tlcs, resolve_onchain_tlc,
-    OnChainTimeoutTlcRole, OnChainTlcResolution,
+    LegacyOnChainTlcSettlement, OnChainTimeoutTlcRole, OnChainTlcResolution,
 };
 use crate::fiber::tests::settle_tlc_set_command_tests::{
     create_test_channel_state_with_tlc, MockStore,
@@ -61,7 +61,13 @@ fn resolve_returns_fulfilled_when_preimage_matches() {
     let preimage = gen_rand_sha256_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
     let payment_hash = payment_hash_for(preimage, hash_algorithm);
-    let store = MockStore::new().with_onchain_preimage(channel_id, payment_hash, preimage);
+    let store = MockStore::new().with_onchain_preimage(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        hash_algorithm,
+        preimage,
+    );
 
     assert_eq!(
         resolve_onchain_tlc(
@@ -76,13 +82,19 @@ fn resolve_returns_fulfilled_when_preimage_matches() {
 }
 
 #[test]
-fn resolve_falls_through_to_settled_when_preimage_mismatches() {
+fn resolve_returns_unknown_when_preimage_mismatches() {
     let channel_id = gen_rand_sha256_hash();
     let correct_preimage = gen_rand_sha256_hash();
     let wrong_preimage = gen_rand_sha256_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
     let payment_hash = payment_hash_for(correct_preimage, hash_algorithm);
-    let store = MockStore::new().with_onchain_preimage(channel_id, payment_hash, wrong_preimage);
+    let store = MockStore::new().with_onchain_preimage(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        hash_algorithm,
+        wrong_preimage,
+    );
 
     assert_eq!(
         resolve_onchain_tlc(
@@ -92,7 +104,61 @@ fn resolve_falls_through_to_settled_when_preimage_mismatches() {
             payment_hash,
             hash_algorithm,
         ),
-        OnChainTlcResolution::SettledWithoutPreimage
+        OnChainTlcResolution::Unknown
+    );
+}
+
+#[test]
+fn legacy_no_preimage_record_is_not_attributed_to_a_tlc() {
+    let channel_id = gen_rand_sha256_hash();
+    let payment_hash = gen_rand_sha256_hash();
+    let store = MockStore::new().with_legacy_onchain_settlement(
+        channel_id,
+        payment_hash,
+        LegacyOnChainTlcSettlement {
+            preimage: None,
+            tx_hash: Some(gen_rand_sha256_hash()),
+            tlc_index: Some(0),
+        },
+    );
+
+    assert_eq!(
+        resolve_onchain_tlc(
+            &channel_id,
+            &store,
+            TLCId::Offered(0),
+            payment_hash,
+            HashAlgorithm::CkbHash,
+        ),
+        OnChainTlcResolution::Unknown
+    );
+}
+
+#[test]
+fn legacy_preimage_record_requires_a_full_hash_match() {
+    let channel_id = gen_rand_sha256_hash();
+    let hash_algorithm = HashAlgorithm::CkbHash;
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = payment_hash_for(preimage, hash_algorithm);
+    let store = MockStore::new().with_legacy_onchain_settlement(
+        channel_id,
+        payment_hash,
+        LegacyOnChainTlcSettlement {
+            preimage: Some(preimage),
+            tx_hash: Some(gen_rand_sha256_hash()),
+            tlc_index: Some(0),
+        },
+    );
+
+    assert_eq!(
+        resolve_onchain_tlc(
+            &channel_id,
+            &store,
+            TLCId::Offered(0),
+            payment_hash,
+            hash_algorithm,
+        ),
+        OnChainTlcResolution::Fulfilled(preimage)
     );
 }
 
@@ -100,7 +166,12 @@ fn resolve_falls_through_to_settled_when_preimage_mismatches() {
 fn resolve_returns_settled_without_preimage() {
     let channel_id = gen_rand_sha256_hash();
     let payment_hash = gen_rand_sha256_hash();
-    let store = MockStore::new().with_onchain_settled(channel_id, payment_hash);
+    let store = MockStore::new().with_onchain_settled(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        HashAlgorithm::CkbHash,
+    );
 
     assert_eq!(
         resolve_onchain_tlc(
@@ -139,7 +210,13 @@ fn resolve_is_channel_scoped() {
     let preimage = gen_rand_sha256_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
     let payment_hash = payment_hash_for(preimage, hash_algorithm);
-    let store = MockStore::new().with_onchain_preimage(channel_id, payment_hash, preimage);
+    let store = MockStore::new().with_onchain_preimage(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        hash_algorithm,
+        preimage,
+    );
 
     assert_eq!(
         resolve_onchain_tlc(
@@ -209,9 +286,27 @@ fn collect_skips_removed_and_uncommitted_tlcs() {
     let mut state = empty_channel_state(channel_id);
     state.tlc_state.offered_tlcs.tlcs = vec![active, removed, uncommitted];
     let store = MockStore::new()
-        .with_onchain_preimage(channel_id, active_hash, active_preimage)
-        .with_onchain_preimage(channel_id, removed_hash, removed_preimage)
-        .with_onchain_preimage(channel_id, uncommitted_hash, uncommitted_preimage);
+        .with_onchain_preimage(
+            channel_id,
+            TLCId::Offered(0),
+            active_hash,
+            hash_algorithm,
+            active_preimage,
+        )
+        .with_onchain_preimage(
+            channel_id,
+            TLCId::Offered(1),
+            removed_hash,
+            hash_algorithm,
+            removed_preimage,
+        )
+        .with_onchain_preimage(
+            channel_id,
+            TLCId::Offered(2),
+            uncommitted_hash,
+            hash_algorithm,
+            uncommitted_preimage,
+        );
 
     let fulfilled = collect_onchain_fulfilled_tlcs(&state, &store);
 
@@ -242,7 +337,21 @@ fn collect_fulfilled_allows_non_unique_prefix_when_full_hash_matches() {
 
     let mut state = empty_channel_state(channel_id);
     state.tlc_state.offered_tlcs.tlcs = vec![first, second];
-    let store = MockStore::new().with_onchain_preimage(channel_id, payment_hash, preimage);
+    let store = MockStore::new()
+        .with_onchain_preimage(
+            channel_id,
+            TLCId::Offered(0),
+            payment_hash,
+            hash_algorithm,
+            preimage,
+        )
+        .with_onchain_preimage(
+            channel_id,
+            TLCId::Offered(1),
+            payment_hash,
+            hash_algorithm,
+            preimage,
+        );
 
     let fulfilled = collect_onchain_fulfilled_tlcs(&state, &store);
 
@@ -298,9 +407,19 @@ fn collect_timeout_settled_includes_forwarded_and_origin_payer() {
     let mut state = empty_channel_state(channel_id);
     state.tlc_state.offered_tlcs.tlcs = vec![matched, no_forwarding, not_settled, not_expired];
     let store = MockStore::new()
-        .with_onchain_settled(channel_id, matched_hash)
-        .with_onchain_settled(channel_id, no_forwarding_hash)
-        .with_onchain_settled(channel_id, not_expired_hash);
+        .with_onchain_settled(channel_id, TLCId::Offered(0), matched_hash, hash_algorithm)
+        .with_onchain_settled(
+            channel_id,
+            TLCId::Offered(1),
+            no_forwarding_hash,
+            hash_algorithm,
+        )
+        .with_onchain_settled(
+            channel_id,
+            TLCId::Offered(3),
+            not_expired_hash,
+            hash_algorithm,
+        );
 
     let expired = collect_onchain_timeout_settled_tlcs(&state, &store, 100);
 
@@ -338,7 +457,12 @@ fn collect_timeout_settled_skips_already_removed() {
 
     let mut state = empty_channel_state(channel_id);
     state.tlc_state.offered_tlcs.tlcs = vec![tlc];
-    let store = MockStore::new().with_onchain_settled(channel_id, payment_hash);
+    let store = MockStore::new().with_onchain_settled(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        hash_algorithm,
+    );
 
     assert!(collect_onchain_timeout_settled_tlcs(&state, &store, 100).is_empty());
 }
@@ -363,7 +487,12 @@ fn collect_received_timeout_skips_uncommitted_tlc_with_same_hash() {
 
     let mut state = empty_channel_state(channel_id);
     state.tlc_state.received_tlcs.tlcs = vec![committed, uncommitted];
-    let store = MockStore::new().with_onchain_settled(channel_id, payment_hash);
+    let store = MockStore::new().with_onchain_settled(
+        channel_id,
+        TLCId::Received(0),
+        payment_hash,
+        hash_algorithm,
+    );
 
     let settled = collect_onchain_received_timeout_settled_tlcs(&state, &store);
 
@@ -381,7 +510,7 @@ fn collect_received_timeout_skips_uncommitted_tlc_with_same_hash() {
 }
 
 #[test]
-fn collect_timeout_skips_non_unique_onchain_settlement_prefixes() {
+fn collect_timeout_uses_exact_tlc_identity_for_shared_prefixes() {
     let channel_id = gen_rand_sha256_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
     let first_hash_bytes = [1u8; 32];
@@ -404,8 +533,64 @@ fn collect_timeout_skips_non_unique_onchain_settlement_prefixes() {
     );
     let mut state = empty_channel_state(channel_id);
     state.tlc_state.offered_tlcs.tlcs = vec![first, second];
-    let store = MockStore::new().with_onchain_settled(channel_id, first_hash);
+    let store = MockStore::new().with_onchain_settled(
+        channel_id,
+        TLCId::Offered(0),
+        first_hash,
+        hash_algorithm,
+    );
 
-    assert!(collect_onchain_timeout_settled_tlcs(&state, &store, 100).is_empty());
+    let settled = collect_onchain_timeout_settled_tlcs(&state, &store, 100);
+    assert_eq!(settled.len(), 1);
+    assert_eq!(settled[0].tlc_id, TLCId::Offered(0));
     assert!(has_unresolved_onchain_tlcs(&state));
+}
+
+#[test]
+fn forged_full_hash_does_not_inherit_removed_tlc_prefix_settlement() {
+    let channel_id = gen_rand_sha256_hash();
+    let hash_algorithm = HashAlgorithm::CkbHash;
+    let preimage = gen_rand_sha256_hash();
+    let fulfilled_hash = payment_hash_for(preimage, hash_algorithm);
+    let mut forged_hash_bytes: [u8; 32] = fulfilled_hash.into();
+    forged_hash_bytes[31] ^= 1;
+    let forged_hash = Hash256::from(forged_hash_bytes);
+
+    let fulfilled = tlc_info(
+        TLCId::Offered(0),
+        TlcStatus::Outbound(OutboundTlcStatus::Committed),
+        fulfilled_hash,
+        hash_algorithm,
+    );
+    let forged = tlc_info(
+        TLCId::Offered(1),
+        TlcStatus::Outbound(OutboundTlcStatus::Committed),
+        forged_hash,
+        hash_algorithm,
+    );
+    let mut state = empty_channel_state(channel_id);
+    state.tlc_state.offered_tlcs.tlcs = vec![fulfilled, forged];
+    let store = MockStore::new().with_onchain_preimage(
+        channel_id,
+        TLCId::Offered(0),
+        fulfilled_hash,
+        hash_algorithm,
+        preimage,
+    );
+
+    let fulfilled = collect_onchain_fulfilled_tlcs(&state, &store);
+    assert_eq!(fulfilled.len(), 1);
+    assert_eq!(fulfilled[0].tlc_id, TLCId::Offered(0));
+
+    state.tlc_state.set_offered_tlc_removed(
+        0,
+        RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
+            payment_preimage: preimage,
+        }),
+    );
+
+    assert!(
+        collect_onchain_timeout_settled_tlcs(&state, &store, 100).is_empty(),
+        "a settlement record for the removed TLC must not settle the forged full hash"
+    );
 }

--- a/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
@@ -114,7 +114,7 @@ fn legacy_no_preimage_record_is_not_attributed_to_a_tlc() {
     let payment_hash = gen_rand_sha256_hash();
     let store = MockStore::new().with_legacy_onchain_settlement(
         channel_id,
-        payment_hash,
+        TLCId::Offered(0),
         LegacyOnChainTlcSettlement {
             preimage: None,
             tx_hash: Some(gen_rand_sha256_hash()),
@@ -142,7 +142,7 @@ fn legacy_preimage_record_requires_a_full_hash_match() {
     let payment_hash = payment_hash_for(preimage, hash_algorithm);
     let store = MockStore::new().with_legacy_onchain_settlement(
         channel_id,
-        payment_hash,
+        TLCId::Offered(0),
         LegacyOnChainTlcSettlement {
             preimage: Some(preimage),
             tx_hash: Some(gen_rand_sha256_hash()),

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -65,23 +65,30 @@ use std::time::{Duration, SystemTime};
 use tracing::{debug, error, info};
 
 #[cfg(feature = "watchtower")]
-fn insert_onchain_preimage<S: WatchtowerStore>(
+fn insert_onchain_preimage<S: WatchtowerStore + ChannelActorStateStore>(
     store: &S,
     channel_id: &Hash256,
     payment_hash: Hash256,
     preimage: Hash256,
 ) {
-    let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
-        .try_into()
-        .expect("20-byte payment hash prefix");
+    let channel_state = store
+        .get_channel_actor_state(channel_id)
+        .expect("channel state exists");
+    let tlc = channel_state
+        .tlc_state
+        .all_tlcs()
+        .find(|tlc| tlc.payment_hash == payment_hash)
+        .expect("TLC with payment hash exists");
     store.insert_watch_preimage(fiber_types::NodeId::local(), payment_hash, preimage);
     store.insert_onchain_tlc_settlement(
         channel_id,
-        payment_hash_prefix,
+        tlc.tlc_id,
         OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: tlc.hash_algorithm,
             preimage: Some(preimage),
-            tx_hash: Some(gen_rand_sha256_hash()),
-            tlc_index: Some(0),
+            tx_hash: gen_rand_sha256_hash(),
+            tlc_index: 0,
         },
     );
 }
@@ -5033,16 +5040,15 @@ async fn test_closed_channel_upstream_settlement_does_not_depend_on_check_channe
         )
         .await;
 
-    let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
-        .try_into()
-        .expect("20-byte payment hash prefix");
     node_1.store.insert_onchain_tlc_settlement(
         &channels[1],
-        payment_hash_prefix,
+        TLCId::Offered(downstream_tlc.id()),
         OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
             preimage: None,
-            tx_hash: Some(gen_rand_sha256_hash()),
-            tlc_index: Some(0),
+            tx_hash: gen_rand_sha256_hash(),
+            tlc_index: 0,
         },
     );
 
@@ -6902,16 +6908,15 @@ async fn test_onchain_settlement_restart_restores_upstream_waiting_commitment_ac
         )
         .await;
 
-    let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
-        .try_into()
-        .expect("20-byte payment hash prefix");
     node_1.store.insert_onchain_tlc_settlement(
         &channels[1],
-        payment_hash_prefix,
+        TLCId::Offered(downstream_tlc.id()),
         OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
             preimage: None,
-            tx_hash: Some(gen_rand_sha256_hash()),
-            tlc_index: Some(0),
+            tx_hash: gen_rand_sha256_hash(),
+            tlc_index: 0,
         },
     );
 

--- a/crates/fiber-lib/src/fiber/tests/payment.rs
+++ b/crates/fiber-lib/src/fiber/tests/payment.rs
@@ -81,6 +81,7 @@ fn insert_onchain_preimage<S: WatchtowerStore + ChannelActorStateStore>(
         .expect("TLC with payment hash exists");
     store.insert_watch_preimage(fiber_types::NodeId::local(), payment_hash, preimage);
     store.insert_onchain_tlc_settlement(
+        &fiber_types::NodeId::local(),
         channel_id,
         tlc.tlc_id,
         OnChainTlcSettlement {
@@ -5041,6 +5042,7 @@ async fn test_closed_channel_upstream_settlement_does_not_depend_on_check_channe
         .await;
 
     node_1.store.insert_onchain_tlc_settlement(
+        &fiber_types::NodeId::local(),
         &channels[1],
         TLCId::Offered(downstream_tlc.id()),
         OnChainTlcSettlement {
@@ -6909,6 +6911,7 @@ async fn test_onchain_settlement_restart_restores_upstream_waiting_commitment_ac
         .await;
 
     node_1.store.insert_onchain_tlc_settlement(
+        &fiber_types::NodeId::local(),
         &channels[1],
         TLCId::Offered(downstream_tlc.id()),
         OnChainTlcSettlement {

--- a/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
@@ -34,8 +34,7 @@ pub(crate) struct MockStore {
     preimages: RefCell<HashMap<Hash256, Hash256>>,
     hold_tlcs: RefCell<HashMap<Hash256, Vec<HoldTlc>>>,
     channel_states: RefCell<HashMap<Hash256, ChannelActorState>>,
-    pub(crate) onchain_settlements: RefCell<HashMap<(Hash256, TLCId), OnChainTlcSettlement>>,
-    legacy_onchain_settlements: RefCell<HashMap<(Hash256, [u8; 20]), LegacyOnChainTlcSettlement>>,
+    pub(crate) onchain_settlements: RefCell<HashMap<(Hash256, TLCId), StoredOnChainTlcSettlement>>,
 }
 
 impl MockStore {
@@ -47,7 +46,6 @@ impl MockStore {
             hold_tlcs: RefCell::new(HashMap::new()),
             channel_states: RefCell::new(HashMap::new()),
             onchain_settlements: RefCell::new(HashMap::new()),
-            legacy_onchain_settlements: RefCell::new(HashMap::new()),
         }
     }
 
@@ -90,9 +88,10 @@ impl MockStore {
         tlc_id: TLCId,
         settlement: OnChainTlcSettlement,
     ) -> Self {
-        self.onchain_settlements
-            .borrow_mut()
-            .insert((channel_id, tlc_id), settlement);
+        self.onchain_settlements.borrow_mut().insert(
+            (channel_id, tlc_id),
+            StoredOnChainTlcSettlement::Exact(settlement),
+        );
         self
     }
 
@@ -140,15 +139,13 @@ impl MockStore {
     pub(crate) fn with_legacy_onchain_settlement(
         self,
         channel_id: Hash256,
-        payment_hash: Hash256,
+        tlc_id: TLCId,
         settlement: LegacyOnChainTlcSettlement,
     ) -> Self {
-        let prefix = payment_hash.as_ref()[..20]
-            .try_into()
-            .expect("payment hash prefix");
-        self.legacy_onchain_settlements
-            .borrow_mut()
-            .insert((channel_id, prefix), settlement);
+        self.onchain_settlements.borrow_mut().insert(
+            (channel_id, tlc_id),
+            StoredOnChainTlcSettlement::Legacy(settlement),
+        );
         self
     }
 }
@@ -284,24 +281,12 @@ impl ChannelActorStateStore for MockStore {
         &self,
         channel_id: &Hash256,
         tlc_id: TLCId,
-        payment_hash: &Hash256,
+        _payment_hash: &Hash256,
     ) -> Option<StoredOnChainTlcSettlement> {
-        if let Some(settlement) = self
-            .onchain_settlements
+        self.onchain_settlements
             .borrow()
             .get(&(*channel_id, tlc_id))
             .cloned()
-        {
-            return Some(StoredOnChainTlcSettlement::Exact(settlement));
-        }
-        let prefix = payment_hash.as_ref()[..20]
-            .try_into()
-            .expect("payment hash prefix");
-        self.legacy_onchain_settlements
-            .borrow()
-            .get(&(*channel_id, prefix))
-            .cloned()
-            .map(StoredOnChainTlcSettlement::Legacy)
     }
 
     fn store_pending_commit_diff(&self, _channel_id: &Hash256, _diff: &CommitDiff) {

--- a/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
@@ -3,7 +3,9 @@
 use crate::fiber::channel::{
     has_pending_tlc_for_payment_hash, ChannelActorState, ChannelActorStateStore, CommitDiff,
 };
-use crate::fiber::onchain_tlc_reconcile::{LegacyOnChainTlcSettlement, OnChainTlcSettlement};
+use crate::fiber::onchain_tlc_reconcile::{
+    LegacyOnChainTlcSettlement, OnChainTlcSettlement, StoredOnChainTlcSettlement,
+};
 use crate::fiber::settle_tlc_set_command::{SettleTlcSetCommand, TlcSettlement};
 use crate::fiber::types::{Hash256, HoldTlc, Pubkey, RemoveTlcReason};
 use crate::gen_rand_sha256_hash;
@@ -282,18 +284,16 @@ impl ChannelActorStateStore for MockStore {
         &self,
         channel_id: &Hash256,
         tlc_id: TLCId,
-    ) -> Option<OnChainTlcSettlement> {
-        self.onchain_settlements
+        payment_hash: &Hash256,
+    ) -> Option<StoredOnChainTlcSettlement> {
+        if let Some(settlement) = self
+            .onchain_settlements
             .borrow()
             .get(&(*channel_id, tlc_id))
             .cloned()
-    }
-
-    fn get_legacy_onchain_tlc_settlement(
-        &self,
-        channel_id: &Hash256,
-        payment_hash: &Hash256,
-    ) -> Option<LegacyOnChainTlcSettlement> {
+        {
+            return Some(StoredOnChainTlcSettlement::Exact(settlement));
+        }
         let prefix = payment_hash.as_ref()[..20]
             .try_into()
             .expect("payment hash prefix");
@@ -301,6 +301,7 @@ impl ChannelActorStateStore for MockStore {
             .borrow()
             .get(&(*channel_id, prefix))
             .cloned()
+            .map(StoredOnChainTlcSettlement::Legacy)
     }
 
     fn store_pending_commit_diff(&self, _channel_id: &Hash256, _diff: &CommitDiff) {

--- a/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
+++ b/crates/fiber-lib/src/fiber/tests/settle_tlc_set_command_tests.rs
@@ -3,7 +3,7 @@
 use crate::fiber::channel::{
     has_pending_tlc_for_payment_hash, ChannelActorState, ChannelActorStateStore, CommitDiff,
 };
-use crate::fiber::onchain_tlc_reconcile::{payment_hash_prefix, OnChainTlcSettlement};
+use crate::fiber::onchain_tlc_reconcile::{LegacyOnChainTlcSettlement, OnChainTlcSettlement};
 use crate::fiber::settle_tlc_set_command::{SettleTlcSetCommand, TlcSettlement};
 use crate::fiber::types::{Hash256, HoldTlc, Pubkey, RemoveTlcReason};
 use crate::gen_rand_sha256_hash;
@@ -32,7 +32,8 @@ pub(crate) struct MockStore {
     preimages: RefCell<HashMap<Hash256, Hash256>>,
     hold_tlcs: RefCell<HashMap<Hash256, Vec<HoldTlc>>>,
     channel_states: RefCell<HashMap<Hash256, ChannelActorState>>,
-    pub(crate) onchain_settlements: RefCell<HashMap<(Hash256, [u8; 20]), OnChainTlcSettlement>>,
+    pub(crate) onchain_settlements: RefCell<HashMap<(Hash256, TLCId), OnChainTlcSettlement>>,
+    legacy_onchain_settlements: RefCell<HashMap<(Hash256, [u8; 20]), LegacyOnChainTlcSettlement>>,
 }
 
 impl MockStore {
@@ -44,6 +45,7 @@ impl MockStore {
             hold_tlcs: RefCell::new(HashMap::new()),
             channel_states: RefCell::new(HashMap::new()),
             onchain_settlements: RefCell::new(HashMap::new()),
+            legacy_onchain_settlements: RefCell::new(HashMap::new()),
         }
     }
 
@@ -83,23 +85,31 @@ impl MockStore {
     pub(crate) fn with_onchain_settlement(
         self,
         channel_id: Hash256,
-        payment_hash: Hash256,
+        tlc_id: TLCId,
         settlement: OnChainTlcSettlement,
     ) -> Self {
         self.onchain_settlements
             .borrow_mut()
-            .insert((channel_id, payment_hash_prefix(&payment_hash)), settlement);
+            .insert((channel_id, tlc_id), settlement);
         self
     }
 
-    pub(crate) fn with_onchain_settled(self, channel_id: Hash256, payment_hash: Hash256) -> Self {
+    pub(crate) fn with_onchain_settled(
+        self,
+        channel_id: Hash256,
+        tlc_id: TLCId,
+        payment_hash: Hash256,
+        hash_algorithm: HashAlgorithm,
+    ) -> Self {
         self.with_onchain_settlement(
             channel_id,
-            payment_hash,
+            tlc_id,
             OnChainTlcSettlement {
+                payment_hash,
+                hash_algorithm,
                 preimage: None,
-                tx_hash: None,
-                tlc_index: None,
+                tx_hash: gen_rand_sha256_hash(),
+                tlc_index: 0,
             },
         )
     }
@@ -107,18 +117,37 @@ impl MockStore {
     pub(crate) fn with_onchain_preimage(
         self,
         channel_id: Hash256,
+        tlc_id: TLCId,
         payment_hash: Hash256,
+        hash_algorithm: HashAlgorithm,
         preimage: Hash256,
     ) -> Self {
         self.with_onchain_settlement(
             channel_id,
-            payment_hash,
+            tlc_id,
             OnChainTlcSettlement {
+                payment_hash,
+                hash_algorithm,
                 preimage: Some(preimage),
-                tx_hash: None,
-                tlc_index: None,
+                tx_hash: gen_rand_sha256_hash(),
+                tlc_index: 0,
             },
         )
+    }
+
+    pub(crate) fn with_legacy_onchain_settlement(
+        self,
+        channel_id: Hash256,
+        payment_hash: Hash256,
+        settlement: LegacyOnChainTlcSettlement,
+    ) -> Self {
+        let prefix = payment_hash.as_ref()[..20]
+            .try_into()
+            .expect("payment hash prefix");
+        self.legacy_onchain_settlements
+            .borrow_mut()
+            .insert((channel_id, prefix), settlement);
+        self
     }
 }
 
@@ -252,11 +281,25 @@ impl ChannelActorStateStore for MockStore {
     fn get_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
-        payment_hash: &Hash256,
+        tlc_id: TLCId,
     ) -> Option<OnChainTlcSettlement> {
         self.onchain_settlements
             .borrow()
-            .get(&(*channel_id, payment_hash_prefix(payment_hash)))
+            .get(&(*channel_id, tlc_id))
+            .cloned()
+    }
+
+    fn get_legacy_onchain_tlc_settlement(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<LegacyOnChainTlcSettlement> {
+        let prefix = payment_hash.as_ref()[..20]
+            .try_into()
+            .expect("payment hash prefix");
+        self.legacy_onchain_settlements
+            .borrow()
+            .get(&(*channel_id, prefix))
             .cloned()
     }
 

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -69,7 +69,6 @@ pub struct Store {
 enum WatchtowerPreimageCleanupTarget<'a> {
     Exact(&'a Hash256),
     ExactSet(&'a HashSet<Hash256>),
-    TlcPaymentHash(&'a [u8; 20]),
 }
 
 #[cfg(feature = "watchtower")]
@@ -78,9 +77,6 @@ impl WatchtowerPreimageCleanupTarget<'_> {
         match self {
             WatchtowerPreimageCleanupTarget::Exact(target) => payment_hash == target,
             WatchtowerPreimageCleanupTarget::ExactSet(targets) => targets.contains(payment_hash),
-            WatchtowerPreimageCleanupTarget::TlcPaymentHash(target) => {
-                payment_hash.as_ref()[..20] == target[..]
-            }
         }
     }
 }
@@ -690,45 +686,66 @@ impl Store {
         channel_data: &ChannelData,
         payment_hash: &Hash256,
     ) -> bool {
-        let exact_key_prefix = [
-            &[WATCHTOWER_TLC_SETTLED_PREFIX],
-            channel_data.channel_id.as_ref(),
-            &[1u8],
-        ]
-        .concat();
-        let has_exact_settlement = self
-            .collect_by_prefix(&exact_key_prefix)
-            .into_iter()
-            .filter(|kv| kv.key.len() == 1 + 32 + 2 + 8)
-            .map(|kv| {
-                deserialize_from::<OnChainTlcSettlement>(kv.value.as_ref(), "OnChainTlcSettlement")
-            })
-            .any(|settlement| &settlement.payment_hash == payment_hash);
-        let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
-            .try_into()
-            .expect("payment hash prefix");
-        let has_legacy_settlement = self
-            .get(Self::legacy_tlc_on_chain_settled_key(
-                &channel_data.channel_id,
-                &payment_hash_prefix,
-            ))
-            .is_some();
-        if has_exact_settlement || has_legacy_settlement {
-            return false;
-        }
-
-        [
-            &channel_data.remote_settlement_data,
-            &channel_data.pending_remote_settlement_data,
-            &channel_data.local_settlement_data,
+        let snapshot_statuses = [
+            (&channel_data.remote_settlement_data, true),
+            (&channel_data.pending_remote_settlement_data, true),
+            (&channel_data.local_settlement_data, false),
         ]
         .into_iter()
-        .any(|settlement_data| {
-            settlement_data
+        .filter_map(|(settlement_data, for_remote)| {
+            let mut has_matching_tlc = false;
+            let mut has_exact_settlement = false;
+            let mut has_unsettled_tlc = false;
+            for tlc in settlement_data
                 .tlcs
                 .iter()
-                .any(|tlc| &tlc.payment_hash == payment_hash)
+                .filter(|tlc| &tlc.payment_hash == payment_hash)
+            {
+                has_matching_tlc = true;
+                let tlc_id = if for_remote {
+                    tlc.tlc_id
+                } else {
+                    tlc.tlc_id.flip()
+                };
+                let is_exactly_settled = self
+                    .get(Self::tlc_on_chain_settled_key(
+                        &channel_data.channel_id,
+                        tlc_id,
+                    ))
+                    .map(|value| {
+                        deserialize_from::<OnChainTlcSettlement>(
+                            value.as_ref(),
+                            "OnChainTlcSettlement",
+                        )
+                    })
+                    .is_some_and(|settlement| {
+                        settlement.payment_hash == tlc.payment_hash
+                            && settlement.hash_algorithm == tlc.hash_algorithm
+                    });
+                has_exact_settlement |= is_exactly_settled;
+                has_unsettled_tlc |= !is_exactly_settled;
+            }
+            has_matching_tlc.then_some((has_exact_settlement, has_unsettled_tlc))
         })
+        .collect::<Vec<_>>();
+
+        // ChannelData retains several candidate commitment snapshots. Once an exact settlement
+        // exists, only snapshots containing exact evidence can represent the active on-chain
+        // chain. Within those candidates every same-hash TLC must be settled before its shared
+        // preimage can be removed. Prefix-keyed legacy records intentionally provide no evidence
+        // here because they cannot identify a specific TLC.
+        if snapshot_statuses
+            .iter()
+            .any(|(has_exact_settlement, _)| *has_exact_settlement)
+        {
+            snapshot_statuses
+                .iter()
+                .any(|(has_exact_settlement, has_unsettled_tlc)| {
+                    *has_exact_settlement && *has_unsettled_tlc
+                })
+        } else {
+            !snapshot_statuses.is_empty()
+        }
     }
 
     fn watch_channel_payment_hashes(channel_data: &ChannelData) -> HashSet<Hash256> {
@@ -1659,18 +1676,6 @@ impl WatchtowerStore for Store {
             .map(|v| deserialize_from(v.as_ref(), "Preimage"))
     }
 
-    fn search_preimage(&self, node_id: &NodeId, payment_hash_prefix: &[u8]) -> Option<Hash256> {
-        let prefix = [&[WATCHTOWER_PREIMAGE_PREFIX], payment_hash_prefix].concat();
-        self.collect_by_prefix(prefix.as_slice())
-            .into_iter()
-            .find(|kv| {
-                let key = &kv.key;
-                let node_offset = 1 + 32;
-                key.len() >= node_offset && key[node_offset..] == node_id.as_ref()[..]
-            })
-            .map(|kv| deserialize_from(kv.value.as_ref(), "Preimage"))
-    }
-
     fn insert_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
@@ -1692,12 +1697,9 @@ impl WatchtowerStore for Store {
         batch.put(key, serialize_to_vec(&settlement, "OnChainTlcSettlement"));
         batch.commit();
         if settlement.preimage.is_none() {
-            let payment_hash_prefix: [u8; 20] = settlement.payment_hash.as_ref()[0..20]
-                .try_into()
-                .expect("payment hash prefix");
             self.cleanup_unused_watch_preimages(
                 None,
-                WatchtowerPreimageCleanupTarget::TlcPaymentHash(&payment_hash_prefix),
+                WatchtowerPreimageCleanupTarget::Exact(&settlement.payment_hash),
             );
         }
     }

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -614,7 +614,7 @@ impl Store {
         .concat()
     }
 
-    fn tlc_on_chain_settled_key(channel_id: &Hash256, tlc_id: TLCId) -> Vec<u8> {
+    fn tlc_on_chain_settled_key(node_id: &NodeId, channel_id: &Hash256, tlc_id: TLCId) -> Vec<u8> {
         let (direction, id) = match tlc_id {
             TLCId::Offered(id) => (0u8, id),
             TLCId::Received(id) => (1u8, id),
@@ -622,8 +622,9 @@ impl Store {
         [
             &[WATCHTOWER_TLC_SETTLED_PREFIX],
             channel_id.as_ref(),
-            &[1u8, direction],
+            &[2u8, direction],
             &id.to_be_bytes(),
+            node_id.as_ref(),
         ]
         .concat()
     }
@@ -683,6 +684,7 @@ impl Store {
 
     fn watch_channel_needs_preimage(
         &self,
+        node_id: &NodeId,
         channel_data: &ChannelData,
         payment_hash: &Hash256,
     ) -> bool {
@@ -709,6 +711,7 @@ impl Store {
                 };
                 let is_exactly_settled = self
                     .get(Self::tlc_on_chain_settled_key(
+                        node_id,
                         &channel_data.channel_id,
                         tlc_id,
                     ))
@@ -762,7 +765,9 @@ impl Store {
     fn watch_preimage_in_use(&self, node_id: &NodeId, payment_hash: &Hash256) -> bool {
         self.watch_channels_for_node(node_id)
             .iter()
-            .any(|channel_data| self.watch_channel_needs_preimage(channel_data, payment_hash))
+            .any(|channel_data| {
+                self.watch_channel_needs_preimage(node_id, channel_data, payment_hash)
+            })
     }
 
     fn watch_preimage_entries(&self, node_id: Option<&NodeId>) -> Vec<(NodeId, Hash256)> {
@@ -1050,7 +1055,13 @@ impl ChannelActorStateStore for Store {
     ) -> Option<StoredOnChainTlcSettlement> {
         #[cfg(feature = "watchtower")]
         {
-            WatchtowerStore::get_onchain_tlc_settlement(self, channel_id, tlc_id, payment_hash)
+            WatchtowerStore::get_onchain_tlc_settlement(
+                self,
+                &NodeId::local(),
+                channel_id,
+                tlc_id,
+                payment_hash,
+            )
         }
         #[cfg(not(feature = "watchtower"))]
         {
@@ -1678,11 +1689,12 @@ impl WatchtowerStore for Store {
 
     fn insert_onchain_tlc_settlement(
         &self,
+        node_id: &NodeId,
         channel_id: &Hash256,
         tlc_id: TLCId,
         settlement: OnChainTlcSettlement,
     ) {
-        let key = Self::tlc_on_chain_settled_key(channel_id, tlc_id);
+        let key = Self::tlc_on_chain_settled_key(node_id, channel_id, tlc_id);
         if settlement.preimage.is_none() {
             if let Some(existing) = self.get(&key) {
                 let existing: OnChainTlcSettlement =
@@ -1706,11 +1718,13 @@ impl WatchtowerStore for Store {
 
     fn get_onchain_tlc_settlement(
         &self,
+        node_id: &NodeId,
         channel_id: &Hash256,
         tlc_id: TLCId,
         payment_hash: &Hash256,
     ) -> Option<StoredOnChainTlcSettlement> {
-        if let Some(value) = self.get(Store::tlc_on_chain_settled_key(channel_id, tlc_id)) {
+        if let Some(value) = self.get(Store::tlc_on_chain_settled_key(node_id, channel_id, tlc_id))
+        {
             return Some(StoredOnChainTlcSettlement::Exact(deserialize_from(
                 value.as_ref(),
                 "OnChainTlcSettlement",

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::cch::{CchOrderStore, CchStoreError};
 use crate::fiber::gossip::GossipMessageStore;
-use crate::fiber::onchain_tlc_reconcile::OnChainTlcSettlement;
+use crate::fiber::onchain_tlc_reconcile::{LegacyOnChainTlcSettlement, OnChainTlcSettlement};
 use crate::fiber::types::HoldTlc;
 #[cfg(feature = "watchtower")]
 use crate::watchtower::WatchtowerStore;
@@ -35,7 +35,7 @@ use fiber_types::schema::*;
 use fiber_types::{
     Attempt, AttemptStatus, BroadcastMessage, BroadcastMessageID, ChannelOpenRecord, ChannelState,
     Cursor, Direction, Hash256, PaymentCustomRecords, PaymentSession, PaymentStatus,
-    PersistentNetworkActorState, Pubkey, TimedResult, CURSOR_SIZE,
+    PersistentNetworkActorState, Pubkey, TLCId, TimedResult, CURSOR_SIZE,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use fiber_types::{CchOrder, CchReceiveBtcOrderCreation};
@@ -607,11 +607,25 @@ impl StoreKeyValue for KeyValue {
 
 #[cfg(feature = "watchtower")]
 impl Store {
-    fn tlc_on_chain_settled_key(channel_id: &Hash256, payment_hash: &[u8; 20]) -> Vec<u8> {
+    fn legacy_tlc_on_chain_settled_key(channel_id: &Hash256, payment_hash: &[u8; 20]) -> Vec<u8> {
         [
             &[WATCHTOWER_TLC_SETTLED_PREFIX],
             channel_id.as_ref(),
             payment_hash.as_ref(),
+        ]
+        .concat()
+    }
+
+    fn tlc_on_chain_settled_key(channel_id: &Hash256, tlc_id: TLCId) -> Vec<u8> {
+        let (direction, id) = match tlc_id {
+            TLCId::Offered(id) => (0u8, id),
+            TLCId::Received(id) => (1u8, id),
+        };
+        [
+            &[WATCHTOWER_TLC_SETTLED_PREFIX],
+            channel_id.as_ref(),
+            &[1u8, direction],
+            &id.to_be_bytes(),
         ]
         .concat()
     }
@@ -674,7 +688,26 @@ impl Store {
         channel_data: &ChannelData,
         payment_hash: &Hash256,
     ) -> bool {
-        if WatchtowerStore::get_onchain_tlc_settlement(self, &channel_data.channel_id, payment_hash)
+        let exact_key_prefix = [
+            &[WATCHTOWER_TLC_SETTLED_PREFIX],
+            channel_data.channel_id.as_ref(),
+            &[1u8],
+        ]
+        .concat();
+        let has_exact_settlement = self
+            .collect_by_prefix(&exact_key_prefix)
+            .into_iter()
+            .filter(|kv| kv.key.len() == 1 + 32 + 2 + 8)
+            .map(|kv| {
+                deserialize_from::<OnChainTlcSettlement>(kv.value.as_ref(), "OnChainTlcSettlement")
+            })
+            .any(|settlement| &settlement.payment_hash == payment_hash);
+        if has_exact_settlement
+            || WatchtowerStore::get_legacy_onchain_tlc_settlement(
+                self,
+                &channel_data.channel_id,
+                payment_hash,
+            )
             .is_some()
         {
             return false;
@@ -991,11 +1024,27 @@ impl ChannelActorStateStore for Store {
     fn get_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
-        payment_hash: &Hash256,
+        tlc_id: TLCId,
     ) -> Option<OnChainTlcSettlement> {
         #[cfg(feature = "watchtower")]
         {
-            WatchtowerStore::get_onchain_tlc_settlement(self, channel_id, payment_hash)
+            WatchtowerStore::get_onchain_tlc_settlement(self, channel_id, tlc_id)
+        }
+        #[cfg(not(feature = "watchtower"))]
+        {
+            let _ = (channel_id, tlc_id);
+            None
+        }
+    }
+
+    fn get_legacy_onchain_tlc_settlement(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<LegacyOnChainTlcSettlement> {
+        #[cfg(feature = "watchtower")]
+        {
+            WatchtowerStore::get_legacy_onchain_tlc_settlement(self, channel_id, payment_hash)
         }
         #[cfg(not(feature = "watchtower"))]
         {
@@ -1636,21 +1685,14 @@ impl WatchtowerStore for Store {
     fn insert_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
-        payment_hash_prefix: [u8; 20],
+        tlc_id: TLCId,
         settlement: OnChainTlcSettlement,
     ) {
-        let key = Self::tlc_on_chain_settled_key(channel_id, &payment_hash_prefix);
+        let key = Self::tlc_on_chain_settled_key(channel_id, tlc_id);
         if settlement.preimage.is_none() {
             if let Some(existing) = self.get(&key) {
-                let existing = if existing.is_empty() {
-                    OnChainTlcSettlement {
-                        preimage: None,
-                        tx_hash: None,
-                        tlc_index: None,
-                    }
-                } else {
-                    deserialize_from(existing.as_ref(), "OnChainTlcSettlement")
-                };
+                let existing: OnChainTlcSettlement =
+                    deserialize_from(existing.as_ref(), "OnChainTlcSettlement");
                 if existing.preimage.is_some() {
                     return;
                 }
@@ -1661,6 +1703,9 @@ impl WatchtowerStore for Store {
         batch.put(key, serialize_to_vec(&settlement, "OnChainTlcSettlement"));
         batch.commit();
         if settlement.preimage.is_none() {
+            let payment_hash_prefix: [u8; 20] = settlement.payment_hash.as_ref()[0..20]
+                .try_into()
+                .expect("payment hash prefix");
             self.cleanup_unused_watch_preimages(
                 None,
                 WatchtowerPreimageCleanupTarget::TlcPaymentHash(&payment_hash_prefix),
@@ -1671,23 +1716,35 @@ impl WatchtowerStore for Store {
     fn get_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
-        payment_hash: &Hash256,
+        tlc_id: TLCId,
     ) -> Option<OnChainTlcSettlement> {
+        self.get(Store::tlc_on_chain_settled_key(channel_id, tlc_id))
+            .map(|value| deserialize_from(value.as_ref(), "OnChainTlcSettlement"))
+    }
+
+    fn get_legacy_onchain_tlc_settlement(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<LegacyOnChainTlcSettlement> {
         let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
             .try_into()
             .expect("payment hash prefix");
-        let value = self.get(Store::tlc_on_chain_settled_key(
+        let value = self.get(Store::legacy_tlc_on_chain_settled_key(
             channel_id,
             &payment_hash_prefix,
         ))?;
         if value.is_empty() {
-            return Some(OnChainTlcSettlement {
+            return Some(LegacyOnChainTlcSettlement {
                 preimage: None,
                 tx_hash: None,
                 tlc_index: None,
             });
         }
-        Some(deserialize_from(value.as_ref(), "OnChainTlcSettlement"))
+        Some(deserialize_from(
+            value.as_ref(),
+            "LegacyOnChainTlcSettlement",
+        ))
     }
 }
 

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::cch::{CchOrderStore, CchStoreError};
 use crate::fiber::gossip::GossipMessageStore;
+use crate::fiber::onchain_tlc_reconcile::StoredOnChainTlcSettlement;
+#[cfg(feature = "watchtower")]
 use crate::fiber::onchain_tlc_reconcile::{LegacyOnChainTlcSettlement, OnChainTlcSettlement};
 use crate::fiber::types::HoldTlc;
 #[cfg(feature = "watchtower")]
@@ -702,14 +704,16 @@ impl Store {
                 deserialize_from::<OnChainTlcSettlement>(kv.value.as_ref(), "OnChainTlcSettlement")
             })
             .any(|settlement| &settlement.payment_hash == payment_hash);
-        if has_exact_settlement
-            || WatchtowerStore::get_legacy_onchain_tlc_settlement(
-                self,
+        let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
+            .try_into()
+            .expect("payment hash prefix");
+        let has_legacy_settlement = self
+            .get(Self::legacy_tlc_on_chain_settled_key(
                 &channel_data.channel_id,
-                payment_hash,
-            )
-            .is_some()
-        {
+                &payment_hash_prefix,
+            ))
+            .is_some();
+        if has_exact_settlement || has_legacy_settlement {
             return false;
         }
 
@@ -1025,30 +1029,15 @@ impl ChannelActorStateStore for Store {
         &self,
         channel_id: &Hash256,
         tlc_id: TLCId,
-    ) -> Option<OnChainTlcSettlement> {
-        #[cfg(feature = "watchtower")]
-        {
-            WatchtowerStore::get_onchain_tlc_settlement(self, channel_id, tlc_id)
-        }
-        #[cfg(not(feature = "watchtower"))]
-        {
-            let _ = (channel_id, tlc_id);
-            None
-        }
-    }
-
-    fn get_legacy_onchain_tlc_settlement(
-        &self,
-        channel_id: &Hash256,
         payment_hash: &Hash256,
-    ) -> Option<LegacyOnChainTlcSettlement> {
+    ) -> Option<StoredOnChainTlcSettlement> {
         #[cfg(feature = "watchtower")]
         {
-            WatchtowerStore::get_legacy_onchain_tlc_settlement(self, channel_id, payment_hash)
+            WatchtowerStore::get_onchain_tlc_settlement(self, channel_id, tlc_id, payment_hash)
         }
         #[cfg(not(feature = "watchtower"))]
         {
-            let _ = (channel_id, payment_hash);
+            let _ = (channel_id, tlc_id, payment_hash);
             None
         }
     }
@@ -1717,16 +1706,15 @@ impl WatchtowerStore for Store {
         &self,
         channel_id: &Hash256,
         tlc_id: TLCId,
-    ) -> Option<OnChainTlcSettlement> {
-        self.get(Store::tlc_on_chain_settled_key(channel_id, tlc_id))
-            .map(|value| deserialize_from(value.as_ref(), "OnChainTlcSettlement"))
-    }
-
-    fn get_legacy_onchain_tlc_settlement(
-        &self,
-        channel_id: &Hash256,
         payment_hash: &Hash256,
-    ) -> Option<LegacyOnChainTlcSettlement> {
+    ) -> Option<StoredOnChainTlcSettlement> {
+        if let Some(value) = self.get(Store::tlc_on_chain_settled_key(channel_id, tlc_id)) {
+            return Some(StoredOnChainTlcSettlement::Exact(deserialize_from(
+                value.as_ref(),
+                "OnChainTlcSettlement",
+            )));
+        }
+
         let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
             .try_into()
             .expect("payment hash prefix");
@@ -1735,16 +1723,18 @@ impl WatchtowerStore for Store {
             &payment_hash_prefix,
         ))?;
         if value.is_empty() {
-            return Some(LegacyOnChainTlcSettlement {
-                preimage: None,
-                tx_hash: None,
-                tlc_index: None,
-            });
+            return Some(StoredOnChainTlcSettlement::Legacy(
+                LegacyOnChainTlcSettlement {
+                    preimage: None,
+                    tx_hash: None,
+                    tlc_index: None,
+                },
+            ));
         }
-        Some(deserialize_from(
+        Some(StoredOnChainTlcSettlement::Legacy(deserialize_from(
             value.as_ref(),
             "LegacyOnChainTlcSettlement",
-        ))
+        )))
     }
 }
 

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -564,6 +564,7 @@ fn test_store_watchtower_preimage_gc_waits_for_watched_tlc() {
     );
 
     store.insert_onchain_tlc_settlement(
+        &node_id,
         &channel_id,
         TLCId::Offered(0),
         OnChainTlcSettlement {
@@ -627,6 +628,7 @@ fn test_store_watchtower_preimage_gc_waits_for_same_hash_sibling_tlc() {
     store.insert_watch_preimage(node_id.clone(), payment_hash, preimage);
 
     store.insert_onchain_tlc_settlement(
+        &node_id,
         &channel_id,
         TLCId::Offered(0),
         OnChainTlcSettlement {
@@ -642,6 +644,69 @@ fn test_store_watchtower_preimage_gc_waits_for_same_hash_sibling_tlc() {
         store.get_watch_preimage(&node_id, &payment_hash),
         Some(preimage),
         "the sibling TLC with the same payment hash still needs the preimage"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_store_watchtower_preimage_gc_isolated_between_tenants() {
+    let path = TempDir::new("test-watchtower-preimage-gc-tenant-scope");
+    let store = open_store(path).expect("created store failed");
+
+    let node_id_a = NodeId::from_bytes(PeerId::random().into_bytes());
+    let node_id_b = NodeId::from_bytes(PeerId::random().into_bytes());
+    let channel_id = gen_rand_sha256_hash();
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash: Hash256 = HashAlgorithm::CkbHash.hash(preimage).into();
+    let settlement_data = SettlementData {
+        local_amount: 100,
+        remote_amount: 200,
+        tlcs: vec![SettlementTlc {
+            tlc_id: TLCId::Offered(0),
+            hash_algorithm: HashAlgorithm::CkbHash,
+            payment_amount: 42,
+            payment_hash,
+            expiry: now_timestamp_as_millis_u64() + 60_000,
+            local_key: Privkey::from(&[5; 32]),
+            remote_key: Privkey::from(&[6; 32]).pubkey(),
+        }],
+    };
+
+    for node_id in [&node_id_a, &node_id_b] {
+        store.insert_watch_channel(
+            node_id.clone(),
+            channel_id,
+            None,
+            Privkey::from(&[1; 32]),
+            Privkey::from(&[2; 32]).pubkey(),
+            Privkey::from(&[3; 32]).pubkey(),
+            Privkey::from(&[4; 32]).pubkey(),
+            settlement_data.clone(),
+        );
+        store.insert_watch_preimage(node_id.clone(), payment_hash, preimage);
+    }
+
+    // This settlement belongs to node A's watched channel. Node B still needs its independently
+    // scoped preimage for a TLC with the same endpoint-local identity and complete payment hash.
+    store.insert_onchain_tlc_settlement(
+        &node_id_a,
+        &channel_id,
+        TLCId::Offered(0),
+        OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            preimage: None,
+            tx_hash: gen_rand_sha256_hash(),
+            tlc_index: 0,
+        },
+    );
+
+    assert_eq!(store.get_watch_preimage(&node_id_a, &payment_hash), None);
+    assert_eq!(
+        store.get_watch_preimage(&node_id_b, &payment_hash),
+        Some(preimage),
+        "one tenant's settlement must not garbage-collect another tenant's preimage"
     );
 }
 
@@ -711,9 +776,16 @@ fn test_onchain_tlc_settlement_roundtrip() {
     let other_channel_id = Hash256::from([2u8; 32]);
     let payment_hash = Hash256::from([3u8; 32]);
     let tlc_id = TLCId::Received(42);
+    let node_id = NodeId::local();
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id,
+            &channel_id,
+            tlc_id,
+            &payment_hash,
+        ),
         None
     );
 
@@ -724,15 +796,22 @@ fn test_onchain_tlc_settlement_roundtrip() {
         tx_hash: Hash256::from([7u8; 32]),
         tlc_index: 2,
     };
-    store.insert_onchain_tlc_settlement(&channel_id, tlc_id, settlement.clone());
+    store.insert_onchain_tlc_settlement(&node_id, &channel_id, tlc_id, settlement.clone());
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id,
+            &channel_id,
+            tlc_id,
+            &payment_hash,
+        ),
         Some(StoredOnChainTlcSettlement::Exact(settlement))
     );
     assert_eq!(
         WatchtowerStore::get_onchain_tlc_settlement(
             &store,
+            &node_id,
             &other_channel_id,
             tlc_id,
             &payment_hash,
@@ -754,6 +833,7 @@ fn test_onchain_tlc_settlements_with_shared_prefix_are_independent() {
     let second_hash = Hash256::from(second_hash_bytes);
     let first_id = TLCId::Offered(0);
     let second_id = TLCId::Offered(1);
+    let node_id = NodeId::local();
     let first = OnChainTlcSettlement {
         payment_hash: first_hash,
         hash_algorithm: HashAlgorithm::CkbHash,
@@ -769,15 +849,27 @@ fn test_onchain_tlc_settlements_with_shared_prefix_are_independent() {
         tlc_index: 1,
     };
 
-    store.insert_onchain_tlc_settlement(&channel_id, first_id, first.clone());
-    store.insert_onchain_tlc_settlement(&channel_id, second_id, second.clone());
+    store.insert_onchain_tlc_settlement(&node_id, &channel_id, first_id, first.clone());
+    store.insert_onchain_tlc_settlement(&node_id, &channel_id, second_id, second.clone());
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, first_id, &first_hash,),
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id,
+            &channel_id,
+            first_id,
+            &first_hash,
+        ),
         Some(StoredOnChainTlcSettlement::Exact(first))
     );
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, second_id, &second_hash,),
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id,
+            &channel_id,
+            second_id,
+            &second_hash,
+        ),
         Some(StoredOnChainTlcSettlement::Exact(second))
     );
 }
@@ -791,6 +883,7 @@ fn test_onchain_tlc_settlement_no_preimage_does_not_downgrade() {
     let channel_id = Hash256::from([1u8; 32]);
     let payment_hash = Hash256::from([3u8; 32]);
     let tlc_id = TLCId::Offered(0);
+    let node_id = NodeId::local();
 
     let with_preimage = OnChainTlcSettlement {
         payment_hash,
@@ -799,8 +892,9 @@ fn test_onchain_tlc_settlement_no_preimage_does_not_downgrade() {
         tx_hash: Hash256::from([7u8; 32]),
         tlc_index: 0,
     };
-    store.insert_onchain_tlc_settlement(&channel_id, tlc_id, with_preimage.clone());
+    store.insert_onchain_tlc_settlement(&node_id, &channel_id, tlc_id, with_preimage.clone());
     store.insert_onchain_tlc_settlement(
+        &node_id,
         &channel_id,
         tlc_id,
         OnChainTlcSettlement {
@@ -813,8 +907,85 @@ fn test_onchain_tlc_settlement_no_preimage_does_not_downgrade() {
     );
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id,
+            &channel_id,
+            tlc_id,
+            &payment_hash,
+        ),
         Some(StoredOnChainTlcSettlement::Exact(with_preimage))
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_onchain_tlc_settlements_are_isolated_between_watchtower_tenants() {
+    let path = TempDir::new("test-onchain-tlc-settlement-tenant-scope");
+    let store = open_store(path).expect("created store failed");
+    let channel_id = Hash256::from([1u8; 32]);
+    let payment_hash = Hash256::from([3u8; 32]);
+    let tlc_id = TLCId::Offered(0);
+    let node_id_a = NodeId::from_bytes(PeerId::random().into_bytes());
+    let node_id_b = NodeId::from_bytes(PeerId::random().into_bytes());
+
+    store.insert_onchain_tlc_settlement(
+        &node_id_a,
+        &channel_id,
+        tlc_id,
+        OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            preimage: Some(Hash256::from([9u8; 32])),
+            tx_hash: Hash256::from([7u8; 32]),
+            tlc_index: 0,
+        },
+    );
+    store.insert_onchain_tlc_settlement(
+        &node_id_b,
+        &channel_id,
+        tlc_id,
+        OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            preimage: None,
+            tx_hash: Hash256::from([8u8; 32]),
+            tlc_index: 0,
+        },
+    );
+
+    assert_eq!(
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id_a,
+            &channel_id,
+            tlc_id,
+            &payment_hash,
+        ),
+        Some(StoredOnChainTlcSettlement::Exact(OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            preimage: Some(Hash256::from([9u8; 32])),
+            tx_hash: Hash256::from([7u8; 32]),
+            tlc_index: 0,
+        }))
+    );
+    assert_eq!(
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id_b,
+            &channel_id,
+            tlc_id,
+            &payment_hash,
+        ),
+        Some(StoredOnChainTlcSettlement::Exact(OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            preimage: None,
+            tx_hash: Hash256::from([8u8; 32]),
+            tlc_index: 0,
+        }))
     );
 }
 
@@ -836,9 +1007,16 @@ fn test_onchain_tlc_settlement_legacy_empty_value() {
 
     store.put(key, []);
     let tlc_id = TLCId::Offered(0);
+    let node_id = NodeId::local();
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id,
+            &channel_id,
+            tlc_id,
+            &payment_hash,
+        ),
         Some(StoredOnChainTlcSettlement::Legacy(
             LegacyOnChainTlcSettlement {
                 preimage: None,
@@ -855,9 +1033,15 @@ fn test_onchain_tlc_settlement_legacy_empty_value() {
         tx_hash: Hash256::from([7u8; 32]),
         tlc_index: 0,
     };
-    store.insert_onchain_tlc_settlement(&channel_id, tlc_id, exact.clone());
+    store.insert_onchain_tlc_settlement(&node_id, &channel_id, tlc_id, exact.clone());
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &node_id,
+            &channel_id,
+            tlc_id,
+            &payment_hash,
+        ),
         Some(StoredOnChainTlcSettlement::Exact(exact)),
         "the unified lookup must prefer an exact record over the legacy prefix fallback"
     );

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -2,7 +2,9 @@ use crate::ckb::signer::LocalSigner;
 use crate::fiber::channel::*;
 use crate::fiber::gossip::{get_latest_startup_broadcast_message_cursor, GossipMessageStore};
 use crate::fiber::network::get_chain_hash;
-use crate::fiber::onchain_tlc_reconcile::{LegacyOnChainTlcSettlement, OnChainTlcSettlement};
+use crate::fiber::onchain_tlc_reconcile::{
+    LegacyOnChainTlcSettlement, OnChainTlcSettlement, StoredOnChainTlcSettlement,
+};
 use crate::fiber::types::new_channel_update_unsigned;
 use crate::fiber::types::*;
 #[allow(unused)]
@@ -648,7 +650,7 @@ fn test_onchain_tlc_settlement_roundtrip() {
     let tlc_id = TLCId::Received(42);
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id),
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
         None
     );
 
@@ -662,11 +664,16 @@ fn test_onchain_tlc_settlement_roundtrip() {
     store.insert_onchain_tlc_settlement(&channel_id, tlc_id, settlement.clone());
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id),
-        Some(settlement)
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        Some(StoredOnChainTlcSettlement::Exact(settlement))
     );
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &other_channel_id, tlc_id),
+        WatchtowerStore::get_onchain_tlc_settlement(
+            &store,
+            &other_channel_id,
+            tlc_id,
+            &payment_hash,
+        ),
         None
     );
 }
@@ -703,12 +710,12 @@ fn test_onchain_tlc_settlements_with_shared_prefix_are_independent() {
     store.insert_onchain_tlc_settlement(&channel_id, second_id, second.clone());
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, first_id),
-        Some(first)
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, first_id, &first_hash,),
+        Some(StoredOnChainTlcSettlement::Exact(first))
     );
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, second_id),
-        Some(second)
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, second_id, &second_hash,),
+        Some(StoredOnChainTlcSettlement::Exact(second))
     );
 }
 
@@ -743,8 +750,8 @@ fn test_onchain_tlc_settlement_no_preimage_does_not_downgrade() {
     );
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id),
-        Some(with_preimage)
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        Some(StoredOnChainTlcSettlement::Exact(with_preimage))
     );
 }
 
@@ -765,14 +772,31 @@ fn test_onchain_tlc_settlement_legacy_empty_value() {
     .concat();
 
     store.put(key, []);
+    let tlc_id = TLCId::Offered(0);
 
     assert_eq!(
-        WatchtowerStore::get_legacy_onchain_tlc_settlement(&store, &channel_id, &payment_hash,),
-        Some(LegacyOnChainTlcSettlement {
-            preimage: None,
-            tx_hash: None,
-            tlc_index: None,
-        })
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        Some(StoredOnChainTlcSettlement::Legacy(
+            LegacyOnChainTlcSettlement {
+                preimage: None,
+                tx_hash: None,
+                tlc_index: None,
+            }
+        ))
+    );
+
+    let exact = OnChainTlcSettlement {
+        payment_hash,
+        hash_algorithm: HashAlgorithm::CkbHash,
+        preimage: None,
+        tx_hash: Hash256::from([7u8; 32]),
+        tlc_index: 0,
+    };
+    store.insert_onchain_tlc_settlement(&channel_id, tlc_id, exact.clone());
+    assert_eq!(
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id, &payment_hash,),
+        Some(StoredOnChainTlcSettlement::Exact(exact)),
+        "the unified lookup must prefer an exact record over the legacy prefix fallback"
     );
 }
 

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -2,7 +2,7 @@ use crate::ckb::signer::LocalSigner;
 use crate::fiber::channel::*;
 use crate::fiber::gossip::{get_latest_startup_broadcast_message_cursor, GossipMessageStore};
 use crate::fiber::network::get_chain_hash;
-use crate::fiber::onchain_tlc_reconcile::OnChainTlcSettlement;
+use crate::fiber::onchain_tlc_reconcile::{LegacyOnChainTlcSettlement, OnChainTlcSettlement};
 use crate::fiber::types::new_channel_update_unsigned;
 use crate::fiber::types::*;
 #[allow(unused)]
@@ -619,14 +619,15 @@ fn test_store_watchtower_preimage_gc_waits_for_watched_tlc() {
         "preimage is retained while a watched TLC still references it"
     );
 
-    let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[..20].try_into().unwrap();
     store.insert_onchain_tlc_settlement(
         &channel_id,
-        payment_hash_prefix,
+        TLCId::Offered(0),
         OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
             preimage: None,
-            tx_hash: Some(gen_rand_sha256_hash()),
-            tlc_index: Some(0),
+            tx_hash: gen_rand_sha256_hash(),
+            tlc_index: 0,
         },
     );
     assert!(
@@ -644,27 +645,70 @@ fn test_onchain_tlc_settlement_roundtrip() {
     let channel_id = Hash256::from([1u8; 32]);
     let other_channel_id = Hash256::from([2u8; 32]);
     let payment_hash = Hash256::from([3u8; 32]);
-    let prefix: [u8; 20] = payment_hash.as_ref()[0..20].try_into().unwrap();
+    let tlc_id = TLCId::Received(42);
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, &payment_hash),
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id),
         None
     );
 
     let settlement = OnChainTlcSettlement {
+        payment_hash,
+        hash_algorithm: HashAlgorithm::Sha256,
         preimage: Some(Hash256::from([9u8; 32])),
-        tx_hash: Some(Hash256::from([7u8; 32])),
-        tlc_index: Some(2),
+        tx_hash: Hash256::from([7u8; 32]),
+        tlc_index: 2,
     };
-    store.insert_onchain_tlc_settlement(&channel_id, prefix, settlement.clone());
+    store.insert_onchain_tlc_settlement(&channel_id, tlc_id, settlement.clone());
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, &payment_hash),
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id),
         Some(settlement)
     );
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &other_channel_id, &payment_hash),
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &other_channel_id, tlc_id),
         None
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_onchain_tlc_settlements_with_shared_prefix_are_independent() {
+    let path = TempDir::new("test-onchain-tlc-settlement-shared-prefix");
+    let store = open_store(path).expect("created store failed");
+    let channel_id = Hash256::from([1u8; 32]);
+    let first_hash = Hash256::from([3u8; 32]);
+    let mut second_hash_bytes = [3u8; 32];
+    second_hash_bytes[31] = 4;
+    let second_hash = Hash256::from(second_hash_bytes);
+    let first_id = TLCId::Offered(0);
+    let second_id = TLCId::Offered(1);
+    let first = OnChainTlcSettlement {
+        payment_hash: first_hash,
+        hash_algorithm: HashAlgorithm::CkbHash,
+        preimage: None,
+        tx_hash: Hash256::from([7u8; 32]),
+        tlc_index: 0,
+    };
+    let second = OnChainTlcSettlement {
+        payment_hash: second_hash,
+        hash_algorithm: HashAlgorithm::CkbHash,
+        preimage: None,
+        tx_hash: Hash256::from([8u8; 32]),
+        tlc_index: 1,
+    };
+
+    store.insert_onchain_tlc_settlement(&channel_id, first_id, first.clone());
+    store.insert_onchain_tlc_settlement(&channel_id, second_id, second.clone());
+
+    assert_eq!(
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, first_id),
+        Some(first)
+    );
+    assert_eq!(
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, second_id),
+        Some(second)
     );
 }
 
@@ -676,26 +720,30 @@ fn test_onchain_tlc_settlement_no_preimage_does_not_downgrade() {
     let store = open_store(path).expect("created store failed");
     let channel_id = Hash256::from([1u8; 32]);
     let payment_hash = Hash256::from([3u8; 32]);
-    let prefix: [u8; 20] = payment_hash.as_ref()[0..20].try_into().unwrap();
+    let tlc_id = TLCId::Offered(0);
 
     let with_preimage = OnChainTlcSettlement {
+        payment_hash,
+        hash_algorithm: HashAlgorithm::CkbHash,
         preimage: Some(Hash256::from([9u8; 32])),
-        tx_hash: Some(Hash256::from([7u8; 32])),
-        tlc_index: Some(0),
+        tx_hash: Hash256::from([7u8; 32]),
+        tlc_index: 0,
     };
-    store.insert_onchain_tlc_settlement(&channel_id, prefix, with_preimage.clone());
+    store.insert_onchain_tlc_settlement(&channel_id, tlc_id, with_preimage.clone());
     store.insert_onchain_tlc_settlement(
         &channel_id,
-        prefix,
+        tlc_id,
         OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
             preimage: None,
-            tx_hash: Some(Hash256::from([8u8; 32])),
-            tlc_index: Some(0),
+            tx_hash: Hash256::from([8u8; 32]),
+            tlc_index: 0,
         },
     );
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, &payment_hash),
+        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, tlc_id),
         Some(with_preimage)
     );
 }
@@ -719,8 +767,8 @@ fn test_onchain_tlc_settlement_legacy_empty_value() {
     store.put(key, []);
 
     assert_eq!(
-        WatchtowerStore::get_onchain_tlc_settlement(&store, &channel_id, &payment_hash),
-        Some(OnChainTlcSettlement {
+        WatchtowerStore::get_legacy_onchain_tlc_settlement(&store, &channel_id, &payment_hash,),
+        Some(LegacyOnChainTlcSettlement {
             preimage: None,
             tx_hash: None,
             tlc_index: None,

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -497,27 +497,6 @@ fn test_store_watchtower_preimage() {
         "query non exist watch preimage"
     );
 
-    assert!(
-        store
-            .search_preimage(&node_id_a, &payment_hash_c.as_ref()[..20])
-            .is_none(),
-        "search a non exist watch preimage"
-    );
-    // search preimage only returns watch preimage
-    assert_eq!(
-        store
-            .search_preimage(&node_id_a, &payment_hash_a.as_ref()[..20])
-            .unwrap(),
-        preimage_a,
-        "search"
-    );
-    assert!(
-        store
-            .search_preimage(&node_id_b, &payment_hash_a.as_ref()[..20])
-            .is_none(),
-        "search should not cross node scope"
-    );
-
     // delete preimage with wrong node
     store.remove_watch_preimage(node_id_a, payment_hash_b);
     assert!(
@@ -533,43 +512,6 @@ fn test_store_watchtower_preimage() {
             .get_watch_preimage(&node_id_b, &payment_hash_b)
             .is_none(),
         "removed"
-    );
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-fn test_store_watchtower_preimage_search_is_node_scoped_with_same_prefix() {
-    let path = TempDir::new("test-watchtower-store-same-prefix");
-    let store = open_store(path).expect("created store failed");
-
-    let node_id_a = NodeId::from_bytes(PeerId::random().into_bytes());
-    let node_id_b = NodeId::from_bytes(PeerId::random().into_bytes());
-
-    let preimage_a = gen_rand_sha256_hash();
-    let preimage_b = gen_rand_sha256_hash();
-
-    let mut payment_hash_bytes = [7u8; 32];
-    payment_hash_bytes[31] = 1;
-    let payment_hash_a: Hash256 = payment_hash_bytes.into();
-
-    payment_hash_bytes[31] = 2;
-    let payment_hash_b: Hash256 = payment_hash_bytes.into();
-
-    let payment_hash_prefix = &payment_hash_a.as_ref()[..20];
-
-    store.insert_watch_preimage(node_id_b.clone(), payment_hash_b, preimage_b);
-    store.insert_watch_preimage(node_id_a.clone(), payment_hash_a, preimage_a);
-
-    assert_eq!(
-        store.search_preimage(&node_id_a, payment_hash_prefix),
-        Some(preimage_a),
-        "search should skip another node's preimage with the same prefix"
-    );
-    assert_eq!(
-        store.search_preimage(&node_id_b, payment_hash_prefix),
-        Some(preimage_b),
-        "search should still find the matching node's preimage"
     );
 }
 
@@ -635,6 +577,127 @@ fn test_store_watchtower_preimage_gc_waits_for_watched_tlc() {
     assert!(
         store.get_watch_preimage(&node_id, &payment_hash).is_none(),
         "watchtower GC removes the preimage after the watched TLC is settled"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_store_watchtower_preimage_gc_waits_for_same_hash_sibling_tlc() {
+    let path = TempDir::new("test-watchtower-preimage-gc-same-hash-sibling");
+    let store = open_store(path).expect("created store failed");
+
+    let node_id = NodeId::local();
+    let channel_id = gen_rand_sha256_hash();
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = HashAlgorithm::CkbHash.hash(preimage).into();
+    let local_settlement_key = Privkey::from(&[1; 32]);
+    let remote_settlement_key = Privkey::from(&[2; 32]).pubkey();
+    let local_funding_pubkey = Privkey::from(&[3; 32]).pubkey();
+    let remote_funding_pubkey = Privkey::from(&[4; 32]).pubkey();
+    let first_tlc = SettlementTlc {
+        tlc_id: TLCId::Offered(0),
+        hash_algorithm: HashAlgorithm::CkbHash,
+        payment_amount: 21,
+        payment_hash,
+        expiry: now_timestamp_as_millis_u64() + 60_000,
+        local_key: Privkey::from(&[5; 32]),
+        remote_key: Privkey::from(&[6; 32]).pubkey(),
+    };
+    let mut second_tlc = first_tlc.clone();
+    second_tlc.tlc_id = TLCId::Offered(1);
+    second_tlc.local_key = Privkey::from(&[7; 32]);
+    second_tlc.remote_key = Privkey::from(&[8; 32]).pubkey();
+    let settlement_data = SettlementData {
+        local_amount: 100,
+        remote_amount: 200,
+        tlcs: vec![first_tlc, second_tlc],
+    };
+
+    store.insert_watch_channel(
+        node_id.clone(),
+        channel_id,
+        None,
+        local_settlement_key,
+        remote_settlement_key,
+        local_funding_pubkey,
+        remote_funding_pubkey,
+        settlement_data,
+    );
+    store.insert_watch_preimage(node_id.clone(), payment_hash, preimage);
+
+    store.insert_onchain_tlc_settlement(
+        &channel_id,
+        TLCId::Offered(0),
+        OnChainTlcSettlement {
+            payment_hash,
+            hash_algorithm: HashAlgorithm::CkbHash,
+            preimage: None,
+            tx_hash: gen_rand_sha256_hash(),
+            tlc_index: 0,
+        },
+    );
+
+    assert_eq!(
+        store.get_watch_preimage(&node_id, &payment_hash),
+        Some(preimage),
+        "the sibling TLC with the same payment hash still needs the preimage"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+fn test_store_watchtower_preimage_gc_ignores_ambiguous_legacy_settlement() {
+    let path = TempDir::new("test-watchtower-preimage-gc-legacy-ambiguous");
+    let store = open_store(path).expect("created store failed");
+
+    let node_id = NodeId::local();
+    let channel_id = gen_rand_sha256_hash();
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash: Hash256 = HashAlgorithm::CkbHash.hash(preimage).into();
+    let settlement_data = SettlementData {
+        local_amount: 100,
+        remote_amount: 200,
+        tlcs: vec![SettlementTlc {
+            tlc_id: TLCId::Offered(0),
+            hash_algorithm: HashAlgorithm::CkbHash,
+            payment_amount: 42,
+            payment_hash,
+            expiry: now_timestamp_as_millis_u64() + 60_000,
+            local_key: Privkey::from(&[5; 32]),
+            remote_key: Privkey::from(&[6; 32]).pubkey(),
+        }],
+    };
+
+    store.insert_watch_channel(
+        node_id.clone(),
+        channel_id,
+        None,
+        Privkey::from(&[1; 32]),
+        Privkey::from(&[2; 32]).pubkey(),
+        Privkey::from(&[3; 32]).pubkey(),
+        Privkey::from(&[4; 32]).pubkey(),
+        settlement_data,
+    );
+    store.insert_watch_preimage(node_id.clone(), payment_hash, preimage);
+
+    let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[..20]
+        .try_into()
+        .expect("payment hash prefix");
+    let legacy_key = [
+        &[WATCHTOWER_TLC_SETTLED_PREFIX],
+        channel_id.as_ref(),
+        payment_hash_prefix.as_ref(),
+    ]
+    .concat();
+    store.put(legacy_key, []);
+    store.remove_watch_preimage(node_id.clone(), payment_hash);
+
+    assert_eq!(
+        store.get_watch_preimage(&node_id, &payment_hash),
+        Some(preimage),
+        "a prefix-keyed legacy record cannot prove that this TLC no longer needs the preimage"
     );
 }
 

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -2252,6 +2252,8 @@ mod tests {
 
     use ckb_types::{core::ScriptHashType, packed::Byte32, prelude::*};
 
+    use crate::fiber::onchain_tlc_reconcile::StoredOnChainTlcSettlement;
+
     use super::*;
 
     #[derive(Default)]
@@ -2366,22 +2368,16 @@ mod tests {
             &self,
             channel_id: &Hash256,
             tlc_id: TLCId,
-        ) -> Option<OnChainTlcSettlement> {
+            _payment_hash: &Hash256,
+        ) -> Option<StoredOnChainTlcSettlement> {
             self.settlements
                 .lock()
                 .expect("lock poisoned")
                 .iter()
                 .find_map(|(id, stored_tlc_id, settlement)| {
-                    (id == channel_id && *stored_tlc_id == tlc_id).then(|| settlement.clone())
+                    (id == channel_id && *stored_tlc_id == tlc_id)
+                        .then(|| StoredOnChainTlcSettlement::Exact(settlement.clone()))
                 })
-        }
-
-        fn get_legacy_onchain_tlc_settlement(
-            &self,
-            _channel_id: &Hash256,
-            _payment_hash: &Hash256,
-        ) -> Option<crate::fiber::onchain_tlc_reconcile::LegacyOnChainTlcSettlement> {
-            None
         }
     }
 

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -36,7 +36,8 @@ use crate::{
         CkbConfig,
     },
     fiber::channel::{
-        settlement_data_to_witness, settlement_tlc_local_pubkey_hash, XUDT_COMPATIBLE_WITNESS,
+        settlement_data_to_witness, settlement_tlc_local_pubkey_hash, settlement_tlc_to_witness,
+        XUDT_COMPATIBLE_WITNESS,
     },
     fiber::onchain_tlc_reconcile::OnChainTlcSettlement,
     now_timestamp_as_millis_u64,
@@ -54,6 +55,7 @@ use crate::{
 };
 use fiber_types::{
     ChannelData, Hash256, HashAlgorithm, NodeId, Privkey, Pubkey, RevocationData, SettlementData,
+    TLCId,
 };
 
 use super::WatchtowerStore;
@@ -529,6 +531,7 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
     first_commitment_block_number: u64,
 ) {
     let lock_args = commitment_lock.args().raw_data();
+    let initial_tlcs = tracked_settlement_tlcs(&commitment_lock, &channel_data, for_remote);
     let script = commitment_lock
         .as_builder()
         .args(lock_args[0..36].to_vec().pack())
@@ -576,15 +579,24 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
         group_by_transaction: Some(true),
     };
 
-    let settlement_witness_input_indices = scan_watched_settlement_txs(
-        search_key.clone(),
-        &ckb_client,
-        &script,
-        first_commitment_tx_out_point.clone(),
-        &channel_data.channel_id,
-        store,
-        &self_node_id,
-    );
+    let settlement_witness_input_indices = if let Some(initial_tlcs) = initial_tlcs {
+        scan_watched_settlement_txs(
+            search_key.clone(),
+            &ckb_client,
+            &script,
+            first_commitment_tx_out_point.clone(),
+            initial_tlcs,
+            &channel_data.channel_id,
+            store,
+            &self_node_id,
+        )
+    } else {
+        error!(
+            "Cannot reconstruct settlement TLC identities for channel {:?}; skipping on-chain TLC reconciliation",
+            channel_data.channel_id
+        );
+        HashMap::new()
+    };
 
     // the live cells number should be 1 or 0 for normal case.
     // however, an attacker may create a lot of cells to implement a tx pinning attack, we have to use loop to get all cells
@@ -722,17 +734,96 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TrackedSettlementTlc {
+    tlc_id: TLCId,
+    payment_hash: Hash256,
+    hash_algorithm: HashAlgorithm,
+    witness: Vec<u8>,
+}
+
+fn settlement_data_for_commitment(
+    channel_data: &ChannelData,
+    for_remote: bool,
+    commitment_number: u64,
+) -> &SettlementData {
+    if for_remote {
+        if channel_data
+            .revocation_data
+            .as_ref()
+            .and_then(|revocation| {
+                commitment_number
+                    .checked_sub(1)
+                    .map(|previous| revocation.commitment_number == previous)
+            })
+            .unwrap_or(false)
+        {
+            &channel_data.remote_settlement_data
+        } else {
+            &channel_data.pending_remote_settlement_data
+        }
+    } else {
+        &channel_data.local_settlement_data
+    }
+}
+
+fn tracked_settlement_tlcs(
+    commitment_lock: &Script,
+    channel_data: &ChannelData,
+    for_remote: bool,
+) -> Option<Vec<TrackedSettlementTlc>> {
+    let lock_args = commitment_lock.args().raw_data();
+    if lock_args.len() < 56 {
+        return None;
+    }
+    let commitment_number = u64::from_be_bytes(lock_args[28..36].try_into().ok()?);
+    let settlement_data =
+        settlement_data_for_commitment(channel_data, for_remote, commitment_number);
+    let committed_witness_hash = &lock_args[36..56];
+    let settlement_witness = settlement_data_to_witness(
+        settlement_data,
+        for_remote,
+        channel_data.local_settlement_key.clone(),
+        channel_data.remote_settlement_key,
+    );
+    if blake160(&settlement_witness).as_ref() != committed_witness_hash {
+        warn!(
+            "Settlement snapshot hash does not match commitment lock for channel {:?}, commitment {}",
+            channel_data.channel_id, commitment_number
+        );
+        return None;
+    }
+
+    Some(
+        settlement_data
+            .tlcs
+            .iter()
+            .map(|tlc| TrackedSettlementTlc {
+                tlc_id: if for_remote {
+                    tlc.tlc_id
+                } else {
+                    tlc.tlc_id.flip()
+                },
+                payment_hash: tlc.payment_hash,
+                hash_algorithm: tlc.hash_algorithm,
+                witness: settlement_tlc_to_witness(tlc, for_remote),
+            })
+            .collect(),
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn scan_watched_settlement_txs<S: WatchtowerStore>(
     search_key: SearchKey,
     ckb_client: &CkbRpcClient,
     commitment_lock_prefix: &Script,
     first_commitment_tx_out_point: OutPoint,
+    initial_tlcs: Vec<TrackedSettlementTlc>,
     channel_id: &Hash256,
     store: &S,
     self_node_id: &NodeId,
 ) -> HashMap<ckb_types::packed::Byte32, usize> {
-    let mut watched_outpoints = HashSet::from([first_commitment_tx_out_point]);
+    let mut watched_outpoints = HashMap::from([(first_commitment_tx_out_point, initial_tlcs)]);
     let mut settlement_witness_input_indices = HashMap::new();
 
     let mut candidates: Vec<Transaction> = Vec::new();
@@ -825,7 +916,7 @@ fn lock_matches_commitment_prefix(lock: &Script, commitment_lock_prefix: &Script
 
 fn process_watched_settlement_tx<S: WatchtowerStore>(
     tx: &Transaction,
-    watched_outpoints: &mut HashSet<OutPoint>,
+    watched_outpoints: &mut HashMap<OutPoint, Vec<TrackedSettlementTlc>>,
     processed_tx_hashes: &mut HashSet<ckb_types::packed::Byte32>,
     commitment_lock_prefix: &Script,
     channel_id: &Hash256,
@@ -841,131 +932,173 @@ fn process_watched_settlement_tx<S: WatchtowerStore>(
     // global input index that spends the watched commitment/settlement cell,
     // not necessarily at `witnesses[0]`.
     let inputs = tx.raw().inputs();
-    let watched_input_index = (0..inputs.len()).find(|index| {
+    let (watched_input_index, watched_outpoint) = (0..inputs.len()).find_map(|index| {
         let previous_output = inputs
-            .get(*index)
+            .get(index)
             .expect("input index checked")
             .previous_output();
-        watched_outpoints.contains(&previous_output)
+        watched_outpoints
+            .contains_key(&previous_output)
+            .then_some((index, previous_output))
     })?;
 
+    let tracked_tlcs = watched_outpoints.get(&watched_outpoint)?.clone();
+    let remaining_tlcs = reconcile_settlement_witness(
+        tx,
+        watched_input_index,
+        channel_id,
+        store,
+        self_node_id,
+        &tracked_tlcs,
+    )?;
     processed_tx_hashes.insert(tx_hash.clone());
-    find_preimages(tx, watched_input_index, channel_id, store, self_node_id);
+    watched_outpoints.remove(&watched_outpoint);
 
     let outputs = tx.raw().outputs();
     if let Some(output) = outputs.get(0) {
         if lock_matches_commitment_prefix(&output.lock(), commitment_lock_prefix) {
-            watched_outpoints.insert(OutPoint::new(tx_hash, 0));
+            watched_outpoints.insert(OutPoint::new(tx_hash, 0), remaining_tlcs);
         }
     }
 
     Some(watched_input_index)
 }
 
-// find all on-chain transactions with the preimage and store them
-fn find_preimages<S: WatchtowerStore>(
+/// Validate a settlement witness against the tracked snapshot, persist exact TLC proofs, and
+/// return the still-pending TLCs in their next-witness order.
+fn reconcile_settlement_witness<S: WatchtowerStore>(
     tx: &Transaction,
     witness_index: usize,
     channel_id: &Hash256,
     store: &S,
     self_node_id: &NodeId,
-) {
-    match tx.witnesses().get(witness_index) {
-        Some(witness) => {
-            let witness = witness.raw_data();
-            if witness.len() > 18 && witness[0..16] == XUDT_COMPATIBLE_WITNESS {
-                if let Some(settlement_witness) =
-                    SettlementWitness::build_from_witness(&witness[16..])
-                {
-                    let tx_hash: Hash256 = tx.calc_tx_hash().into();
-                    for unlock in settlement_witness.unlocks {
-                        if unlock.unlock_type < 0xFE {
-                            if let Some(tlc) = settlement_witness
-                                .pending_htlcs
-                                .get(unlock.unlock_type as usize)
-                            {
-                                if unlock.with_preimage {
-                                    let preimage = unlock.preimage.unwrap();
-                                    let payment_hash = tlc.hash_algorithm().hash(preimage.as_ref());
-                                    if payment_hash.starts_with(&tlc.payment_hash) {
-                                        debug!(
-                                            "watchtower observed on-chain preimage for channel {:?} tlc index {} payment_hash_prefix {:?} tx {:?}",
-                                            channel_id,
-                                            unlock.unlock_type,
-                                            tlc.payment_hash,
-                                            tx.calc_tx_hash(),
-                                        );
-                                        store.insert_watch_preimage(
-                                            self_node_id.clone(),
-                                            payment_hash.into(),
-                                            preimage,
-                                        );
-                                        store.insert_onchain_tlc_settlement(
-                                            channel_id,
-                                            tlc.payment_hash,
-                                            OnChainTlcSettlement {
-                                                preimage: Some(preimage),
-                                                tx_hash: Some(tx_hash),
-                                                tlc_index: Some(unlock.unlock_type),
-                                            },
-                                        );
-                                    } else {
-                                        warn!("Found a preimage for payment hash: {:?}, but not match the tlc, tx hash: {:?}", payment_hash, tx.calc_tx_hash());
-                                    }
-                                } else {
-                                    debug!(
-                                        "watchtower observed on-chain TLC settled without preimage for channel {:?} tlc index {} payment_hash_prefix {:?} tx {:?}",
-                                        channel_id,
-                                        unlock.unlock_type,
-                                        tlc.payment_hash,
-                                        tx.calc_tx_hash(),
-                                    );
-                                    store.insert_onchain_tlc_settlement(
-                                        channel_id,
-                                        tlc.payment_hash,
-                                        OnChainTlcSettlement {
-                                            preimage: None,
-                                            tx_hash: Some(tx_hash),
-                                            tlc_index: Some(unlock.unlock_type),
-                                        },
-                                    );
-                                }
-                            }
-                        } else {
-                            debug!(
-                                "watchtower observed final party unlock 0x{:02x} for channel {:?} with {} pending TLCs tx {:?}",
-                                unlock.unlock_type,
-                                channel_id,
-                                settlement_witness.pending_htlcs.len(),
-                                tx.calc_tx_hash(),
-                            );
-                            settlement_witness
-                                .pending_htlcs
-                                .iter()
-                                .enumerate()
-                                .for_each(|(index, tlc)| {
-                                    store.insert_onchain_tlc_settlement(
-                                        channel_id,
-                                        tlc.payment_hash,
-                                        OnChainTlcSettlement {
-                                            preimage: None,
-                                            tx_hash: Some(tx_hash),
-                                            tlc_index: Some(index as u8),
-                                        },
-                                    );
-                                })
-                        }
-                    }
-                }
-            }
+    tracked_tlcs: &[TrackedSettlementTlc],
+) -> Option<Vec<TrackedSettlementTlc>> {
+    let Some(witness) = tx.witnesses().get(witness_index) else {
+        warn!(
+            "Found a commitment tx, but the witnesses are empty: {:?}",
+            tx.calc_tx_hash()
+        );
+        return None;
+    };
+    let witness = witness.raw_data();
+    if witness.len() <= 18 || witness[0..16] != XUDT_COMPATIBLE_WITNESS {
+        warn!(
+            "Found a commitment tx with an invalid settlement witness: {:?}",
+            tx.calc_tx_hash()
+        );
+        return None;
+    }
+    let Some(settlement_witness) = SettlementWitness::build_from_witness(&witness[16..]) else {
+        warn!(
+            "Cannot decode settlement witness for tx {:?}",
+            tx.calc_tx_hash()
+        );
+        return None;
+    };
+    if settlement_witness.pending_htlcs.len() != tracked_tlcs.len()
+        || settlement_witness
+            .pending_htlcs
+            .iter()
+            .zip(tracked_tlcs)
+            .any(|(witness_tlc, tracked_tlc)| witness_tlc.to_witness() != tracked_tlc.witness)
+    {
+        warn!(
+            "Settlement witness TLC list does not match the tracked commitment snapshot for channel {:?}, tx {:?}",
+            channel_id,
+            tx.calc_tx_hash()
+        );
+        return None;
+    }
+
+    let tx_hash: Hash256 = tx.calc_tx_hash().into();
+    let mut settled_indices = HashSet::new();
+    let mut final_party_unlock = false;
+    for unlock in settlement_witness.unlocks {
+        if unlock.unlock_type >= 0xFE {
+            final_party_unlock = true;
+            debug!(
+                "watchtower observed final party unlock 0x{:02x} for channel {:?} with {} pending TLCs tx {:?}",
+                unlock.unlock_type,
+                channel_id,
+                tracked_tlcs.len(),
+                tx.calc_tx_hash(),
+            );
+            continue;
         }
-        None => {
+
+        let index = unlock.unlock_type as usize;
+        let Some(tlc) = tracked_tlcs.get(index) else {
             warn!(
-                "Found a commitment tx, but the witnesses are empty: {:?}",
+                "Settlement witness references invalid TLC index {} for channel {:?}, tx {:?}",
+                index,
+                channel_id,
                 tx.calc_tx_hash()
             );
+            return None;
+        };
+        settled_indices.insert(index);
+        let preimage = if unlock.with_preimage {
+            Some(unlock.preimage?)
+        } else {
+            None
+        };
+        if let Some(preimage) = preimage {
+            let discovered_payment_hash: Hash256 = tlc.hash_algorithm.hash(preimage).into();
+            if discovered_payment_hash == tlc.payment_hash {
+                store.insert_watch_preimage(self_node_id.clone(), tlc.payment_hash, preimage);
+            } else {
+                warn!(
+                    "On-chain preimage for channel {:?} tlc {:?} tx {:?} hashes to {:?}, expected full hash {:?}",
+                    channel_id,
+                    tlc.tlc_id,
+                    tx.calc_tx_hash(),
+                    discovered_payment_hash,
+                    tlc.payment_hash
+                );
+            }
         }
+        store.insert_onchain_tlc_settlement(
+            channel_id,
+            tlc.tlc_id,
+            OnChainTlcSettlement {
+                payment_hash: tlc.payment_hash,
+                hash_algorithm: tlc.hash_algorithm,
+                preimage,
+                tx_hash,
+                tlc_index: unlock.unlock_type,
+            },
+        );
     }
+
+    if final_party_unlock {
+        for (index, tlc) in tracked_tlcs.iter().enumerate() {
+            if settled_indices.contains(&index) {
+                continue;
+            }
+            store.insert_onchain_tlc_settlement(
+                channel_id,
+                tlc.tlc_id,
+                OnChainTlcSettlement {
+                    payment_hash: tlc.payment_hash,
+                    hash_algorithm: tlc.hash_algorithm,
+                    preimage: None,
+                    tx_hash,
+                    tlc_index: index as u8,
+                },
+            );
+        }
+        return Some(Vec::new());
+    }
+
+    Some(
+        tracked_tlcs
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !settled_indices.contains(index))
+            .map(|(_, tlc)| tlc.clone())
+            .collect(),
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1012,24 +1145,8 @@ fn build_settlement_tx<S: WatchtowerStore>(
     }
     let mut delay_epoch = delay_epoch.unwrap();
     let is_first_settlement = settlement_witness.is_none();
-    let settlement_data = if for_remote {
-        if channel_data
-            .revocation_data
-            .as_ref()
-            .and_then(|r| {
-                commitment_number
-                    .checked_sub(1)
-                    .map(|prev| r.commitment_number == prev)
-            })
-            .unwrap_or(false)
-        {
-            channel_data.remote_settlement_data.clone()
-        } else {
-            channel_data.pending_remote_settlement_data.clone()
-        }
-    } else {
-        channel_data.local_settlement_data.clone()
-    };
+    let settlement_data =
+        settlement_data_for_commitment(&channel_data, for_remote, commitment_number).clone();
 
     let fee_provider_lock_script =
         get_script_by_contract(Contract::Secp256k1Lock, signer.pubkey_hash());
@@ -1924,14 +2041,6 @@ impl Htlc {
         vec
     }
 
-    pub fn hash_algorithm(&self) -> HashAlgorithm {
-        if (self.htlc_type >> 1) & 0b0000001 == 0 {
-            HashAlgorithm::CkbHash
-        } else {
-            HashAlgorithm::Sha256
-        }
-    }
-
     pub fn is_offered(&self) -> bool {
         self.htlc_type & 0b0000001 == 0
     }
@@ -2147,7 +2256,7 @@ mod tests {
 
     #[derive(Default)]
     struct TestWatchtowerStore {
-        settlements: Mutex<Vec<(Hash256, [u8; 20], OnChainTlcSettlement)>>,
+        settlements: Mutex<Vec<(Hash256, TLCId, OnChainTlcSettlement)>>,
     }
 
     impl TestWatchtowerStore {
@@ -2156,11 +2265,16 @@ mod tests {
                 .lock()
                 .expect("lock poisoned")
                 .iter()
-                .map(|(channel_id, payment_hash, _)| (*channel_id, *payment_hash))
+                .map(|(channel_id, _, settlement)| {
+                    let prefix = settlement.payment_hash.as_ref()[..20]
+                        .try_into()
+                        .expect("payment hash prefix");
+                    (*channel_id, prefix)
+                })
                 .collect()
         }
 
-        fn settlements(&self) -> Vec<(Hash256, [u8; 20], OnChainTlcSettlement)> {
+        fn settlements(&self) -> Vec<(Hash256, TLCId, OnChainTlcSettlement)> {
             self.settlements.lock().expect("lock poisoned").clone()
         }
     }
@@ -2239,32 +2353,35 @@ mod tests {
         fn insert_onchain_tlc_settlement(
             &self,
             channel_id: &Hash256,
-            payment_hash: [u8; 20],
+            tlc_id: TLCId,
             settlement: OnChainTlcSettlement,
         ) {
-            self.settlements.lock().expect("lock poisoned").push((
-                *channel_id,
-                payment_hash,
-                settlement,
-            ));
+            self.settlements
+                .lock()
+                .expect("lock poisoned")
+                .push((*channel_id, tlc_id, settlement));
         }
 
         fn get_onchain_tlc_settlement(
             &self,
             channel_id: &Hash256,
-            payment_hash: &Hash256,
+            tlc_id: TLCId,
         ) -> Option<OnChainTlcSettlement> {
-            let payment_hash_prefix: [u8; 20] = payment_hash.as_ref()[0..20]
-                .try_into()
-                .expect("payment hash prefix");
             self.settlements
                 .lock()
                 .expect("lock poisoned")
                 .iter()
-                .find_map(|(id, hash_prefix, settlement)| {
-                    (id == channel_id && hash_prefix == &payment_hash_prefix)
-                        .then(|| settlement.clone())
+                .find_map(|(id, stored_tlc_id, settlement)| {
+                    (id == channel_id && *stored_tlc_id == tlc_id).then(|| settlement.clone())
                 })
+        }
+
+        fn get_legacy_onchain_tlc_settlement(
+            &self,
+            _channel_id: &Hash256,
+            _payment_hash: &Hash256,
+        ) -> Option<crate::fiber::onchain_tlc_reconcile::LegacyOnChainTlcSettlement> {
+            None
         }
     }
 
@@ -2295,17 +2412,57 @@ mod tests {
         )
     }
 
+    fn test_htlc(payment_hash: [u8; 20]) -> Htlc {
+        Htlc {
+            htlc_type: 0,
+            payment_amount: 1_000,
+            payment_hash,
+            remote_htlc_pubkey_hash: [4u8; 20],
+            local_htlc_pubkey_hash: [5u8; 20],
+            htlc_expiry: 0,
+        }
+    }
+
+    fn tracked_tlc(payment_hash_prefix: [u8; 20], tlc_id: u64) -> TrackedSettlementTlc {
+        let mut payment_hash = [0u8; 32];
+        payment_hash[..20].copy_from_slice(&payment_hash_prefix);
+        payment_hash[24..].copy_from_slice(&tlc_id.to_be_bytes());
+        TrackedSettlementTlc {
+            tlc_id: TLCId::Offered(tlc_id),
+            payment_hash: payment_hash.into(),
+            hash_algorithm: HashAlgorithm::CkbHash,
+            witness: test_htlc(payment_hash_prefix).to_witness(),
+        }
+    }
+
+    fn watched_outpoints(
+        outpoint: OutPoint,
+        payment_hashes: &[[u8; 20]],
+    ) -> HashMap<OutPoint, Vec<TrackedSettlementTlc>> {
+        HashMap::from([(
+            outpoint,
+            payment_hashes
+                .iter()
+                .enumerate()
+                .map(|(index, payment_hash)| tracked_tlc(*payment_hash, index as u64))
+                .collect(),
+        )])
+    }
+
     fn settlement_witness_with_unlock(payment_hash: [u8; 20], unlock: Unlock) -> Vec<u8> {
+        settlement_witness_with_unlocks(&[payment_hash], vec![unlock])
+    }
+
+    fn settlement_witness_with_unlocks(
+        payment_hashes: &[[u8; 20]],
+        unlocks: Vec<Unlock>,
+    ) -> Vec<u8> {
         let settlement_witness = SettlementWitness {
-            pending_htlc_count: 1,
-            pending_htlcs: vec![Htlc {
-                htlc_type: 0,
-                payment_amount: 1_000,
-                payment_hash,
-                remote_htlc_pubkey_hash: [4u8; 20],
-                local_htlc_pubkey_hash: [5u8; 20],
-                htlc_expiry: 0,
-            }],
+            pending_htlc_count: payment_hashes.len(),
+            pending_htlcs: payment_hashes
+                .iter()
+                .map(|payment_hash| test_htlc(*payment_hash))
+                .collect(),
             settlement_remote_pubkey_hash: [6u8; 20],
             settlement_remote_amount: 2_000,
             settlement_local_pubkey_hash: [7u8; 20],
@@ -2313,13 +2470,16 @@ mod tests {
             unlocks: vec![],
         };
 
-        [
+        let mut witness = [
             XUDT_COMPATIBLE_WITNESS.as_slice(),
-            &[0x01],
+            &[unlocks.len() as u8],
             settlement_witness.to_witness().as_slice(),
-            unlock.to_witness().as_slice(),
         ]
-        .concat()
+        .concat();
+        for unlock in unlocks {
+            witness.extend_from_slice(&unlock.to_witness());
+        }
+        witness
     }
 
     fn settlement_witness_final_party_unlock(
@@ -2328,17 +2488,7 @@ mod tests {
     ) -> Vec<u8> {
         let settlement_witness = SettlementWitness {
             pending_htlc_count: 2,
-            pending_htlcs: payment_hashes
-                .into_iter()
-                .map(|payment_hash| Htlc {
-                    htlc_type: 0,
-                    payment_amount: 1_000,
-                    payment_hash,
-                    remote_htlc_pubkey_hash: [4u8; 20],
-                    local_htlc_pubkey_hash: [5u8; 20],
-                    htlc_expiry: 0,
-                })
-                .collect(),
+            pending_htlcs: payment_hashes.into_iter().map(test_htlc).collect(),
             settlement_remote_pubkey_hash: [6u8; 20],
             settlement_remote_amount: 2_000,
             settlement_local_pubkey_hash: [7u8; 20],
@@ -2407,7 +2557,8 @@ mod tests {
             settlement_lock(&lock_prefix),
             Some(settlement_witness(payment_hash)),
         );
-        let mut watched_outpoints = HashSet::from([OutPoint::new([7u8; 32].pack(), 0)]);
+        let mut watched_outpoints =
+            watched_outpoints(OutPoint::new([7u8; 32].pack(), 0), &[[43u8; 20]]);
         let mut processed_tx_hashes = HashSet::new();
         let store = TestWatchtowerStore::default();
         let self_node_id = NodeId::local();
@@ -2439,7 +2590,7 @@ mod tests {
             vec![settlement_lock(&lock_prefix)],
             vec![settlement_witness(malicious_payment_hash), vec![]],
         );
-        let mut watched_outpoints = HashSet::from([watched_out_point]);
+        let mut watched_outpoints = watched_outpoints(watched_out_point, &[malicious_payment_hash]);
         let mut processed_tx_hashes = HashSet::new();
         let store = TestWatchtowerStore::default();
         let self_node_id = NodeId::local();
@@ -2454,7 +2605,7 @@ mod tests {
             &self_node_id,
         );
 
-        assert_eq!(processed, Some(1));
+        assert_eq!(processed, None);
         assert!(store.settled_tlcs().is_empty());
     }
 
@@ -2469,7 +2620,9 @@ mod tests {
             settlement_lock(&lock_prefix),
             Some(settlement_witness(payment_hash)),
         );
-        let mut watched_outpoints = HashSet::from([first_commitment_out_point]);
+        let tracked = tracked_tlc(payment_hash, 0);
+        let mut watched_outpoints =
+            HashMap::from([(first_commitment_out_point, vec![tracked.clone()])]);
         let mut processed_tx_hashes = HashSet::new();
         let store = TestWatchtowerStore::default();
         let self_node_id = NodeId::local();
@@ -2490,15 +2643,66 @@ mod tests {
             store.settlements(),
             vec![(
                 channel_id,
-                payment_hash,
+                TLCId::Offered(0),
                 OnChainTlcSettlement {
+                    payment_hash: tracked.payment_hash,
+                    hash_algorithm: HashAlgorithm::CkbHash,
                     preimage: None,
-                    tx_hash: Some(tx.calc_tx_hash().into()),
-                    tlc_index: Some(0),
+                    tx_hash: tx.calc_tx_hash().into(),
+                    tlc_index: 0,
                 },
             )]
         );
-        assert!(watched_outpoints.contains(&OutPoint::new(tx.calc_tx_hash(), 0)));
+        assert!(watched_outpoints.contains_key(&OutPoint::new(tx.calc_tx_hash(), 0)));
+    }
+
+    #[test]
+    fn shared_prefix_unlock_index_maps_to_exact_tlc() {
+        let lock_prefix = commitment_lock_prefix();
+        let channel_id: Hash256 = [9u8; 32].into();
+        let shared_prefix = [42u8; 20];
+        let tracked = [tracked_tlc(shared_prefix, 0), tracked_tlc(shared_prefix, 1)];
+        assert_ne!(tracked[0].payment_hash, tracked[1].payment_hash);
+
+        let first_commitment_out_point = OutPoint::new([7u8; 32].pack(), 0);
+        let tx = tx_with_input_output_and_witness(
+            first_commitment_out_point.clone(),
+            settlement_lock(&lock_prefix),
+            Some(settlement_witness_with_unlocks(
+                &[shared_prefix, shared_prefix],
+                vec![Unlock {
+                    unlock_type: 1,
+                    with_preimage: false,
+                    signature: [0u8; 65],
+                    preimage: None,
+                }],
+            )),
+        );
+        let mut watched_outpoints = HashMap::from([(first_commitment_out_point, tracked.to_vec())]);
+        let mut processed_tx_hashes = HashSet::new();
+        let store = TestWatchtowerStore::default();
+
+        assert_eq!(
+            process_watched_settlement_tx(
+                &tx,
+                &mut watched_outpoints,
+                &mut processed_tx_hashes,
+                &lock_prefix,
+                &channel_id,
+                &store,
+                &NodeId::local(),
+            ),
+            Some(0)
+        );
+
+        let settlements = store.settlements();
+        assert_eq!(settlements.len(), 1);
+        assert_eq!(settlements[0].1, TLCId::Offered(1));
+        assert_eq!(settlements[0].2.payment_hash, tracked[1].payment_hash);
+        let remaining = watched_outpoints
+            .get(&OutPoint::new(tx.calc_tx_hash(), 0))
+            .expect("next settlement outpoint tracked");
+        assert_eq!(remaining, &tracked[..1]);
     }
 
     #[test]
@@ -2512,7 +2716,11 @@ mod tests {
             settlement_lock(&lock_prefix),
             Some(settlement_witness_final_party_unlock(payment_hashes, 0xFE)),
         );
-        let mut watched_outpoints = HashSet::from([first_commitment_out_point]);
+        let tracked = [
+            tracked_tlc(payment_hashes[0], 0),
+            tracked_tlc(payment_hashes[1], 1),
+        ];
+        let mut watched_outpoints = HashMap::from([(first_commitment_out_point, tracked.to_vec())]);
         let mut processed_tx_hashes = HashSet::new();
         let store = TestWatchtowerStore::default();
         let self_node_id = NodeId::local();
@@ -2540,20 +2748,24 @@ mod tests {
             vec![
                 (
                     channel_id,
-                    payment_hashes[0],
+                    TLCId::Offered(0),
                     OnChainTlcSettlement {
+                        payment_hash: tracked[0].payment_hash,
+                        hash_algorithm: HashAlgorithm::CkbHash,
                         preimage: None,
-                        tx_hash: Some(tx.calc_tx_hash().into()),
-                        tlc_index: Some(0),
+                        tx_hash: tx.calc_tx_hash().into(),
+                        tlc_index: 0,
                     },
                 ),
                 (
                     channel_id,
-                    payment_hashes[1],
+                    TLCId::Offered(1),
                     OnChainTlcSettlement {
+                        payment_hash: tracked[1].payment_hash,
+                        hash_algorithm: HashAlgorithm::CkbHash,
                         preimage: None,
-                        tx_hash: Some(tx.calc_tx_hash().into()),
-                        tlc_index: Some(1),
+                        tx_hash: tx.calc_tx_hash().into(),
+                        tlc_index: 1,
                     },
                 ),
             ]
@@ -2572,7 +2784,7 @@ mod tests {
             vec![settlement_witness(payment_hash)],
         );
         let extra_same_prefix_out_point = OutPoint::new(tx.calc_tx_hash(), 1);
-        let mut watched_outpoints = HashSet::from([first_commitment_out_point]);
+        let mut watched_outpoints = watched_outpoints(first_commitment_out_point, &[payment_hash]);
         let mut processed_tx_hashes = HashSet::new();
         let store = TestWatchtowerStore::default();
         let self_node_id = NodeId::local();
@@ -2588,7 +2800,7 @@ mod tests {
         );
 
         assert_eq!(processed, Some(0));
-        assert!(!watched_outpoints.contains(&extra_same_prefix_out_point));
+        assert!(!watched_outpoints.contains_key(&extra_same_prefix_out_point));
     }
 
     #[test]
@@ -2601,14 +2813,25 @@ mod tests {
         let parent_tx = tx_with_input_output_and_witness(
             first_commitment_out_point.clone(),
             settlement_lock(&lock_prefix),
-            Some(settlement_witness(parent_payment_hash)),
+            Some(settlement_witness_with_unlocks(
+                &[parent_payment_hash, child_payment_hash],
+                vec![Unlock {
+                    unlock_type: 0,
+                    with_preimage: false,
+                    signature: [0u8; 65],
+                    preimage: None,
+                }],
+            )),
         );
         let child_tx = tx_with_input_output_and_witness(
             OutPoint::new(parent_tx.calc_tx_hash(), 0),
             settlement_lock(&lock_prefix),
             Some(settlement_witness(child_payment_hash)),
         );
-        let mut watched_outpoints = HashSet::from([first_commitment_out_point]);
+        let mut watched_outpoints = watched_outpoints(
+            first_commitment_out_point,
+            &[parent_payment_hash, child_payment_hash],
+        );
         let mut processed_tx_hashes = HashSet::new();
         let store = TestWatchtowerStore::default();
         let self_node_id = NodeId::local();
@@ -2645,6 +2868,10 @@ mod tests {
                 (channel_id, child_payment_hash)
             ]
         );
+        let settlements = store.settlements();
+        assert_eq!(settlements[0].1, TLCId::Offered(0));
+        assert_eq!(settlements[1].1, TLCId::Offered(1));
+        assert_eq!(settlements[1].2.tlc_index, 0);
     }
 
     #[test]
@@ -2657,14 +2884,25 @@ mod tests {
         let parent_tx = tx_with_input_output_and_witness(
             first_commitment_out_point.clone(),
             settlement_lock(&lock_prefix),
-            Some(settlement_witness(parent_payment_hash)),
+            Some(settlement_witness_with_unlocks(
+                &[parent_payment_hash, child_payment_hash],
+                vec![Unlock {
+                    unlock_type: 0,
+                    with_preimage: false,
+                    signature: [0u8; 65],
+                    preimage: None,
+                }],
+            )),
         );
         let child_tx = tx_with_input_output_and_witness(
             OutPoint::new(parent_tx.calc_tx_hash(), 0),
             settlement_lock(&lock_prefix),
             Some(settlement_witness(child_payment_hash)),
         );
-        let mut watched_outpoints = HashSet::from([first_commitment_out_point]);
+        let mut watched_outpoints = watched_outpoints(
+            first_commitment_out_point,
+            &[parent_payment_hash, child_payment_hash],
+        );
         let mut processed_tx_hashes = HashSet::new();
         let store = TestWatchtowerStore::default();
         let self_node_id = NodeId::local();
@@ -2720,5 +2958,8 @@ mod tests {
                 (channel_id, child_payment_hash)
             ]
         );
+        let settlements = store.settlements();
+        assert_eq!(settlements[0].1, TLCId::Offered(0));
+        assert_eq!(settlements[1].1, TLCId::Offered(1));
     }
 }

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -579,24 +579,23 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
         group_by_transaction: Some(true),
     };
 
-    let settlement_witness_input_indices = if let Some(initial_tlcs) = initial_tlcs {
-        scan_watched_settlement_txs(
-            search_key.clone(),
-            &ckb_client,
-            &script,
-            first_commitment_tx_out_point.clone(),
-            initial_tlcs,
-            &channel_data.channel_id,
-            store,
-            &self_node_id,
-        )
-    } else {
+    let Some(initial_tlcs) = initial_tlcs else {
         error!(
-            "Cannot reconstruct settlement TLC identities for channel {:?}; skipping on-chain TLC reconciliation",
+            "Cannot reconstruct settlement TLC identities for channel {:?}; skipping on-chain TLC reconciliation and settlement construction",
             channel_data.channel_id
         );
-        HashMap::new()
+        return;
     };
+    let settlement_scan = scan_watched_settlement_txs(
+        search_key.clone(),
+        &ckb_client,
+        &script,
+        first_commitment_tx_out_point.clone(),
+        initial_tlcs,
+        &channel_data.channel_id,
+        store,
+        &self_node_id,
+    );
 
     // the live cells number should be 1 or 0 for normal case.
     // however, an attacker may create a lot of cells to implement a tx pinning attack, we have to use loop to get all cells
@@ -617,6 +616,16 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
                     let commitment_tx_hash = cell.out_point.tx_hash.clone();
                     let commitment_tx_out_point =
                         OutPoint::new(commitment_tx_hash.pack(), cell.out_point.index.value());
+                    let Some(tracked_tlcs) = settlement_scan
+                        .tracked_tlcs_by_outpoint
+                        .get(&commitment_tx_out_point)
+                    else {
+                        warn!(
+                            "Found a live settlement cell without a verified TLC identity mapping: {:?}",
+                            commitment_tx_out_point
+                        );
+                        continue;
+                    };
                     // is it the first commitment tx which has unlocked funding output or not
                     let is_first = commitment_tx_out_point == first_commitment_tx_out_point;
                     let cell_header: HeaderView =
@@ -645,10 +654,10 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
                                     match tx.inner {
                                         Either::Left(tx) => {
                                             let tx: Transaction = tx.inner.into();
-                                            let Some(witness_index) =
-                                                settlement_witness_input_indices
-                                                    .get(&commitment_tx_hash.pack())
-                                                    .copied()
+                                            let Some(witness_index) = settlement_scan
+                                                .witness_input_indices
+                                                .get(&commitment_tx_hash.pack())
+                                                .copied()
                                             else {
                                                 warn!("Found a commitment tx, but it does not spend a watched commitment outpoint: {:?}", commitment_tx_hash);
                                                 continue;
@@ -705,6 +714,7 @@ fn try_settle_commitment_tx<S: WatchtowerStore>(
                         for_remote,
                         channel_data.clone(),
                         settlement_witness,
+                        tracked_tlcs,
                         signer,
                         cell_collector,
                         store,
@@ -740,6 +750,11 @@ struct TrackedSettlementTlc {
     payment_hash: Hash256,
     hash_algorithm: HashAlgorithm,
     witness: Vec<u8>,
+}
+
+struct WatchedSettlementScan {
+    witness_input_indices: HashMap<ckb_types::packed::Byte32, usize>,
+    tracked_tlcs_by_outpoint: HashMap<OutPoint, Vec<TrackedSettlementTlc>>,
 }
 
 fn settlement_data_for_commitment(
@@ -822,7 +837,7 @@ fn scan_watched_settlement_txs<S: WatchtowerStore>(
     channel_id: &Hash256,
     store: &S,
     self_node_id: &NodeId,
-) -> HashMap<ckb_types::packed::Byte32, usize> {
+) -> WatchedSettlementScan {
     let mut watched_outpoints = HashMap::from([(first_commitment_tx_out_point, initial_tlcs)]);
     let mut settlement_witness_input_indices = HashMap::new();
 
@@ -904,7 +919,10 @@ fn scan_watched_settlement_txs<S: WatchtowerStore>(
             break;
         }
     }
-    settlement_witness_input_indices
+    WatchedSettlementScan {
+        witness_input_indices: settlement_witness_input_indices,
+        tracked_tlcs_by_outpoint: watched_outpoints,
+    }
 }
 
 fn lock_matches_commitment_prefix(lock: &Script, commitment_lock_prefix: &Script) -> bool {
@@ -1101,6 +1119,27 @@ fn reconcile_settlement_witness<S: WatchtowerStore>(
     )
 }
 
+fn verified_watch_preimage<S: WatchtowerStore>(
+    store: &S,
+    self_node_id: &NodeId,
+    tracked_tlc: &TrackedSettlementTlc,
+) -> Option<Hash256> {
+    let preimage = store.get_watch_preimage(self_node_id, &tracked_tlc.payment_hash)?;
+    let discovered_payment_hash: Hash256 = tracked_tlc.hash_algorithm.hash(preimage).into();
+    if discovered_payment_hash == tracked_tlc.payment_hash {
+        Some(preimage)
+    } else {
+        warn!(
+            "Ignoring watchtower preimage for tlc {:?}: derived hash {:?} using {:?}, expected {:?}",
+            tracked_tlc.tlc_id,
+            discovered_payment_hash,
+            tracked_tlc.hash_algorithm,
+            tracked_tlc.payment_hash,
+        );
+        None
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_settlement_tx<S: WatchtowerStore>(
     commitment_cell: Cell,
@@ -1111,6 +1150,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
     for_remote: bool,
     channel_data: ChannelData,
     settlement_witness: Option<SettlementWitness>,
+    tracked_tlcs: &[TrackedSettlementTlc],
     signer: &LocalSigner,
     cell_collector: &mut DefaultCellCollector,
     store: &S,
@@ -1158,6 +1198,19 @@ fn build_settlement_tx<S: WatchtowerStore>(
     let (unlock, mut unlock_amount, unlock_key, new_settlement_witness) = match settlement_witness {
         Some(mut sw) => {
             if sw.update() {
+                if sw.pending_htlcs.len() != tracked_tlcs.len()
+                    || sw.pending_htlcs.iter().zip(tracked_tlcs).any(
+                        |(witness_tlc, tracked_tlc)| {
+                            witness_tlc.to_witness() != tracked_tlc.witness
+                        },
+                    )
+                {
+                    warn!(
+                        "Current settlement witness does not match the verified TLC identity mapping for channel {:?}",
+                        channel_data.channel_id
+                    );
+                    return Ok(None);
+                }
                 debug!("channel_data local_settlement_key pubkey hash: {:?}，sw settlement_remote_pubkey_hash: {:?}, sw settlement_local_pubkey_hash: {:?}, for_remote: {}",
                     channel_data_local_settlement_pubkey_hash(&channel_data), sw.settlement_remote_pubkey_hash, sw.settlement_local_pubkey_hash, for_remote);
                 if for_remote {
@@ -1209,9 +1262,11 @@ fn build_settlement_tx<S: WatchtowerStore>(
                                 } else if let Some(private_key) =
                                     tlc.find_matched_private_key(&settlement_data, true)
                                 {
-                                    if let Some(preimage) =
-                                        store.search_preimage(self_node_id, &tlc.payment_hash)
-                                    {
+                                    if let Some(preimage) = verified_watch_preimage(
+                                        store,
+                                        self_node_id,
+                                        &tracked_tlcs[i],
+                                    ) {
                                         unlock_option = Some((
                                             Unlock {
                                                 unlock_type: i as u8,
@@ -1307,7 +1362,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
                                 tlc.find_matched_private_key(&settlement_data, true)
                             {
                                 if let Some(preimage) =
-                                    store.search_preimage(self_node_id, &tlc.payment_hash)
+                                    verified_watch_preimage(store, self_node_id, &tracked_tlcs[i])
                                 {
                                     unlock_option = Some((
                                         Unlock {
@@ -1367,6 +1422,19 @@ fn build_settlement_tx<S: WatchtowerStore>(
             }
         }
         None => {
+            if settlement_data.tlcs.len() != tracked_tlcs.len()
+                || settlement_data.tlcs.iter().zip(tracked_tlcs).any(
+                    |(settlement_tlc, tracked_tlc)| {
+                        settlement_tlc_to_witness(settlement_tlc, for_remote) != tracked_tlc.witness
+                    },
+                )
+            {
+                warn!(
+                    "Initial settlement data does not match the verified TLC identity mapping for channel {:?}",
+                    channel_data.channel_id
+                );
+                return Ok(None);
+            }
             let mut pending_tlcs_count = settlement_data.tlcs.len();
             let mut unlock_option = None;
             for (i, tlc) in settlement_data.tlcs.iter().enumerate() {
@@ -1401,7 +1469,7 @@ fn build_settlement_tx<S: WatchtowerStore>(
                             <= current_epoch.to_rational()
                         {
                             if let Some(preimage) =
-                                store.get_watch_preimage(self_node_id, &tlc.payment_hash)
+                                verified_watch_preimage(store, self_node_id, &tracked_tlcs[i])
                             {
                                 unlock_option = Some((
                                     Unlock {
@@ -2259,6 +2327,7 @@ mod tests {
     #[derive(Default)]
     struct TestWatchtowerStore {
         settlements: Mutex<Vec<(Hash256, TLCId, OnChainTlcSettlement)>>,
+        preimages: Mutex<Vec<(NodeId, Hash256, Hash256)>>,
     }
 
     impl TestWatchtowerStore {
@@ -2326,30 +2395,24 @@ mod tests {
         ) {
         }
 
-        fn insert_watch_preimage(
-            &self,
-            _node_id: NodeId,
-            _payment_hash: Hash256,
-            _preimage: Hash256,
-        ) {
+        fn insert_watch_preimage(&self, node_id: NodeId, payment_hash: Hash256, preimage: Hash256) {
+            self.preimages
+                .lock()
+                .expect("lock poisoned")
+                .push((node_id, payment_hash, preimage));
         }
 
         fn remove_watch_preimage(&self, _node_id: NodeId, _payment_hash: Hash256) {}
 
-        fn get_watch_preimage(
-            &self,
-            _node_id: &NodeId,
-            _payment_hash: &Hash256,
-        ) -> Option<Hash256> {
-            None
-        }
-
-        fn search_preimage(
-            &self,
-            _node_id: &NodeId,
-            _payment_hash_prefix: &[u8],
-        ) -> Option<Hash256> {
-            None
+        fn get_watch_preimage(&self, node_id: &NodeId, payment_hash: &Hash256) -> Option<Hash256> {
+            self.preimages
+                .lock()
+                .expect("lock poisoned")
+                .iter()
+                .find_map(|(stored_node_id, stored_payment_hash, preimage)| {
+                    (stored_node_id == node_id && stored_payment_hash == payment_hash)
+                        .then_some(*preimage)
+                })
         }
 
         fn insert_onchain_tlc_settlement(
@@ -2541,6 +2604,126 @@ mod tests {
             tx_builder = tx_builder.witness(witness.pack());
         }
         tx_builder.build().data()
+    }
+
+    #[test]
+    fn settlement_builder_rejects_preimage_for_different_full_hash() {
+        let self_node_id = NodeId::local();
+        let preimage: Hash256 = [11u8; 32].into();
+        let stored_payment_hash: Hash256 = HashAlgorithm::CkbHash.hash(preimage).into();
+        let mut queried_payment_hash_bytes: [u8; 32] = stored_payment_hash
+            .as_ref()
+            .try_into()
+            .expect("payment hash");
+        queried_payment_hash_bytes[31] ^= 1;
+        let queried_payment_hash: Hash256 = queried_payment_hash_bytes.into();
+        let local_settlement_key = Privkey::from(&[1; 32]);
+        let remote_settlement_key = Privkey::from(&[2; 32]).pubkey();
+        let settlement_tlc = fiber_types::SettlementTlc {
+            tlc_id: TLCId::Offered(0),
+            hash_algorithm: HashAlgorithm::CkbHash,
+            payment_amount: 1_000,
+            payment_hash: queried_payment_hash,
+            expiry: 60_000,
+            local_key: Privkey::from(&[3; 32]),
+            remote_key: Privkey::from(&[4; 32]).pubkey(),
+        };
+        let tracked_tlcs = vec![TrackedSettlementTlc {
+            tlc_id: settlement_tlc.tlc_id.flip(),
+            payment_hash: settlement_tlc.payment_hash,
+            hash_algorithm: settlement_tlc.hash_algorithm,
+            witness: settlement_tlc_to_witness(&settlement_tlc, false),
+        }];
+        let settlement_data = SettlementData {
+            local_amount: 100_000_000_000,
+            remote_amount: 100_000_000_000,
+            tlcs: vec![settlement_tlc],
+        };
+        let channel_data = ChannelData {
+            channel_id: [9u8; 32].into(),
+            funding_udt_type_script: None,
+            local_settlement_key: local_settlement_key.clone(),
+            remote_settlement_key,
+            local_funding_pubkey: Privkey::from(&[5; 32]).pubkey(),
+            remote_funding_pubkey: Privkey::from(&[6; 32]).pubkey(),
+            remote_settlement_data: settlement_data.clone(),
+            pending_remote_settlement_data: settlement_data.clone(),
+            local_settlement_data: settlement_data.clone(),
+            revocation_data: None,
+        };
+        let settlement_witness = SettlementWitness::build_from_witness(
+            &[
+                &[0u8],
+                settlement_data_to_witness(
+                    &settlement_data,
+                    false,
+                    local_settlement_key,
+                    remote_settlement_key,
+                )
+                .as_slice(),
+            ]
+            .concat(),
+        )
+        .expect("settlement witness");
+
+        let delay_epoch = EpochNumberWithFraction::new(3, 0, 1);
+        let since = Since::new(
+            SinceType::EpochNumberWithFraction,
+            delay_epoch.full_value(),
+            true,
+        )
+        .value();
+        let mut lock_args = vec![0u8; 20];
+        lock_args.extend_from_slice(&since.to_le_bytes());
+        lock_args.extend_from_slice(&0u64.to_be_bytes());
+        let lock = Script::new_builder()
+            .code_hash(Byte32::from([1u8; 32]))
+            .hash_type(ScriptHashType::Type)
+            .args(lock_args.pack())
+            .build();
+        let type_script = Script::new_builder()
+            .code_hash(Byte32::from([2u8; 32]))
+            .hash_type(ScriptHashType::Type)
+            .build();
+        let commitment_cell = Cell {
+            output: CellOutput::new_builder()
+                .capacity(200_000_000_000u64)
+                .lock(lock)
+                .type_(Some(type_script).pack())
+                .build()
+                .into(),
+            // A safe builder returns before inspecting output data because no exact preimage
+            // exists for the queried full hash. A prefix-only regression would reach this
+            // deliberately invalid sentinel.
+            output_data: Some(ckb_jsonrpc_types::JsonBytes::from_vec(Vec::new())),
+            out_point: OutPoint::new(Byte32::from([3u8; 32]), 0).into(),
+            block_number: 0u64.into(),
+            tx_index: 0u32.into(),
+        };
+        let store = TestWatchtowerStore::default();
+        store.insert_watch_preimage(self_node_id.clone(), stored_payment_hash, preimage);
+        let signer = LocalSigner::new(SecretKey::from_slice(&[7u8; 32]).expect("secret key"));
+        let mut cell_collector = new_default_cell_collector("http://127.0.0.1:8114");
+
+        let result = build_settlement_tx(
+            commitment_cell,
+            EpochNumberWithFraction::new(10, 0, 1),
+            EpochNumberWithFraction::new(10, 0, 1),
+            0,
+            &self_node_id,
+            false,
+            channel_data,
+            Some(settlement_witness),
+            &tracked_tlcs,
+            &signer,
+            &mut cell_collector,
+            &store,
+        );
+
+        assert!(
+            matches!(result, Ok(None)),
+            "a preimage for a different full hash must not start settlement construction: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -1031,10 +1031,8 @@ fn reconcile_settlement_witness<S: WatchtowerStore>(
 
     let tx_hash: Hash256 = tx.calc_tx_hash().into();
     let mut settled_indices = HashSet::new();
-    let mut final_party_unlock = false;
     for unlock in settlement_witness.unlocks {
         if unlock.unlock_type >= 0xFE {
-            final_party_unlock = true;
             debug!(
                 "watchtower observed final party unlock 0x{:02x} for channel {:?} with {} pending TLCs tx {:?}",
                 unlock.unlock_type,
@@ -1077,6 +1075,7 @@ fn reconcile_settlement_witness<S: WatchtowerStore>(
             }
         }
         store.insert_onchain_tlc_settlement(
+            self_node_id,
             channel_id,
             tlc.tlc_id,
             OnChainTlcSettlement {
@@ -1087,26 +1086,6 @@ fn reconcile_settlement_witness<S: WatchtowerStore>(
                 tlc_index: unlock.unlock_type,
             },
         );
-    }
-
-    if final_party_unlock {
-        for (index, tlc) in tracked_tlcs.iter().enumerate() {
-            if settled_indices.contains(&index) {
-                continue;
-            }
-            store.insert_onchain_tlc_settlement(
-                channel_id,
-                tlc.tlc_id,
-                OnChainTlcSettlement {
-                    payment_hash: tlc.payment_hash,
-                    hash_algorithm: tlc.hash_algorithm,
-                    preimage: None,
-                    tx_hash,
-                    tlc_index: index as u8,
-                },
-            );
-        }
-        return Some(Vec::new());
     }
 
     Some(
@@ -2417,6 +2396,7 @@ mod tests {
 
         fn insert_onchain_tlc_settlement(
             &self,
+            _node_id: &NodeId,
             channel_id: &Hash256,
             tlc_id: TLCId,
             settlement: OnChainTlcSettlement,
@@ -2429,6 +2409,7 @@ mod tests {
 
         fn get_onchain_tlc_settlement(
             &self,
+            _node_id: &NodeId,
             channel_id: &Hash256,
             tlc_id: TLCId,
             _payment_hash: &Hash256,
@@ -2885,7 +2866,7 @@ mod tests {
     }
 
     #[test]
-    fn final_party_unlock_marks_pending_tlcs_without_preimage() {
+    fn final_party_unlock_keeps_pending_tlcs_tracked() {
         let lock_prefix = commitment_lock_prefix();
         let channel_id: Hash256 = [9u8; 32].into();
         let payment_hashes = [[41u8; 20], [42u8; 20]];
@@ -2915,39 +2896,71 @@ mod tests {
         );
 
         assert_eq!(processed, Some(0));
-        assert_eq!(
-            store.settled_tlcs(),
-            vec![
-                (channel_id, payment_hashes[0]),
-                (channel_id, payment_hashes[1])
-            ]
+        assert!(
+            store.settlements().is_empty(),
+            "a party-balance unlock is not a settlement proof for any pending TLC"
         );
         assert_eq!(
-            store.settlements(),
-            vec![
-                (
-                    channel_id,
-                    TLCId::Offered(0),
-                    OnChainTlcSettlement {
-                        payment_hash: tracked[0].payment_hash,
-                        hash_algorithm: HashAlgorithm::CkbHash,
+            watched_outpoints.get(&OutPoint::new(tx.calc_tx_hash(), 0)),
+            Some(&tracked.to_vec()),
+            "the successor witness still contains every pending TLC"
+        );
+    }
+
+    #[test]
+    fn final_party_unlock_only_removes_explicitly_unlocked_tlc() {
+        let lock_prefix = commitment_lock_prefix();
+        let channel_id: Hash256 = [9u8; 32].into();
+        let payment_hashes = [[41u8; 20], [42u8; 20]];
+        let first_commitment_out_point = OutPoint::new([7u8; 32].pack(), 0);
+        let tx = tx_with_input_output_and_witness(
+            first_commitment_out_point.clone(),
+            settlement_lock(&lock_prefix),
+            Some(settlement_witness_with_unlocks(
+                &payment_hashes,
+                vec![
+                    Unlock {
+                        unlock_type: 0xFE,
+                        with_preimage: false,
+                        signature: [0u8; 65],
                         preimage: None,
-                        tx_hash: tx.calc_tx_hash().into(),
-                        tlc_index: 0,
                     },
-                ),
-                (
-                    channel_id,
-                    TLCId::Offered(1),
-                    OnChainTlcSettlement {
-                        payment_hash: tracked[1].payment_hash,
-                        hash_algorithm: HashAlgorithm::CkbHash,
+                    Unlock {
+                        unlock_type: 1,
+                        with_preimage: false,
+                        signature: [0u8; 65],
                         preimage: None,
-                        tx_hash: tx.calc_tx_hash().into(),
-                        tlc_index: 1,
                     },
-                ),
-            ]
+                ],
+            )),
+        );
+        let tracked = [
+            tracked_tlc(payment_hashes[0], 0),
+            tracked_tlc(payment_hashes[1], 1),
+        ];
+        let mut watched_outpoints = HashMap::from([(first_commitment_out_point, tracked.to_vec())]);
+        let mut processed_tx_hashes = HashSet::new();
+        let store = TestWatchtowerStore::default();
+
+        let processed = process_watched_settlement_tx(
+            &tx,
+            &mut watched_outpoints,
+            &mut processed_tx_hashes,
+            &lock_prefix,
+            &channel_id,
+            &store,
+            &NodeId::local(),
+        );
+
+        assert_eq!(processed, Some(0));
+        let settlements = store.settlements();
+        assert_eq!(settlements.len(), 1);
+        assert_eq!(settlements[0].1, TLCId::Offered(1));
+        assert_eq!(settlements[0].2.payment_hash, tracked[1].payment_hash);
+        assert_eq!(
+            watched_outpoints.get(&OutPoint::new(tx.calc_tx_hash(), 0)),
+            Some(&tracked[..1].to_vec()),
+            "only the explicitly index-unlocked TLC leaves the successor witness"
         );
     }
 

--- a/crates/fiber-lib/src/watchtower/store.rs
+++ b/crates/fiber-lib/src/watchtower/store.rs
@@ -68,9 +68,6 @@ pub trait WatchtowerStore {
     /// Get a watch preimage owned by the given node.
     fn get_watch_preimage(&self, node_id: &NodeId, payment_hash: &Hash256) -> Option<Hash256>;
 
-    /// Search for the stored preimage with the given payment hash prefix, should be the first 20 bytes of the payment hash.
-    fn search_preimage(&self, node_id: &NodeId, payment_hash_prefix: &[u8]) -> Option<Hash256>;
-
     /// Insert the only valid on-chain settlement proof for a TLC.
     ///
     /// This must only be written after resolving an observed witness index against the immutable

--- a/crates/fiber-lib/src/watchtower/store.rs
+++ b/crates/fiber-lib/src/watchtower/store.rs
@@ -76,6 +76,7 @@ pub trait WatchtowerStore {
     /// were observed in that witness.
     fn insert_onchain_tlc_settlement(
         &self,
+        node_id: &NodeId,
         channel_id: &Hash256,
         tlc_id: TLCId,
         settlement: OnChainTlcSettlement,
@@ -84,6 +85,7 @@ pub trait WatchtowerStore {
     /// Returns an exact settlement proof for this TLC, or a legacy prefix-keyed record.
     fn get_onchain_tlc_settlement(
         &self,
+        node_id: &NodeId,
         channel_id: &Hash256,
         tlc_id: TLCId,
         payment_hash: &Hash256,

--- a/crates/fiber-lib/src/watchtower/store.rs
+++ b/crates/fiber-lib/src/watchtower/store.rs
@@ -3,7 +3,8 @@ use ckb_types::packed::Script;
 use musig2::{secp::Point, KeyAggContext};
 
 use crate::ckb::contracts::{get_script_by_contract, Contract};
-use crate::fiber::onchain_tlc_reconcile::OnChainTlcSettlement;
+use crate::fiber::onchain_tlc_reconcile::{LegacyOnChainTlcSettlement, OnChainTlcSettlement};
+use fiber_types::TLCId;
 use fiber_types::{ChannelData, Hash256, NodeId, Privkey, Pubkey, RevocationData, SettlementData};
 
 pub trait WatchtowerStore {
@@ -72,13 +73,14 @@ pub trait WatchtowerStore {
 
     /// Insert the only valid on-chain settlement proof for a TLC.
     ///
-    /// This must only be written from an observed settlement witness scoped by channel id and
-    /// payment-hash prefix. Locally-known preimages may be stored as watchtower preimages, but
-    /// must not be written here unless they were observed in that witness.
+    /// This must only be written after resolving an observed witness index against the immutable
+    /// settlement snapshot committed by the force-closed commitment transaction. Locally-known
+    /// preimages may be stored as watchtower preimages, but must not be written here unless they
+    /// were observed in that witness.
     fn insert_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
-        payment_hash_prefix: [u8; 20],
+        tlc_id: TLCId,
         settlement: OnChainTlcSettlement,
     );
 
@@ -86,8 +88,15 @@ pub trait WatchtowerStore {
     fn get_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
-        payment_hash: &Hash256,
+        tlc_id: TLCId,
     ) -> Option<OnChainTlcSettlement>;
+
+    /// Returns a prefix-keyed settlement record written by an older version.
+    fn get_legacy_onchain_tlc_settlement(
+        &self,
+        channel_id: &Hash256,
+        payment_hash: &Hash256,
+    ) -> Option<LegacyOnChainTlcSettlement>;
 }
 
 /// Compute the x-only aggregated public key for a channel.

--- a/crates/fiber-lib/src/watchtower/store.rs
+++ b/crates/fiber-lib/src/watchtower/store.rs
@@ -3,7 +3,7 @@ use ckb_types::packed::Script;
 use musig2::{secp::Point, KeyAggContext};
 
 use crate::ckb::contracts::{get_script_by_contract, Contract};
-use crate::fiber::onchain_tlc_reconcile::{LegacyOnChainTlcSettlement, OnChainTlcSettlement};
+use crate::fiber::onchain_tlc_reconcile::{OnChainTlcSettlement, StoredOnChainTlcSettlement};
 use fiber_types::TLCId;
 use fiber_types::{ChannelData, Hash256, NodeId, Privkey, Pubkey, RevocationData, SettlementData};
 
@@ -84,19 +84,13 @@ pub trait WatchtowerStore {
         settlement: OnChainTlcSettlement,
     );
 
-    /// Returns the channel-scoped on-chain settlement proof for a TLC, if any.
+    /// Returns an exact settlement proof for this TLC, or a legacy prefix-keyed record.
     fn get_onchain_tlc_settlement(
         &self,
         channel_id: &Hash256,
         tlc_id: TLCId,
-    ) -> Option<OnChainTlcSettlement>;
-
-    /// Returns a prefix-keyed settlement record written by an older version.
-    fn get_legacy_onchain_tlc_settlement(
-        &self,
-        channel_id: &Hash256,
         payment_hash: &Hash256,
-    ) -> Option<LegacyOnChainTlcSettlement>;
+    ) -> Option<StoredOnChainTlcSettlement>;
 }
 
 /// Compute the x-only aggregated public key for a channel.


### PR DESCRIPTION
## Summary

- reconstruct the ordered TLC snapshot committed by a force-closed commitment transaction
- carry that snapshot along the watched settlement outpoint lineage and resolve each indexed witness unlock to an exact `TLCId`
- persist exact settlement proofs by `(node_id, channel_id, TLCId)` together with the full 32-byte payment hash and hash algorithm
- treat `0xFE`/`0xFF` as party-balance unlocks only: they neither settle pending TLCs nor remove them from the tracked successor snapshot
- retain watchtower preimages until every same-hash TLC for the same watchtower tenant has its own exact settlement proof
- construct preimage unlocks only from a tenant-scoped, full-hash lookup and verify the TLC's hash algorithm before signing
- keep legacy prefix-keyed records readable without allowing ambiguous no-preimage records to resolve or garbage-collect a TLC

## Root cause

Settlement witnesses encode each pending TLC with only a 20-byte payment-hash prefix and refer to it by its index in the witness. The previous reconciliation code persisted observations under `(channel_id, payment_hash_prefix)` and later looked them up using the same non-unique prefix. Although it recorded `tlc_index`, that index was not used to identify the TLC.

This made a full-hash preimage mismatch unsafe: the record only proved that some TLC under the prefix was consumed, but reconciliation interpreted the mismatch as `SettledWithoutPreimage` for the queried TLC. A duplicate-prefix guard was insufficient because it counted only currently reconcilable TLCs. Once the correctly fulfilled TLC was removed, another pending TLC sharing the prefix could inherit the record and be finalized without independent on-chain proof.

Several follow-on paths could also collapse the per-TLC model:

- preimage GC could treat one same-hash sibling's proof as proof for every sibling
- settlement construction could select a preimage by the 20-byte witness prefix
- `0xFE`/`0xFF` party unlocks were interpreted as settling every remaining TLC, although the contract only clears a party balance/pubkey and leaves pending TLCs in the successor witness
- exact proof keys omitted the watchtower client `node_id`, allowing two tenants watching the same channel ID and endpoint-local `TLCId` to share a record

## Defense in depth

### 1. Anchor scanning to the real channel outpoint lineage

The watchtower starts from the commitment output that descends from the channel's exact funding outpoint. A candidate settlement transaction is parsed only when one of its inputs spends the currently tracked outpoint. After a valid transition, only the expected commitment output is carried forward.

An unrelated user can create a cell with the same lock prefix, but that cell is outside the tracked lineage and cannot write settlement state or become a settlement-construction target.

### 2. Reconstruct and authenticate the settlement snapshot

For the observed commitment number, the watchtower selects the corresponding local or remote `SettlementData`, serializes it into contract witness form, and checks its `blake160` against the hash committed in the commitment-lock args. If the snapshot cannot be reconstructed or does not match the commitment, reconciliation and settlement construction are skipped.

The full 32-byte payment hash comes from this authenticated channel snapshot; it is not inferred from the 20-byte on-chain encoding.

### 3. Carry exact identities through every settlement transition

The scanner maintains:

`live outpoint -> ordered Vec<TrackedSettlementTlc>`

Each tracked entry contains the normalized `TLCId`, full payment hash, hash algorithm, and serialized witness entry. Before accepting a settlement witness, the code verifies that its pending-TLC list has the same length, ordering, and witness bytes as the tracked vector. Each indexed unlock is bounds-checked and resolved through that vector:

`witness index -> TLCId -> full payment_hash + hash_algorithm`

Only explicit TLC index unlocks produce proofs and remove entries. `0xFE`/`0xFF` only unlock party balances, so all still-pending TLCs remain in the successor mapping. This keeps the tracker aligned with the next on-chain witness and prevents fabricated no-preimage proofs.

### 4. Scope exact proofs to the watchtower tenant

New versioned records use `(node_id, channel_id, TLCId)` as their storage identity. The `node_id` is the owner of the watched channel, so two endpoints using the same watchtower cannot collide even when their endpoint-local `TLCId` values, channel ID, full payment hash, and algorithm happen to match.

Resolution additionally checks the stored full hash and hash algorithm against the queried TLC. A preimage is accepted only when hashing it with the committed algorithm equals the complete 32-byte payment hash; otherwise the result is `Unknown` and no TLC, payment, or invoice state is mutated.

### 5. Keep preimages until every sibling and tenant is safe

Preimage cleanup evaluates each active TLC independently using the tenant-scoped exact proof. A preimage remains while any same-hash sibling in the watched snapshot lacks its own exact settlement proof. A proof from one watchtower client cannot garbage-collect another client's preimage.

Prefix-keyed legacy records are deliberately ignored for GC because they cannot identify a specific TLC or tenant.

### 6. Build unlocks from exact preimages only

Settlement construction uses the current outpoint's verified `TrackedSettlementTlc` vector, queries the tenant's preimage by the full payment hash, and verifies:

`hash_algorithm.hash(preimage) == full_payment_hash`

If identity mapping is unavailable, witness ordering differs, the full-hash lookup misses, or the algorithm check fails, no preimage unlock is constructed.

## Legacy compatibility

Legacy prefix-keyed records remain readable, but conservatively:

- a legacy preimage proves fulfillment only after a complete 32-byte hash match
- a legacy no-preimage record resolves to `Unknown`
- a legacy record never causes watchtower preimage deletion

## Impact

Force-close reconciliation, preimage retention, and settlement construction now use the same exact TLC identity model. A settlement result cannot transfer between sibling TLCs, between TLCs sharing only a 20-byte prefix, or between watchtower tenants. Party-balance unlocks cannot fabricate TLC settlement proofs. This preserves the forwarding invariant that an intermediate node only settles one side when it has evidence sufficient to settle the corresponding side safely.

## TDD and validation

The four new regression tests were added first and failed on `7ce62163`, demonstrating both bugs before implementation:

- final-party unlock retains pending TLCs
- final-party plus indexed unlock removes only the indexed TLC
- settlement records are isolated between watchtower tenants
- preimage GC is isolated between watchtower tenants

Validation after the fix:

- `cargo nextest run -p fnn --features sqlite --no-fail-fast` — 1161 passed, 8 skipped
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all -- --check`
- local E2E `watchtower/force-close-with-pending-tlcs` — 24/24 requests, 27/27 assertions
- local E2E `watchtower/force-close-remote-with-pending-tlcs-and-stop-watchtower` — 21/21 requests, 22/22 assertions
- local E2E `watchtower/force-close-with-consecutive-settlement` — 24/24 requests, 26/26 assertions

Existing regression coverage also includes forged shared-prefix TLCs, exact witness-index mapping across successive settlements, same-hash sibling preimage retention, ambiguous legacy retention, settlement-builder full-hash rejection, legacy compatibility, unrelated same-prefix cells, non-first watched inputs, and extra same-prefix outputs.
