### PR TITLE
fix: unblock retryable TLC operations after channel reestablishment

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -7433,6 +7433,7 @@ impl ChannelActorState {
         self.tlc_state.waiting_ack
             || self.remote_revocation_nonce_for_send.is_none()
             || self.remote_revocation_nonce_for_verify.is_none()
+                && self.remote_revocation_nonce_for_next.is_none()
     }
 
     fn check_tlc_limits(&self, add_amount: u128, is_sent: bool) -> ProcessingChannelResult {
@@ -9140,7 +9141,7 @@ impl ChannelActorState {
     ) -> ProcessingChannelResult {
         validate_commit_diff_for_replay_inputs(
             self.get_id(),
-            self.is_waiting_tlc_ack(),
+            self.tlc_state.waiting_ack,
             self.get_local_commitment_number(),
             self.get_remote_commitment_number(),
             reestablish_channel,


### PR DESCRIPTION
## Summary

Fixes #1584 — Payments may remain Inflight after rapid channel reconnects due to a stuck retryable TLC operation queue.

## Root Cause

The `is_waiting_tlc_ack()` function at `crates/fiber-lib/src/fiber/channel.rs:7432` checks `remote_revocation_nonce_for_verify.is_none()` unconditionally, blocking all TLC operations when the verify nonce is missing.

This is a normal state: after processing a peer's `RevokeAndAck` while `send` is still `Some`, the nonce pipeline sets `verify = None` (line 8622 of `handle_revoke_and_ack_peer_message`). The channel is still fully operational — we can sign new commitments using `send` and `last_committed_remote_nonce`.

However, when commitment numbers match after reestablishment and no peer message is expected, `verify=None` persists indefinitely, permanently blocking the retryable TLC operation queue (`apply_retryable_tlc_operations`).

## Changes

1. **Relax `is_waiting_tlc_ack()`**: Only treat `verify=None` as blocking when `next` is also `None`. When `next` is available (a valid nonce for the next commitment round), the channel should not be considered blocked.

2. **Fix `validate_commit_diff_for_replay` call site**: This function was passing `is_waiting_tlc_ack()` to `validate_commit_diff_for_replay_inputs`, but that downstream function treats the parameter as the raw `waiting_ack` flag (line 4705: `if !waiting_ack`). The broader condition would incorrectly fail validation when `verify=None` but the channel was not actually waiting for an ACK. Fixed to pass `tlc_state.waiting_ack` directly.

## Behavior Change

When `waiting_ack=false`, `send=Some`, `verify=None`, `next=Some` (a normal post-reestablish state):

| | Before | After |
|---|---|---|
| `is_waiting_tlc_ack()` | `true` (blocked) | `false` (allowed) |
| `validate_commit_diff_for_replay` | reads raw flag correctly | reads raw flag correctly |

Retryable TLC operations can now proceed and will trigger the normal commitment cycle that advances the nonce pipeline.