### PR TITLE
fix(cch): make send_btc recovery durable and idempotent

### DIFF
--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -31,7 +31,7 @@ use crate::cch::{CchConfig, CchError, CchOrderStore, CchStoreError, OutgoingFeeL
 use crate::ckb::contracts::{get_script_by_contract, Contract};
 use crate::fiber::config::MAX_PAYMENT_TLC_EXPIRY_LIMIT;
 use crate::fiber::NetworkActorMessage;
-use crate::invoice::{CkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder};
+use crate::invoice::{Attribute, CkbInvoice, CkbInvoiceStatus, Currency, InvoiceBuilder};
 use crate::now_timestamp_as_millis_u64;
 use crate::store::store_impl::StoreChange;
 use crate::time::Duration;
@@ -460,6 +460,10 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 // A timed-out RPC leaves its message in the mailbox. Do not begin a new
                 // state-changing operation when its caller is no longer waiting for the result.
                 if port.is_closed() {
+                    return Ok(());
+                }
+                if let Err(err) = state.ensure_send_btc_currency(send_btc.currency) {
+                    let _ = port.send(Err(err));
                     return Ok(());
                 }
                 let payment_hash = Bolt11Invoice::from_str(&send_btc.btc_pay_req)
@@ -979,6 +983,7 @@ impl<S: CchOrderStore> CchState<S> {
     }
 
     async fn send_btc(&self, send_btc: SendBTC) -> Result<(CchOrder, bool), CchError> {
+        self.ensure_send_btc_currency(send_btc.currency)?;
         let invoice = Bolt11Invoice::from_str(&send_btc.btc_pay_req)?;
         tracing::debug!(
             "BTC invoice parsed payment_hash={:x} currency={:?} has_amount={}",
@@ -1003,14 +1008,6 @@ impl<S: CchOrderStore> CchState<S> {
         }
 
         let order_created_at = now_timestamp_as_millis_u64() / 1000;
-
-        // Validate that the currency matches the configured CKB network (#981)
-        if send_btc.currency != self.currency {
-            return Err(CchError::CKBInvoiceNetworkMismatch {
-                expected: self.currency,
-                actual: send_btc.currency,
-            });
-        }
 
         // Validate that the BTC invoice network matches the expected BTC network (#978)
         let expected_ln_currency = expected_ln_currency(self.currency);
@@ -1070,11 +1067,13 @@ impl<S: CchOrderStore> CchState<S> {
             .checked_add(fee_sats)
             .ok_or(CchError::SendBTCOrderAmountTooLarge)?;
 
+        let incoming_invoice_deadline = order_created_at
+            .checked_add(incoming_invoice_expiry_delta_seconds)
+            .ok_or(CchError::SendBTCOrderCreationExpired(payment_hash))?;
         let invoice_builder = InvoiceBuilder::new(send_btc.currency)
             .amount(Some(invoice_amount_sats))
             .payment_hash(payment_hash)
             .hash_algorithm(HashAlgorithm::Sha256)
-            .expiry_time(Duration::from_secs(incoming_invoice_expiry_delta_seconds))
             .final_expiry_delta(
                 self.config
                     .ckb_final_tlc_expiry_delta_seconds
@@ -1087,14 +1086,11 @@ impl<S: CchOrderStore> CchState<S> {
                     })?,
             )
             .udt_type_script(wrapped_btc_type_script.clone().into());
-
-        let incoming_invoice = if let Some((public_key, secret_key)) = &self.node_keypair {
-            invoice_builder
-                .payee_pub_key(*public_key)
-                .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, secret_key))
-        } else {
-            invoice_builder.build()
-        }?;
+        let incoming_invoice = self.build_send_btc_fiber_invoice_until(
+            invoice_builder,
+            payment_hash,
+            incoming_invoice_deadline,
+        )?;
 
         // Reserve tracker capacity before persisting the intent. The intent is the durable
         // boundary: after this point a lost RPC response can be reconciled by payment hash.
@@ -1157,6 +1153,17 @@ impl<S: CchOrderStore> CchState<S> {
             Err(CchStoreError::NotFound(_)) => Ok(None),
             Err(err) => Err(err.into()),
             Ok(creation) => Ok(Some(creation)),
+        }
+    }
+
+    fn ensure_send_btc_currency(&self, currency: Currency) -> Result<(), CchError> {
+        if currency == self.currency {
+            Ok(())
+        } else {
+            Err(CchError::CKBInvoiceNetworkMismatch {
+                expected: self.currency,
+                actual: currency,
+            })
         }
     }
 
@@ -1226,7 +1233,16 @@ impl<S: CchOrderStore> CchState<S> {
             Some(info) => info,
             None => {
                 let invoice = self.refresh_send_btc_fiber_invoice(&creation)?;
-                match self.fiber_agent_ref.call_add_invoice(invoice).await {
+                let deadline_seconds = self.send_btc_creation_deadline(&creation)?;
+                match self
+                    .fiber_agent_ref
+                    .call_add_invoice(
+                        invoice,
+                        deadline_seconds,
+                        self.config.min_outgoing_invoice_expiry_delta_seconds,
+                    )
+                    .await
+                {
                     Ok(invoice) => crate::cch::cch_fiber_agent::FiberInvoiceInfo {
                         invoice,
                         status: CkbInvoiceStatus::Open,
@@ -1342,37 +1358,62 @@ impl<S: CchOrderStore> CchState<S> {
         &self,
         creation: &CchSendBtcOrderCreation,
     ) -> Result<CkbInvoice, CchError> {
-        let now_millis = now_timestamp_as_millis_u64();
-        let now_seconds_ceiling = now_millis
-            .checked_add(999)
-            .ok_or(CchError::SendBTCOrderCreationExpired(creation.payment_hash))?
-            / 1_000;
-        let remaining_seconds = self
-            .send_btc_creation_deadline(creation)?
-            .checked_sub(now_seconds_ceiling)
-            .ok_or(CchError::SendBTCOrderCreationExpired(creation.payment_hash))?;
-        if remaining_seconds < self.config.min_outgoing_invoice_expiry_delta_seconds {
-            return Err(CchError::SendBTCOrderCreationExpired(creation.payment_hash));
-        }
-
         let template = &creation.incoming_invoice;
         let mut builder = InvoiceBuilder::new(template.currency)
             .amount(template.amount)
             .payment_hash(creation.payment_hash)
             .hash_algorithm(template.hash_algorithm().copied().unwrap_or_default())
-            .expiry_time(Duration::from_secs(remaining_seconds))
             .final_expiry_delta(template.final_tlc_minimum_expiry_delta_or_default());
         if let Some(script) = template.udt_type_script() {
             builder = builder.udt_type_script(script.clone());
         }
-        if let Some((public_key, secret_key)) = &self.node_keypair {
-            builder
-                .payee_pub_key(*public_key)
-                .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, secret_key))
-                .map_err(Into::into)
-        } else {
-            builder.build().map_err(Into::into)
+        self.build_send_btc_fiber_invoice_until(
+            builder,
+            creation.payment_hash,
+            self.send_btc_creation_deadline(creation)?,
+        )
+    }
+
+    fn build_send_btc_fiber_invoice_until(
+        &self,
+        mut builder: InvoiceBuilder,
+        payment_hash: Hash256,
+        deadline_seconds: u64,
+    ) -> Result<CkbInvoice, CchError> {
+        if let Some((public_key, _)) = &self.node_keypair {
+            builder = builder.payee_pub_key(*public_key);
         }
+
+        // Invoice timestamps are millisecond-precise while expiry attributes contain whole
+        // seconds. Fix the timestamp first, then round the remaining lifetime down so the
+        // resulting absolute expiry can never extend past the BTC/order deadline.
+        let mut invoice = builder.build()?;
+        let deadline_millis = u128::from(deadline_seconds)
+            .checked_mul(1_000)
+            .ok_or(CchError::SendBTCOrderCreationExpired(payment_hash))?;
+        let remaining_seconds = deadline_millis
+            .checked_sub(invoice.data.timestamp)
+            .and_then(|remaining| u64::try_from(remaining / 1_000).ok())
+            .ok_or(CchError::SendBTCOrderCreationExpired(payment_hash))?;
+        let required_expiry_seconds = self
+            .config
+            .min_outgoing_invoice_expiry_delta_seconds
+            .checked_add(self.fiber_agent_ref.add_invoice_expiry_margin_seconds())
+            .ok_or(CchError::SendBTCOrderCreationExpired(payment_hash))?;
+        if remaining_seconds < required_expiry_seconds {
+            return Err(CchError::SendBTCOrderCreationExpired(payment_hash));
+        }
+        invoice
+            .data
+            .attrs
+            .push(Attribute::ExpiryTime(Duration::from_secs(
+                remaining_seconds,
+            )));
+
+        if let Some((_, secret_key)) = &self.node_keypair {
+            invoice.update_signature(|hash| SECP256K1.sign_ecdsa_recoverable(hash, secret_key))?;
+        }
+        Ok(invoice)
     }
 
     fn remaining_outgoing_invoice_expiry_seconds(

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -36,7 +36,8 @@ use crate::now_timestamp_as_millis_u64;
 use crate::store::store_impl::StoreChange;
 use crate::time::Duration;
 use fiber_types::{
-    AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation, HashAlgorithm,
+    AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation,
+    CchSendBtcOrderCreation, HashAlgorithm,
 };
 use fiber_types::{Hash256, Privkey};
 
@@ -159,6 +160,12 @@ pub enum CchMessage {
         retry_count: u32,
     },
 
+    /// Resume a durable `send_btc` creation left by an interrupted attempt.
+    ResumeSendBTCOrderCreation {
+        payment_hash: Hash256,
+        retry_count: u32,
+    },
+
     /// Expire an active order after its configured expiry window elapses.
     ExpireOrder(Hash256),
 
@@ -211,6 +218,7 @@ pub struct CchState<S> {
     pub(super) scheduler: ActorRef<SchedulerMessage>,
     pub(super) store: S,
     pending_receive_btc_creation_retries: HashSet<Hash256>,
+    pending_send_btc_creation_retries: HashSet<Hash256>,
     /// The CKB network currency this node is configured for.
     pub(super) currency: Currency,
 }
@@ -342,6 +350,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             scheduler,
             currency: args.currency,
             pending_receive_btc_creation_retries: HashSet::new(),
+            pending_send_btc_creation_retries: HashSet::new(),
         };
 
         Ok(state)
@@ -426,6 +435,17 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             }
         }
 
+        // A creation intent is persisted before the external Fiber side effect. Replaying these
+        // messages makes a crash or lost RPC response during `send_btc` recoverable.
+        for payment_hash in state.store.get_send_btc_order_creation_keys_iter() {
+            if state.pending_send_btc_creation_retries.insert(payment_hash) {
+                myself.send_message(CchMessage::ResumeSendBTCOrderCreation {
+                    payment_hash,
+                    retry_count: 0,
+                })?;
+            }
+        }
+
         Ok(())
     }
 
@@ -437,16 +457,38 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
     ) -> Result<(), ActorProcessingErr> {
         match message {
             CchMessage::SendBTC(send_btc, port) => {
+                // A timed-out RPC leaves its message in the mailbox. Do not begin a new
+                // state-changing operation when its caller is no longer waiting for the result.
+                if port.is_closed() {
+                    return Ok(());
+                }
+                let payment_hash = Bolt11Invoice::from_str(&send_btc.btc_pay_req)
+                    .ok()
+                    .map(|invoice| Hash256::from(*invoice.payment_hash()));
                 let result = state.send_btc(send_btc).await;
-                if let Ok(order) = &result {
+                if let Ok((order, true)) = &result {
                     // Schedule jobs for new order
-                    state.schedule_job_for_non_final_order(order);
+                    state.schedule_job_on_entering(order);
                     let actions = ActionDispatcher::on_starting(order);
                     append_actions(myself, order.payment_hash, actions)?;
+                } else if let (Some(payment_hash), Err(err)) = (payment_hash, &result) {
+                    if state
+                        .get_send_btc_order_creation_or_none(&payment_hash)?
+                        .is_some()
+                        && is_retryable_send_btc_creation_error(err)
+                    {
+                        schedule_send_btc_creation_retry(
+                            &myself,
+                            &mut state.pending_send_btc_creation_retries,
+                            payment_hash,
+                            0,
+                            &err.to_string(),
+                        );
+                    }
                 }
                 if !port.is_closed() {
                     // ignore error
-                    let _ = port.send(result);
+                    let _ = port.send(result.map(|(order, _)| order));
                 }
                 Ok(())
             }
@@ -639,7 +681,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     .remove(&payment_hash);
                 match state.resume_receive_btc_order_creation(payment_hash).await {
                     Ok(Some(order)) => {
-                        state.schedule_job_for_non_final_order(&order);
+                        state.schedule_job_on_entering(&order);
                         let actions = ActionDispatcher::on_starting(&order);
                         append_actions(myself, order.payment_hash, actions)?;
                     }
@@ -656,6 +698,39 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     Err(err) => {
                         tracing::error!(
                             "Permanently failed to resume receive_btc creation {:x}: {}. The durable intent is retained for operator inspection",
+                            payment_hash,
+                            err
+                        );
+                    }
+                }
+                Ok(())
+            }
+            CchMessage::ResumeSendBTCOrderCreation {
+                payment_hash,
+                retry_count,
+            } => {
+                state
+                    .pending_send_btc_creation_retries
+                    .remove(&payment_hash);
+                match state.resume_send_btc_order_creation(payment_hash).await {
+                    Ok(Some(order)) => {
+                        state.schedule_job_for_non_final_order(&order);
+                        let actions = ActionDispatcher::on_starting(&order);
+                        append_actions(myself, order.payment_hash, actions)?;
+                    }
+                    Ok(None) => {}
+                    Err(err) if is_retryable_send_btc_creation_error(&err) => {
+                        schedule_send_btc_creation_retry(
+                            &myself,
+                            &mut state.pending_send_btc_creation_retries,
+                            payment_hash,
+                            retry_count,
+                            &err.to_string(),
+                        );
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            "Permanently failed to resume send_btc creation {:x}: {}. The durable intent is retained for operator inspection",
                             payment_hash,
                             err
                         );
@@ -866,7 +941,30 @@ impl<S: CchOrderStore> CchState<S> {
         Ok(get_script_by_contract(Contract::SimpleUDT, &args).into())
     }
 
-    async fn send_btc(&self, send_btc: SendBTC) -> Result<CchOrder, CchError> {
+    async fn send_btc(&self, send_btc: SendBTC) -> Result<(CchOrder, bool), CchError> {
+        let invoice = Bolt11Invoice::from_str(&send_btc.btc_pay_req)?;
+        tracing::debug!(
+            "BTC invoice parsed payment_hash={:x} currency={:?} has_amount={}",
+            Hash256::from(*invoice.payment_hash()),
+            invoice.currency(),
+            invoice.amount_milli_satoshis().is_some()
+        );
+        let payment_hash = Hash256::from(*invoice.payment_hash());
+
+        // A retry after an RPC timeout must return the durable result instead of reserving the
+        // same payment tracker a second time.
+        if let Some(order) = self.get_order_or_none(&payment_hash)? {
+            self.ensure_send_btc_request_matches_order(&send_btc.btc_pay_req, &order)?;
+            return Ok((order, false));
+        }
+        if let Some(creation) = self.get_send_btc_order_creation_or_none(&payment_hash)? {
+            self.ensure_send_btc_request_matches_creation(&send_btc.btc_pay_req, &creation)?;
+            return self
+                .complete_send_btc_order_creation_with_tracking(creation)
+                .await
+                .map(|order| (order, true));
+        }
+
         let order_created_at = now_timestamp_as_millis_u64() / 1000;
 
         // Validate that the currency matches the configured CKB network (#981)
@@ -877,14 +975,6 @@ impl<S: CchOrderStore> CchState<S> {
             });
         }
 
-        let invoice = Bolt11Invoice::from_str(&send_btc.btc_pay_req)?;
-        tracing::debug!(
-            "BTC invoice parsed payment_hash={:x} currency={:?} has_amount={}",
-            Hash256::from(*invoice.payment_hash()),
-            invoice.currency(),
-            invoice.amount_milli_satoshis().is_some()
-        );
-
         // Validate that the BTC invoice network matches the expected BTC network (#978)
         let expected_ln_currency = expected_ln_currency(self.currency);
         let actual_ln_currency = invoice.currency();
@@ -894,8 +984,6 @@ impl<S: CchOrderStore> CchState<S> {
                 actual: format!("{:?}", actual_ln_currency),
             });
         }
-
-        let payment_hash = Hash256::from(*invoice.payment_hash());
 
         let invoice_created_at = invoice.duration_since_epoch().as_secs();
         if invoice_created_at > order_created_at {
@@ -921,7 +1009,9 @@ impl<S: CchOrderStore> CchState<S> {
             .expires_at()
             .and_then(|expired_at| expired_at.as_secs().checked_sub(order_created_at))
             .ok_or(CchError::BTCInvoiceExpired)?;
-        if outgoing_invoice_expiry_delta_seconds
+        let incoming_invoice_expiry_delta_seconds =
+            outgoing_invoice_expiry_delta_seconds.min(self.config.order_expiry_delta_seconds);
+        if incoming_invoice_expiry_delta_seconds
             < self.config.min_outgoing_invoice_expiry_delta_seconds
         {
             return Err(CchError::OutgoingInvoiceExpiryTooShort);
@@ -947,7 +1037,7 @@ impl<S: CchOrderStore> CchState<S> {
             .amount(Some(invoice_amount_sats))
             .payment_hash(payment_hash)
             .hash_algorithm(HashAlgorithm::Sha256)
-            .expiry_time(Duration::from_secs(outgoing_invoice_expiry_delta_seconds))
+            .expiry_time(Duration::from_secs(incoming_invoice_expiry_delta_seconds))
             .final_expiry_delta(
                 self.config
                     .ckb_final_tlc_expiry_delta_seconds
@@ -961,7 +1051,7 @@ impl<S: CchOrderStore> CchState<S> {
             )
             .udt_type_script(wrapped_btc_type_script.clone().into());
 
-        let invoice = if let Some((public_key, secret_key)) = &self.node_keypair {
+        let incoming_invoice = if let Some((public_key, secret_key)) = &self.node_keypair {
             invoice_builder
                 .payee_pub_key(*public_key)
                 .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, secret_key))
@@ -969,49 +1059,283 @@ impl<S: CchOrderStore> CchState<S> {
             invoice_builder.build()
         }?;
 
+        // Reserve tracker capacity before persisting the intent. The intent is the durable
+        // boundary: after this point a lost RPC response can be reconciled by payment hash.
+        self.reserve_lnd_payment_tracking(payment_hash).await?;
+        let creation = CchSendBtcOrderCreation {
+            created_at: order_created_at,
+            order_expiry_delta_seconds: self.config.order_expiry_delta_seconds,
+            btc_pay_req: send_btc.btc_pay_req,
+            payment_hash,
+            incoming_invoice,
+            fee_sats,
+            wrapped_btc_type_script,
+        };
+        let result = async {
+            self.store
+                .insert_send_btc_order_creation(creation.clone())?;
+            self.complete_send_btc_order_creation(creation).await
+        }
+        .await;
+        if result.is_err() {
+            self.release_lnd_payment_tracking(payment_hash);
+        }
+        result.map(|order| (order, true))
+    }
+
+    async fn reserve_lnd_payment_tracking(&self, payment_hash: Hash256) -> Result<(), CchError> {
         let reservation = ractor::call!(self.lnd_tracker, |reply| {
             LndTrackerMessage::ReservePaymentTracking(payment_hash, reply)
         })
         .map_err(|err| CchError::LndPaymentTrackerError(err.to_string()))?;
         match reservation {
-            PaymentTrackingReservationResult::Reserved => {}
+            PaymentTrackingReservationResult::Reserved => Ok(()),
             PaymentTrackingReservationResult::AlreadyTracked => {
-                return Err(CchError::LndPaymentAlreadyTracked(payment_hash));
+                Err(CchError::LndPaymentAlreadyTracked(payment_hash))
             }
-            PaymentTrackingReservationResult::CapacityExceeded => {
-                return Err(CchError::LndPaymentTrackerCapacityExceeded(
-                    MAX_TRACKED_PAYMENTS,
-                ));
-            }
+            PaymentTrackingReservationResult::CapacityExceeded => Err(
+                CchError::LndPaymentTrackerCapacityExceeded(MAX_TRACKED_PAYMENTS),
+            ),
         }
+    }
 
-        let result = async {
-            let invoice = self.fiber_agent_ref.call_add_invoice(invoice).await?;
-
-            let order = CchOrder {
-                amount_sats: invoice_amount_sats,
-                created_at: order_created_at,
-                expiry_delta_seconds: self.config.order_expiry_delta_seconds,
-                failure_reason: None,
-                incoming_invoice: CchInvoice::Fiber(invoice),
-                outgoing_pay_req: send_btc.btc_pay_req,
-                payment_preimage: None,
-                status: CchOrderStatus::Pending,
-                fee_sats,
+    fn release_lnd_payment_tracking(&self, payment_hash: Hash256) {
+        if let Err(err) = self
+            .lnd_tracker
+            .send_message(LndTrackerMessage::StopTrackingPayment(payment_hash))
+        {
+            tracing::warn!(
+                "Failed to release payment tracker reservation for {:x}: {}",
                 payment_hash,
-                wrapped_btc_type_script,
-            };
+                err
+            );
+        }
+    }
 
-            self.store.insert_cch_order(order.clone())?;
-            Ok(order)
+    fn get_send_btc_order_creation_or_none(
+        &self,
+        payment_hash: &Hash256,
+    ) -> Result<Option<CchSendBtcOrderCreation>, CchError> {
+        match self.store.get_send_btc_order_creation(payment_hash) {
+            Err(CchStoreError::NotFound(_)) => Ok(None),
+            Err(err) => Err(err.into()),
+            Ok(creation) => Ok(Some(creation)),
+        }
+    }
+
+    fn ensure_send_btc_request_matches_order(
+        &self,
+        btc_pay_req: &str,
+        order: &CchOrder,
+    ) -> Result<(), CchError> {
+        if order.outgoing_pay_req == btc_pay_req
+            && matches!(order.incoming_invoice, CchInvoice::Fiber(_))
+        {
+            Ok(())
+        } else {
+            Err(CchError::ConflictingSendBTCRequest(order.payment_hash))
+        }
+    }
+
+    fn ensure_send_btc_request_matches_creation(
+        &self,
+        btc_pay_req: &str,
+        creation: &CchSendBtcOrderCreation,
+    ) -> Result<(), CchError> {
+        if creation.btc_pay_req == btc_pay_req {
+            Ok(())
+        } else {
+            Err(CchError::ConflictingSendBTCRequest(creation.payment_hash))
+        }
+    }
+
+    async fn resume_send_btc_order_creation(
+        &self,
+        payment_hash: Hash256,
+    ) -> Result<Option<CchOrder>, CchError> {
+        if self.get_order_or_none(&payment_hash)?.is_some() {
+            // The order is authoritative if a crash happened after its batch commit but before
+            // the actor observed completion.
+            self.store.delete_send_btc_order_creation(&payment_hash);
+            return Ok(None);
+        }
+        let Some(creation) = self.get_send_btc_order_creation_or_none(&payment_hash)? else {
+            return Ok(None);
         };
-        let result = result.await;
+        self.complete_send_btc_order_creation_with_tracking(creation)
+            .await
+            .map(Some)
+    }
+
+    async fn complete_send_btc_order_creation_with_tracking(
+        &self,
+        creation: CchSendBtcOrderCreation,
+    ) -> Result<CchOrder, CchError> {
+        let payment_hash = creation.payment_hash;
+        self.reserve_lnd_payment_tracking(payment_hash).await?;
+        let result = self.complete_send_btc_order_creation(creation).await;
         if result.is_err() {
-            let _ = self
-                .lnd_tracker
-                .send_message(LndTrackerMessage::StopTrackingPayment(payment_hash));
+            self.release_lnd_payment_tracking(payment_hash);
         }
         result
+    }
+
+    async fn complete_send_btc_order_creation(
+        &self,
+        creation: CchSendBtcOrderCreation,
+    ) -> Result<CchOrder, CchError> {
+        let payment_hash = creation.payment_hash;
+        let invoice_info = match self.fiber_agent_ref.call_get_invoice(payment_hash).await? {
+            Some(info) => info,
+            None => {
+                let invoice = self.refresh_send_btc_fiber_invoice(&creation)?;
+                match self.fiber_agent_ref.call_add_invoice(invoice).await {
+                    Ok(invoice) => crate::cch::cch_fiber_agent::FiberInvoiceInfo {
+                        invoice,
+                        status: CkbInvoiceStatus::Open,
+                    },
+                    Err(add_error) => {
+                        match self.fiber_agent_ref.call_get_invoice(payment_hash).await? {
+                            Some(info) => info,
+                            None => return Err(add_error),
+                        }
+                    }
+                }
+            }
+        };
+        let incoming_invoice = invoice_info.invoice;
+        self.ensure_send_btc_fiber_invoice_matches(&creation, &incoming_invoice)?;
+
+        let (status, failure_reason) = match invoice_info.status {
+            CkbInvoiceStatus::Open => (CchOrderStatus::Pending, None),
+            CkbInvoiceStatus::Received => (CchOrderStatus::IncomingAccepted, None),
+            CkbInvoiceStatus::Cancelled => (
+                CchOrderStatus::Failed,
+                Some("Fiber invoice was cancelled before order recovery".to_string()),
+            ),
+            CkbInvoiceStatus::Expired => (
+                CchOrderStatus::Failed,
+                Some("Fiber invoice expired before order recovery".to_string()),
+            ),
+            CkbInvoiceStatus::Paid => {
+                return Err(CchError::FiberInvoiceMismatch(payment_hash));
+            }
+        };
+
+        let amount_sats = incoming_invoice
+            .amount
+            .ok_or(CchError::SendBTCOrderAmountTooLarge)?;
+        let order = CchOrder {
+            amount_sats,
+            created_at: creation.created_at,
+            expiry_delta_seconds: creation.order_expiry_delta_seconds,
+            failure_reason,
+            incoming_invoice: CchInvoice::Fiber(incoming_invoice),
+            outgoing_pay_req: creation.btc_pay_req.clone(),
+            payment_preimage: None,
+            status,
+            fee_sats: creation.fee_sats,
+            payment_hash,
+            wrapped_btc_type_script: creation.wrapped_btc_type_script,
+        };
+
+        match self.store.complete_send_btc_order_creation(order.clone()) {
+            Ok(()) => Ok(order),
+            Err(CchStoreError::Duplicated(_)) => {
+                let existing = self.store.get_cch_order(&payment_hash)?;
+                self.ensure_send_btc_request_matches_order(&creation.btc_pay_req, &existing)?;
+                self.store.delete_send_btc_order_creation(&payment_hash);
+                Ok(existing)
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn ensure_send_btc_fiber_invoice_matches(
+        &self,
+        creation: &CchSendBtcOrderCreation,
+        invoice: &CkbInvoice,
+    ) -> Result<(), CchError> {
+        let deadline_millis = self
+            .send_btc_creation_deadline(creation)?
+            .checked_mul(1_000)
+            .map(u128::from)
+            .ok_or(CchError::SendBTCOrderCreationExpired(creation.payment_hash))?;
+        let invoice_expiry_millis = invoice
+            .expiry_time()
+            .and_then(|expiry| invoice.data.timestamp.checked_add(expiry.as_millis()));
+        if *invoice.payment_hash() == creation.payment_hash
+            && invoice.currency == creation.incoming_invoice.currency
+            && invoice.amount == creation.incoming_invoice.amount
+            && invoice.hash_algorithm().copied().unwrap_or_default()
+                == creation
+                    .incoming_invoice
+                    .hash_algorithm()
+                    .copied()
+                    .unwrap_or_default()
+            && invoice.final_tlc_minimum_expiry_delta_or_default()
+                == creation
+                    .incoming_invoice
+                    .final_tlc_minimum_expiry_delta_or_default()
+            && invoice.udt_type_script() == creation.incoming_invoice.udt_type_script()
+            && invoice_expiry_millis.is_some_and(|expiry| expiry <= deadline_millis)
+        {
+            Ok(())
+        } else {
+            Err(CchError::FiberInvoiceMismatch(creation.payment_hash))
+        }
+    }
+
+    fn send_btc_creation_deadline(
+        &self,
+        creation: &CchSendBtcOrderCreation,
+    ) -> Result<u64, CchError> {
+        let btc_deadline = Bolt11Invoice::from_str(&creation.btc_pay_req)?
+            .expires_at()
+            .map(|expiry| expiry.as_secs())
+            .ok_or(CchError::SendBTCOrderCreationExpired(creation.payment_hash))?;
+        let order_deadline = creation
+            .created_at
+            .checked_add(creation.order_expiry_delta_seconds)
+            .ok_or(CchError::SendBTCOrderCreationExpired(creation.payment_hash))?;
+        Ok(btc_deadline.min(order_deadline))
+    }
+
+    fn refresh_send_btc_fiber_invoice(
+        &self,
+        creation: &CchSendBtcOrderCreation,
+    ) -> Result<CkbInvoice, CchError> {
+        let now_millis = now_timestamp_as_millis_u64();
+        let now_seconds_ceiling = now_millis
+            .checked_add(999)
+            .ok_or(CchError::SendBTCOrderCreationExpired(creation.payment_hash))?
+            / 1_000;
+        let remaining_seconds = self
+            .send_btc_creation_deadline(creation)?
+            .checked_sub(now_seconds_ceiling)
+            .ok_or(CchError::SendBTCOrderCreationExpired(creation.payment_hash))?;
+        if remaining_seconds < self.config.min_outgoing_invoice_expiry_delta_seconds {
+            return Err(CchError::SendBTCOrderCreationExpired(creation.payment_hash));
+        }
+
+        let template = &creation.incoming_invoice;
+        let mut builder = InvoiceBuilder::new(template.currency)
+            .amount(template.amount)
+            .payment_hash(creation.payment_hash)
+            .hash_algorithm(template.hash_algorithm().copied().unwrap_or_default())
+            .expiry_time(Duration::from_secs(remaining_seconds))
+            .final_expiry_delta(template.final_tlc_minimum_expiry_delta_or_default());
+        if let Some(script) = template.udt_type_script() {
+            builder = builder.udt_type_script(script.clone());
+        }
+        if let Some((public_key, secret_key)) = &self.node_keypair {
+            builder
+                .payee_pub_key(*public_key)
+                .build_with_sign(|hash| SECP256K1.sign_ecdsa_recoverable(hash, secret_key))
+                .map_err(Into::into)
+        } else {
+            builder.build().map_err(Into::into)
+        }
     }
 
     fn remaining_outgoing_invoice_expiry_seconds(
@@ -1659,6 +1983,15 @@ fn is_retryable_receive_btc_creation_error(error: &CchError) -> bool {
     )
 }
 
+fn is_retryable_send_btc_creation_error(error: &CchError) -> bool {
+    matches!(
+        error,
+        CchError::LndPaymentTrackerError(_)
+            | CchError::LndPaymentTrackerCapacityExceeded(_)
+            | CchError::FiberNodeError(_)
+    )
+}
+
 fn schedule_receive_btc_creation_retry(
     myself: &ActorRef<CchMessage>,
     pending_retries: &mut HashSet<Hash256>,
@@ -1682,6 +2015,34 @@ fn schedule_receive_btc_creation_retry(
         delay
     );
     myself.send_after(delay, move || CchMessage::ResumeReceiveBTCOrderCreation {
+        payment_hash,
+        retry_count: retry_count.saturating_add(1),
+    });
+}
+
+fn schedule_send_btc_creation_retry(
+    myself: &ActorRef<CchMessage>,
+    pending_retries: &mut HashSet<Hash256>,
+    payment_hash: Hash256,
+    retry_count: u32,
+    reason: &str,
+) {
+    if !pending_retries.insert(payment_hash) {
+        tracing::debug!(
+            "send_btc creation retry for payment hash {:x} is already pending",
+            payment_hash
+        );
+        return;
+    }
+    let delay = calculate_retry_delay(retry_count);
+    tracing::error!(
+        "send_btc creation for payment hash {:x} failed (retry {}): {}. Retrying in {:?}",
+        payment_hash,
+        retry_count,
+        reason,
+        delay
+    );
+    myself.send_after(delay, move || CchMessage::ResumeSendBTCOrderCreation {
         payment_hash,
         retry_count: retry_count.saturating_add(1),
     });

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -221,6 +221,20 @@ pub struct CchArgs<S> {
 }
 
 #[derive(Clone)]
+struct DeferredInvoiceStatus {
+    status: CkbInvoiceStatus,
+    failure_reason: Option<String>,
+}
+
+impl DeferredInvoiceStatus {
+    fn merge(&mut self, newer: Self) {
+        if invoice_status_rank(newer.status) >= invoice_status_rank(self.status) {
+            *self = newer;
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct CchState<S> {
     pub(super) config: CchConfig,
     pub(super) fiber_agent_ref: CchFiberAgentRef,
@@ -235,7 +249,7 @@ pub struct CchState<S> {
     pending_send_btc_creation_retries: HashSet<Hash256>,
     active_send_btc_creation_workers: HashSet<Hash256>,
     active_send_btc_requests: HashMap<Hash256, String>,
-    deferred_send_btc_invoice_events: HashMap<Hash256, CchTrackingEvent>,
+    deferred_send_btc_invoice_statuses: HashMap<Hash256, DeferredInvoiceStatus>,
     /// The CKB network currency this node is configured for.
     pub(super) currency: Currency,
 }
@@ -371,7 +385,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             pending_send_btc_creation_retries: HashSet::new(),
             active_send_btc_creation_workers: HashSet::new(),
             active_send_btc_requests: HashMap::new(),
-            deferred_send_btc_invoice_events: HashMap::new(),
+            deferred_send_btc_invoice_statuses: HashMap::new(),
         };
 
         Ok(state)
@@ -558,7 +572,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     .pending_send_btc_creation_retries
                     .remove(&payment_hash);
                 if let Ok((_, is_new)) = &result {
-                    match state.reconcile_deferred_send_btc_invoice_event(payment_hash) {
+                    match state.reconcile_deferred_send_btc_invoice_status(payment_hash) {
                         Ok((order, event_applied)) => {
                             if *is_new || event_applied {
                                 state.schedule_job_on_entering(&order);
@@ -595,10 +609,14 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                                     err
                                 );
                             }
-                            state.deferred_send_btc_invoice_events.remove(&payment_hash);
+                            state
+                                .deferred_send_btc_invoice_statuses
+                                .remove(&payment_hash);
                         }
                     } else {
-                        state.deferred_send_btc_invoice_events.remove(&payment_hash);
+                        state
+                            .deferred_send_btc_invoice_statuses
+                            .remove(&payment_hash);
                     }
                 }
                 state.active_send_btc_creation_workers.remove(&payment_hash);
@@ -855,13 +873,15 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 match result {
                     Ok(Some(_)) => {
                         let (order, _) =
-                            state.reconcile_deferred_send_btc_invoice_event(payment_hash)?;
+                            state.reconcile_deferred_send_btc_invoice_status(payment_hash)?;
                         state.schedule_job_on_entering(&order);
                         let actions = ActionDispatcher::on_starting(&order);
                         append_actions(myself.clone(), order.payment_hash, actions)?;
                     }
                     Ok(None) => {
-                        state.deferred_send_btc_invoice_events.remove(&payment_hash);
+                        state
+                            .deferred_send_btc_invoice_statuses
+                            .remove(&payment_hash);
                     }
                     Err(err) if is_retryable_send_btc_creation_error(&err) => {
                         schedule_send_btc_creation_retry(
@@ -878,7 +898,9 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                             payment_hash,
                             err
                         );
-                        state.deferred_send_btc_invoice_events.remove(&payment_hash);
+                        state
+                            .deferred_send_btc_invoice_statuses
+                            .remove(&payment_hash);
                     }
                 }
                 state.active_send_btc_creation_workers.remove(&payment_hash);
@@ -941,6 +963,30 @@ fn receive_btc_order_creation_is_expired(
     {
         Some(expiry_time) => expiry_time <= current_time,
         None => true,
+    }
+}
+
+fn deferred_invoice_status_advances_order(
+    order_status: CchOrderStatus,
+    invoice_status: CkbInvoiceStatus,
+) -> bool {
+    match invoice_status {
+        CkbInvoiceStatus::Open => false,
+        CkbInvoiceStatus::Received => order_status == CchOrderStatus::Pending,
+        CkbInvoiceStatus::Cancelled | CkbInvoiceStatus::Expired => matches!(
+            order_status,
+            CchOrderStatus::Pending | CchOrderStatus::IncomingAccepted
+        ),
+        CkbInvoiceStatus::Paid => order_status == CchOrderStatus::OutgoingSuccess,
+    }
+}
+
+fn invoice_status_rank(status: CkbInvoiceStatus) -> u8 {
+    match status {
+        CkbInvoiceStatus::Open => 0,
+        CkbInvoiceStatus::Received => 1,
+        CkbInvoiceStatus::Cancelled | CkbInvoiceStatus::Expired => 2,
+        CkbInvoiceStatus::Paid => 3,
     }
 }
 
@@ -2074,17 +2120,28 @@ impl<S: CchOrderStore> CchState<S> {
         }
     }
 
-    fn reconcile_deferred_send_btc_invoice_event(
+    fn reconcile_deferred_send_btc_invoice_status(
         &mut self,
         payment_hash: Hash256,
     ) -> Result<(CchOrder, bool), CchError> {
         let order = self
             .get_order_or_none(&payment_hash)?
             .ok_or(CchStoreError::NotFound(payment_hash))?;
-        let Some(event) = self.deferred_send_btc_invoice_events.remove(&payment_hash) else {
+        let Some(deferred) = self
+            .deferred_send_btc_invoice_statuses
+            .remove(&payment_hash)
+        else {
             return Ok((order, false));
         };
 
+        if !deferred_invoice_status_advances_order(order.status, deferred.status) {
+            return Ok((order, false));
+        }
+        let event = CchTrackingEvent::InvoiceChanged {
+            payment_hash,
+            status: deferred.status,
+            failure_reason: deferred.failure_reason,
+        };
         match self.apply_tracking_event_to_order(order.clone(), event)? {
             Some(updated_order) => Ok((updated_order, true)),
             None => Ok((order, false)),
@@ -2096,17 +2153,29 @@ impl<S: CchOrderStore> CchState<S> {
         event: CchTrackingEvent,
     ) -> Result<Vec<CchOrderAction>> {
         let payment_hash = *event.payment_hash();
-        if matches!(&event, CchTrackingEvent::InvoiceChanged { .. })
-            && (self
-                .active_send_btc_creation_workers
+        if self
+            .active_send_btc_creation_workers
+            .contains(&payment_hash)
+            || self
+                .pending_send_btc_creation_retries
                 .contains(&payment_hash)
-                || self
-                    .pending_send_btc_creation_retries
-                    .contains(&payment_hash))
         {
-            self.deferred_send_btc_invoice_events
-                .insert(payment_hash, event);
-            return Ok(vec![]);
+            if let CchTrackingEvent::InvoiceChanged {
+                status,
+                failure_reason,
+                ..
+            } = &event
+            {
+                let deferred = DeferredInvoiceStatus {
+                    status: *status,
+                    failure_reason: failure_reason.clone(),
+                };
+                self.deferred_send_btc_invoice_statuses
+                    .entry(payment_hash)
+                    .and_modify(|current| current.merge(deferred.clone()))
+                    .or_insert(deferred);
+                return Ok(vec![]);
+            }
         }
 
         let order = match self.get_active_order_or_none(&payment_hash)? {
@@ -2453,7 +2522,23 @@ pub(crate) fn redacted_store_change_summary(change: &StoreChange) -> RedactedSto
 
 #[cfg(test)]
 mod tests {
-    use super::{is_lnd_invoice_not_found, LND_NO_INVOICES_CREATED_ERROR};
+    use super::{is_lnd_invoice_not_found, DeferredInvoiceStatus, LND_NO_INVOICES_CREATED_ERROR};
+    use crate::invoice::CkbInvoiceStatus;
+
+    #[test]
+    fn test_deferred_invoice_status_merge_does_not_regress() {
+        let mut deferred = DeferredInvoiceStatus {
+            status: CkbInvoiceStatus::Received,
+            failure_reason: None,
+        };
+
+        deferred.merge(DeferredInvoiceStatus {
+            status: CkbInvoiceStatus::Open,
+            failure_reason: None,
+        });
+
+        assert_eq!(deferred.status, CkbInvoiceStatus::Received);
+    }
 
     #[test]
     fn test_lnd_invoice_not_found_status_classification() {

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -465,8 +465,38 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 let payment_hash = Bolt11Invoice::from_str(&send_btc.btc_pay_req)
                     .ok()
                     .map(|invoice| Hash256::from(*invoice.payment_hash()));
-                let result = state.send_btc(send_btc).await;
+                let pending_error = match payment_hash {
+                    Some(payment_hash)
+                        if state
+                            .pending_send_btc_creation_retries
+                            .contains(&payment_hash) =>
+                    {
+                        match state.get_send_btc_order_creation_or_none(&payment_hash) {
+                            Ok(Some(creation)) => Some(
+                                state
+                                    .ensure_send_btc_request_matches_creation(
+                                        &send_btc.btc_pay_req,
+                                        &creation,
+                                    )
+                                    .err()
+                                    .unwrap_or(CchError::SendBTCOrderCreationInProgress(
+                                        payment_hash,
+                                    )),
+                            ),
+                            Ok(None) => None,
+                            Err(err) => Some(err),
+                        }
+                    }
+                    _ => None,
+                };
+                let result = match pending_error {
+                    Some(err) => Err(err),
+                    None => state.send_btc(send_btc).await,
+                };
                 if let Ok((order, true)) = &result {
+                    state
+                        .pending_send_btc_creation_retries
+                        .remove(&order.payment_hash);
                     // Schedule jobs for new order
                     state.schedule_job_on_entering(order);
                     let actions = ActionDispatcher::on_starting(order);
@@ -475,15 +505,22 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     if state
                         .get_send_btc_order_creation_or_none(&payment_hash)?
                         .is_some()
-                        && is_retryable_send_btc_creation_error(err)
                     {
-                        schedule_send_btc_creation_retry(
-                            &myself,
-                            &mut state.pending_send_btc_creation_retries,
-                            payment_hash,
-                            0,
-                            &err.to_string(),
-                        );
+                        if is_retryable_send_btc_creation_error(err) {
+                            schedule_send_btc_creation_retry(
+                                &myself,
+                                &mut state.pending_send_btc_creation_retries,
+                                payment_hash,
+                                0,
+                                &err.to_string(),
+                            );
+                        } else if !matches!(err, CchError::SendBTCOrderCreationInProgress(_)) {
+                            tracing::error!(
+                                "Permanently failed to complete send_btc creation {:x}: {}. The durable intent is retained for operator inspection",
+                                payment_hash,
+                                err
+                            );
+                        }
                     }
                 }
                 if !port.is_closed() {
@@ -714,7 +751,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     .remove(&payment_hash);
                 match state.resume_send_btc_order_creation(payment_hash).await {
                     Ok(Some(order)) => {
-                        state.schedule_job_for_non_final_order(&order);
+                        state.schedule_job_on_entering(&order);
                         let actions = ActionDispatcher::on_starting(&order);
                         append_actions(myself, order.payment_hash, actions)?;
                     }

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -235,6 +235,7 @@ pub struct CchState<S> {
     pending_send_btc_creation_retries: HashSet<Hash256>,
     active_send_btc_creation_workers: HashSet<Hash256>,
     active_send_btc_requests: HashMap<Hash256, String>,
+    deferred_send_btc_invoice_events: HashMap<Hash256, CchTrackingEvent>,
     /// The CKB network currency this node is configured for.
     pub(super) currency: Currency,
 }
@@ -370,6 +371,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             pending_send_btc_creation_retries: HashSet::new(),
             active_send_btc_creation_workers: HashSet::new(),
             active_send_btc_requests: HashMap::new(),
+            deferred_send_btc_invoice_events: HashMap::new(),
         };
 
         Ok(state)
@@ -549,20 +551,30 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             }
             CchMessage::SendBTCWorkerCompleted {
                 payment_hash,
-                result,
+                mut result,
                 port,
             } => {
-                state.active_send_btc_creation_workers.remove(&payment_hash);
-                state.active_send_btc_requests.remove(&payment_hash);
                 state
                     .pending_send_btc_creation_retries
                     .remove(&payment_hash);
-                if let Ok((order, true)) = &result {
-                    // Schedule jobs for new order
-                    state.schedule_job_on_entering(order);
-                    let actions = ActionDispatcher::on_starting(order);
-                    append_actions(myself.clone(), order.payment_hash, actions)?;
-                } else if let Err(err) = &result {
+                if let Ok((_, is_new)) = &result {
+                    match state.reconcile_deferred_send_btc_invoice_event(payment_hash) {
+                        Ok((order, event_applied)) => {
+                            if *is_new || event_applied {
+                                state.schedule_job_on_entering(&order);
+                                let actions = if *is_new {
+                                    ActionDispatcher::on_starting(&order)
+                                } else {
+                                    ActionDispatcher::on_entering(&order)
+                                };
+                                append_actions(myself.clone(), order.payment_hash, actions)?;
+                            }
+                            result = Ok((order, *is_new));
+                        }
+                        Err(err) => result = Err(err),
+                    }
+                }
+                if let Err(err) = &result {
                     if state
                         .get_send_btc_order_creation_or_none(&payment_hash)?
                         .is_some()
@@ -575,15 +587,22 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                                 0,
                                 &err.to_string(),
                             );
-                        } else if !matches!(err, CchError::SendBTCOrderCreationInProgress(_)) {
-                            tracing::error!(
-                                "Permanently failed to complete send_btc creation {:x}: {}. The durable intent is retained for operator inspection",
-                                payment_hash,
-                                err
-                            );
+                        } else {
+                            if !matches!(err, CchError::SendBTCOrderCreationInProgress(_)) {
+                                tracing::error!(
+                                    "Permanently failed to complete send_btc creation {:x}: {}. The durable intent is retained for operator inspection",
+                                    payment_hash,
+                                    err
+                                );
+                            }
+                            state.deferred_send_btc_invoice_events.remove(&payment_hash);
                         }
+                    } else {
+                        state.deferred_send_btc_invoice_events.remove(&payment_hash);
                     }
                 }
+                state.active_send_btc_creation_workers.remove(&payment_hash);
+                state.active_send_btc_requests.remove(&payment_hash);
                 if !port.is_closed() {
                     let _ = port.send(result.map(|(order, _)| order));
                 }
@@ -833,14 +852,17 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 retry_count,
                 result,
             } => {
-                state.active_send_btc_creation_workers.remove(&payment_hash);
                 match result {
-                    Ok(Some(order)) => {
+                    Ok(Some(_)) => {
+                        let (order, _) =
+                            state.reconcile_deferred_send_btc_invoice_event(payment_hash)?;
                         state.schedule_job_on_entering(&order);
                         let actions = ActionDispatcher::on_starting(&order);
                         append_actions(myself.clone(), order.payment_hash, actions)?;
                     }
-                    Ok(None) => {}
+                    Ok(None) => {
+                        state.deferred_send_btc_invoice_events.remove(&payment_hash);
+                    }
                     Err(err) if is_retryable_send_btc_creation_error(&err) => {
                         schedule_send_btc_creation_retry(
                             &myself,
@@ -856,8 +878,10 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                             payment_hash,
                             err
                         );
+                        state.deferred_send_btc_invoice_events.remove(&payment_hash);
                     }
                 }
+                state.active_send_btc_creation_workers.remove(&payment_hash);
                 Ok(())
             }
             CchMessage::ExpireOrder(payment_hash) => {
@@ -2017,12 +2041,11 @@ impl<S: CchOrderStore> CchState<S> {
         Ok(invoice)
     }
 
-    async fn handle_tracking_event(&self, event: CchTrackingEvent) -> Result<Vec<CchOrderAction>> {
-        let mut order = match self.get_active_order_or_none(event.payment_hash())? {
-            None => return Ok(vec![]),
-            Some(order) => order,
-        };
-
+    fn apply_tracking_event_to_order(
+        &self,
+        mut order: CchOrder,
+        event: CchTrackingEvent,
+    ) -> std::result::Result<Option<CchOrder>, CchError> {
         if order.status == CchOrderStatus::Pending
             && matches!(
                 &event,
@@ -2035,17 +2058,63 @@ impl<S: CchOrderStore> CchState<S> {
             let current_time = now_timestamp_as_millis_u64() / 1000;
             if order.update_if_expired_with_reason(current_time, "Order expired") {
                 self.store.update_cch_order(order.clone());
-                self.schedule_job_on_entering(&order);
                 tracing::info!(
                     "Rejected incoming invoice event for expired pending order {:x}",
                     order.payment_hash
                 );
-                return Ok(vec![]);
+                return Ok(Some(order));
             }
         }
 
         if CchOrderStateMachine::apply(&mut order, event.into())?.is_some() {
             self.store.update_cch_order(order.clone());
+            Ok(Some(order))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn reconcile_deferred_send_btc_invoice_event(
+        &mut self,
+        payment_hash: Hash256,
+    ) -> Result<(CchOrder, bool), CchError> {
+        let order = self
+            .get_order_or_none(&payment_hash)?
+            .ok_or(CchStoreError::NotFound(payment_hash))?;
+        let Some(event) = self.deferred_send_btc_invoice_events.remove(&payment_hash) else {
+            return Ok((order, false));
+        };
+
+        match self.apply_tracking_event_to_order(order.clone(), event)? {
+            Some(updated_order) => Ok((updated_order, true)),
+            None => Ok((order, false)),
+        }
+    }
+
+    async fn handle_tracking_event(
+        &mut self,
+        event: CchTrackingEvent,
+    ) -> Result<Vec<CchOrderAction>> {
+        let payment_hash = *event.payment_hash();
+        if matches!(&event, CchTrackingEvent::InvoiceChanged { .. })
+            && (self
+                .active_send_btc_creation_workers
+                .contains(&payment_hash)
+                || self
+                    .pending_send_btc_creation_retries
+                    .contains(&payment_hash))
+        {
+            self.deferred_send_btc_invoice_events
+                .insert(payment_hash, event);
+            return Ok(vec![]);
+        }
+
+        let order = match self.get_active_order_or_none(&payment_hash)? {
+            None => return Ok(vec![]),
+            Some(order) => order,
+        };
+
+        if let Some(order) = self.apply_tracking_event_to_order(order, event)? {
             self.schedule_job_on_entering(&order);
             Ok(ActionDispatcher::on_entering(&order))
         } else {

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -8,7 +8,7 @@ use ractor::{
 };
 use secp256k1::{PublicKey, SecretKey, SECP256K1};
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use tentacle::secio::SecioKeyPair;
@@ -166,6 +166,18 @@ pub enum CchMessage {
         retry_count: u32,
     },
 
+    SendBTCWorkerCompleted {
+        payment_hash: Hash256,
+        result: Result<(CchOrder, bool), CchError>,
+        port: RpcReplyPort<Result<CchOrder, CchError>>,
+    },
+
+    ResumeSendBTCOrderCreationWorkerCompleted {
+        payment_hash: Hash256,
+        retry_count: u32,
+        result: Result<Option<CchOrder>, CchError>,
+    },
+
     /// Expire an active order after its configured expiry window elapses.
     ExpireOrder(Hash256),
 
@@ -208,6 +220,7 @@ pub struct CchArgs<S> {
     pub(crate) lnd_invoice_client: Option<Arc<dyn LndInvoiceClient>>,
 }
 
+#[derive(Clone)]
 pub struct CchState<S> {
     pub(super) config: CchConfig,
     pub(super) fiber_agent_ref: CchFiberAgentRef,
@@ -217,8 +230,11 @@ pub struct CchState<S> {
     pub(super) lnd_tracker: ActorRef<LndTrackerMessage>,
     pub(super) scheduler: ActorRef<SchedulerMessage>,
     pub(super) store: S,
+    task_tracker: TaskTracker,
     pending_receive_btc_creation_retries: HashSet<Hash256>,
     pending_send_btc_creation_retries: HashSet<Hash256>,
+    active_send_btc_creation_workers: HashSet<Hash256>,
+    active_send_btc_requests: HashMap<Hash256, String>,
     /// The CKB network currency this node is configured for.
     pub(super) currency: Currency,
 }
@@ -348,9 +364,12 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             lnd_invoice_client,
             lnd_tracker,
             scheduler,
+            task_tracker: args.tracker,
             currency: args.currency,
             pending_receive_btc_creation_retries: HashSet::new(),
             pending_send_btc_creation_retries: HashSet::new(),
+            active_send_btc_creation_workers: HashSet::new(),
+            active_send_btc_requests: HashMap::new(),
         };
 
         Ok(state)
@@ -466,46 +485,84 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     let _ = port.send(Err(err));
                     return Ok(());
                 }
-                let payment_hash = Bolt11Invoice::from_str(&send_btc.btc_pay_req)
-                    .ok()
-                    .map(|invoice| Hash256::from(*invoice.payment_hash()));
-                let pending_error = match payment_hash {
-                    Some(payment_hash)
-                        if state
-                            .pending_send_btc_creation_retries
-                            .contains(&payment_hash) =>
-                    {
-                        match state.get_send_btc_order_creation_or_none(&payment_hash) {
-                            Ok(Some(creation)) => Some(
-                                state
-                                    .ensure_send_btc_request_matches_creation(
-                                        &send_btc.btc_pay_req,
-                                        &creation,
-                                    )
-                                    .err()
-                                    .unwrap_or(CchError::SendBTCOrderCreationInProgress(
-                                        payment_hash,
-                                    )),
-                            ),
-                            Ok(None) => None,
-                            Err(err) => Some(err),
-                        }
+                let payment_hash = match Bolt11Invoice::from_str(&send_btc.btc_pay_req) {
+                    Ok(invoice) => Hash256::from(*invoice.payment_hash()),
+                    Err(err) => {
+                        let _ = port.send(Err(err.into()));
+                        return Ok(());
                     }
-                    _ => None,
                 };
-                let result = match pending_error {
-                    Some(err) => Err(err),
-                    None => state.send_btc(send_btc).await,
-                };
-                if let Ok((order, true)) = &result {
+                if state
+                    .active_send_btc_creation_workers
+                    .contains(&payment_hash)
+                    || state
+                        .pending_send_btc_creation_retries
+                        .contains(&payment_hash)
+                {
+                    let pending_error = match state
+                        .get_send_btc_order_creation_or_none(&payment_hash)
+                    {
+                        Ok(Some(creation)) => Some(
+                            state
+                                .ensure_send_btc_request_matches_creation(
+                                    &send_btc.btc_pay_req,
+                                    &creation,
+                                )
+                                .err()
+                                .unwrap_or(CchError::SendBTCOrderCreationInProgress(payment_hash)),
+                        ),
+                        Ok(None) => match state.active_send_btc_requests.get(&payment_hash) {
+                            Some(btc_pay_req) if btc_pay_req != &send_btc.btc_pay_req => {
+                                Some(CchError::ConflictingSendBTCRequest(payment_hash))
+                            }
+                            Some(_) => Some(CchError::SendBTCOrderCreationInProgress(payment_hash)),
+                            None => None,
+                        },
+                        Err(err) => Some(err),
+                    };
+                    if let Some(err) = pending_error {
+                        let _ = port.send(Err(err));
+                        return Ok(());
+                    }
                     state
                         .pending_send_btc_creation_retries
-                        .remove(&order.payment_hash);
+                        .remove(&payment_hash);
+                    state.active_send_btc_creation_workers.remove(&payment_hash);
+                    state.active_send_btc_requests.remove(&payment_hash);
+                }
+
+                let worker_state = state.clone();
+                state.active_send_btc_creation_workers.insert(payment_hash);
+                state
+                    .active_send_btc_requests
+                    .insert(payment_hash, send_btc.btc_pay_req.clone());
+                let myself = myself.clone();
+                state.task_tracker.spawn(async move {
+                    let result = worker_state.send_btc(send_btc).await;
+                    let _ = myself.send_message(CchMessage::SendBTCWorkerCompleted {
+                        payment_hash,
+                        result,
+                        port,
+                    });
+                });
+                Ok(())
+            }
+            CchMessage::SendBTCWorkerCompleted {
+                payment_hash,
+                result,
+                port,
+            } => {
+                state.active_send_btc_creation_workers.remove(&payment_hash);
+                state.active_send_btc_requests.remove(&payment_hash);
+                state
+                    .pending_send_btc_creation_retries
+                    .remove(&payment_hash);
+                if let Ok((order, true)) = &result {
                     // Schedule jobs for new order
                     state.schedule_job_on_entering(order);
                     let actions = ActionDispatcher::on_starting(order);
-                    append_actions(myself, order.payment_hash, actions)?;
-                } else if let (Some(payment_hash), Err(err)) = (payment_hash, &result) {
+                    append_actions(myself.clone(), order.payment_hash, actions)?;
+                } else if let Err(err) = &result {
                     if state
                         .get_send_btc_order_creation_or_none(&payment_hash)?
                         .is_some()
@@ -528,7 +585,6 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     }
                 }
                 if !port.is_closed() {
-                    // ignore error
                     let _ = port.send(result.map(|(order, _)| order));
                 }
                 Ok(())
@@ -753,11 +809,36 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 state
                     .pending_send_btc_creation_retries
                     .remove(&payment_hash);
-                match state.resume_send_btc_order_creation(payment_hash).await {
+                if !state.active_send_btc_creation_workers.insert(payment_hash) {
+                    return Ok(());
+                }
+                let worker_state = state.clone();
+                let myself = myself.clone();
+                state.task_tracker.spawn(async move {
+                    let result = worker_state
+                        .resume_send_btc_order_creation(payment_hash)
+                        .await;
+                    let _ = myself.send_message(
+                        CchMessage::ResumeSendBTCOrderCreationWorkerCompleted {
+                            payment_hash,
+                            retry_count,
+                            result,
+                        },
+                    );
+                });
+                Ok(())
+            }
+            CchMessage::ResumeSendBTCOrderCreationWorkerCompleted {
+                payment_hash,
+                retry_count,
+                result,
+            } => {
+                state.active_send_btc_creation_workers.remove(&payment_hash);
+                match result {
                     Ok(Some(order)) => {
                         state.schedule_job_on_entering(&order);
                         let actions = ActionDispatcher::on_starting(&order);
-                        append_actions(myself, order.payment_hash, actions)?;
+                        append_actions(myself.clone(), order.payment_hash, actions)?;
                     }
                     Ok(None) => {}
                     Err(err) if is_retryable_send_btc_creation_error(&err) => {

--- a/crates/fiber-lib/src/cch/cch_fiber_agent.rs
+++ b/crates/fiber-lib/src/cch/cch_fiber_agent.rs
@@ -20,7 +20,7 @@ use crate::fiber::{
     network::SendPaymentResponse, payment::SendPaymentCommand, NetworkActorCommand,
     NetworkActorMessage, ASSUME_NETWORK_ACTOR_ALIVE,
 };
-use crate::invoice::{CancelInvoiceError, CkbInvoice, SettleInvoiceError};
+use crate::invoice::{CancelInvoiceError, CkbInvoice, CkbInvoiceStatus, SettleInvoiceError};
 use crate::rpc::{
     invoice::{
         GetInvoiceResult, InvoiceParams, InvoiceResult, NewInvoiceParams, SettleInvoiceParams,
@@ -36,6 +36,13 @@ use crate::rpc::{
 pub struct OutgoingFeeLimit {
     pub max_fee_amount: u128,
     pub max_fee_rate: u64,
+}
+
+/// Authoritative Fiber invoice data used to reconcile an interrupted CCH creation.
+#[derive(Clone)]
+pub struct FiberInvoiceInfo {
+    pub invoice: CkbInvoice,
+    pub status: CkbInvoiceStatus,
 }
 
 #[derive(Debug, Error)]
@@ -85,6 +92,7 @@ impl From<CancelInvoiceError> for CchFiberCancelInvoiceError {
 /// Messages for the fiber agent actor. Each variant carries an RpcReplyPort for the response.
 pub enum CchFiberAgentMessage {
     AddInvoice(CkbInvoice, RpcReplyPort<Result<CkbInvoice>>),
+    GetInvoice(Hash256, RpcReplyPort<Result<FiberInvoiceInfo>>),
     SendPayment(
         String,
         Option<u64>,
@@ -146,6 +154,10 @@ impl Actor for CchFiberAgentActor {
         match message {
             CchFiberAgentMessage::AddInvoice(invoice, port) => {
                 let result = state.add_invoice(invoice).await;
+                let _ = port.send(result);
+            }
+            CchFiberAgentMessage::GetInvoice(payment_hash, port) => {
+                let result = state.get_invoice(payment_hash).await;
                 let _ = port.send(result);
             }
             CchFiberAgentMessage::SendPayment(
@@ -226,6 +238,25 @@ impl CchFiberAgentHttpBackend {
             .request::<InvoiceResult, _>("new_invoice", rpc_params![invoice_params])
             .await?;
         CkbInvoice::from_str(&response.invoice_address).map_err(Into::into)
+    }
+
+    async fn get_invoice(&self, payment_hash: Hash256) -> Result<FiberInvoiceInfo> {
+        let invoice_params = InvoiceParams {
+            payment_hash: payment_hash.into(),
+        };
+        let response = self
+            .client
+            .request::<GetInvoiceResult, _>("get_invoice", rpc_params![invoice_params])
+            .await?;
+        let invoice = CkbInvoice::from_str(&response.invoice_address)?;
+        let status = match response.status {
+            fiber_json_types::CkbInvoiceStatus::Open => CkbInvoiceStatus::Open,
+            fiber_json_types::CkbInvoiceStatus::Cancelled => CkbInvoiceStatus::Cancelled,
+            fiber_json_types::CkbInvoiceStatus::Expired => CkbInvoiceStatus::Expired,
+            fiber_json_types::CkbInvoiceStatus::Received => CkbInvoiceStatus::Received,
+            fiber_json_types::CkbInvoiceStatus::Paid => CkbInvoiceStatus::Paid,
+        };
+        Ok(FiberInvoiceInfo { invoice, status })
     }
 
     pub async fn send_payment(
@@ -524,6 +555,7 @@ impl CchFiberAgentRef {
         match self {
             Self::InProcess(network_actor) => {
                 let invoice_cloned = invoice.clone();
+                let payment_hash = *invoice.payment_hash();
                 let msg = move |tx: RpcReplyPort<Result<(), crate::invoice::InvoiceError>>| {
                     NetworkActorMessage::Command(NetworkActorCommand::AddInvoice(
                         invoice.clone(),
@@ -533,14 +565,68 @@ impl CchFiberAgentRef {
                 };
                 call!(network_actor, msg)
                     .map_err(to_fiber_err)?
-                    .map_err(to_fiber_err)?;
+                    .map_err(|err| match err {
+                        crate::invoice::InvoiceError::InvoiceAlreadyExists => {
+                            CchError::FiberInvoiceAlreadyExists(payment_hash)
+                        }
+                        err => to_fiber_err(err),
+                    })?;
                 Ok(invoice_cloned)
             }
             Self::Rpc(rpc_actor) => call!(rpc_actor, |port| {
                 CchFiberAgentMessage::AddInvoice(invoice.clone(), port)
             })
             .map_err(to_fiber_err)?
-            .map_err(CchError::FiberNodeError),
+            .map_err(|err| {
+                if err
+                    .to_string()
+                    .to_ascii_lowercase()
+                    .contains("invoice already exists")
+                {
+                    CchError::FiberInvoiceAlreadyExists(*invoice.payment_hash())
+                } else {
+                    CchError::FiberNodeError(err)
+                }
+            }),
+        }
+    }
+
+    /// Retrieve authoritative Fiber invoice data for recovery.
+    pub async fn call_get_invoice(
+        &self,
+        payment_hash: Hash256,
+    ) -> Result<Option<FiberInvoiceInfo>, CchError> {
+        match self {
+            Self::InProcess(network_actor) => {
+                let result = call!(network_actor, |port| {
+                    NetworkActorMessage::Command(NetworkActorCommand::GetInvoice(
+                        payment_hash,
+                        port,
+                    ))
+                })
+                .map_err(to_fiber_err)?;
+                match result {
+                    Ok((invoice, status)) => Ok(Some(FiberInvoiceInfo { invoice, status })),
+                    Err(crate::invoice::InvoiceError::InvoiceNotFound) => Ok(None),
+                    Err(err) => Err(to_fiber_err(err)),
+                }
+            }
+            Self::Rpc(rpc_actor) => call!(rpc_actor, |port| {
+                CchFiberAgentMessage::GetInvoice(payment_hash, port)
+            })
+            .map_err(to_fiber_err)?
+            .map(Some)
+            .or_else(|err| {
+                if err
+                    .to_string()
+                    .to_ascii_lowercase()
+                    .contains("invoice not found")
+                {
+                    Ok(None)
+                } else {
+                    Err(CchError::FiberNodeError(err))
+                }
+            }),
         }
     }
 

--- a/crates/fiber-lib/src/cch/cch_fiber_agent.rs
+++ b/crates/fiber-lib/src/cch/cch_fiber_agent.rs
@@ -121,6 +121,7 @@ pub enum CchFiberAgentMessage {
 }
 
 const FIBER_HTTP_REQUEST_TIMEOUT: StdDuration = StdDuration::from_secs(60);
+const FIBER_AGENT_CALL_TIMEOUT_MILLIS: u64 = 61_000;
 pub(crate) const FIBER_HTTP_INVOICE_CREATION_MARGIN_SECONDS: u64 =
     FIBER_HTTP_REQUEST_TIMEOUT.as_secs() + 1;
 
@@ -623,7 +624,7 @@ impl CchFiberAgentRef {
                         tx,
                     ))
                 };
-                call!(network_actor, msg)
+                ractor::call_t!(network_actor, msg, FIBER_AGENT_CALL_TIMEOUT_MILLIS)
                     .map_err(to_fiber_err)?
                     .map_err(|err| match err {
                         crate::invoice::InvoiceError::InvoiceAlreadyExists => {
@@ -633,14 +634,18 @@ impl CchFiberAgentRef {
                     })?;
                 Ok(invoice_cloned)
             }
-            Self::Rpc(rpc_actor) => call!(rpc_actor, |port| {
-                CchFiberAgentMessage::AddInvoice(
-                    invoice.clone(),
-                    deadline_seconds,
-                    min_expiry_seconds,
-                    port,
-                )
-            })
+            Self::Rpc(rpc_actor) => ractor::call_t!(
+                rpc_actor,
+                |port| {
+                    CchFiberAgentMessage::AddInvoice(
+                        invoice.clone(),
+                        deadline_seconds,
+                        min_expiry_seconds,
+                        port,
+                    )
+                },
+                FIBER_AGENT_CALL_TIMEOUT_MILLIS
+            )
             .map_err(to_fiber_err)?
             .map_err(|err| {
                 if err
@@ -663,12 +668,16 @@ impl CchFiberAgentRef {
     ) -> Result<Option<FiberInvoiceInfo>, CchError> {
         match self {
             Self::InProcess(network_actor) => {
-                let result = call!(network_actor, |port| {
-                    NetworkActorMessage::Command(NetworkActorCommand::GetInvoice(
-                        payment_hash,
-                        port,
-                    ))
-                })
+                let result = ractor::call_t!(
+                    network_actor,
+                    |port| {
+                        NetworkActorMessage::Command(NetworkActorCommand::GetInvoice(
+                            payment_hash,
+                            port,
+                        ))
+                    },
+                    FIBER_AGENT_CALL_TIMEOUT_MILLIS
+                )
                 .map_err(to_fiber_err)?;
                 match result {
                     Ok((invoice, status)) => Ok(Some(FiberInvoiceInfo { invoice, status })),
@@ -676,9 +685,11 @@ impl CchFiberAgentRef {
                     Err(err) => Err(to_fiber_err(err)),
                 }
             }
-            Self::Rpc(rpc_actor) => call!(rpc_actor, |port| {
-                CchFiberAgentMessage::GetInvoice(payment_hash, port)
-            })
+            Self::Rpc(rpc_actor) => ractor::call_t!(
+                rpc_actor,
+                |port| CchFiberAgentMessage::GetInvoice(payment_hash, port),
+                FIBER_AGENT_CALL_TIMEOUT_MILLIS
+            )
             .map_err(to_fiber_err)?
             .map(Some)
             .or_else(|err| {

--- a/crates/fiber-lib/src/cch/cch_fiber_agent.rs
+++ b/crates/fiber-lib/src/cch/cch_fiber_agent.rs
@@ -6,7 +6,7 @@ use jsonrpsee::{
     rpc_params,
 };
 use ractor::{call, forward, Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
-use std::str::FromStr as _;
+use std::{str::FromStr as _, time::Duration as StdDuration};
 
 use fiber_types::payment::PaymentStatus;
 use fiber_types::Hash256;
@@ -21,6 +21,7 @@ use crate::fiber::{
     NetworkActorMessage, ASSUME_NETWORK_ACTOR_ALIVE,
 };
 use crate::invoice::{CancelInvoiceError, CkbInvoice, CkbInvoiceStatus, SettleInvoiceError};
+use crate::now_timestamp_as_millis_u64;
 use crate::rpc::{
     invoice::{
         GetInvoiceResult, InvoiceParams, InvoiceResult, NewInvoiceParams, SettleInvoiceParams,
@@ -91,7 +92,7 @@ impl From<CancelInvoiceError> for CchFiberCancelInvoiceError {
 
 /// Messages for the fiber agent actor. Each variant carries an RpcReplyPort for the response.
 pub enum CchFiberAgentMessage {
-    AddInvoice(CkbInvoice, RpcReplyPort<Result<CkbInvoice>>),
+    AddInvoice(CkbInvoice, u64, u64, RpcReplyPort<Result<CkbInvoice>>),
     GetInvoice(Hash256, RpcReplyPort<Result<FiberInvoiceInfo>>),
     SendPayment(
         String,
@@ -117,6 +118,31 @@ pub enum CchFiberAgentMessage {
         Hash256,
         RpcReplyPort<Result<(), CchFiberCancelInvoiceError>>,
     ),
+}
+
+const FIBER_HTTP_REQUEST_TIMEOUT: StdDuration = StdDuration::from_secs(60);
+pub(crate) const FIBER_HTTP_INVOICE_CREATION_MARGIN_SECONDS: u64 =
+    FIBER_HTTP_REQUEST_TIMEOUT.as_secs() + 1;
+
+fn bounded_http_invoice_expiry_seconds(
+    deadline_seconds: u64,
+    min_expiry_seconds: u64,
+    now_millis: u64,
+) -> Result<u64> {
+    let now_seconds_ceiling = now_millis
+        .checked_add(999)
+        .ok_or_else(|| anyhow!("current time overflow while creating CCH Fiber invoice"))?
+        / 1_000;
+    let expiry_seconds = deadline_seconds
+        .checked_sub(now_seconds_ceiling)
+        .and_then(|remaining| remaining.checked_sub(FIBER_HTTP_INVOICE_CREATION_MARGIN_SECONDS))
+        .ok_or_else(|| anyhow!("CCH Fiber invoice deadline is too close for an HTTP request"))?;
+    if expiry_seconds < min_expiry_seconds {
+        return Err(anyhow!(
+            "CCH Fiber invoice has only {expiry_seconds}s after reserving the HTTP request window; at least {min_expiry_seconds}s is required"
+        ));
+    }
+    Ok(expiry_seconds)
 }
 
 /// Http-only backend state for the fiber agent actor.
@@ -152,8 +178,15 @@ impl Actor for CchFiberAgentActor {
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         match message {
-            CchFiberAgentMessage::AddInvoice(invoice, port) => {
-                let result = state.add_invoice(invoice).await;
+            CchFiberAgentMessage::AddInvoice(
+                invoice,
+                deadline_seconds,
+                min_expiry_seconds,
+                port,
+            ) => {
+                let result = state
+                    .add_invoice(invoice, deadline_seconds, min_expiry_seconds)
+                    .await;
                 let _ = port.send(result);
             }
             CchFiberAgentMessage::GetInvoice(payment_hash, port) => {
@@ -210,18 +243,33 @@ impl Actor for CchFiberAgentActor {
 impl CchFiberAgentHttpBackend {
     /// Build the Http backend from a Fiber RPC URL. Used when spawning [CchFiberAgentActor].
     pub fn try_new(url: &str) -> Result<Self> {
-        let client = HttpClientBuilder::default().build(url)?;
+        let client = HttpClientBuilder::default()
+            .request_timeout(FIBER_HTTP_REQUEST_TIMEOUT)
+            .build(url)?;
         Ok(Self { client })
     }
 
-    pub async fn add_invoice(&self, invoice: CkbInvoice) -> Result<CkbInvoice> {
+    pub async fn add_invoice(
+        &self,
+        invoice: CkbInvoice,
+        deadline_seconds: u64,
+        min_expiry_seconds: u64,
+    ) -> Result<CkbInvoice> {
+        let expiry_seconds = bounded_http_invoice_expiry_seconds(
+            deadline_seconds,
+            min_expiry_seconds,
+            now_timestamp_as_millis_u64(),
+        )?;
         let invoice_params = NewInvoiceParams {
             amount: invoice
                 .amount
                 .ok_or_else(|| anyhow!("cch invoice requires amount"))?,
             payment_hash: Some((*invoice.payment_hash()).into()),
             hash_algorithm: invoice.hash_algorithm().copied().map(Into::into),
-            expiry: invoice.expiry_time().map(|duration| duration.as_secs()),
+            // The HTTP Fiber node rebuilds the invoice with a new timestamp. Reserve the full
+            // request timeout so that timestamp plus this relative expiry remains bounded by the
+            // CCH order's absolute deadline.
+            expiry: Some(expiry_seconds),
             final_expiry_delta: Some(invoice.final_tlc_minimum_expiry_delta_or_default()),
             udt_type_script: invoice
                 .udt_type_script()
@@ -550,8 +598,20 @@ fn to_fiber_err(e: impl std::fmt::Display) -> CchError {
 }
 
 impl CchFiberAgentRef {
+    pub(crate) fn add_invoice_expiry_margin_seconds(&self) -> u64 {
+        match self {
+            Self::InProcess(_) => 0,
+            Self::Rpc(_) => FIBER_HTTP_INVOICE_CREATION_MARGIN_SECONDS,
+        }
+    }
+
     /// Add invoice; returns the (possibly updated) invoice.
-    pub async fn call_add_invoice(&self, invoice: CkbInvoice) -> Result<CkbInvoice, CchError> {
+    pub async fn call_add_invoice(
+        &self,
+        invoice: CkbInvoice,
+        deadline_seconds: u64,
+        min_expiry_seconds: u64,
+    ) -> Result<CkbInvoice, CchError> {
         match self {
             Self::InProcess(network_actor) => {
                 let invoice_cloned = invoice.clone();
@@ -574,7 +634,12 @@ impl CchFiberAgentRef {
                 Ok(invoice_cloned)
             }
             Self::Rpc(rpc_actor) => call!(rpc_actor, |port| {
-                CchFiberAgentMessage::AddInvoice(invoice.clone(), port)
+                CchFiberAgentMessage::AddInvoice(
+                    invoice.clone(),
+                    deadline_seconds,
+                    min_expiry_seconds,
+                    port,
+                )
             })
             .map_err(to_fiber_err)?
             .map_err(|err| {
@@ -936,6 +1001,38 @@ fn map_get_payment_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn http_invoice_expiry_reserves_the_request_timeout_before_deadline() {
+        let request_started_millis = 10_250;
+        let deadline_seconds = 100;
+        let expiry_seconds =
+            bounded_http_invoice_expiry_seconds(deadline_seconds, 10, request_started_millis)
+                .expect("enough time remains");
+        let latest_remote_timestamp_millis =
+            u128::from(request_started_millis) + FIBER_HTTP_REQUEST_TIMEOUT.as_millis() - 1;
+
+        assert!(
+            latest_remote_timestamp_millis + u128::from(expiry_seconds) * 1_000
+                <= u128::from(deadline_seconds) * 1_000
+        );
+    }
+
+    #[test]
+    fn http_invoice_expiry_rejects_an_insufficient_request_window() {
+        let now_millis = 10_250;
+        let now_seconds_ceiling = 11;
+        let min_expiry_seconds = 10;
+        let deadline_seconds =
+            now_seconds_ceiling + FIBER_HTTP_REQUEST_TIMEOUT.as_secs() + min_expiry_seconds - 1;
+
+        assert!(bounded_http_invoice_expiry_seconds(
+            deadline_seconds,
+            min_expiry_seconds,
+            now_millis,
+        )
+        .is_err());
+    }
 
     #[test]
     fn cancel_invoice_error_classification_uses_error_type() {

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -87,6 +87,8 @@ pub enum CchError {
     ConflictingSendBTCRequest(Hash256),
     #[error("receive_btc order creation for payment hash {0} is already being recovered")]
     ReceiveBTCOrderCreationInProgress(Hash256),
+    #[error("send_btc order creation for payment hash {0} is already being recovered")]
+    SendBTCOrderCreationInProgress(Hash256),
     #[error("receive_btc order creation for payment hash {0} has expired")]
     ReceiveBTCOrderCreationExpired(Hash256),
     #[error("send_btc order creation for payment hash {0} has expired")]

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -83,10 +83,14 @@ pub enum CchError {
     LndRpcError(String),
     #[error("Conflicting receive_btc request for payment hash {0}")]
     ConflictingReceiveBTCRequest(Hash256),
+    #[error("Conflicting send_btc request for payment hash {0}")]
+    ConflictingSendBTCRequest(Hash256),
     #[error("receive_btc order creation for payment hash {0} is already being recovered")]
     ReceiveBTCOrderCreationInProgress(Hash256),
     #[error("receive_btc order creation for payment hash {0} has expired")]
     ReceiveBTCOrderCreationExpired(Hash256),
+    #[error("send_btc order creation for payment hash {0} has expired")]
+    SendBTCOrderCreationExpired(Hash256),
     #[error("LND invoice for payment hash {payment_hash} does not match the CCH order: {reason}")]
     LndInvoiceMismatch {
         payment_hash: Hash256,
@@ -106,6 +110,10 @@ pub enum CchError {
     LndInvoiceTrackerError(String),
     #[error("Fiber node error: {0}")]
     FiberNodeError(anyhow::Error),
+    #[error("Fiber invoice already exists: {0}")]
+    FiberInvoiceAlreadyExists(Hash256),
+    #[error("Fiber invoice does not match send_btc creation intent: {0}")]
+    FiberInvoiceMismatch(Hash256),
 }
 
 pub type CchResult<T> = std::result::Result<T, CchError>;

--- a/crates/fiber-lib/src/cch/order/order_store.rs
+++ b/crates/fiber-lib/src/cch/order/order_store.rs
@@ -1,5 +1,5 @@
 use crate::cch::error::CchStoreError;
-use fiber_types::{CchOrder, CchReceiveBtcOrderCreation, Hash256};
+use fiber_types::{CchOrder, CchReceiveBtcOrderCreation, CchSendBtcOrderCreation, Hash256};
 
 pub trait CchOrderStore {
     /// Gets an order from the store.
@@ -41,4 +41,25 @@ pub trait CchOrderStore {
 
     /// Deletes a durable `receive_btc` creation intent.
     fn delete_receive_btc_order_creation(&self, payment_hash: &Hash256);
+
+    /// Gets a durable `send_btc` creation intent by payment hash.
+    fn get_send_btc_order_creation(
+        &self,
+        payment_hash: &Hash256,
+    ) -> Result<CchSendBtcOrderCreation, CchStoreError>;
+
+    /// Inserts a durable `send_btc` creation intent.
+    fn insert_send_btc_order_creation(
+        &self,
+        creation: CchSendBtcOrderCreation,
+    ) -> Result<(), CchStoreError>;
+
+    /// Iterates over all durable `send_btc` creation intent keys.
+    fn get_send_btc_order_creation_keys_iter(&self) -> impl IntoIterator<Item = Hash256>;
+
+    /// Atomically replaces a durable `send_btc` creation intent with its completed order.
+    fn complete_send_btc_order_creation(&self, order: CchOrder) -> Result<(), CchStoreError>;
+
+    /// Deletes a durable `send_btc` creation intent.
+    fn delete_send_btc_order_creation(&self, payment_hash: &Hash256);
 }

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -419,6 +419,9 @@ struct MockNetworkState {
     add_invoice_delay: Arc<Mutex<Duration>>,
     /// Optional invoice status emitted after AddInvoice stores the invoice but before it replies.
     add_invoice_status_before_reply: Arc<Mutex<Option<CkbInvoiceStatus>>>,
+    /// Simulates a lost AddInvoice response followed by authoritative GetInvoice recovery.
+    add_invoice_reconciliation_before_reply:
+        Arc<Mutex<Option<(CkbInvoiceStatus, CkbInvoiceStatus)>>>,
     /// Authoritative Fiber invoices returned by GetInvoice during recovery.
     fiber_invoices: Arc<Mutex<std::collections::HashMap<Hash256, (CkbInvoice, CkbInvoiceStatus)>>>,
     /// Durable Fiber store used by store-backed recovery tests.
@@ -454,6 +457,26 @@ impl Actor for MockNetworkActor {
             NetworkActorMessage::Command(cmd) => match cmd {
                 NetworkActorCommand::AddInvoice(invoice, _opt_hash, reply) => {
                     let delay = *state.add_invoice_delay.lock().unwrap();
+                    let reconciliation = *state
+                        .add_invoice_reconciliation_before_reply
+                        .lock()
+                        .unwrap();
+                    if let Some((event_status, authoritative_status)) = reconciliation {
+                        let payment_hash = *invoice.payment_hash();
+                        state
+                            .fiber_invoices
+                            .lock()
+                            .unwrap()
+                            .insert(payment_hash, (invoice, authoritative_status));
+                        state.event_port.send(CchTrackingEvent::InvoiceChanged {
+                            payment_hash,
+                            status: event_status,
+                            failure_reason: None,
+                        });
+                        tokio::time::sleep(delay).await;
+                        let _ = reply.send(Err(InvoiceError::InvoiceAlreadyExists));
+                        return Ok(());
+                    }
                     let status_before_reply =
                         *state.add_invoice_status_before_reply.lock().unwrap();
                     if status_before_reply.is_none() {
@@ -862,6 +885,18 @@ impl TestHarness {
             .unwrap() = Some(status);
     }
 
+    fn reconcile_invoice_after_add_invoice_response_loss(
+        &self,
+        event_status: CkbInvoiceStatus,
+        authoritative_status: CkbInvoiceStatus,
+    ) {
+        *self
+            .mock_state
+            .add_invoice_reconciliation_before_reply
+            .lock()
+            .unwrap() = Some((event_status, authoritative_status));
+    }
+
     fn insert_fiber_invoice(&self, invoice: CkbInvoice, status: CkbInvoiceStatus) {
         self.mock_state
             .fiber_invoices
@@ -991,6 +1026,7 @@ async fn setup_test_harness_with_config_store_and_lnd(
         add_invoice_already_exists: Arc::new(AtomicBool::new(false)),
         add_invoice_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
         add_invoice_status_before_reply: Arc::new(Mutex::new(None)),
+        add_invoice_reconciliation_before_reply: Arc::new(Mutex::new(None)),
         fiber_invoices: Arc::new(Mutex::new(std::collections::HashMap::new())),
         payment_store: None,
         settle_invoice_already_paid: Arc::new(Mutex::new(false)),
@@ -1057,6 +1093,7 @@ async fn setup_store_backed_test_harness_with_store(
         add_invoice_already_exists: Arc::new(AtomicBool::new(false)),
         add_invoice_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
         add_invoice_status_before_reply: Arc::new(Mutex::new(None)),
+        add_invoice_reconciliation_before_reply: Arc::new(Mutex::new(None)),
         fiber_invoices: Arc::new(Mutex::new(std::collections::HashMap::new())),
         payment_store: Some(store.clone()),
         settle_invoice_already_paid: Arc::new(Mutex::new(false)),
@@ -1424,6 +1461,23 @@ async fn test_send_btc_preserves_invoice_status_cancelled_before_order_is_persis
         CchOrderStatus::Failed,
         "a cancellation consumed while creation is active must be reflected in the new order"
     );
+}
+
+#[tokio::test]
+async fn test_send_btc_ignores_stale_deferred_status_after_authoritative_recovery() {
+    let harness = setup_test_harness().await;
+    harness.set_add_invoice_delay(Duration::from_millis(100));
+    harness.reconcile_invoice_after_add_invoice_response_loss(
+        CkbInvoiceStatus::Open,
+        CkbInvoiceStatus::Received,
+    );
+
+    let (order, _) = harness
+        .create_send_btc_order_with_seed(220)
+        .await
+        .expect("stale deferred status must not fail send_btc completion");
+
+    assert_eq!(order.status, CchOrderStatus::IncomingAccepted);
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -1248,7 +1248,7 @@ async fn test_send_btc_releases_reservation_when_invoice_creation_fails() {
 }
 
 #[tokio::test]
-async fn test_send_btc_does_not_execute_queued_request_after_rpc_timeout() {
+async fn test_send_btc_request_started_before_rpc_timeout_completes_durably() {
     let store = MockCchOrderStore::new();
     let harness = setup_test_harness_with_store(store.clone()).await;
     harness.set_add_invoice_delay(Duration::from_millis(100));
@@ -1306,12 +1306,102 @@ async fn test_send_btc_does_not_execute_queued_request_after_rpc_timeout() {
 
     tokio::time::sleep(Duration::from_millis(300)).await;
 
-    assert!(store.get_cch_order(&second_payment_hash).is_err());
+    assert!(store.get_cch_order(&second_payment_hash).is_ok());
     assert_eq!(
         store.get_cch_order_keys_iter().into_iter().count(),
-        1,
-        "a timed-out queued send_btc must not create an order"
+        2,
+        "requests accepted before their RPC timeout must complete durably"
     );
+}
+
+#[tokio::test]
+async fn test_send_btc_invoice_creation_does_not_block_actor_mailbox() {
+    let store = MockCchOrderStore::new();
+    insert_pending_send_btc_orders(&store, 1);
+    let existing_payment_hash = test_payment_hash(0);
+    let harness = setup_test_harness_with_store(store).await;
+    harness.set_add_invoice_delay(Duration::from_millis(200));
+    let actor = harness.actor.clone();
+    let slow_payment_hash = create_valid_preimage_pair(216).1;
+    let slow_btc_pay_req =
+        create_test_lightning_invoice_with_payment_hash(slow_payment_hash).to_string();
+
+    let slow_creation = tokio::spawn(async move {
+        actor
+            .call(
+                |reply| {
+                    CchMessage::SendBTC(
+                        crate::cch::SendBTC {
+                            btc_pay_req: slow_btc_pay_req,
+                            currency: Currency::Fibb,
+                        },
+                        reply,
+                    )
+                },
+                Some(Duration::from_secs(1)),
+            )
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let existing_order = harness
+        .actor
+        .call(
+            |reply| CchMessage::GetCchOrder(existing_payment_hash, reply),
+            Some(Duration::from_millis(50)),
+        )
+        .await
+        .expect("get order message should be sent")
+        .expect("CchActor mailbox must remain responsive")
+        .expect("existing order");
+
+    assert_eq!(existing_order.payment_hash, existing_payment_hash);
+    slow_creation
+        .await
+        .expect("slow creation task")
+        .expect("send_btc message should be sent")
+        .expect("slow creation should finish")
+        .expect("send_btc order");
+}
+
+#[tokio::test]
+async fn test_send_btc_recovery_does_not_block_actor_mailbox() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    insert_pending_send_btc_orders(&store, 1);
+    let existing_payment_hash = test_payment_hash(0);
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    harness.set_add_invoice_delay(Duration::from_millis(200));
+    let recovery_payment_hash = create_valid_preimage_pair(217).1;
+    store
+        .insert_send_btc_order_creation(create_send_btc_order_creation(
+            &config,
+            recovery_payment_hash,
+        ))
+        .expect("insert recovery intent");
+
+    harness
+        .actor
+        .send_message(CchMessage::ResumeSendBTCOrderCreation {
+            payment_hash: recovery_payment_hash,
+            retry_count: 0,
+        })
+        .expect("start send_btc recovery");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let existing_order = harness
+        .actor
+        .call(
+            |reply| CchMessage::GetCchOrder(existing_payment_hash, reply),
+            Some(Duration::from_millis(50)),
+        )
+        .await
+        .expect("get order message should be sent")
+        .expect("CchActor mailbox must remain responsive during recovery")
+        .expect("existing order");
+
+    assert_eq!(existing_order.payment_hash, existing_payment_hash);
+    wait_for_mock_order(&store, recovery_payment_hash).await;
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -1370,6 +1370,158 @@ async fn test_send_btc_rpc_timeout_is_idempotent_on_retry() {
 }
 
 #[tokio::test]
+async fn test_send_btc_idempotent_order_rejects_currency_mismatch() {
+    let harness = setup_test_harness().await;
+    let (order, _) = harness
+        .create_send_btc_order_with_seed(212)
+        .await
+        .expect("create send_btc order");
+
+    let error = call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req: order.outgoing_pay_req,
+            currency: Currency::Fibd,
+        }
+    )
+    .expect("actor call failed")
+    .expect_err("an idempotent retry must still validate currency");
+
+    assert!(matches!(
+        error,
+        CchError::CKBInvoiceNetworkMismatch {
+            expected: Currency::Fibb,
+            actual: Currency::Fibd,
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_send_btc_idempotent_creation_rejects_currency_mismatch() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    let payment_hash = create_valid_preimage_pair(213).1;
+    let creation = create_send_btc_order_creation(&config, payment_hash);
+    let btc_pay_req = creation.btc_pay_req.clone();
+    store.insert_send_btc_order_creation(creation).unwrap();
+
+    let error = call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req,
+            currency: Currency::Fibd,
+        }
+    )
+    .expect("actor call failed")
+    .expect_err("a persisted creation retry must still validate currency");
+
+    assert!(matches!(
+        error,
+        CchError::CKBInvoiceNetworkMismatch {
+            expected: Currency::Fibb,
+            actual: Currency::Fibd,
+        }
+    ));
+    assert!(store.get_cch_order(&payment_hash).is_err());
+}
+
+#[tokio::test]
+async fn test_send_btc_pending_recovery_rejects_currency_mismatch() {
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_store(store).await;
+    harness.set_add_invoice_failure(true);
+    let payment_hash = create_valid_preimage_pair(214).1;
+    let btc_pay_req = create_test_lightning_invoice_with_payment_hash(payment_hash).to_string();
+
+    call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req: btc_pay_req.clone(),
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed")
+    .expect_err("mocked invoice creation must fail");
+
+    let error = call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req,
+            currency: Currency::Fibd,
+        }
+    )
+    .expect("actor call failed")
+    .expect_err("pending recovery retry must still validate currency");
+
+    assert!(matches!(
+        error,
+        CchError::CKBInvoiceNetworkMismatch {
+            expected: Currency::Fibb,
+            actual: Currency::Fibd,
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_send_btc_persisted_invoice_respects_absolute_deadline() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_config_and_store(config, store.clone()).await;
+    harness.set_add_invoice_failure(true);
+    let payment_hash = create_valid_preimage_pair(215).1;
+    let btc_invoice = create_test_lightning_invoice_with_payment_hash(payment_hash);
+
+    while !(100..=800).contains(
+        &SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .subsec_millis(),
+    ) {
+        tokio::task::yield_now().await;
+    }
+
+    call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req: btc_invoice.to_string(),
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed")
+    .expect_err("mocked invoice creation must fail");
+
+    let creation = store
+        .get_send_btc_order_creation(&payment_hash)
+        .expect("durable send_btc creation");
+    let absolute_deadline_millis = u128::from(
+        btc_invoice
+            .expires_at()
+            .expect("BTC invoice expiry")
+            .as_secs()
+            .min(
+                creation
+                    .created_at
+                    .checked_add(creation.order_expiry_delta_seconds)
+                    .expect("order deadline"),
+            ),
+    ) * 1_000;
+    let persisted_invoice_deadline_millis = creation.incoming_invoice.data.timestamp
+        + creation
+            .incoming_invoice
+            .expiry_time()
+            .expect("Fiber invoice expiry")
+            .as_millis();
+
+    assert!(persisted_invoice_deadline_millis <= absolute_deadline_millis);
+}
+
+#[tokio::test]
 async fn test_send_btc_client_retries_share_one_recovery_chain() {
     let store = MockCchOrderStore::new();
     let harness = setup_test_harness_with_store(store.clone()).await;

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -417,6 +417,8 @@ struct MockNetworkState {
     add_invoice_already_exists: Arc<AtomicBool>,
     /// Artificial delay before returning the Fiber invoice creation response.
     add_invoice_delay: Arc<Mutex<Duration>>,
+    /// Optional invoice status emitted after AddInvoice stores the invoice but before it replies.
+    add_invoice_status_before_reply: Arc<Mutex<Option<CkbInvoiceStatus>>>,
     /// Authoritative Fiber invoices returned by GetInvoice during recovery.
     fiber_invoices: Arc<Mutex<std::collections::HashMap<Hash256, (CkbInvoice, CkbInvoiceStatus)>>>,
     /// Durable Fiber store used by store-backed recovery tests.
@@ -452,17 +454,31 @@ impl Actor for MockNetworkActor {
             NetworkActorMessage::Command(cmd) => match cmd {
                 NetworkActorCommand::AddInvoice(invoice, _opt_hash, reply) => {
                     let delay = *state.add_invoice_delay.lock().unwrap();
-                    tokio::time::sleep(delay).await;
+                    let status_before_reply =
+                        *state.add_invoice_status_before_reply.lock().unwrap();
+                    if status_before_reply.is_none() {
+                        tokio::time::sleep(delay).await;
+                    }
                     if state.fail_add_invoice.load(Ordering::SeqCst) {
                         let _ = reply.send(Err(InvoiceError::InvoiceNotFound));
                     } else if state.add_invoice_already_exists.load(Ordering::SeqCst) {
                         let _ = reply.send(Err(InvoiceError::InvoiceAlreadyExists));
                     } else {
+                        let payment_hash = *invoice.payment_hash();
+                        let status = status_before_reply.unwrap_or(CkbInvoiceStatus::Open);
                         state
                             .fiber_invoices
                             .lock()
                             .unwrap()
-                            .insert(*invoice.payment_hash(), (invoice, CkbInvoiceStatus::Open));
+                            .insert(payment_hash, (invoice, status));
+                        if status_before_reply.is_some() {
+                            state.event_port.send(CchTrackingEvent::InvoiceChanged {
+                                payment_hash,
+                                status,
+                                failure_reason: None,
+                            });
+                            tokio::time::sleep(delay).await;
+                        }
                         let _ = reply.send(Ok(()));
                     }
                 }
@@ -838,6 +854,14 @@ impl TestHarness {
         *self.mock_state.add_invoice_delay.lock().unwrap() = delay;
     }
 
+    fn emit_invoice_status_before_add_invoice_reply(&self, status: CkbInvoiceStatus) {
+        *self
+            .mock_state
+            .add_invoice_status_before_reply
+            .lock()
+            .unwrap() = Some(status);
+    }
+
     fn insert_fiber_invoice(&self, invoice: CkbInvoice, status: CkbInvoiceStatus) {
         self.mock_state
             .fiber_invoices
@@ -966,6 +990,7 @@ async fn setup_test_harness_with_config_store_and_lnd(
         fail_add_invoice: Arc::new(AtomicBool::new(false)),
         add_invoice_already_exists: Arc::new(AtomicBool::new(false)),
         add_invoice_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
+        add_invoice_status_before_reply: Arc::new(Mutex::new(None)),
         fiber_invoices: Arc::new(Mutex::new(std::collections::HashMap::new())),
         payment_store: None,
         settle_invoice_already_paid: Arc::new(Mutex::new(false)),
@@ -1031,6 +1056,7 @@ async fn setup_store_backed_test_harness_with_store(
         fail_add_invoice: Arc::new(AtomicBool::new(false)),
         add_invoice_already_exists: Arc::new(AtomicBool::new(false)),
         add_invoice_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
+        add_invoice_status_before_reply: Arc::new(Mutex::new(None)),
         fiber_invoices: Arc::new(Mutex::new(std::collections::HashMap::new())),
         payment_store: Some(store.clone()),
         settle_invoice_already_paid: Arc::new(Mutex::new(false)),
@@ -1362,6 +1388,42 @@ async fn test_send_btc_invoice_creation_does_not_block_actor_mailbox() {
         .expect("send_btc message should be sent")
         .expect("slow creation should finish")
         .expect("send_btc order");
+}
+
+#[tokio::test]
+async fn test_send_btc_preserves_invoice_status_received_before_order_is_persisted() {
+    let harness = setup_test_harness().await;
+    harness.set_add_invoice_delay(Duration::from_millis(100));
+    harness.emit_invoice_status_before_add_invoice_reply(CkbInvoiceStatus::Received);
+
+    let (order, _) = harness
+        .create_send_btc_order_with_seed(218)
+        .await
+        .expect("send_btc order");
+
+    assert_eq!(
+        order.status,
+        CchOrderStatus::IncomingAccepted,
+        "an invoice event consumed while creation is active must be reflected in the new order"
+    );
+}
+
+#[tokio::test]
+async fn test_send_btc_preserves_invoice_status_cancelled_before_order_is_persisted() {
+    let harness = setup_test_harness().await;
+    harness.set_add_invoice_delay(Duration::from_millis(100));
+    harness.emit_invoice_status_before_add_invoice_reply(CkbInvoiceStatus::Cancelled);
+
+    let (order, _) = harness
+        .create_send_btc_order_with_seed(219)
+        .await
+        .expect("send_btc order");
+
+    assert_eq!(
+        order.status,
+        CchOrderStatus::Failed,
+        "a cancellation consumed while creation is active must be reflected in the new order"
+    );
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -1370,6 +1370,65 @@ async fn test_send_btc_rpc_timeout_is_idempotent_on_retry() {
 }
 
 #[tokio::test]
+async fn test_send_btc_client_retries_share_one_recovery_chain() {
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_store(store.clone()).await;
+    harness.set_add_invoice_failure(true);
+    let payment_hash = create_valid_preimage_pair(209).1;
+    let btc_pay_req = create_test_lightning_invoice_with_payment_hash(payment_hash).to_string();
+
+    let first_error = call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req: btc_pay_req.clone(),
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed")
+    .unwrap_err();
+    assert!(matches!(first_error, CchError::FiberNodeError(_)));
+
+    let retry_error = call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req: btc_pay_req.clone(),
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed")
+    .unwrap_err();
+    assert!(matches!(
+        retry_error,
+        CchError::SendBTCOrderCreationInProgress(hash) if hash == payment_hash
+    ));
+
+    let conflicting_error = call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req: create_test_lightning_invoice_with_payment_hash_and_amount(
+                payment_hash,
+                100_001,
+            )
+            .to_string(),
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed")
+    .unwrap_err();
+    assert!(matches!(
+        conflicting_error,
+        CchError::ConflictingSendBTCRequest(hash) if hash == payment_hash
+    ));
+
+    harness.set_add_invoice_failure(false);
+    let recovered = wait_for_mock_order(&store, payment_hash).await;
+    assert_eq!(recovered.outgoing_pay_req, btc_pay_req);
+}
+
+#[tokio::test]
 async fn test_send_btc_creation_resumes_after_actor_restart() {
     let config = CchConfig {
         lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
@@ -1519,6 +1578,37 @@ async fn test_send_btc_recovers_received_fiber_invoice_status() {
 }
 
 #[tokio::test]
+async fn test_send_btc_final_recovery_releases_payment_tracking_capacity() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    insert_pending_send_btc_orders(&store, MAX_TRACKED_PAYMENTS - 1);
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    let payment_hash = create_valid_preimage_pair(210).1;
+    let creation = create_send_btc_order_creation(&config, payment_hash);
+    harness.insert_fiber_invoice(
+        creation.incoming_invoice.clone(),
+        CkbInvoiceStatus::Cancelled,
+    );
+    store.insert_send_btc_order_creation(creation).unwrap();
+
+    harness
+        .actor
+        .send_message(CchMessage::ResumeSendBTCOrderCreation {
+            payment_hash,
+            retry_count: 0,
+        })
+        .expect("actor should accept send_btc recovery");
+    let recovered = wait_for_mock_order(&store, payment_hash).await;
+    assert_eq!(recovered.status, CchOrderStatus::Failed);
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    harness
+        .create_send_btc_order_with_seed(211)
+        .await
+        .expect("final recovery must release its payment tracking reservation");
+}
+
+#[tokio::test]
 async fn test_send_btc_recovery_preserves_absolute_btc_expiry() {
     let config = receive_btc_recovery_test_config();
     let store = MockCchOrderStore::new();
@@ -1538,16 +1628,14 @@ async fn test_send_btc_recovery_preserves_absolute_btc_expiry() {
     let btc_deadline_millis = u128::from(btc_invoice.expires_at().unwrap().as_secs()) * 1_000;
     store.insert_send_btc_order_creation(creation).unwrap();
 
-    call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req: btc_invoice.to_string(),
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed")
-    .expect("retry should complete the persisted creation");
+    harness
+        .actor
+        .send_message(CchMessage::ResumeSendBTCOrderCreation {
+            payment_hash,
+            retry_count: 0,
+        })
+        .expect("actor should accept send_btc recovery");
+    wait_for_mock_order(&store, payment_hash).await;
     let (fiber_invoice, _) = harness
         .fiber_invoice(payment_hash)
         .expect("recovery should create the Fiber invoice");

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -430,6 +430,31 @@ struct MockNetworkState {
     settle_invoice_already_paid: Arc<Mutex<bool>>,
 }
 
+impl MockNetworkState {
+    fn new(event_port: Arc<OutputPort<CchTrackingEvent>>, payment_store: Option<Store>) -> Self {
+        Self {
+            cch_actor: Arc::new(Mutex::new(None)),
+            event_port,
+            sent_fiber_payments: Default::default(),
+            cancelled_fiber_invoices: Default::default(),
+            preflighted_fiber_payments: Default::default(),
+            fiber_preflight_error: Default::default(),
+            fiber_preflight_delay: Default::default(),
+            sent_fiber_payment_fees: Default::default(),
+            sent_fiber_payment_fee_rates: Default::default(),
+            send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
+            fail_add_invoice: Default::default(),
+            add_invoice_already_exists: Default::default(),
+            add_invoice_delay: Default::default(),
+            add_invoice_status_before_reply: Default::default(),
+            add_invoice_reconciliation_before_reply: Default::default(),
+            fiber_invoices: Default::default(),
+            payment_store,
+            settle_invoice_already_paid: Default::default(),
+        }
+    }
+}
+
 /// Mock network actor that handles commands from action executors
 struct MockNetworkActor;
 
@@ -854,17 +879,34 @@ impl TestHarness {
         let lightning_invoice = create_test_lightning_invoice_with_payment_hash(payment_hash);
         let btc_pay_req = lightning_invoice.to_string();
 
-        let order = call!(
+        let order = self.send_btc(btc_pay_req, Currency::Fibb).await?;
+
+        Ok((order, preimage))
+    }
+
+    async fn send_btc(
+        &self,
+        btc_pay_req: String,
+        currency: Currency,
+    ) -> Result<CchOrder, CchError> {
+        call!(
             self.actor,
             CchMessage::SendBTC,
             crate::cch::actor::SendBTC {
                 btc_pay_req,
-                currency: Currency::Fibb,
+                currency,
             }
         )
-        .expect("actor call failed")?;
+        .expect("actor call failed")
+    }
 
-        Ok((order, preimage))
+    fn resume_send_btc_creation(&self, payment_hash: Hash256) {
+        self.actor
+            .send_message(CchMessage::ResumeSendBTCOrderCreation {
+                payment_hash,
+                retry_count: 0,
+            })
+            .expect("actor should accept send_btc recovery");
     }
 
     fn set_add_invoice_failure(&self, fail: bool) {
@@ -1011,26 +1053,7 @@ async fn setup_test_harness_with_config_store_and_lnd(
 ) -> TestHarness {
     let event_port = Arc::new(OutputPort::<CchTrackingEvent>::default());
 
-    let mock_state = MockNetworkState {
-        cch_actor: Arc::new(Mutex::new(None)),
-        event_port: event_port.clone(),
-        sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
-        cancelled_fiber_invoices: Arc::new(Mutex::new(std::collections::HashSet::new())),
-        preflighted_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
-        fiber_preflight_error: Arc::new(Mutex::new(None)),
-        fiber_preflight_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
-        sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
-        sent_fiber_payment_fee_rates: Arc::new(Mutex::new(std::collections::HashMap::new())),
-        send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
-        fail_add_invoice: Arc::new(AtomicBool::new(false)),
-        add_invoice_already_exists: Arc::new(AtomicBool::new(false)),
-        add_invoice_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
-        add_invoice_status_before_reply: Arc::new(Mutex::new(None)),
-        add_invoice_reconciliation_before_reply: Arc::new(Mutex::new(None)),
-        fiber_invoices: Arc::new(Mutex::new(std::collections::HashMap::new())),
-        payment_store: None,
-        settle_invoice_already_paid: Arc::new(Mutex::new(false)),
-    };
+    let mock_state = MockNetworkState::new(event_port.clone(), None);
 
     let (network_actor, _) = Actor::spawn(None, MockNetworkActor, mock_state.clone())
         .await
@@ -1078,26 +1101,7 @@ async fn setup_store_backed_test_harness_with_store(
         store_change_port_clone.send(change);
     }));
 
-    let mock_state = MockNetworkState {
-        cch_actor: Arc::new(Mutex::new(None)),
-        event_port: event_port.clone(),
-        sent_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
-        cancelled_fiber_invoices: Arc::new(Mutex::new(std::collections::HashSet::new())),
-        preflighted_fiber_payments: Arc::new(Mutex::new(std::collections::HashSet::new())),
-        fiber_preflight_error: Arc::new(Mutex::new(None)),
-        fiber_preflight_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
-        sent_fiber_payment_fees: Arc::new(Mutex::new(std::collections::HashMap::new())),
-        sent_fiber_payment_fee_rates: Arc::new(Mutex::new(std::collections::HashMap::new())),
-        send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
-        fail_add_invoice: Arc::new(AtomicBool::new(false)),
-        add_invoice_already_exists: Arc::new(AtomicBool::new(false)),
-        add_invoice_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
-        add_invoice_status_before_reply: Arc::new(Mutex::new(None)),
-        add_invoice_reconciliation_before_reply: Arc::new(Mutex::new(None)),
-        fiber_invoices: Arc::new(Mutex::new(std::collections::HashMap::new())),
-        payment_store: Some(store.clone()),
-        settle_invoice_already_paid: Arc::new(Mutex::new(false)),
-    };
+    let mock_state = MockNetworkState::new(event_port.clone(), Some(store.clone()));
 
     let (network_actor, _) = Actor::spawn(None, MockNetworkActor, mock_state.clone())
         .await
@@ -1428,39 +1432,26 @@ async fn test_send_btc_invoice_creation_does_not_block_actor_mailbox() {
 }
 
 #[tokio::test]
-async fn test_send_btc_preserves_invoice_status_received_before_order_is_persisted() {
-    let harness = setup_test_harness().await;
-    harness.set_add_invoice_delay(Duration::from_millis(100));
-    harness.emit_invoice_status_before_add_invoice_reply(CkbInvoiceStatus::Received);
+async fn test_send_btc_preserves_invoice_status_before_order_is_persisted() {
+    for (seed, invoice_status, expected_order_status) in [
+        (
+            218,
+            CkbInvoiceStatus::Received,
+            CchOrderStatus::IncomingAccepted,
+        ),
+        (219, CkbInvoiceStatus::Cancelled, CchOrderStatus::Failed),
+    ] {
+        let harness = setup_test_harness().await;
+        harness.set_add_invoice_delay(Duration::from_millis(100));
+        harness.emit_invoice_status_before_add_invoice_reply(invoice_status);
 
-    let (order, _) = harness
-        .create_send_btc_order_with_seed(218)
-        .await
-        .expect("send_btc order");
+        let (order, _) = harness
+            .create_send_btc_order_with_seed(seed)
+            .await
+            .expect("send_btc order");
 
-    assert_eq!(
-        order.status,
-        CchOrderStatus::IncomingAccepted,
-        "an invoice event consumed while creation is active must be reflected in the new order"
-    );
-}
-
-#[tokio::test]
-async fn test_send_btc_preserves_invoice_status_cancelled_before_order_is_persisted() {
-    let harness = setup_test_harness().await;
-    harness.set_add_invoice_delay(Duration::from_millis(100));
-    harness.emit_invoice_status_before_add_invoice_reply(CkbInvoiceStatus::Cancelled);
-
-    let (order, _) = harness
-        .create_send_btc_order_with_seed(219)
-        .await
-        .expect("send_btc order");
-
-    assert_eq!(
-        order.status,
-        CchOrderStatus::Failed,
-        "a cancellation consumed while creation is active must be reflected in the new order"
-    );
+        assert_eq!(order.status, expected_order_status, "{invoice_status:?}");
+    }
 }
 
 #[tokio::test]
@@ -1496,13 +1487,7 @@ async fn test_send_btc_recovery_does_not_block_actor_mailbox() {
         ))
         .expect("insert recovery intent");
 
-    harness
-        .actor
-        .send_message(CchMessage::ResumeSendBTCOrderCreation {
-            payment_hash: recovery_payment_hash,
-            retry_count: 0,
-        })
-        .expect("start send_btc recovery");
+    harness.resume_send_btc_creation(recovery_payment_hash);
     tokio::time::sleep(Duration::from_millis(20)).await;
 
     let existing_order = harness
@@ -1556,16 +1541,10 @@ async fn test_send_btc_rpc_timeout_is_idempotent_on_retry() {
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     };
-    let retried = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req,
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed")
-    .expect("retry should return the already-created order");
+    let retried = harness
+        .send_btc(btc_pay_req, Currency::Fibb)
+        .await
+        .expect("retry should return the already-created order");
 
     assert_eq!(retried.payment_hash, created.payment_hash);
     assert_eq!(
@@ -1583,16 +1562,10 @@ async fn test_send_btc_idempotent_order_rejects_currency_mismatch() {
         .await
         .expect("create send_btc order");
 
-    let error = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req: order.outgoing_pay_req,
-            currency: Currency::Fibd,
-        }
-    )
-    .expect("actor call failed")
-    .expect_err("an idempotent retry must still validate currency");
+    let error = harness
+        .send_btc(order.outgoing_pay_req, Currency::Fibd)
+        .await
+        .expect_err("an idempotent retry must still validate currency");
 
     assert!(matches!(
         error,
@@ -1605,24 +1578,15 @@ async fn test_send_btc_idempotent_order_rejects_currency_mismatch() {
 
 #[tokio::test]
 async fn test_send_btc_idempotent_creation_rejects_currency_mismatch() {
-    let config = receive_btc_recovery_test_config();
-    let store = MockCchOrderStore::new();
-    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
-    let payment_hash = create_valid_preimage_pair(213).1;
-    let creation = create_send_btc_order_creation(&config, payment_hash);
+    let (harness, store, creation) = setup_send_btc_recovery_test(213).await;
+    let payment_hash = creation.payment_hash;
     let btc_pay_req = creation.btc_pay_req.clone();
     store.insert_send_btc_order_creation(creation).unwrap();
 
-    let error = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req,
-            currency: Currency::Fibd,
-        }
-    )
-    .expect("actor call failed")
-    .expect_err("a persisted creation retry must still validate currency");
+    let error = harness
+        .send_btc(btc_pay_req, Currency::Fibd)
+        .await
+        .expect_err("a persisted creation retry must still validate currency");
 
     assert!(matches!(
         error,
@@ -1642,27 +1606,15 @@ async fn test_send_btc_pending_recovery_rejects_currency_mismatch() {
     let payment_hash = create_valid_preimage_pair(214).1;
     let btc_pay_req = create_test_lightning_invoice_with_payment_hash(payment_hash).to_string();
 
-    call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req: btc_pay_req.clone(),
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed")
-    .expect_err("mocked invoice creation must fail");
+    harness
+        .send_btc(btc_pay_req.clone(), Currency::Fibb)
+        .await
+        .expect_err("mocked invoice creation must fail");
 
-    let error = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req,
-            currency: Currency::Fibd,
-        }
-    )
-    .expect("actor call failed")
-    .expect_err("pending recovery retry must still validate currency");
+    let error = harness
+        .send_btc(btc_pay_req, Currency::Fibd)
+        .await
+        .expect_err("pending recovery retry must still validate currency");
 
     assert!(matches!(
         error,
@@ -1691,16 +1643,10 @@ async fn test_send_btc_persisted_invoice_respects_absolute_deadline() {
         tokio::task::yield_now().await;
     }
 
-    call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req: btc_invoice.to_string(),
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed")
-    .expect_err("mocked invoice creation must fail");
+    harness
+        .send_btc(btc_invoice.to_string(), Currency::Fibb)
+        .await
+        .expect_err("mocked invoice creation must fail");
 
     let creation = store
         .get_send_btc_order_creation(&payment_hash)
@@ -1735,47 +1681,29 @@ async fn test_send_btc_client_retries_share_one_recovery_chain() {
     let payment_hash = create_valid_preimage_pair(209).1;
     let btc_pay_req = create_test_lightning_invoice_with_payment_hash(payment_hash).to_string();
 
-    let first_error = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req: btc_pay_req.clone(),
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed")
-    .unwrap_err();
+    let first_error = harness
+        .send_btc(btc_pay_req.clone(), Currency::Fibb)
+        .await
+        .unwrap_err();
     assert!(matches!(first_error, CchError::FiberNodeError(_)));
 
-    let retry_error = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req: btc_pay_req.clone(),
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed")
-    .unwrap_err();
+    let retry_error = harness
+        .send_btc(btc_pay_req.clone(), Currency::Fibb)
+        .await
+        .unwrap_err();
     assert!(matches!(
         retry_error,
         CchError::SendBTCOrderCreationInProgress(hash) if hash == payment_hash
     ));
 
-    let conflicting_error = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req: create_test_lightning_invoice_with_payment_hash_and_amount(
-                payment_hash,
-                100_001,
-            )
-            .to_string(),
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed")
-    .unwrap_err();
+    let conflicting_error = harness
+        .send_btc(
+            create_test_lightning_invoice_with_payment_hash_and_amount(payment_hash, 100_001)
+                .to_string(),
+            Currency::Fibb,
+        )
+        .await
+        .unwrap_err();
     assert!(matches!(
         conflicting_error,
         CchError::ConflictingSendBTCRequest(hash) if hash == payment_hash
@@ -1788,27 +1716,14 @@ async fn test_send_btc_client_retries_share_one_recovery_chain() {
 
 #[tokio::test]
 async fn test_send_btc_creation_resumes_after_actor_restart() {
-    let config = CchConfig {
-        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
-        wrapped_btc_type_script_args: "0x".to_string(),
-        min_outgoing_invoice_expiry_delta_seconds: 60,
-        ..Default::default()
-    };
+    let config = receive_btc_recovery_test_config();
     let store = MockCchOrderStore::new();
     let first = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
     first.set_add_invoice_failure(true);
     let payment_hash = create_valid_preimage_pair(203).1;
     let btc_pay_req = create_test_lightning_invoice_with_payment_hash(payment_hash).to_string();
 
-    let first_result = call!(
-        first.actor,
-        CchMessage::SendBTC,
-        crate::cch::SendBTC {
-            btc_pay_req: btc_pay_req.clone(),
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed");
+    let first_result = first.send_btc(btc_pay_req.clone(), Currency::Fibb).await;
     assert!(first_result.is_err(), "the first Fiber call should fail");
     assert!(store.get_send_btc_order_creation(&payment_hash).is_ok());
 
@@ -1827,26 +1742,12 @@ async fn test_send_btc_creation_resumes_after_actor_restart() {
 
 #[tokio::test]
 async fn test_send_btc_recovers_existing_fiber_invoice_from_intent() {
-    let config = CchConfig {
-        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
-        wrapped_btc_type_script_args: "0x".to_string(),
-        min_outgoing_invoice_expiry_delta_seconds: 60,
-        ..Default::default()
-    };
-    let store = MockCchOrderStore::new();
-    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
-    let payment_hash = create_valid_preimage_pair(204).1;
-    let creation = create_send_btc_order_creation(&config, payment_hash);
+    let (harness, store, creation) = setup_send_btc_recovery_test(204).await;
+    let payment_hash = creation.payment_hash;
     harness.insert_fiber_invoice(creation.incoming_invoice.clone(), CkbInvoiceStatus::Open);
     store.insert_send_btc_order_creation(creation).unwrap();
 
-    harness
-        .actor
-        .send_message(CchMessage::ResumeSendBTCOrderCreation {
-            payment_hash,
-            retry_count: 0,
-        })
-        .expect("actor should accept send_btc recovery");
+    harness.resume_send_btc_creation(payment_hash);
     let order = wait_for_mock_order(&store, payment_hash).await;
 
     assert_eq!(order.payment_hash, payment_hash);
@@ -1858,23 +1759,14 @@ async fn test_send_btc_recovers_existing_fiber_invoice_from_intent() {
 
 #[tokio::test]
 async fn test_send_btc_expired_creation_does_not_create_fiber_invoice() {
-    let config = receive_btc_recovery_test_config();
-    let store = MockCchOrderStore::new();
-    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
-    let payment_hash = create_valid_preimage_pair(205).1;
-    let mut creation = create_send_btc_order_creation(&config, payment_hash);
+    let (harness, store, mut creation) = setup_send_btc_recovery_test(205).await;
+    let payment_hash = creation.payment_hash;
     creation.created_at = creation
         .created_at
         .saturating_sub(creation.order_expiry_delta_seconds + 1);
     store.insert_send_btc_order_creation(creation).unwrap();
 
-    harness
-        .actor
-        .send_message(CchMessage::ResumeSendBTCOrderCreation {
-            payment_hash,
-            retry_count: 0,
-        })
-        .expect("actor should accept send_btc recovery");
+    harness.resume_send_btc_creation(payment_hash);
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     assert!(store.get_cch_order(&payment_hash).is_err());
@@ -1884,11 +1776,8 @@ async fn test_send_btc_expired_creation_does_not_create_fiber_invoice() {
 
 #[tokio::test]
 async fn test_send_btc_rejects_mismatched_existing_fiber_invoice() {
-    let config = receive_btc_recovery_test_config();
-    let store = MockCchOrderStore::new();
-    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
-    let payment_hash = create_valid_preimage_pair(206).1;
-    let creation = create_send_btc_order_creation(&config, payment_hash);
+    let (harness, store, creation) = setup_send_btc_recovery_test(206).await;
+    let payment_hash = creation.payment_hash;
     let wrong_invoice = create_test_fiber_invoice_with_amount_and_expiry(
         payment_hash,
         creation.incoming_invoice.amount.unwrap() + 1,
@@ -1897,13 +1786,7 @@ async fn test_send_btc_rejects_mismatched_existing_fiber_invoice() {
     harness.insert_fiber_invoice(wrong_invoice, CkbInvoiceStatus::Open);
     store.insert_send_btc_order_creation(creation).unwrap();
 
-    harness
-        .actor
-        .send_message(CchMessage::ResumeSendBTCOrderCreation {
-            payment_hash,
-            retry_count: 0,
-        })
-        .expect("actor should accept send_btc recovery");
+    harness.resume_send_btc_creation(payment_hash);
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     assert!(store.get_cch_order(&payment_hash).is_err());
@@ -1912,24 +1795,15 @@ async fn test_send_btc_rejects_mismatched_existing_fiber_invoice() {
 
 #[tokio::test]
 async fn test_send_btc_recovers_received_fiber_invoice_status() {
-    let config = receive_btc_recovery_test_config();
-    let store = MockCchOrderStore::new();
-    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
-    let payment_hash = create_valid_preimage_pair(207).1;
-    let creation = create_send_btc_order_creation(&config, payment_hash);
+    let (harness, store, creation) = setup_send_btc_recovery_test(207).await;
+    let payment_hash = creation.payment_hash;
     harness.insert_fiber_invoice(
         creation.incoming_invoice.clone(),
         CkbInvoiceStatus::Received,
     );
     store.insert_send_btc_order_creation(creation).unwrap();
 
-    harness
-        .actor
-        .send_message(CchMessage::ResumeSendBTCOrderCreation {
-            payment_hash,
-            retry_count: 0,
-        })
-        .expect("actor should accept send_btc recovery");
+    harness.resume_send_btc_creation(payment_hash);
     let order = wait_for_mock_order(&store, payment_hash).await;
 
     assert_eq!(order.status, CchOrderStatus::IncomingAccepted);
@@ -1949,13 +1823,7 @@ async fn test_send_btc_final_recovery_releases_payment_tracking_capacity() {
     );
     store.insert_send_btc_order_creation(creation).unwrap();
 
-    harness
-        .actor
-        .send_message(CchMessage::ResumeSendBTCOrderCreation {
-            payment_hash,
-            retry_count: 0,
-        })
-        .expect("actor should accept send_btc recovery");
+    harness.resume_send_btc_creation(payment_hash);
     let recovered = wait_for_mock_order(&store, payment_hash).await;
     assert_eq!(recovered.status, CchOrderStatus::Failed);
 
@@ -1968,10 +1836,8 @@ async fn test_send_btc_final_recovery_releases_payment_tracking_capacity() {
 
 #[tokio::test]
 async fn test_send_btc_recovery_preserves_absolute_btc_expiry() {
-    let config = receive_btc_recovery_test_config();
-    let store = MockCchOrderStore::new();
-    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
-    let payment_hash = create_valid_preimage_pair(208).1;
+    let (harness, store, mut creation) = setup_send_btc_recovery_test(208).await;
+    let payment_hash = creation.payment_hash;
     let invoice_timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -1980,19 +1846,12 @@ async fn test_send_btc_recovery_preserves_absolute_btc_expiry() {
         payment_hash,
         invoice_timestamp,
     );
-    let mut creation = create_send_btc_order_creation(&config, payment_hash);
     creation.created_at = invoice_timestamp.as_secs();
     creation.btc_pay_req = btc_invoice.to_string();
     let btc_deadline_millis = u128::from(btc_invoice.expires_at().unwrap().as_secs()) * 1_000;
     store.insert_send_btc_order_creation(creation).unwrap();
 
-    harness
-        .actor
-        .send_message(CchMessage::ResumeSendBTCOrderCreation {
-            payment_hash,
-            retry_count: 0,
-        })
-        .expect("actor should accept send_btc recovery");
+    harness.resume_send_btc_creation(payment_hash);
     wait_for_mock_order(&store, payment_hash).await;
     let (fiber_invoice, _) = harness
         .fiber_invoice(payment_hash)
@@ -3325,15 +3184,7 @@ async fn test_send_btc_rejects_currency_mismatch() {
     let btc_pay_req = lightning_invoice.to_string();
 
     // Try to send with Fibd currency (node is configured for Fibb)
-    let result = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::actor::SendBTC {
-            btc_pay_req,
-            currency: Currency::Fibd,
-        }
-    )
-    .expect("actor call failed");
+    let result = harness.send_btc(btc_pay_req, Currency::Fibd).await;
 
     match result {
         Err(CchError::CKBInvoiceNetworkMismatch { expected, actual }) => {
@@ -3359,15 +3210,7 @@ async fn test_send_btc_rejects_btc_invoice_network_mismatch() {
     );
     let btc_pay_req = lightning_invoice.to_string();
 
-    let result = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::actor::SendBTC {
-            btc_pay_req,
-            currency: Currency::Fibb, // Matches configured currency
-        }
-    )
-    .expect("actor call failed");
+    let result = harness.send_btc(btc_pay_req, Currency::Fibb).await;
 
     match result {
         Err(CchError::BTCInvoiceNetworkMismatch { expected, actual }) => {
@@ -3393,15 +3236,7 @@ async fn test_send_btc_rejects_future_btc_invoice_timestamp() {
     );
     let btc_pay_req = lightning_invoice.to_string();
 
-    let result = call!(
-        harness.actor,
-        CchMessage::SendBTC,
-        crate::cch::actor::SendBTC {
-            btc_pay_req,
-            currency: Currency::Fibb,
-        }
-    )
-    .expect("actor call failed");
+    let result = harness.send_btc(btc_pay_req, Currency::Fibb).await;
 
     match result {
         Err(CchError::BTCInvoiceCreationTimeInFuture {
@@ -3908,6 +3743,17 @@ fn receive_btc_recovery_test_config() -> CchConfig {
         min_outgoing_invoice_expiry_delta_seconds: 60,
         ..Default::default()
     }
+}
+
+async fn setup_send_btc_recovery_test(
+    seed: u8,
+) -> (TestHarness, MockCchOrderStore, CchSendBtcOrderCreation) {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    let payment_hash = create_valid_preimage_pair(seed).1;
+    let creation = create_send_btc_order_creation(&config, payment_hash);
+    (harness, store, creation)
 }
 
 fn create_send_btc_order_creation(

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -34,8 +34,8 @@ use crate::store::{store_impl::StoreChange, Store};
 use crate::tests::test_utils::{generate_store, TempDir};
 use crate::time::{Duration, SystemTime, UNIX_EPOCH};
 use fiber_types::{
-    AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation, Hash256,
-    HashAlgorithm, PaymentHopData, PaymentStatus,
+    AttemptStatus, CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation,
+    CchSendBtcOrderCreation, Hash256, HashAlgorithm, PaymentHopData, PaymentStatus,
 };
 use lnd_grpc_tonic_client::{invoicesrpc, lnrpc};
 use ractor::{call, port::OutputPortSubscriberTrait, Actor, ActorRef, OutputPort};
@@ -61,6 +61,7 @@ pub struct MockCchOrderStore {
 struct MockCchOrderStoreState {
     orders: HashMap<Hash256, CchOrder>,
     receive_btc_order_creations: HashMap<Hash256, CchReceiveBtcOrderCreation>,
+    send_btc_order_creations: HashMap<Hash256, CchSendBtcOrderCreation>,
 }
 
 impl MockCchOrderStore {
@@ -163,6 +164,63 @@ impl CchOrderStore for MockCchOrderStore {
             .lock()
             .unwrap()
             .receive_btc_order_creations
+            .remove(payment_hash);
+    }
+
+    fn get_send_btc_order_creation(
+        &self,
+        payment_hash: &Hash256,
+    ) -> Result<CchSendBtcOrderCreation, CchStoreError> {
+        self.state
+            .lock()
+            .unwrap()
+            .send_btc_order_creations
+            .get(payment_hash)
+            .cloned()
+            .ok_or(CchStoreError::NotFound(*payment_hash))
+    }
+
+    fn insert_send_btc_order_creation(
+        &self,
+        creation: CchSendBtcOrderCreation,
+    ) -> Result<(), CchStoreError> {
+        let mut state = self.state.lock().unwrap();
+        let payment_hash = creation.payment_hash;
+        match state
+            .send_btc_order_creations
+            .insert(payment_hash, creation)
+        {
+            Some(_) => Err(CchStoreError::Duplicated(payment_hash)),
+            None => Ok(()),
+        }
+    }
+
+    fn get_send_btc_order_creation_keys_iter(&self) -> impl IntoIterator<Item = Hash256> {
+        self.state
+            .lock()
+            .unwrap()
+            .send_btc_order_creations
+            .keys()
+            .copied()
+            .collect::<Vec<_>>()
+    }
+
+    fn complete_send_btc_order_creation(&self, order: CchOrder) -> Result<(), CchStoreError> {
+        let mut state = self.state.lock().unwrap();
+        let payment_hash = order.payment_hash;
+        if state.orders.contains_key(&payment_hash) {
+            return Err(CchStoreError::Duplicated(payment_hash));
+        }
+        state.orders.insert(payment_hash, order);
+        state.send_btc_order_creations.remove(&payment_hash);
+        Ok(())
+    }
+
+    fn delete_send_btc_order_creation(&self, payment_hash: &Hash256) {
+        self.state
+            .lock()
+            .unwrap()
+            .send_btc_order_creations
             .remove(payment_hash);
     }
 }
@@ -355,6 +413,12 @@ struct MockNetworkState {
     send_payment_status: Arc<Mutex<PaymentStatus>>,
     /// Makes mocked Fiber invoice creation fail after payment tracking was reserved.
     fail_add_invoice: Arc<AtomicBool>,
+    /// Makes mocked Fiber invoice creation report an existing invoice.
+    add_invoice_already_exists: Arc<AtomicBool>,
+    /// Artificial delay before returning the Fiber invoice creation response.
+    add_invoice_delay: Arc<Mutex<Duration>>,
+    /// Authoritative Fiber invoices returned by GetInvoice during recovery.
+    fiber_invoices: Arc<Mutex<std::collections::HashMap<Hash256, (CkbInvoice, CkbInvoiceStatus)>>>,
     /// Durable Fiber store used by store-backed recovery tests.
     payment_store: Option<Store>,
     /// Whether mocked Fiber SettleInvoice should return an already-paid error.
@@ -386,12 +450,31 @@ impl Actor for MockNetworkActor {
     ) -> Result<(), ractor::ActorProcessingErr> {
         match message {
             NetworkActorMessage::Command(cmd) => match cmd {
-                NetworkActorCommand::AddInvoice(_invoice, _opt_hash, reply) => {
+                NetworkActorCommand::AddInvoice(invoice, _opt_hash, reply) => {
+                    let delay = *state.add_invoice_delay.lock().unwrap();
+                    tokio::time::sleep(delay).await;
                     if state.fail_add_invoice.load(Ordering::SeqCst) {
+                        let _ = reply.send(Err(InvoiceError::InvoiceNotFound));
+                    } else if state.add_invoice_already_exists.load(Ordering::SeqCst) {
                         let _ = reply.send(Err(InvoiceError::InvoiceAlreadyExists));
                     } else {
+                        state
+                            .fiber_invoices
+                            .lock()
+                            .unwrap()
+                            .insert(*invoice.payment_hash(), (invoice, CkbInvoiceStatus::Open));
                         let _ = reply.send(Ok(()));
                     }
+                }
+                NetworkActorCommand::GetInvoice(payment_hash, reply) => {
+                    let result = state
+                        .fiber_invoices
+                        .lock()
+                        .unwrap()
+                        .get(&payment_hash)
+                        .cloned()
+                        .ok_or(InvoiceError::InvoiceNotFound);
+                    let _ = reply.send(result);
                 }
                 NetworkActorCommand::SendPayment(cmd, reply) => {
                     // Extract payment hash from invoice
@@ -751,6 +834,27 @@ impl TestHarness {
             .store(fail, Ordering::SeqCst);
     }
 
+    fn set_add_invoice_delay(&self, delay: Duration) {
+        *self.mock_state.add_invoice_delay.lock().unwrap() = delay;
+    }
+
+    fn insert_fiber_invoice(&self, invoice: CkbInvoice, status: CkbInvoiceStatus) {
+        self.mock_state
+            .fiber_invoices
+            .lock()
+            .unwrap()
+            .insert(*invoice.payment_hash(), (invoice, status));
+    }
+
+    fn fiber_invoice(&self, payment_hash: Hash256) -> Option<(CkbInvoice, CkbInvoiceStatus)> {
+        self.mock_state
+            .fiber_invoices
+            .lock()
+            .unwrap()
+            .get(&payment_hash)
+            .cloned()
+    }
+
     /// Insert an order directly into the database (for testing without LND)
     async fn insert_order_directly(&self, order: CchOrder) -> Result<(), CchError> {
         call!(self.actor, CchMessage::InsertOrder, order).expect("actor call failed")
@@ -860,6 +964,9 @@ async fn setup_test_harness_with_config_store_and_lnd(
         sent_fiber_payment_fee_rates: Arc::new(Mutex::new(std::collections::HashMap::new())),
         send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
         fail_add_invoice: Arc::new(AtomicBool::new(false)),
+        add_invoice_already_exists: Arc::new(AtomicBool::new(false)),
+        add_invoice_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
+        fiber_invoices: Arc::new(Mutex::new(std::collections::HashMap::new())),
         payment_store: None,
         settle_invoice_already_paid: Arc::new(Mutex::new(false)),
     };
@@ -922,6 +1029,9 @@ async fn setup_store_backed_test_harness_with_store(
         sent_fiber_payment_fee_rates: Arc::new(Mutex::new(std::collections::HashMap::new())),
         send_payment_status: Arc::new(Mutex::new(PaymentStatus::Inflight)),
         fail_add_invoice: Arc::new(AtomicBool::new(false)),
+        add_invoice_already_exists: Arc::new(AtomicBool::new(false)),
+        add_invoice_delay: Arc::new(Mutex::new(Duration::from_secs(0))),
+        fiber_invoices: Arc::new(Mutex::new(std::collections::HashMap::new())),
         payment_store: Some(store.clone()),
         settle_invoice_already_paid: Arc::new(Mutex::new(false)),
     };
@@ -1031,11 +1141,19 @@ fn create_test_lightning_invoice_with_payment_hash_amount_and_timestamp(
 
 /// Create a test Fiber invoice for testing
 fn create_test_fiber_invoice(payment_hash: Hash256) -> CkbInvoice {
-    create_test_fiber_invoice_with_amount(payment_hash, 100000)
+    create_test_fiber_invoice_with_amount_and_expiry(payment_hash, 100000, 3600)
 }
 
 /// Create a test Fiber invoice with a specific amount
 fn create_test_fiber_invoice_with_amount(payment_hash: Hash256, amount: u128) -> CkbInvoice {
+    create_test_fiber_invoice_with_amount_and_expiry(payment_hash, amount, 3600)
+}
+
+fn create_test_fiber_invoice_with_amount_and_expiry(
+    payment_hash: Hash256,
+    amount: u128,
+    expiry_seconds: u64,
+) -> CkbInvoice {
     // Create a deterministic keypair for tests
     let private_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
     let public_key = secp256k1::PublicKey::from_secret_key(&Secp256k1::new(), &private_key);
@@ -1054,7 +1172,7 @@ fn create_test_fiber_invoice_with_amount(payment_hash: Hash256, amount: u128) ->
             attrs: vec![
                 Attribute::FinalHtlcMinimumExpiryDelta(default_expiry_delta_ms),
                 Attribute::Description("test".to_string()),
-                Attribute::ExpiryTime(Duration::from_secs(3600)),
+                Attribute::ExpiryTime(Duration::from_secs(expiry_seconds)),
                 Attribute::PayeePublicKey(public_key),
             ],
         },
@@ -1127,6 +1245,316 @@ async fn test_send_btc_releases_reservation_when_invoice_creation_fails() {
         .create_send_btc_order_with_seed(201)
         .await
         .expect("failed invoice creation must release payment tracking capacity");
+}
+
+#[tokio::test]
+async fn test_send_btc_does_not_execute_queued_request_after_rpc_timeout() {
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_store(store.clone()).await;
+    harness.set_add_invoice_delay(Duration::from_millis(100));
+
+    let first_invoice =
+        create_test_lightning_invoice_with_payment_hash(create_valid_preimage_pair(200).1)
+            .to_string();
+    let second_payment_hash = create_valid_preimage_pair(201).1;
+    let second_invoice =
+        create_test_lightning_invoice_with_payment_hash(second_payment_hash).to_string();
+
+    let first_call = harness
+        .actor
+        .call(
+            |reply| {
+                CchMessage::SendBTC(
+                    crate::cch::SendBTC {
+                        btc_pay_req: first_invoice,
+                        currency: Currency::Fibb,
+                    },
+                    reply,
+                )
+            },
+            Some(Duration::from_millis(10)),
+        )
+        .await;
+    assert!(
+        first_call
+            .expect("first actor message should be sent")
+            .is_timeout(),
+        "the first RPC should time out while Fiber invoice creation is delayed"
+    );
+
+    let second_call = harness
+        .actor
+        .call(
+            |reply| {
+                CchMessage::SendBTC(
+                    crate::cch::SendBTC {
+                        btc_pay_req: second_invoice,
+                        currency: Currency::Fibb,
+                    },
+                    reply,
+                )
+            },
+            Some(Duration::from_millis(10)),
+        )
+        .await;
+    assert!(
+        second_call
+            .expect("second actor message should be sent")
+            .is_timeout(),
+        "the queued RPC should time out before the actor is available"
+    );
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    assert!(store.get_cch_order(&second_payment_hash).is_err());
+    assert_eq!(
+        store.get_cch_order_keys_iter().into_iter().count(),
+        1,
+        "a timed-out queued send_btc must not create an order"
+    );
+}
+
+#[tokio::test]
+async fn test_send_btc_rpc_timeout_is_idempotent_on_retry() {
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_store(store.clone()).await;
+    harness.set_add_invoice_delay(Duration::from_millis(100));
+
+    let payment_hash = create_valid_preimage_pair(202).1;
+    let btc_pay_req = create_test_lightning_invoice_with_payment_hash(payment_hash).to_string();
+    let timed_out = harness
+        .actor
+        .call(
+            |reply| {
+                CchMessage::SendBTC(
+                    crate::cch::SendBTC {
+                        btc_pay_req: btc_pay_req.clone(),
+                        currency: Currency::Fibb,
+                    },
+                    reply,
+                )
+            },
+            Some(Duration::from_millis(10)),
+        )
+        .await;
+    assert!(
+        timed_out
+            .expect("actor message should be sent")
+            .is_timeout(),
+        "the first RPC should time out"
+    );
+
+    let created = loop {
+        if let Ok(order) = store.get_cch_order(&payment_hash) {
+            break order;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    };
+    let retried = call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req,
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed")
+    .expect("retry should return the already-created order");
+
+    assert_eq!(retried.payment_hash, created.payment_hash);
+    assert_eq!(
+        store.get_cch_order_keys_iter().into_iter().count(),
+        1,
+        "retrying a timed-out send_btc must not create a second order"
+    );
+}
+
+#[tokio::test]
+async fn test_send_btc_creation_resumes_after_actor_restart() {
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ..Default::default()
+    };
+    let store = MockCchOrderStore::new();
+    let first = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    first.set_add_invoice_failure(true);
+    let payment_hash = create_valid_preimage_pair(203).1;
+    let btc_pay_req = create_test_lightning_invoice_with_payment_hash(payment_hash).to_string();
+
+    let first_result = call!(
+        first.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req: btc_pay_req.clone(),
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed");
+    assert!(first_result.is_err(), "the first Fiber call should fail");
+    assert!(store.get_send_btc_order_creation(&payment_hash).is_ok());
+
+    first.actor.stop(None);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let _restarted = setup_test_harness_with_config_and_store(config, store.clone()).await;
+    let order = wait_for_mock_order(&store, payment_hash).await;
+
+    assert_eq!(order.outgoing_pay_req, btc_pay_req);
+    assert!(matches!(
+        store.get_send_btc_order_creation(&payment_hash),
+        Err(CchStoreError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn test_send_btc_recovers_existing_fiber_invoice_from_intent() {
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ..Default::default()
+    };
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    let payment_hash = create_valid_preimage_pair(204).1;
+    let creation = create_send_btc_order_creation(&config, payment_hash);
+    harness.insert_fiber_invoice(creation.incoming_invoice.clone(), CkbInvoiceStatus::Open);
+    store.insert_send_btc_order_creation(creation).unwrap();
+
+    harness
+        .actor
+        .send_message(CchMessage::ResumeSendBTCOrderCreation {
+            payment_hash,
+            retry_count: 0,
+        })
+        .expect("actor should accept send_btc recovery");
+    let order = wait_for_mock_order(&store, payment_hash).await;
+
+    assert_eq!(order.payment_hash, payment_hash);
+    assert!(matches!(
+        store.get_send_btc_order_creation(&payment_hash),
+        Err(CchStoreError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn test_send_btc_expired_creation_does_not_create_fiber_invoice() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    let payment_hash = create_valid_preimage_pair(205).1;
+    let mut creation = create_send_btc_order_creation(&config, payment_hash);
+    creation.created_at = creation
+        .created_at
+        .saturating_sub(creation.order_expiry_delta_seconds + 1);
+    store.insert_send_btc_order_creation(creation).unwrap();
+
+    harness
+        .actor
+        .send_message(CchMessage::ResumeSendBTCOrderCreation {
+            payment_hash,
+            retry_count: 0,
+        })
+        .expect("actor should accept send_btc recovery");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    assert!(store.get_cch_order(&payment_hash).is_err());
+    assert!(harness.fiber_invoice(payment_hash).is_none());
+    assert!(store.get_send_btc_order_creation(&payment_hash).is_ok());
+}
+
+#[tokio::test]
+async fn test_send_btc_rejects_mismatched_existing_fiber_invoice() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    let payment_hash = create_valid_preimage_pair(206).1;
+    let creation = create_send_btc_order_creation(&config, payment_hash);
+    let wrong_invoice = create_test_fiber_invoice_with_amount_and_expiry(
+        payment_hash,
+        creation.incoming_invoice.amount.unwrap() + 1,
+        3_500,
+    );
+    harness.insert_fiber_invoice(wrong_invoice, CkbInvoiceStatus::Open);
+    store.insert_send_btc_order_creation(creation).unwrap();
+
+    harness
+        .actor
+        .send_message(CchMessage::ResumeSendBTCOrderCreation {
+            payment_hash,
+            retry_count: 0,
+        })
+        .expect("actor should accept send_btc recovery");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    assert!(store.get_cch_order(&payment_hash).is_err());
+    assert!(store.get_send_btc_order_creation(&payment_hash).is_ok());
+}
+
+#[tokio::test]
+async fn test_send_btc_recovers_received_fiber_invoice_status() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    let payment_hash = create_valid_preimage_pair(207).1;
+    let creation = create_send_btc_order_creation(&config, payment_hash);
+    harness.insert_fiber_invoice(
+        creation.incoming_invoice.clone(),
+        CkbInvoiceStatus::Received,
+    );
+    store.insert_send_btc_order_creation(creation).unwrap();
+
+    harness
+        .actor
+        .send_message(CchMessage::ResumeSendBTCOrderCreation {
+            payment_hash,
+            retry_count: 0,
+        })
+        .expect("actor should accept send_btc recovery");
+    let order = wait_for_mock_order(&store, payment_hash).await;
+
+    assert_eq!(order.status, CchOrderStatus::IncomingAccepted);
+}
+
+#[tokio::test]
+async fn test_send_btc_recovery_preserves_absolute_btc_expiry() {
+    let config = receive_btc_recovery_test_config();
+    let store = MockCchOrderStore::new();
+    let harness = setup_test_harness_with_config_and_store(config.clone(), store.clone()).await;
+    let payment_hash = create_valid_preimage_pair(208).1;
+    let invoice_timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .saturating_sub(Duration::from_secs(1_800));
+    let btc_invoice = create_test_lightning_invoice_with_payment_hash_and_timestamp(
+        payment_hash,
+        invoice_timestamp,
+    );
+    let mut creation = create_send_btc_order_creation(&config, payment_hash);
+    creation.created_at = invoice_timestamp.as_secs();
+    creation.btc_pay_req = btc_invoice.to_string();
+    let btc_deadline_millis = u128::from(btc_invoice.expires_at().unwrap().as_secs()) * 1_000;
+    store.insert_send_btc_order_creation(creation).unwrap();
+
+    call!(
+        harness.actor,
+        CchMessage::SendBTC,
+        crate::cch::SendBTC {
+            btc_pay_req: btc_invoice.to_string(),
+            currency: Currency::Fibb,
+        }
+    )
+    .expect("actor call failed")
+    .expect("retry should complete the persisted creation");
+    let (fiber_invoice, _) = harness
+        .fiber_invoice(payment_hash)
+        .expect("recovery should create the Fiber invoice");
+    let fiber_deadline_millis =
+        fiber_invoice.data.timestamp + fiber_invoice.expiry_time().unwrap().as_millis();
+
+    assert!(fiber_deadline_millis <= btc_deadline_millis);
 }
 
 #[tokio::test]
@@ -2063,8 +2491,8 @@ async fn test_scheduled_expiry_cancels_fiber_incoming_invoice() {
     let config = CchConfig {
         lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
         wrapped_btc_type_script_args: "0x".to_string(),
-        min_outgoing_invoice_expiry_delta_seconds: 60,
-        order_expiry_delta_seconds: 1,
+        min_outgoing_invoice_expiry_delta_seconds: 1,
+        order_expiry_delta_seconds: 2,
         ..Default::default()
     };
     let harness = setup_test_harness_with_config(config).await;
@@ -2073,7 +2501,7 @@ async fn test_scheduled_expiry_cancels_fiber_incoming_invoice() {
     let payment_hash = order.payment_hash;
 
     harness
-        .wait_for_order_status(payment_hash, CchOrderStatus::Failed, 2500)
+        .wait_for_order_status(payment_hash, CchOrderStatus::Failed, 3500)
         .await;
     harness
         .wait_for_fiber_invoice_cancelled(payment_hash, 1000)
@@ -3036,6 +3464,32 @@ fn receive_btc_recovery_test_config() -> CchConfig {
     }
 }
 
+fn create_send_btc_order_creation(
+    config: &CchConfig,
+    payment_hash: Hash256,
+) -> CchSendBtcOrderCreation {
+    let amount_sats = 100_000u128;
+    let fee_sats = amount_sats * u128::from(config.fee_rate_per_million_sats) / 1_000_000
+        + u128::from(config.base_fee_sats);
+    CchSendBtcOrderCreation {
+        created_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        order_expiry_delta_seconds: config.order_expiry_delta_seconds,
+        btc_pay_req: create_test_lightning_invoice_with_payment_hash(payment_hash).to_string(),
+        payment_hash,
+        // Keep the recovered Fiber invoice strictly inside the one-hour test BTC invoice.
+        incoming_invoice: create_test_fiber_invoice_with_amount_and_expiry(
+            payment_hash,
+            amount_sats + fee_sats,
+            3_500,
+        ),
+        fee_sats,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+    }
+}
+
 fn create_receive_btc_order_creation(
     config: &CchConfig,
     payment_hash: Hash256,
@@ -3605,6 +4059,52 @@ fn test_store_atomically_completes_receive_btc_order_creation() {
     );
     assert!(matches!(
         store.get_receive_btc_order_creation(&payment_hash),
+        Err(CchStoreError::NotFound(hash)) if hash == payment_hash
+    ));
+}
+
+#[test]
+fn test_store_atomically_completes_send_btc_order_creation() {
+    let (store, _store_dir) = generate_store();
+    let (_, payment_hash) = create_valid_preimage_pair(205);
+    let btc_pay_req = create_test_lightning_invoice_with_payment_hash(payment_hash).to_string();
+    let incoming_invoice = create_test_fiber_invoice(payment_hash);
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let creation = CchSendBtcOrderCreation {
+        created_at,
+        order_expiry_delta_seconds: 3_600,
+        btc_pay_req: btc_pay_req.clone(),
+        payment_hash,
+        incoming_invoice: incoming_invoice.clone(),
+        fee_sats: 1_000,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+    };
+    store.insert_send_btc_order_creation(creation).unwrap();
+
+    let order = CchOrder {
+        created_at,
+        expiry_delta_seconds: 3_600,
+        wrapped_btc_type_script: ckb_jsonrpc_types::Script::default(),
+        outgoing_pay_req: btc_pay_req,
+        incoming_invoice: CchInvoice::Fiber(incoming_invoice),
+        payment_hash,
+        payment_preimage: None,
+        amount_sats: 100_000,
+        fee_sats: 1_000,
+        status: CchOrderStatus::Pending,
+        failure_reason: None,
+    };
+    store.complete_send_btc_order_creation(order).unwrap();
+
+    assert_eq!(
+        store.get_cch_order(&payment_hash).unwrap().payment_hash,
+        payment_hash
+    );
+    assert!(matches!(
+        store.get_send_btc_order_creation(&payment_hash),
         Err(CchStoreError::NotFound(hash)) if hash == payment_hash
     ));
 }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -977,6 +977,10 @@ pub enum NetworkActorCommand {
         Option<Hash256>,
         RpcReplyPort<Result<(), InvoiceError>>,
     ),
+    GetInvoice(
+        Hash256,
+        RpcReplyPort<Result<(CkbInvoice, CkbInvoiceStatus), InvoiceError>>,
+    ),
 
     SettleInvoice(
         Hash256,
@@ -3064,6 +3068,26 @@ where
             }
             NetworkActorCommand::AddInvoice(invoice, preimage, reply) => {
                 let _ = reply.send(self.add_invoice(invoice, preimage));
+            }
+            NetworkActorCommand::GetInvoice(payment_hash, reply) => {
+                let result = self
+                    .store
+                    .get_invoice(&payment_hash)
+                    .ok_or(InvoiceError::InvoiceNotFound)
+                    .and_then(|invoice| {
+                        let status = self
+                            .store
+                            .get_invoice_status(&payment_hash)
+                            .ok_or(InvoiceError::InvoiceNotFound)?;
+                        let status = match status {
+                            CkbInvoiceStatus::Open if invoice.is_expired() => {
+                                CkbInvoiceStatus::Expired
+                            }
+                            status => status,
+                        };
+                        Ok((invoice, status))
+                    });
+                let _ = reply.send(result);
             }
 
             #[cfg(any(debug_assertions, feature = "bench"))]

--- a/crates/fiber-lib/src/store/.schema.json
+++ b/crates/fiber-lib/src/store/.schema.json
@@ -10,6 +10,7 @@
   "CchOrder": "301b7fbdc941fb6afa8d596e15de1fc66974927fed0af7bf3b67e0e2bd5c931f",
   "CchOrderStatus": "a9b5b58aec4d7830709a505310a6367ff3431de38a27bfde3c56505487470e9c",
   "CchReceiveBtcOrderCreation": "47b59c3dbcaf9a0c2ce7218fbacaa44cf6a7ceb0c42669a7209a9d02f1bc637e",
+  "CchSendBtcOrderCreation": "b3d2fc0b097892f5dfd95e36610106e08ce02e816e2917a9ffcfdc70fdab6a43",
   "ChannelActorData": "9fbf0df167319fb30ffa9b94e16b328f5405e354b6f42fb43320ec668324d132",
   "ChannelAnnouncement": "c563d7eae48dbc39b8dedce964b836aece184be176d8687150c0ef5abc2c81db",
   "ChannelBasePublicKeys": "c711ccbe027f8bf52b7123393e447a650b838d327fa1832a28d92e88125317e2",

--- a/crates/fiber-lib/src/store/store_impl/mod.rs
+++ b/crates/fiber-lib/src/store/store_impl/mod.rs
@@ -40,7 +40,7 @@ use fiber_types::{
     PersistentNetworkActorState, Pubkey, TLCId, TimedResult, CURSOR_SIZE,
 };
 #[cfg(not(target_arch = "wasm32"))]
-use fiber_types::{CchOrder, CchReceiveBtcOrderCreation};
+use fiber_types::{CchOrder, CchReceiveBtcOrderCreation, CchSendBtcOrderCreation};
 #[cfg(feature = "watchtower")]
 use fiber_types::{ChannelData, NodeId, Privkey, RevocationData, SettlementData};
 
@@ -324,6 +324,14 @@ pub fn check_validate<P: AsRef<Path>>(path: P) -> Result<(), String> {
                     &mut errors,
                 );
             }
+            #[cfg(not(target_arch = "wasm32"))]
+            CCH_SEND_BTC_ORDER_CREATION_PREFIX => {
+                check_deserialization::<CchSendBtcOrderCreation>(
+                    &value,
+                    "CCH_SEND_BTC_ORDER_CREATION_PREFIX",
+                    &mut errors,
+                );
+            }
             #[cfg(feature = "watchtower")]
             WATCHTOWER_CHANNEL_PREFIX => {
                 check_deserialization::<ChannelData>(
@@ -438,6 +446,8 @@ pub enum KeyValue {
     CchOrder(Hash256, CchOrder),
     #[cfg(not(target_arch = "wasm32"))]
     CchReceiveBtcOrderCreation(Hash256, CchReceiveBtcOrderCreation),
+    #[cfg(not(target_arch = "wasm32"))]
+    CchSendBtcOrderCreation(Hash256, CchSendBtcOrderCreation),
     ChannelOpenRecord(Hash256, ChannelOpenRecord),
 }
 
@@ -571,6 +581,10 @@ impl StoreKeyValue for KeyValue {
                 payment_hash.as_ref(),
             ]
             .concat(),
+            #[cfg(not(target_arch = "wasm32"))]
+            KeyValue::CchSendBtcOrderCreation(payment_hash, _data) => {
+                [&[CCH_SEND_BTC_ORDER_CREATION_PREFIX], payment_hash.as_ref()].concat()
+            }
             KeyValue::ChannelOpenRecord(channel_id, _) => {
                 [&[CHANNEL_OPEN_RECORD_PREFIX], channel_id.as_ref()].concat()
             }
@@ -618,6 +632,10 @@ impl StoreKeyValue for KeyValue {
             #[cfg(not(target_arch = "wasm32"))]
             KeyValue::CchReceiveBtcOrderCreation(_, creation) => {
                 serialize_to_vec(creation, "CchReceiveBtcOrderCreation")
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            KeyValue::CchSendBtcOrderCreation(_, creation) => {
+                serialize_to_vec(creation, "CchSendBtcOrderCreation")
             }
             KeyValue::ChannelOpenRecord(_, record) => serialize_to_vec(record, "ChannelOpenRecord"),
         }
@@ -2257,6 +2275,70 @@ impl CchOrderStore for Store {
             payment_hash.as_ref(),
         ]
         .concat();
+        let mut batch = self.batch();
+        batch.delete(key);
+        batch.commit();
+    }
+
+    fn get_send_btc_order_creation(
+        &self,
+        payment_hash: &Hash256,
+    ) -> Result<CchSendBtcOrderCreation, CchStoreError> {
+        let key = [&[CCH_SEND_BTC_ORDER_CREATION_PREFIX], payment_hash.as_ref()].concat();
+        self.get(key)
+            .map(|value| deserialize_from(&value, "CchSendBtcOrderCreation"))
+            .ok_or(CchStoreError::NotFound(*payment_hash))
+    }
+
+    fn insert_send_btc_order_creation(
+        &self,
+        creation: CchSendBtcOrderCreation,
+    ) -> Result<(), CchStoreError> {
+        let key = [
+            &[CCH_SEND_BTC_ORDER_CREATION_PREFIX],
+            creation.payment_hash.as_ref(),
+        ]
+        .concat();
+        if self.get(&key).is_some() {
+            return Err(CchStoreError::Duplicated(creation.payment_hash));
+        }
+        let mut batch = self.batch();
+        let kv = KeyValue::CchSendBtcOrderCreation(creation.payment_hash, creation);
+        batch.put(kv.key(), kv.value());
+        batch.commit();
+        Ok(())
+    }
+
+    fn get_send_btc_order_creation_keys_iter(&self) -> impl IntoIterator<Item = Hash256> {
+        const PREFIX_LEN: usize = 1;
+        const PREFIX: [u8; PREFIX_LEN] = [CCH_SEND_BTC_ORDER_CREATION_PREFIX];
+        self.collect_by_prefix(&PREFIX).into_iter().map(|kv| {
+            Hash256::try_from(&kv.key[PREFIX_LEN..])
+                .expect("CchSendBtcOrderCreation key must be Hash256")
+        })
+    }
+
+    fn complete_send_btc_order_creation(&self, order: CchOrder) -> Result<(), CchStoreError> {
+        let order_key = [&[CCH_ORDER_PREFIX], order.payment_hash.as_ref()].concat();
+        if self.get(&order_key).is_some() {
+            return Err(CchStoreError::Duplicated(order.payment_hash));
+        }
+
+        let creation_key = [
+            &[CCH_SEND_BTC_ORDER_CREATION_PREFIX],
+            order.payment_hash.as_ref(),
+        ]
+        .concat();
+        let mut batch = self.batch();
+        let kv = KeyValue::CchOrder(order.payment_hash, order);
+        batch.put(kv.key(), kv.value());
+        batch.delete(creation_key);
+        batch.commit();
+        Ok(())
+    }
+
+    fn delete_send_btc_order_creation(&self, payment_hash: &Hash256) {
+        let key = [&[CCH_SEND_BTC_ORDER_CREATION_PREFIX], payment_hash.as_ref()].concat();
         let mut batch = self.batch();
         batch.delete(key);
         batch.commit();

--- a/crates/fiber-types/src/cch.rs
+++ b/crates/fiber-types/src/cch.rs
@@ -127,6 +127,33 @@ pub struct CchReceiveBtcOrderCreation {
     pub max_outgoing_fee_percentage: u64,
 }
 
+/// Durable intent for creating the Fiber incoming invoice of a `send_btc` order.
+///
+/// The intent is written before the Fiber RPC side effect and atomically removed
+/// when the final [`CchOrder`] is persisted. The BTC payment hash is the
+/// idempotency key for recovering a request whose RPC response was lost.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CchSendBtcOrderCreation {
+    /// Seconds since epoch when order creation was accepted.
+    #[serde_as(as = "U64Hex")]
+    pub created_at: u64,
+    /// Relative expiry time copied from the CCH configuration at acceptance time.
+    #[serde_as(as = "U64Hex")]
+    pub order_expiry_delta_seconds: u64,
+    /// Original BTC invoice. Exact equality is used to reject conflicting retries.
+    pub btc_pay_req: String,
+    /// Idempotency key shared by the BTC invoice, Fiber invoice, and CCH order.
+    pub payment_hash: Hash256,
+    /// Fiber invoice prepared before the external Fiber call.
+    pub incoming_invoice: CkbInvoice,
+    /// Fee charged by the CCH operator.
+    #[serde_as(as = "U128Hex")]
+    pub fee_sats: u128,
+    /// Wrapped BTC type script included in the Fiber invoice.
+    pub wrapped_btc_type_script: ckb_jsonrpc_types::Script,
+}
+
 impl CchOrder {
     /// Return the amount required by the incoming invoice, in satoshis.
     ///

--- a/crates/fiber-types/src/lib.rs
+++ b/crates/fiber-types/src/lib.rs
@@ -32,7 +32,9 @@ pub mod serde_utils;
 pub mod sample;
 
 #[cfg(feature = "cch")]
-pub use cch::{CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation};
+pub use cch::{
+    CchInvoice, CchOrder, CchOrderStatus, CchReceiveBtcOrderCreation, CchSendBtcOrderCreation,
+};
 pub use channel::*;
 pub use config::*;
 pub use invoice::*;

--- a/crates/fiber-types/src/schema.rs
+++ b/crates/fiber-types/src/schema.rs
@@ -19,6 +19,7 @@
 //! | 201          | Hash256              | ChannelOpenRecord           |
 //! | 232          | Payment_hash         | CchOrder                    |
 //! | 233          | Payment_hash         | CchReceiveBtcOrderCreation  |
+//! | 234          | Payment_hash         | CchSendBtcOrderCreation    |
 //! +--------------+----------------------+-----------------------------+
 
 pub const CHANNEL_ACTOR_STATE_PREFIX: u8 = 0;
@@ -54,3 +55,5 @@ pub use watchtower::*;
 pub const CCH_ORDER_PREFIX: u8 = 232;
 #[cfg(not(target_arch = "wasm32"))]
 pub const CCH_RECEIVE_BTC_ORDER_CREATION_PREFIX: u8 = 233;
+#[cfg(not(target_arch = "wasm32"))]
+pub const CCH_SEND_BTC_ORDER_CREATION_PREFIX: u8 = 234;


### PR DESCRIPTION
## Summary

- prevent queued `send_btc` requests from starting after their RPC reply port has closed
- persist a durable `send_btc` creation intent before creating the Fiber invoice
- make retries and startup recovery idempotent by Lightning payment hash
- reconcile the authoritative Fiber invoice and status before creating or restoring an order

Closes #1601.

## Root cause

The CCH RPC timeout closes the actor reply port, but it does not remove the corresponding message from the actor mailbox. A delayed `send_btc` message could therefore begin after the client had already received a timeout, create a Fiber invoice, persist a CCH order, and then discard the result.

There is also an ambiguous failure window after invoice creation: the Fiber side effect may succeed even if the response is lost. Retrying creation without durable intent and reconciliation can either reject a recoverable request or duplicate follow-up work.

## Changes

This applies the durable recovery model already used by `receive_btc` to the opposite payment direction:

- write a `CchSendBtcOrderCreation` intent before the external Fiber side effect
- atomically replace the intent with the completed CCH order
- recover incomplete intents during actor startup with deduplicated exponential-backoff retries
- return an existing order for an identical retry and reject conflicting requests with the same payment hash
- query the real Fiber invoice for both in-process and HTTP backends, including its current status
- validate recovered invoice amount, currency, hash algorithm, UDT script, final TLC delta, payment hash, and absolute expiry
- recover `Open` invoices as `Pending`, `Received` invoices as `IncomingAccepted`, and cancelled or expired invoices as failed orders
- dispatch startup actions only when an order was newly created or recovered, so an idempotent retry does not resend the outgoing payment

Recovery uses the earlier of the Lightning invoice expiry and the CCH order deadline. A missing Fiber invoice is never created after that deadline, and HTTP retries use only the remaining lifetime instead of restarting the original relative expiry.

## Validation

- `cargo nextest run --no-fail-fast -p fnn -p fiber-bin --features rocksdb`: 1174 passed, 8 skipped
- complete CCH suite on RocksDB: 193 passed
- `send_btc` suite on RocksDB: 18 passed
- `send_btc` suite on SQLite + watchtower: 18 passed
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all -- --check`
- `make check-migrate`
- `git diff --check`
