### PR TITLE
fix(cch): keep RPCs responsive during startup recovery

### DIFF
--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -132,6 +132,18 @@ pub enum CchMessage {
 
     GetCchOrder(Hash256, RpcReplyPort<Result<CchOrder, CchError>>),
 
+    /// Continue startup recovery after taking a snapshot of persisted keys.
+    #[doc(hidden)]
+    ContinueStartupRecovery {
+        orders: Vec<CchOrder>,
+        receive_creation_keys: Vec<Hash256>,
+        send_creation_keys: Vec<Hash256>,
+        recovered_orders: usize,
+        recovered_receive_creations: usize,
+        recovered_send_creations: usize,
+        started_at_millis: u64,
+    },
+
     TrackingEvent(CchTrackingEvent),
 
     /// Store change event from the Fiber node (either in-process or via WebSocket).
@@ -184,6 +196,10 @@ pub enum CchMessage {
     /// Test-only message to insert an order directly into the database
     #[cfg(test)]
     InsertOrder(CchOrder, RpcReplyPort<Result<(), CchError>>),
+
+    /// Test-only readiness probe for startup recovery.
+    #[cfg(test)]
+    GetStartupRecoveryStatus(RpcReplyPort<bool>),
 }
 
 impl From<CchTrackingEvent> for CchMessage {
@@ -250,6 +266,7 @@ pub struct CchState<S> {
     active_send_btc_creation_workers: HashSet<Hash256>,
     active_send_btc_requests: HashMap<Hash256, String>,
     deferred_send_btc_invoice_statuses: HashMap<Hash256, DeferredInvoiceStatus>,
+    startup_recovery_in_progress: bool,
     /// The CKB network currency this node is configured for.
     pub(super) currency: Currency,
 }
@@ -386,6 +403,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
             active_send_btc_creation_workers: HashSet::new(),
             active_send_btc_requests: HashMap::new(),
             deferred_send_btc_invoice_statuses: HashMap::new(),
+            startup_recovery_in_progress: true,
         };
 
         Ok(state)
@@ -396,90 +414,39 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
         myself: ActorRef<Self::Msg>,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
-        let current_time = now_timestamp_as_millis_u64() / 1000;
-
-        // Load all orders from the database
-        for mut order in state
-            .store
-            .get_cch_order_keys_iter()
-            .into_iter()
-            .filter_map(|payment_hash| state.store.get_cch_order(&payment_hash).ok())
-        {
-            // Only process active (non-final) orders
-            if order.is_final() {
-                let actions = ActionDispatcher::on_starting(&order);
-                if let Err(err) = append_actions(myself.clone(), order.payment_hash, actions) {
-                    tracing::error!(
-                        "Failed to schedule final-order resume actions for order {:x}: {}",
-                        order.payment_hash,
-                        err
-                    );
-                }
-                state.schedule_job_for_final_order(&order);
-                continue;
+        let store = state.store.clone();
+        let started_at_millis = now_timestamp_as_millis_u64();
+        let load_snapshot = move || {
+            let orders = store
+                .get_cch_order_keys_iter()
+                .into_iter()
+                .filter_map(|payment_hash| store.get_cch_order(&payment_hash).ok())
+                .collect();
+            let receive_creation_keys = store
+                .get_receive_btc_order_creation_keys_iter()
+                .into_iter()
+                .collect();
+            let send_creation_keys = store
+                .get_send_btc_order_creation_keys_iter()
+                .into_iter()
+                .collect();
+            if let Err(err) = myself.send_message(CchMessage::ContinueStartupRecovery {
+                orders,
+                receive_creation_keys,
+                send_creation_keys,
+                recovered_orders: 0,
+                recovered_receive_creations: 0,
+                recovered_send_creations: 0,
+                started_at_millis,
+            }) {
+                tracing::error!("Failed to start CCH recovery from persisted state: {}", err);
             }
+        };
 
-            // Check if order is expired and mark as Failed if so
-            if order.update_if_expired(current_time) {
-                let payment_hash = order.payment_hash;
-                state.store.update_cch_order(order.clone());
-                let actions = ActionDispatcher::on_entering(&order);
-                append_actions(myself.clone(), payment_hash, actions)?;
-                state.schedule_job_for_final_order(&order);
-                tracing::info!("Marked expired order {:x} as Failed", payment_hash);
-                continue;
-            }
-
-            if matches!(&order.incoming_invoice, CchInvoice::Fiber(_)) {
-                // Restore reservations before dispatching payment tracking. Orders created before
-                // the admission limit remain recoverable even when they exceed the new limit.
-                state
-                    .lnd_tracker
-                    .send_message(LndTrackerMessage::RestorePaymentTracking(
-                        order.payment_hash,
-                    ))?;
-            }
-
-            // Schedule expiry job for non-final orders
-            state.schedule_job_for_non_final_order(&order);
-
-            // Resume tracking for non-expired active orders
-            let actions = ActionDispatcher::on_starting(&order);
-            if let Err(err) = append_actions(myself.clone(), order.payment_hash, actions) {
-                tracing::error!(
-                    "Failed to schedule resume actions for order {:x}: {}",
-                    order.payment_hash,
-                    err
-                );
-            } else {
-                tracing::debug!("Resumed tracking for active order {:x}", order.payment_hash);
-            }
-        }
-
-        // A creation intent is persisted before the external LND side effect. Replaying these
-        // messages makes a crash between AddHoldInvoice and the final order write recoverable.
-        for payment_hash in state.store.get_receive_btc_order_creation_keys_iter() {
-            if state
-                .pending_receive_btc_creation_retries
-                .insert(payment_hash)
-            {
-                myself.send_message(CchMessage::ResumeReceiveBTCOrderCreation {
-                    payment_hash,
-                    retry_count: 0,
-                })?;
-            }
-        }
-
-        // A creation intent is persisted before the external Fiber side effect. Replaying these
-        // messages makes a crash or lost RPC response during `send_btc` recoverable.
-        for payment_hash in state.store.get_send_btc_order_creation_keys_iter() {
-            if state.pending_send_btc_creation_retries.insert(payment_hash) {
-                myself.send_message(CchMessage::ResumeSendBTCOrderCreation {
-                    payment_hash,
-                    retry_count: 0,
-                })?;
-            }
-        }
+        #[cfg(not(target_family = "wasm"))]
+        state.task_tracker.spawn_blocking(load_snapshot);
+        #[cfg(target_family = "wasm")]
+        state.task_tracker.spawn(async move { load_snapshot() });
 
         Ok(())
     }
@@ -492,6 +459,10 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
     ) -> Result<(), ActorProcessingErr> {
         match message {
             CchMessage::SendBTC(send_btc, port) => {
+                if state.startup_recovery_in_progress {
+                    let _ = port.send(Err(CchError::StartupRecoveryInProgress));
+                    return Ok(());
+                }
                 // A timed-out RPC leaves its message in the mailbox. Do not begin a new
                 // state-changing operation when its caller is no longer waiting for the result.
                 if port.is_closed() {
@@ -627,6 +598,10 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 Ok(())
             }
             CchMessage::ReceiveBTC(receive_btc, port) => {
+                if state.startup_recovery_in_progress {
+                    let _ = port.send(Err(CchError::StartupRecoveryInProgress));
+                    return Ok(());
+                }
                 let payment_hash = CkbInvoice::from_str(&receive_btc.fiber_pay_req)
                     .ok()
                     .map(|invoice| *invoice.payment_hash());
@@ -702,6 +677,65 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     // ignore error
                     let _ = port.send(result);
                 }
+                Ok(())
+            }
+            CchMessage::ContinueStartupRecovery {
+                mut orders,
+                mut receive_creation_keys,
+                mut send_creation_keys,
+                mut recovered_orders,
+                mut recovered_receive_creations,
+                mut recovered_send_creations,
+                started_at_millis,
+            } => {
+                if let Some(order) = orders.pop() {
+                    recovered_orders += 1;
+                    state.recover_persisted_order(&myself, order)?;
+                } else if let Some(payment_hash) = receive_creation_keys.pop() {
+                    recovered_receive_creations += 1;
+                    if state
+                        .pending_receive_btc_creation_retries
+                        .insert(payment_hash)
+                    {
+                        myself.send_message(CchMessage::ResumeReceiveBTCOrderCreation {
+                            payment_hash,
+                            retry_count: 0,
+                        })?;
+                    }
+                } else if let Some(payment_hash) = send_creation_keys.pop() {
+                    recovered_send_creations += 1;
+                    if state.pending_send_btc_creation_retries.insert(payment_hash) {
+                        myself.send_message(CchMessage::ResumeSendBTCOrderCreation {
+                            payment_hash,
+                            retry_count: 0,
+                        })?;
+                    }
+                } else {
+                    state.startup_recovery_in_progress = false;
+                    tracing::info!(
+                        recovered_orders,
+                        recovered_receive_creations,
+                        recovered_send_creations,
+                        elapsed_millis =
+                            now_timestamp_as_millis_u64().saturating_sub(started_at_millis),
+                        "CCH startup recovery completed"
+                    );
+                    return Ok(());
+                }
+
+                // Give RPC tasks a chance to enqueue work before scheduling the next recovery
+                // item. Re-sending immediately can otherwise monopolize the actor while it
+                // dispatches actions for a large snapshot.
+                tokio::task::yield_now().await;
+                myself.send_message(CchMessage::ContinueStartupRecovery {
+                    orders,
+                    receive_creation_keys,
+                    send_creation_keys,
+                    recovered_orders,
+                    recovered_receive_creations,
+                    recovered_send_creations,
+                    started_at_millis,
+                })?;
                 Ok(())
             }
             CchMessage::TrackingEvent(event) => {
@@ -919,6 +953,11 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 }
                 Ok(())
             }
+            #[cfg(test)]
+            CchMessage::GetStartupRecoveryStatus(port) => {
+                let _ = port.send(state.startup_recovery_in_progress);
+                Ok(())
+            }
         }
     }
 }
@@ -991,6 +1030,59 @@ fn invoice_status_rank(status: CkbInvoiceStatus) -> u8 {
 }
 
 impl<S: CchOrderStore> CchState<S> {
+    fn recover_persisted_order(
+        &mut self,
+        myself: &ActorRef<CchMessage>,
+        mut order: CchOrder,
+    ) -> Result<(), ActorProcessingErr> {
+        if order.is_final() {
+            let actions = ActionDispatcher::on_starting(&order);
+            if let Err(err) = append_actions(myself.clone(), order.payment_hash, actions) {
+                tracing::error!(
+                    "Failed to schedule final-order resume actions for order {:x}: {}",
+                    order.payment_hash,
+                    err
+                );
+            }
+            self.schedule_job_for_final_order(&order);
+            return Ok(());
+        }
+
+        let current_time = now_timestamp_as_millis_u64() / 1000;
+        if order.update_if_expired(current_time) {
+            let payment_hash = order.payment_hash;
+            self.store.update_cch_order(order.clone());
+            let actions = ActionDispatcher::on_entering(&order);
+            append_actions(myself.clone(), payment_hash, actions)?;
+            self.schedule_job_for_final_order(&order);
+            tracing::info!("Marked expired order {:x} as Failed", payment_hash);
+            return Ok(());
+        }
+
+        if matches!(&order.incoming_invoice, CchInvoice::Fiber(_)) {
+            // Restore reservations before dispatching payment tracking. Orders created before
+            // the admission limit remain recoverable even when they exceed the new limit.
+            self.lnd_tracker
+                .send_message(LndTrackerMessage::RestorePaymentTracking(
+                    order.payment_hash,
+                ))?;
+        }
+
+        self.schedule_job_for_non_final_order(&order);
+        let actions = ActionDispatcher::on_starting(&order);
+        if let Err(err) = append_actions(myself.clone(), order.payment_hash, actions) {
+            tracing::error!(
+                "Failed to schedule resume actions for order {:x}: {}",
+                order.payment_hash,
+                err
+            );
+        } else {
+            tracing::debug!("Resumed tracking for active order {:x}", order.payment_hash);
+        }
+
+        Ok(())
+    }
+
     /// Get a CCH order by payment hash, returning None if not found.
     /// This handles the common pattern of checking for NotFound vs other errors.
     fn get_order_or_none(&self, payment_hash: &Hash256) -> Result<Option<CchOrder>, CchError> {

--- a/crates/fiber-lib/src/cch/actor.rs
+++ b/crates/fiber-lib/src/cch/actor.rs
@@ -43,6 +43,7 @@ use fiber_types::{Hash256, Privkey};
 
 pub const ACTION_RETRY_BASE_MILLIS: u64 = 1000; // 1 second initial delay
 pub const ACTION_RETRY_MAX_MILLIS: u64 = 600_000; // 10 minute max delay
+const STARTUP_RECOVERY_ITEM_DELAY_MILLIS: u64 = 1;
 
 /// Average time per Bitcoin block in milliseconds (10 minutes = 600 seconds = 600,000 ms).
 pub const BTC_BLOCK_TIME_MILLIS: u64 = 600_000;
@@ -135,7 +136,7 @@ pub enum CchMessage {
     /// Continue startup recovery after taking a snapshot of persisted keys.
     #[doc(hidden)]
     ContinueStartupRecovery {
-        orders: Vec<CchOrder>,
+        order_keys: Vec<Hash256>,
         receive_creation_keys: Vec<Hash256>,
         send_creation_keys: Vec<Hash256>,
         recovered_orders: usize,
@@ -417,11 +418,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
         let store = state.store.clone();
         let started_at_millis = now_timestamp_as_millis_u64();
         let load_snapshot = move || {
-            let orders = store
-                .get_cch_order_keys_iter()
-                .into_iter()
-                .filter_map(|payment_hash| store.get_cch_order(&payment_hash).ok())
-                .collect();
+            let order_keys = store.get_cch_order_keys_iter().into_iter().collect();
             let receive_creation_keys = store
                 .get_receive_btc_order_creation_keys_iter()
                 .into_iter()
@@ -431,7 +428,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 .into_iter()
                 .collect();
             if let Err(err) = myself.send_message(CchMessage::ContinueStartupRecovery {
-                orders,
+                order_keys,
                 receive_creation_keys,
                 send_creation_keys,
                 recovered_orders: 0,
@@ -680,7 +677,7 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 Ok(())
             }
             CchMessage::ContinueStartupRecovery {
-                mut orders,
+                mut order_keys,
                 mut receive_creation_keys,
                 mut send_creation_keys,
                 mut recovered_orders,
@@ -688,9 +685,14 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                 mut recovered_send_creations,
                 started_at_millis,
             } => {
-                if let Some(order) = orders.pop() {
-                    recovered_orders += 1;
-                    state.recover_persisted_order(&myself, order)?;
+                if let Some(payment_hash) = order_keys.pop() {
+                    // Keep only compact keys in the startup snapshot. Reading the order when its
+                    // recovery turn arrives both bounds snapshot memory and observes any state
+                    // transition that happened while earlier keys were being processed.
+                    if let Some(order) = state.get_order_or_none(&payment_hash)? {
+                        recovered_orders += 1;
+                        state.recover_persisted_order(&myself, order)?;
+                    }
                 } else if let Some(payment_hash) = receive_creation_keys.pop() {
                     recovered_receive_creations += 1;
                     if state
@@ -723,19 +725,21 @@ impl<S: CchOrderStore + Send + Sync + Clone + 'static> Actor for CchActor<S> {
                     return Ok(());
                 }
 
-                // Give RPC tasks a chance to enqueue work before scheduling the next recovery
-                // item. Re-sending immediately can otherwise monopolize the actor while it
-                // dispatches actions for a large snapshot.
-                tokio::task::yield_now().await;
-                myself.send_message(CchMessage::ContinueStartupRecovery {
-                    orders,
-                    receive_creation_keys,
-                    send_creation_keys,
-                    recovered_orders,
-                    recovered_receive_creations,
-                    recovered_send_creations,
-                    started_at_millis,
-                })?;
+                // Keep a single recovery continuation in flight and leave a mailbox window
+                // between store reads. An immediate self-message can otherwise stay ahead of
+                // RPC work while recovering a large key snapshot.
+                myself.send_after(
+                    Duration::from_millis(STARTUP_RECOVERY_ITEM_DELAY_MILLIS),
+                    move || CchMessage::ContinueStartupRecovery {
+                        order_keys,
+                        receive_creation_keys,
+                        send_creation_keys,
+                        recovered_orders,
+                        recovered_receive_creations,
+                        recovered_send_creations,
+                        started_at_millis,
+                    },
+                );
                 Ok(())
             }
             CchMessage::TrackingEvent(event) => {

--- a/crates/fiber-lib/src/cch/error.rs
+++ b/crates/fiber-lib/src/cch/error.rs
@@ -14,6 +14,8 @@ pub enum CchStoreError {
 
 #[derive(Error, Debug)]
 pub enum CchError {
+    #[error("CCH startup recovery is still initializing")]
+    StartupRecoveryInProgress,
     #[error("Configuration error: {0}")]
     ConfigError(String),
     #[error("Store error: {0}")]

--- a/crates/fiber-lib/src/cch/tests/actor_tests.rs
+++ b/crates/fiber-lib/src/cch/tests/actor_tests.rs
@@ -62,23 +62,36 @@ struct MockCchOrderStoreState {
     orders: HashMap<Hash256, CchOrder>,
     receive_btc_order_creations: HashMap<Hash256, CchReceiveBtcOrderCreation>,
     send_btc_order_creations: HashMap<Hash256, CchSendBtcOrderCreation>,
+    get_order_delay: Duration,
+    get_order_calls: usize,
 }
 
 impl MockCchOrderStore {
     pub fn new() -> Self {
         Self::default()
     }
+
+    fn set_get_order_delay(&self, delay: Duration) {
+        self.state.lock().unwrap().get_order_delay = delay;
+    }
+
+    fn get_order_call_count(&self) -> usize {
+        self.state.lock().unwrap().get_order_calls
+    }
 }
 
 impl CchOrderStore for MockCchOrderStore {
     fn get_cch_order(&self, payment_hash: &Hash256) -> Result<CchOrder, CchStoreError> {
-        self.state
-            .lock()
-            .unwrap()
-            .orders
-            .get(payment_hash)
-            .ok_or(CchStoreError::NotFound(*payment_hash))
-            .cloned()
+        let (order, delay) = {
+            let mut state = self.state.lock().unwrap();
+            state.get_order_calls += 1;
+            (
+                state.orders.get(payment_hash).cloned(),
+                state.get_order_delay,
+            )
+        };
+        std::thread::sleep(delay);
+        order.ok_or(CchStoreError::NotFound(*payment_hash))
     }
 
     fn insert_cch_order(&self, order: CchOrder) -> Result<(), CchStoreError> {
@@ -1051,6 +1064,21 @@ async fn setup_test_harness_with_config_store_and_lnd(
     store: MockCchOrderStore,
     lnd_invoice_client: Option<Arc<dyn LndInvoiceClient>>,
 ) -> TestHarness {
+    let harness = setup_test_harness_with_config_store_and_lnd_without_recovery_wait(
+        config,
+        store,
+        lnd_invoice_client,
+    )
+    .await;
+    wait_for_startup_recovery(&harness.actor).await;
+    harness
+}
+
+async fn setup_test_harness_with_config_store_and_lnd_without_recovery_wait(
+    config: CchConfig,
+    store: MockCchOrderStore,
+    lnd_invoice_client: Option<Arc<dyn LndInvoiceClient>>,
+) -> TestHarness {
     let event_port = Arc::new(OutputPort::<CchTrackingEvent>::default());
 
     let mock_state = MockNetworkState::new(event_port.clone(), None);
@@ -1082,6 +1110,23 @@ async fn setup_test_harness_with_config_store_and_lnd(
         event_port,
         mock_state,
         _store: store,
+    }
+}
+
+async fn wait_for_startup_recovery(actor: &ActorRef<CchMessage>) {
+    loop {
+        let in_progress = actor
+            .call(
+                CchMessage::GetStartupRecoveryStatus,
+                Some(Duration::from_secs(1)),
+            )
+            .await
+            .expect("startup recovery status message should be sent")
+            .expect("CchActor mailbox must answer startup recovery status");
+        if !in_progress {
+            return;
+        }
+        tokio::task::yield_now().await;
     }
 }
 
@@ -1273,6 +1318,68 @@ fn insert_pending_send_btc_orders(store: &MockCchOrderStore, count: usize) {
             })
             .expect("insert pending send_btc order");
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_startup_order_recovery_does_not_block_actor_mailbox() {
+    let store = MockCchOrderStore::new();
+    insert_pending_send_btc_orders(&store, 8);
+    store.set_get_order_delay(Duration::from_millis(30));
+    let existing_payment_hash = test_payment_hash(0);
+    let config = CchConfig {
+        lnd_rpc_url: "https://127.0.0.1:10009".to_string(),
+        wrapped_btc_type_script_args: "0x".to_string(),
+        min_outgoing_invoice_expiry_delta_seconds: 60,
+        ..Default::default()
+    };
+    let harness = setup_test_harness_with_config_store_and_lnd_without_recovery_wait(
+        config,
+        store.clone(),
+        None,
+    )
+    .await;
+
+    while store.get_order_call_count() == 0 {
+        tokio::task::yield_now().await;
+    }
+
+    let startup_send = harness
+        .actor
+        .call(
+            |reply| {
+                CchMessage::SendBTC(
+                    crate::cch::SendBTC {
+                        btc_pay_req: create_test_lightning_invoice_with_payment_hash(
+                            create_valid_preimage_pair(250).1,
+                        )
+                        .to_string(),
+                        currency: Currency::Fibb,
+                    },
+                    reply,
+                )
+            },
+            Some(Duration::from_millis(100)),
+        )
+        .await
+        .expect("send_btc message should be sent")
+        .expect("CchActor mailbox must answer during startup recovery");
+    assert!(matches!(
+        startup_send,
+        Err(CchError::StartupRecoveryInProgress)
+    ));
+
+    let existing_order = harness
+        .actor
+        .call(
+            |reply| CchMessage::GetCchOrder(existing_payment_hash, reply),
+            Some(Duration::from_millis(100)),
+        )
+        .await
+        .expect("get order message should be sent")
+        .expect("CchActor mailbox must remain responsive during startup recovery")
+        .expect("existing order");
+
+    assert_eq!(existing_order.payment_hash, existing_payment_hash);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- move the persisted CCH key snapshot load off the actor startup critical path
- keep only payment hashes in the recovery snapshot and load each order immediately before recovery
- replay persisted orders and durable creation intents incrementally with a single delayed continuation so the actor mailbox remains responsive
- return an explicit `StartupRecoveryInProgress` error from `send_btc` and `receive_btc` until recovery completes
- keep order queries responsive during initialization and log recovery counts and elapsed time

## Tests

- `cargo nextest run -p fnn --all-features test_startup_order_recovery_does_not_block_actor_mailbox`
- `cargo nextest run -p fnn --all-features 'cch::'` (208 passed)
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all -- --check`

Closes #1606