### PR TITLE
fix(cch): raise default fees for multi-hop payments

### DIFF
--- a/crates/fiber-lib/src/cch/config.rs
+++ b/crates/fiber-lib/src/cch/config.rs
@@ -10,8 +10,12 @@ pub const DEFAULT_BTC_FINAL_TLC_EXPIRY_DELTA_BLOCKS: u64 = 360; // 60 hours (~10
 pub const DEFAULT_CKB_FINAL_TLC_EXPIRY_DELTA_SECONDS: u64 = 60 * 60 * 60; // 60 hours
 /// Default minimum outgoing invoice relative expiry time in seconds.
 pub const DEFAULT_MIN_OUTGOING_INVOICE_EXPIRY_DELTA_SECONDS: u64 = 6 * 60 * 60; // 6 hours
+/// Default fixed fee charged for each cross-chain order, in satoshis.
+pub const DEFAULT_BASE_FEE_SATS: u64 = 100;
+/// Default proportional fee charged per million satoshis of order value.
+pub const DEFAULT_FEE_RATE_PER_MILLION_SATS: u64 = 3000;
 /// Default percentage of the collected CCH fee that may be spent on outgoing routing fees.
-pub const DEFAULT_MAX_OUTGOING_FEE_PERCENTAGE: u64 = 100;
+pub const DEFAULT_MAX_OUTGOING_FEE_PERCENTAGE: u64 = 80;
 
 // Use prefix `cch-`/`CCH_`
 #[derive(ClapSerde, Debug, Clone)]
@@ -69,21 +73,21 @@ pub struct CchConfig {
     )]
     pub order_expiry_delta_seconds: u64,
 
-    #[default(0)]
+    #[default(DEFAULT_BASE_FEE_SATS)]
     #[arg(
         name = "CCH_BASE_FEE_SATS",
         long = "cch-base-fee-sats",
         env,
-        help = "The base fee charged for each cross-chain order, default is 0"
+        help = format!("The base fee charged for each cross-chain order, default is {}", DEFAULT_BASE_FEE_SATS)
     )]
     pub base_fee_sats: u64,
 
-    #[default(1)]
+    #[default(DEFAULT_FEE_RATE_PER_MILLION_SATS)]
     #[arg(
         name = "CCH_FEE_RATE_PER_MILLION_SATS",
         long = "cch-fee-rate-per-million-sats",
         env,
-        help = "The proportional fee charged per million satoshis based on the cross-chain order value, default is 1"
+        help = format!("The proportional fee charged per million satoshis based on the cross-chain order value, default is {}", DEFAULT_FEE_RATE_PER_MILLION_SATS)
     )]
     pub fee_rate_per_million_sats: u64,
 
@@ -92,8 +96,8 @@ pub struct CchConfig {
     ///
     /// The outgoing payment fee is capped at `fee_sats * max_outgoing_fee_percentage / 100`,
     /// where `fee_sats` is the fee charged on the incoming/order leg. This guarantees the
-    /// outgoing route fee never exceeds the fee the operator collected. Defaults to 100,
-    /// i.e. the entire collected fee may be spent on the outgoing route.
+    /// outgoing route fee never exceeds the fee the operator collected. Defaults to 80,
+    /// leaving at least 20% of the collected fee for the operator.
     #[default(DEFAULT_MAX_OUTGOING_FEE_PERCENTAGE)]
     #[arg(
         name = "CCH_MAX_OUTGOING_FEE_PERCENTAGE",

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -1866,7 +1866,14 @@ async fn dispatch_fiber_outgoing_and_capture_fee(
 /// route fee far larger than the fee the operator charged.
 #[tokio::test]
 async fn test_receive_btc_outgoing_fiber_fee_capped_at_collected_fee() {
-    let harness = setup_test_harness().await;
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        max_outgoing_fee_percentage: 100,
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config(config).await;
 
     // Pick economics where the default Fiber cap (0.5% * amount = 5000) vastly exceeds the
     // tiny collected CCH fee (100). Without binding, the route could spend up to 5000.
@@ -1916,7 +1923,14 @@ async fn test_receive_btc_outgoing_fiber_fee_scaled_by_percentage() {
 /// (`amount_sats == principal`) and fixed orders (`amount_sats == principal + CCH fee`).
 #[tokio::test]
 async fn test_receive_btc_outgoing_fiber_fee_rate_uses_outgoing_principal() {
-    let harness = setup_test_harness().await;
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        max_outgoing_fee_percentage: 100,
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config(config).await;
     let principal_sats = 100_000;
     let fee_sats = 30_000;
     let expected_rate = 300; // ceil(30_000 * 1000 / 100_000)

--- a/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/dispatcher_tests.rs
@@ -503,10 +503,37 @@ fn test_config_validate_rejects_out_of_range() {
 }
 
 #[test]
-fn test_config_default_percentage_is_full() {
-    use crate::cch::CchConfig;
-    // The default must be a valid, full-budget percentage so existing deployments keep working.
+fn test_config_default_percentage_reserves_operator_margin() {
+    use crate::cch::{config::DEFAULT_MAX_OUTGOING_FEE_PERCENTAGE, CchConfig};
+
     let config = CchConfig::default();
-    assert_eq!(config.max_outgoing_fee_percentage, 100);
+    assert_eq!(
+        config.max_outgoing_fee_percentage,
+        DEFAULT_MAX_OUTGOING_FEE_PERCENTAGE
+    );
+    assert!(config.max_outgoing_fee_percentage < 100);
     assert!(config.validate().is_ok());
+}
+
+#[test]
+fn test_default_cch_fee_budget_covers_a_default_fiber_intermediate_hop() {
+    use crate::cch::{
+        actions::send_outgoing_payment::outgoing_fee_budget_from_fee_sats, CchConfig,
+    };
+    use crate::fiber::config::DEFAULT_TLC_FEE_PROPORTIONAL_MILLIONTHS;
+
+    const ORDER_AMOUNT_SATS: u128 = 1_000_000;
+    let config = CchConfig::default();
+    let collected_fee_sats =
+        ORDER_AMOUNT_SATS.saturating_mul(config.fee_rate_per_million_sats as u128) / 1_000_000
+            + config.base_fee_sats as u128;
+    let outgoing_budget_sats =
+        outgoing_fee_budget_from_fee_sats(collected_fee_sats, config.max_outgoing_fee_percentage);
+    let one_hop_fee_sats =
+        ORDER_AMOUNT_SATS.saturating_mul(DEFAULT_TLC_FEE_PROPORTIONAL_MILLIONTHS) / 1_000_000;
+
+    assert!(
+        outgoing_budget_sats >= one_hop_fee_sats,
+        "default CCH outgoing budget {outgoing_budget_sats} sats must cover one default Fiber intermediate-hop fee of {one_hop_fee_sats} sats"
+    );
 }

--- a/tests/bruno/e2e/cross-chain-hub-separate/02-create-send-btc-order.bru
+++ b/tests/bruno/e2e/cross-chain-hub-separate/02-create-send-btc-order.bru
@@ -32,6 +32,7 @@ body:json {
 assert {
   res.status: eq 200
   res.body.error: isUndefined
+  res.body.result.fee_sats: eq "0x190"
 }
 
 script:post-response {

--- a/tests/bruno/e2e/cross-chain-hub-separate/08-check-hub-received-wrapped-btc.bru
+++ b/tests/bruno/e2e/cross-chain-hub-separate/08-check-hub-received-wrapped-btc.bru
@@ -51,7 +51,7 @@ script:post-response {
     console.log(`Try ${i+1}/${n}`);
   }
   
-  if (parseInt(res.body.result.channels[0].local_balance, 16) === 100000) {
+  if (parseInt(res.body.result.channels[0].local_balance, 16) === 100400) {
     console.log("Hub has received the payment");
     await new Promise(r => setTimeout(r, 1000));
     bru.setVar("iteration", 0);

--- a/tests/bruno/e2e/cross-chain-hub-separate/11-create-receive-btc-order.bru
+++ b/tests/bruno/e2e/cross-chain-hub-separate/11-create-receive-btc-order.bru
@@ -32,6 +32,7 @@ assert {
   res.status: eq 200
   res.body.error: isUndefined
   res.body.result.incoming_invoice.Lightning: isDefined
+  res.body.result.fee_sats: eq "0xfa"
 }
 
 script:post-response {

--- a/tests/bruno/e2e/cross-chain-hub-separate/14-check-hub-received-btc-in-lnd.bru
+++ b/tests/bruno/e2e/cross-chain-hub-separate/14-check-hub-received-btc-in-lnd.bru
@@ -32,7 +32,7 @@ script:post-response {
   }
   
   const before = parseInt(bru.getVar("LND_BOB_BALANCE"), 10);
-  if (parseInt(res.body.remote_balance.sat, 10) - before === 50000) {
+  if (parseInt(res.body.remote_balance.sat, 10) - before === 50250) {
     console.log("Hub has received the payment");
     await new Promise(r => setTimeout(r, 1000));
     bru.setVar("iteration", 0);

--- a/tests/bruno/e2e/cross-chain-hub-separate/15-check-payee-received-wrapped-btc.bru
+++ b/tests/bruno/e2e/cross-chain-hub-separate/15-check-payee-received-wrapped-btc.bru
@@ -32,5 +32,5 @@ assert {
   res.body.error: isUndefined
   res.body.result.channels: isDefined
   res.body.result.channels[0].channel_id: eq {{N1N3_CHANNEL_ID}}
-  res.body.result.channels[0].local_balance: eq "0x249f0"
+  res.body.result.channels[0].local_balance: eq "0x24860"
 }

--- a/tests/bruno/e2e/cross-chain-hub/02-create-send-btc-order.bru
+++ b/tests/bruno/e2e/cross-chain-hub/02-create-send-btc-order.bru
@@ -32,6 +32,7 @@ body:json {
 assert {
   res.status: eq 200
   res.body.error: isUndefined
+  res.body.result.fee_sats: eq "0x190"
 }
 
 script:post-response {

--- a/tests/bruno/e2e/cross-chain-hub/08-check-hub-received-wrapped-btc.bru
+++ b/tests/bruno/e2e/cross-chain-hub/08-check-hub-received-wrapped-btc.bru
@@ -51,7 +51,7 @@ script:post-response {
     console.log(`Try ${i+1}/${n}`);
   }
   
-  if (parseInt(res.body.result.channels[0].local_balance, 16) === 100000) {
+  if (parseInt(res.body.result.channels[0].local_balance, 16) === 100400) {
     console.log("Hub has received the payment");
     await new Promise(r => setTimeout(r, 1000));
     bru.setVar("iteration", 0);

--- a/tests/bruno/e2e/cross-chain-hub/11-create-receive-btc-order.bru
+++ b/tests/bruno/e2e/cross-chain-hub/11-create-receive-btc-order.bru
@@ -32,6 +32,7 @@ assert {
   res.status: eq 200
   res.body.error: isUndefined
   res.body.result.incoming_invoice.Lightning: isDefined
+  res.body.result.fee_sats: eq "0xfa"
 }
 
 script:post-response {

--- a/tests/bruno/e2e/cross-chain-hub/14-check-hub-received-btc-in-lnd.bru
+++ b/tests/bruno/e2e/cross-chain-hub/14-check-hub-received-btc-in-lnd.bru
@@ -32,7 +32,7 @@ script:post-response {
   }
   
   const before = parseInt(bru.getVar("LND_BOB_BALANCE"), 10);
-  if (parseInt(res.body.remote_balance.sat, 10) - before === 50000) {
+  if (parseInt(res.body.remote_balance.sat, 10) - before === 50250) {
     console.log("Hub has received the payment");
     await new Promise(r => setTimeout(r, 1000));
     bru.setVar("iteration", 0);

--- a/tests/bruno/e2e/cross-chain-hub/15-check-payee-received-wrapped-btc.bru
+++ b/tests/bruno/e2e/cross-chain-hub/15-check-payee-received-wrapped-btc.bru
@@ -32,5 +32,5 @@ assert {
   res.body.error: isUndefined
   res.body.result.channels: isDefined
   res.body.result.channels[0].channel_id: eq {{N1N3_CHANNEL_ID}}
-  res.body.result.channels[0].local_balance: eq "0x249f0"
+  res.body.result.channels[0].local_balance: eq "0x24860"
 }


### PR DESCRIPTION
## Summary

- raise the default CCH base fee from 0 to 100 sats
- raise the default proportional fee from 1 ppm to 3,000 ppm
- reserve 20% of the collected fee for the operator by changing the default outgoing routing budget from 100% to 80%
- keep CLI help text in sync with the new defaults
- add a regression test proving the default budget can pay for an intermediate Fiber hop

## Why

The previous defaults produced an effectively zero outgoing routing budget. For a 1,000,000 sat order, CCH collected only 1 sat and therefore allowed only 1 sat for the outgoing route. A single intermediate Fiber hop at the default 1,000 ppm fee rate requires about 1,000 sats, so normal multi-hop routes failed even when pathfinding, liquidity, and expiry were otherwise valid.

With the new defaults, a 1,000,000 sat order collects 3,100 sats and makes 2,480 sats available for outgoing routing. This covers a typical short multi-hop route while retaining a 20% operator margin.

Existing tests that specifically verify a full-fee cap now explicitly configure a 100% outgoing budget so their intent remains independent of the production default.

## Validation

- reproduced the issue with a regression test: the previous default budget was 1 sat versus a 1,000 sat default intermediate-hop fee
- `cargo nextest run --no-fail-fast -p fnn -p fiber-bin 'cch::tests'` — 176 passed
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #1593
