### PR TITLE
fix: pace channel reestablishment messages

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -485,6 +485,10 @@ where
         if state.reestablishing {
             match message {
                 FiberChannelMessage::ReestablishChannel(ref reestablish_channel) => {
+                    // The peer's reestablish message can overtake our paced
+                    // PeerReconnected event. Claim and send our side of the handshake
+                    // before processing theirs so neither side is left waiting.
+                    state.on_peer_reconnected();
                     let pending_commit_diff = self.store.get_pending_commit_diff(&state.get_id());
                     state
                         .handle_reestablish_channel_message(
@@ -5681,7 +5685,7 @@ impl ChannelActorState {
     }
 
     fn on_peer_reconnected(&mut self) {
-        if self.reestablishing {
+        if self.reestablishing && self.connectivity_state == ChannelConnectivityState::Offline {
             self.connectivity_state = ChannelConnectivityState::Syncing;
             self.send_reestablish_message();
         }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -48,6 +48,8 @@ use tokio_util::codec::length_delimited;
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, trace, warn};
 
+pub(crate) const CHANNEL_REESTABLISH_INTERVAL: Duration = Duration::from_millis(10);
+
 use super::channel::{
     get_funding_and_reserved_amount, AcceptChannelParameter, ChannelActor, ChannelActorMessage,
     ChannelActorStateStore, ChannelCommand, ChannelCommandWithId, ChannelEvent,
@@ -904,6 +906,9 @@ pub enum NetworkActorCommand {
     InstallTestChannelActor(Hash256, ActorRef<ChannelActorMessage>, RpcReplyPort<()>),
     // Check peer send us Init message in an expected time, otherwise disconnect with the peer.
     CheckPeerInit(Pubkey, SessionId),
+    // Pace persisted channel reestablishment without blocking the NetworkActor. The channel ids
+    // stay in one heap allocation while each continuation only moves the Vec header.
+    ReestablishChannels(Pubkey, SessionId, Vec<Hash256>),
     // For internal use and debugging only. Most of the messages requires some
     // changes to local state. Even if we can send a message to a peer, some
     // part of the local state is not changed.
@@ -2494,6 +2499,35 @@ where
                             ))
                             .expect(ASSUME_NETWORK_MYSELF_ALIVE);
                     }
+                }
+            }
+            NetworkActorCommand::ReestablishChannels(pubkey, session_id, mut channel_ids) => {
+                if !matches!(
+                    state.peer_session_map.get(&pubkey),
+                    Some(peer) if peer.session_id == session_id && peer.features.is_some()
+                ) {
+                    debug!(
+                        peer = format!("{pubkey:?}"),
+                        session = format!("{session_id:?}"),
+                        "Dropping stale channel reestablishment continuation"
+                    );
+                    return Ok(());
+                }
+
+                if let Some(channel_id) = channel_ids.pop() {
+                    if let Err(err) = state.reestablish_channel(channel_id).await {
+                        error!("Failed to reestablish channel {:x}: {:?}", channel_id, err);
+                    }
+                }
+
+                if !channel_ids.is_empty() {
+                    myself.send_after(CHANNEL_REESTABLISH_INTERVAL, move || {
+                        NetworkActorMessage::new_command(NetworkActorCommand::ReestablishChannels(
+                            pubkey,
+                            session_id,
+                            channel_ids,
+                        ))
+                    });
                 }
             }
             NetworkActorCommand::CheckChannelsShutdown => {
@@ -6597,7 +6631,7 @@ where
 
     pub async fn on_init_msg(
         &mut self,
-        _myself: ActorRef<NetworkActorMessage>,
+        myself: ActorRef<NetworkActorMessage>,
         peer_pubkey: Pubkey,
         init_msg: Init,
     ) -> ProcessingChannelResult {
@@ -6650,12 +6684,24 @@ where
                 &peer_pubkey
             )));
         }
-        debug_event!(_myself, "PeerInit");
+        debug_event!(myself, "PeerInit");
         if let Some(channels) = self.peer_channel_index.get_channels(&peer_pubkey) {
-            for channel_id in channels {
-                if let Err(e) = self.reestablish_channel(channel_id).await {
-                    error!("Failed to reestablish channel {:x}: {:?}", &channel_id, &e);
-                }
+            let channel_ids = channels.into_iter().collect::<Vec<_>>();
+            if !channel_ids.is_empty() {
+                let session_id = self
+                    .peer_session_map
+                    .get(&peer_pubkey)
+                    .expect("peer session checked above")
+                    .session_id;
+                myself
+                    .send_message(NetworkActorMessage::new_command(
+                        NetworkActorCommand::ReestablishChannels(
+                            peer_pubkey,
+                            session_id,
+                            channel_ids,
+                        ),
+                    ))
+                    .expect(ASSUME_NETWORK_ACTOR_ALIVE);
             }
         }
 

--- a/crates/fiber-lib/src/fiber/peer_message_policy.rs
+++ b/crates/fiber-lib/src/fiber/peer_message_policy.rs
@@ -332,6 +332,11 @@ impl Default for PeerMessagePolicy {
 mod tests {
     use fiber_types::Privkey;
 
+    use crate::fiber::{
+        network::CHANNEL_REESTABLISH_INTERVAL,
+        types::{FiberMessage, ReestablishChannel},
+    };
+
     use super::*;
 
     fn expect_allowed(policy: &mut PeerMessagePolicy, peer: &Pubkey, bytes: u64, now_ms: u64) {
@@ -411,6 +416,34 @@ mod tests {
         assert_eq!(policy.admit(&peer, 1, 0), PeerMessageAdmission::Ban);
 
         expect_allowed(&mut policy, &peer, 1, PEER_MESSAGE_BAN_DURATION_MS);
+    }
+
+    #[test]
+    fn paced_reestablishment_allows_more_channels_than_peer_burst() {
+        const PERSISTED_CHANNELS: u32 = 540;
+        let peer = Privkey::from_slice(&[21u8; 32]).pubkey();
+        let mut policy = PeerMessagePolicy::new();
+        let frame_bytes = FiberMessage::reestablish_channel(ReestablishChannel {
+            channel_id: Default::default(),
+            local_commitment_number: 0,
+            remote_commitment_number: 0,
+        })
+        .to_molecule_bytes()
+        .len() as u64;
+        assert_eq!(frame_bytes, 68);
+        for index in 0..PERSISTED_CHANNELS {
+            expect_allowed(
+                &mut policy,
+                &peer,
+                frame_bytes,
+                u64::from(index).saturating_mul(CHANNEL_REESTABLISH_INTERVAL.as_millis() as u64),
+            );
+        }
+        assert!(!policy.is_banned(
+            &peer,
+            u64::from(PERSISTED_CHANNELS)
+                .saturating_mul(CHANNEL_REESTABLISH_INTERVAL.as_millis() as u64)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- pace persisted channel reestablishment messages at a 10 ms interval instead of sending every channel at once after peer initialization
- bind each delayed continuation to the originating session so stale reconnect work is discarded
- add a regression test covering 540 persisted channels, beyond the per-peer burst allowance

## Root cause

After a peer completed `Init`, the network actor notified every associated channel immediately. Each channel then sent one `ReestablishChannel` message, so peers with more than 400 existing channels exhausted the per-peer message burst allowance. The remaining buffered messages accumulated enough rate-limit violations to disconnect and temporarily ban a legitimate peer.

## Impact

Channel reestablishment is now paced at approximately 100 messages per second, below the 200 messages per second admission rate. The existing admission limits remain unchanged, while nodes with many persisted channels can reconnect without triggering the malicious-peer protections.

Each continuation also verifies the current `SessionId`, preventing delayed work from an old connection from running against a replacement session.

## Testing

- `cargo nextest run -p fnn -p fiber-bin peer_message_policy`
- `cargo nextest run -p fnn -p fiber-bin fiber::network::tests`
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all -- --check`

Closes #1586