### PR TITLE
fix: enforce restrictive file permissions in backup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,9 +2303,12 @@ version = "0.9.0-rc7"
 dependencies = [
  "ckb-chain-spec",
  "ckb-resource",
+ "fiber-store",
  "fnn",
  "jsonrpsee",
+ "nix 0.29.0",
  "ractor",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/fiber-bin/Cargo.toml
+++ b/crates/fiber-bin/Cargo.toml
@@ -33,3 +33,10 @@ tokio = { version = "1", features = [
 ] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", features = ["fs"] }
+
+[dev-dependencies]
+fiber-store = { path = "../fiber-store", features = ["rocksdb"] }
+tempfile = "3.10.1"

--- a/crates/fiber-bin/src/main.rs
+++ b/crates/fiber-bin/src/main.rs
@@ -62,8 +62,24 @@ fn cli_progress(progress: MigrationProgress) {
     );
 }
 
-#[tokio::main]
-pub async fn main() -> Result<(), ExitMessage> {
+pub fn main() -> Result<(), ExitMessage> {
+    // Set the process-wide policy before Tokio starts any worker threads. RocksDB creates
+    // files from background threads throughout the lifetime of the node.
+    #[cfg(unix)]
+    {
+        use nix::sys::stat::{umask, Mode};
+
+        umask(Mode::from_bits_truncate(0o077));
+    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| ExitMessage(format!("failed to initialize Tokio runtime: {}", err)))?;
+    runtime.block_on(run())
+}
+
+async fn run() -> Result<(), ExitMessage> {
     // ractor will set "id" for each actor:
     // https://github.com/slawlor/ractor/blob/67d657e4cdcb8884a9ccc9b758704cbb447ac163/ractor/src/actor/mod.rs#L701
     // here we map it with the node prefix

--- a/crates/fiber-bin/tests/permissions.rs
+++ b/crates/fiber-bin/tests/permissions.rs
@@ -1,0 +1,68 @@
+#![cfg(all(unix, not(feature = "sqlite")))]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+use fiber_store::{StorageBackend, Store};
+use nix::sys::stat::{umask, Mode};
+use tempfile::tempdir;
+
+const UMASK_TEST_CHILD: &str = "FNN_UMASK_TEST_CHILD";
+
+#[test]
+fn test_restrictive_umask_applies_to_new_rocksdb_files() {
+    if std::env::var_os(UMASK_TEST_CHILD).is_none() {
+        let status = Command::new(std::env::current_exe().expect("get current test executable"))
+            .args([
+                "--exact",
+                "test_restrictive_umask_applies_to_new_rocksdb_files",
+                "--nocapture",
+            ])
+            .env(UMASK_TEST_CHILD, "1")
+            .status()
+            .expect("run umask test child");
+        assert!(status.success(), "umask test child failed");
+        return;
+    }
+
+    // Apply the same process-wide policy as FNN before RocksDB creates any files.
+    umask(Mode::from_bits_truncate(0o077));
+
+    let dir = tempdir().expect("create temporary directory");
+    let store_path = dir.path().join("store");
+    let backup_path = dir.path().join("backup");
+    let store = Store::open_db(&store_path).expect("open RocksDB");
+    store.put(b"key", b"value");
+    store.backup(&backup_path).expect("create checkpoint");
+
+    let sst_files = fs::read_dir(&store_path)
+        .expect("read store directory")
+        .map(|entry| entry.expect("read store entry").path())
+        .filter(|path| path.extension().is_some_and(|extension| extension == "sst"))
+        .collect::<Vec<_>>();
+    assert!(
+        !sst_files.is_empty(),
+        "checkpoint should flush at least one SST file"
+    );
+
+    assert_private_tree(&store_path);
+    assert_private_tree(&backup_path);
+}
+
+fn assert_private_tree(path: &std::path::Path) {
+    let metadata = fs::metadata(path).expect("read path metadata");
+    let expected_mode = if metadata.is_dir() { 0o700 } else { 0o600 };
+    assert_eq!(
+        metadata.permissions().mode() & 0o777,
+        expected_mode,
+        "unexpected permissions for {}",
+        path.display()
+    );
+
+    if metadata.is_dir() {
+        for entry in fs::read_dir(path).expect("read directory") {
+            assert_private_tree(&entry.expect("read directory entry").path());
+        }
+    }
+}


### PR DESCRIPTION

Fixes #1585.

FNN previously corrected the permissions of existing RocksDB files after opening the database. Files created later by RocksDB, such as SST files produced during checkpoint or backup operations, were not covered by that correction and could inherit the default `0o022` umask, resulting in `0o644` permissions.

This PR:

- sets the process-wide umask to `0o077` on Unix before starting the Tokio runtime;
- ensures subsequently created files use owner-only permissions (`0o600`) and directories use `0o700`;
- covers both the live RocksDB store and backup/checkpoint directories;
- leaves Windows behavior unchanged;
- adds an integration test that verifies permissions recursively for newly created store and backup files.

The umask is applied before Tokio starts worker threads because RocksDB may create files from background threads throughout the node's lifetime.


```bash
cargo nextest run -p fiber-bin --test permissions