### PR TITLE
fix: resolve stuck retryable TLC operations after channel reestablishment

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -8615,7 +8615,9 @@ impl ChannelActorState {
 
         // update the remote_revocation_nonce_for_send and remote_revocation_nonce_for_verify for next round if needed
         self.remote_revocation_nonce_for_next = Some(next_revocation_nonce);
-        if self.remote_revocation_nonce_for_send.is_none() {
+        if self.remote_revocation_nonce_for_send.is_none()
+            || self.remote_revocation_nonce_for_verify.is_none()
+        {
             self.remote_revocation_nonce_for_send = self.remote_revocation_nonce_for_next.clone();
             self.remote_revocation_nonce_for_verify = self.remote_revocation_nonce_for_next.clone();
         } else {


### PR DESCRIPTION
## Summary

Fixes #1584 — Payments remain Inflight after rapid channel reconnects due to a stuck retryable TLC operation queue.

## Root Cause

The nonce update logic in `handle_revoke_and_ack_peer_message` (line 8618) only promotes `next` to `send` and `verify` when `send` is `None`. But after a round where WE initiated (sent CommitmentSigned), the peer's RevokeAndAck leaves `send=Some`, `verify=None`, `next=Some`. This is the **stuck state**:

- `waiting_ack=false` — no pending messages
- `send=Some` — we can sign
- `verify=None` — blocks `is_waiting_tlc_ack()` → blocks all retryable TLC operations
- `next=Some` — a valid nonce for the next round exists

Since `send` is `Some`, the promotion condition never triggers, and `verify` stays `None` permanently — unless the peer initiates a new round.

## Fix

Change the promotion condition to also trigger when `verify` is `None`:

```rust
// Before:
if self.remote_revocation_nonce_for_send.is_none() {

// After:
if self.remote_revocation_nonce_for_send.is_none()
    || self.remote_revocation_nonce_for_verify.is_none()
{
```

This promotes both `send` and `verify` from `next` after every RevokeAndAck processing, ensuring the nonce pipeline always advances and the retry queue is never permanently blocked.

## Testing

All 196 channel tests pass, including:
- 7 reestablish tests
- 1 restart stress test (`test_restart_stress_multiple_restarts`)
- All payment, TLC, and shutdown tests