### PR TITLE
fix: complete on-chain TLC reconciliation for terminal sweeps and uncommitted removes (#1611, #1612)

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3082,7 +3082,16 @@ where
                         ))
                         .expect(ASSUME_NETWORK_ACTOR_ALIVE);
                     if let TLCId::Offered(id) = tlc.tlc_id {
-                        state.tlc_state.set_offered_tlc_removed(id, reason);
+                        // A peer RemoveTlc may already have marked this TLC removed without the
+                        // commitment handshake completing (issue #1612). Only mark it again when
+                        // it was never removed: `set_offered_tlc_removed` asserts Committed.
+                        if state
+                            .tlc_state
+                            .get(&TLCId::Offered(id))
+                            .is_some_and(|t| t.removed_reason.is_none())
+                        {
+                            state.tlc_state.set_offered_tlc_removed(id, reason);
+                        }
                     }
                 }
             }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -3564,8 +3564,17 @@ where
                         ))
                         .expect(ASSUME_NETWORK_ACTOR_ALIVE);
                     if let TLCId::Offered(id) = tlc.tlc_id {
-                        actor_state.tlc_state.set_offered_tlc_removed(id, reason);
-                        actor_state_changed = true;
+                        // A peer RemoveTlc may already have marked this TLC removed without the
+                        // commitment handshake completing (issue #1612). Only mark it again when
+                        // it was never removed: `set_offered_tlc_removed` asserts Committed.
+                        if actor_state
+                            .tlc_state
+                            .get(&TLCId::Offered(id))
+                            .is_some_and(|t| t.removed_reason.is_none())
+                        {
+                            actor_state.tlc_state.set_offered_tlc_removed(id, reason);
+                            actor_state_changed = true;
+                        }
                     }
                 }
             }

--- a/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
@@ -256,7 +256,6 @@ pub(crate) fn collect_onchain_timeout_settled_tlcs(
     state
         .tlc_state
         .get_expired_offered_tlcs(expect_expiry)
-        .filter(|tlc| tlc.removed_reason.is_none())
         .filter_map(|tlc| {
             if !matches!(
                 resolve_onchain_tlc(

--- a/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
@@ -454,6 +454,9 @@ fn collect_timeout_settled_skips_already_removed() {
     tlc.removed_reason = Some(RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
         payment_preimage: gen_rand_sha256_hash(),
     }));
+    // A confirmed remove has completed its commitment handshake and was already propagated
+    // upstream, so on-chain timeout reconciliation must skip it.
+    tlc.removed_confirmed_at = Some(1);
 
     let mut state = empty_channel_state(channel_id);
     state.tlc_state.offered_tlcs.tlcs = vec![tlc];
@@ -465,6 +468,44 @@ fn collect_timeout_settled_skips_already_removed() {
     );
 
     assert!(collect_onchain_timeout_settled_tlcs(&state, &store, 100).is_empty());
+}
+
+#[test]
+fn collect_timeout_settled_collects_uncommitted_removed() {
+    // Issue #1612: a TLC marked removed by a peer RemoveTlc message whose remove commitment
+    // handshake never completed (channel shutting down with WAITING_COMMITMENT_CONFIRMATION)
+    // still needs on-chain timeout reconciliation. `removed_reason` is set but
+    // `removed_confirmed_at` is not, so the upstream RemoveTlc was never propagated.
+    let channel_id = gen_rand_sha256_hash();
+    let hash_algorithm = HashAlgorithm::CkbHash;
+    let payment_hash = gen_rand_sha256_hash();
+    let mut tlc = tlc_info(
+        TLCId::Offered(0),
+        TlcStatus::Outbound(OutboundTlcStatus::RemoteRemoved),
+        payment_hash,
+        hash_algorithm,
+    );
+    tlc.removed_reason = Some(RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
+        TlcErr::new(TlcErrorCode::ExpiryTooSoon),
+        &TEST_SHARED_SECRET,
+    )));
+
+    let mut state = empty_channel_state(channel_id);
+    state.tlc_state.offered_tlcs.tlcs = vec![tlc];
+    let store = MockStore::new().with_onchain_settled(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        hash_algorithm,
+    );
+
+    let expired = collect_onchain_timeout_settled_tlcs(&state, &store, 100);
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].tlc_id, TLCId::Offered(0));
+    assert_eq!(
+        expired[0].role,
+        OnChainTimeoutTlcRole::OriginPayer { attempt_id: None }
+    );
 }
 
 #[test]

--- a/crates/fiber-lib/src/watchtower/actor.rs
+++ b/crates/fiber-lib/src/watchtower/actor.rs
@@ -961,6 +961,10 @@ fn process_watched_settlement_tx<S: WatchtowerStore>(
     })?;
 
     let tracked_tlcs = watched_outpoints.get(&watched_outpoint)?.clone();
+    // A terminal settlement consumes the last commitment cell: when the transaction does
+    // not produce a successor commitment output, every still-pending TLC is carried
+    // off-chain by the final-party sweep and needs an explicit settlement record.
+    let terminal = !has_successor_commitment_output(tx, commitment_lock_prefix);
     let remaining_tlcs = reconcile_settlement_witness(
         tx,
         watched_input_index,
@@ -968,18 +972,26 @@ fn process_watched_settlement_tx<S: WatchtowerStore>(
         store,
         self_node_id,
         &tracked_tlcs,
+        terminal,
     )?;
     processed_tx_hashes.insert(tx_hash.clone());
     watched_outpoints.remove(&watched_outpoint);
 
-    let outputs = tx.raw().outputs();
-    if let Some(output) = outputs.get(0) {
-        if lock_matches_commitment_prefix(&output.lock(), commitment_lock_prefix) {
-            watched_outpoints.insert(OutPoint::new(tx_hash, 0), remaining_tlcs);
-        }
+    if has_successor_commitment_output(tx, commitment_lock_prefix) {
+        watched_outpoints.insert(OutPoint::new(tx_hash, 0), remaining_tlcs);
     }
 
     Some(watched_input_index)
+}
+
+/// Whether a settlement transaction produces a successor commitment cell carrying the
+/// still-pending TLCs. The commitment lock contract always emits that cell as the first
+/// output; when it is absent, the transaction is a terminal sweep that consumes the last
+/// commitment cell and settles every remaining TLC.
+fn has_successor_commitment_output(tx: &Transaction, commitment_lock_prefix: &Script) -> bool {
+    tx.raw().outputs().get(0).is_some_and(|output| {
+        lock_matches_commitment_prefix(&output.lock(), commitment_lock_prefix)
+    })
 }
 
 /// Validate a settlement witness against the tracked snapshot, persist exact TLC proofs, and
@@ -991,6 +1003,7 @@ fn reconcile_settlement_witness<S: WatchtowerStore>(
     store: &S,
     self_node_id: &NodeId,
     tracked_tlcs: &[TrackedSettlementTlc],
+    terminal: bool,
 ) -> Option<Vec<TrackedSettlementTlc>> {
     let Some(witness) = tx.witnesses().get(witness_index) else {
         warn!(
@@ -1040,6 +1053,29 @@ fn reconcile_settlement_witness<S: WatchtowerStore>(
                 tracked_tlcs.len(),
                 tx.calc_tx_hash(),
             );
+            if terminal {
+                // The unlock consumes the last commitment cell, so the contract only admits
+                // the sweep when every still-pending TLC is claimable by the sweeping party
+                // (expired or already fulfilled). Each remaining TLC is therefore settled
+                // without a preimage here. Without an exact record, the channel would keep
+                // ONCHAIN_SETTLEMENT_CONFIRMED forever and never propagate `RemoveTlc`
+                // upstream (issue #1611).
+                for (index, tlc) in tracked_tlcs.iter().enumerate() {
+                    store.insert_onchain_tlc_settlement(
+                        self_node_id,
+                        channel_id,
+                        tlc.tlc_id,
+                        OnChainTlcSettlement {
+                            payment_hash: tlc.payment_hash,
+                            hash_algorithm: tlc.hash_algorithm,
+                            preimage: None,
+                            tx_hash,
+                            tlc_index: index as u8,
+                        },
+                    );
+                }
+                return Some(Vec::new());
+            }
             continue;
         }
 
@@ -2905,6 +2941,82 @@ mod tests {
             Some(&tracked.to_vec()),
             "the successor witness still contains every pending TLC"
         );
+    }
+
+    #[test]
+    fn terminal_final_party_unlock_records_settled_without_preimage() {
+        // Issue #1611: after #1583 the watchtower skips every final-party unlock. When the
+        // unlock consumes the last commitment cell (no successor commitment output), the
+        // terminal sweep carries every still-pending TLC off-chain. B (the offering party of
+        // the expired TLC) may legally sweep it, but without a settlement record the channel
+        // reconciliation stays incomplete forever and `RemoveTlc` is never propagated upstream.
+        let lock_prefix = commitment_lock_prefix();
+        let channel_id: Hash256 = [9u8; 32].into();
+        let payment_hashes = [[41u8; 20], [42u8; 20]];
+        let first_commitment_out_point = OutPoint::new([7u8; 32].pack(), 0);
+        let tracked = [
+            tracked_tlc(payment_hashes[0], 0),
+            tracked_tlc(payment_hashes[1], 1),
+        ];
+        // A terminal settlement consumes the last commitment cell: the output is a plain
+        // party-balance cell, not a successor commitment cell carrying the pending TLCs.
+        let party_balance_lock = Script::new_builder().args([1u8; 8].to_vec().pack()).build();
+        for unlock_type in [0xFE, 0xFF] {
+            let tx = tx_with_input_output_and_witness(
+                first_commitment_out_point.clone(),
+                party_balance_lock.clone(),
+                Some(settlement_witness_with_unlocks(
+                    &payment_hashes,
+                    vec![Unlock {
+                        unlock_type,
+                        with_preimage: false,
+                        signature: [0u8; 65],
+                        preimage: None,
+                    }],
+                )),
+            );
+            let mut watched_outpoints =
+                HashMap::from([(first_commitment_out_point.clone(), tracked.to_vec())]);
+            let mut processed_tx_hashes = HashSet::new();
+            let store = TestWatchtowerStore::default();
+            let self_node_id = NodeId::local();
+
+            let processed = process_watched_settlement_tx(
+                &tx,
+                &mut watched_outpoints,
+                &mut processed_tx_hashes,
+                &lock_prefix,
+                &channel_id,
+                &store,
+                &self_node_id,
+            );
+
+            assert_eq!(processed, Some(0), "unlock 0x{:02x}", unlock_type);
+            let settlements = store.settlements();
+            assert_eq!(
+                settlements.len(),
+                2,
+                "unlock 0x{:02x}: every terminal-swept TLC needs a settlement record",
+                unlock_type
+            );
+            for (index, tlc) in tracked.iter().enumerate() {
+                let (stored_channel_id, stored_tlc_id, settlement) = &settlements[index];
+                assert_eq!(stored_channel_id, &channel_id);
+                assert_eq!(stored_tlc_id, &tlc.tlc_id);
+                assert_eq!(settlement.payment_hash, tlc.payment_hash);
+                assert_eq!(settlement.hash_algorithm, tlc.hash_algorithm);
+                assert!(
+                    settlement.preimage.is_none(),
+                    "unlock 0x{:02x}: terminal sweep settles the TLC without a preimage",
+                    unlock_type
+                );
+            }
+            assert!(
+                watched_outpoints.is_empty(),
+                "unlock 0x{:02x}: no successor commitment cell remains after a terminal sweep",
+                unlock_type
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two fixes for on-chain TLC reconciliation on force-closed channels, addressing two sister issues reported against the exact-TLC settlement model introduced in #1583.

### 1. Terminal final-party sweep leaves pending TLCs unreconciled (#1611)

After #1583 the watchtower skips every final-party unlock (`0xFE`/`0xFF`). When such an unlock consumes the last commitment cell (no successor commitment output), the terminal sweep carries every still-pending TLC off-chain without recording an exact settlement proof. The channel then keeps `ONCHAIN_SETTLEMENT_CONFIRMED` forever, reconciliation never completes, and `RemoveTlc` is never propagated upstream.

**Fix (watchtower):** detect a terminal settlement (no successor commitment output) in `process_watched_settlement_tx` and, when a final-party unlock is observed on such a transaction, persist an exact no-preimage settlement (`OnChainTlcSettlement { preimage: None }`) for every remaining tracked TLC. Intermediate final-party unlocks (with a successor commitment cell) keep the previous behavior: pending TLCs stay tracked.

### 2. Uncommitted `RemoteRemoved` TLC is skipped during on-chain timeout reconciliation (#1612)

When a peer `RemoveTlc` arrives while the channel is shutting down with `WAITING_COMMITMENT_CONFIRMATION`, `set_offered_tlc_removed` marks the TLC `RemoteRemoved` but the remove commitment handshake never completes, so `removed_confirmed_at` stays `None` and the upstream `RemoveTlc` is never propagated. On-chain timeout reconciliation skipped such TLCs because `collect_onchain_timeout_settled_tlcs` filtered on `removed_reason.is_none()`, while `get_expired_offered_tlcs` already scopes to unconfirmed removes via `removed_confirmed_at.is_none()`. The channel then finalized settlement and stopped, leaving the upstream offered TLC permanently present.

**Fix (fiber):** drop the redundant `removed_reason` filter so uncommitted removed TLCs are collected and relayed upstream once their on-chain timeout settlement is observed. Guard the `OriginPayer` path in both the live-actor and no-live-actor reconciliation flows against re-marking an already removed TLC (`set_offered_tlc_removed` asserts `Committed`).

## TDD

- `terminal_final_party_unlock_records_settled_without_preimage` fails on `e6cb7ac7` (0 settlement records) and passes with the watchtower fix; covers both `0xFE` and `0xFF`.
- `collect_timeout_settled_collects_uncommitted_removed` fails on `e6cb7ac7` (0 collected) and passes with the fiber fix.
- `collect_timeout_settled_skips_already_removed` now pins the confirmed-remove case (`removed_confirmed_at` set).

## Validation

- `cargo nextest run -p fnn -p fiber-bin --no-fail-fast` — 1200 passed, 8 skipped
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`

## Notes

A symmetric fulfill variant of #1612 (uncommitted removed TLC settled on-chain with a preimage is skipped by `collect_onchain_fulfilled_tlcs` via `can_reconcile_onchain_fulfillment`) is out of scope and can be followed up separately.