### PR TITLE
fix: finalize on-chain settlement for TLCs with a non-matching preimage

### DIFF
--- a/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
@@ -141,10 +141,10 @@ pub(crate) fn resolve_onchain_tlc(
                 return OnChainTlcResolution::Fulfilled(preimage);
             }
             warn!(
-                "Ignoring invalid on-chain preimage for channel {:?} tlc {:?} tx {:?}: derived hash {:?}, expected {:?}",
+                "On-chain preimage for channel {:?} tlc {:?} tx {:?} does not match the full payment hash (derived {:?}, expected {:?}); treating as settled without preimage",
                 channel_id, tlc_id, settlement.tx_hash, discovered_payment_hash, payment_hash
             );
-            OnChainTlcResolution::Unknown
+            OnChainTlcResolution::SettledWithoutPreimage
         }
         StoredOnChainTlcSettlement::Legacy(legacy) => {
             let Some(preimage) = legacy.preimage else {

--- a/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
@@ -82,7 +82,7 @@ fn resolve_returns_fulfilled_when_preimage_matches() {
 }
 
 #[test]
-fn resolve_returns_unknown_when_preimage_mismatches() {
+fn resolve_returns_settled_without_preimage_when_preimage_mismatches() {
     let channel_id = gen_rand_sha256_hash();
     let correct_preimage = gen_rand_sha256_hash();
     let wrong_preimage = gen_rand_sha256_hash();
@@ -104,7 +104,7 @@ fn resolve_returns_unknown_when_preimage_mismatches() {
             payment_hash,
             hash_algorithm,
         ),
-        OnChainTlcResolution::Unknown
+        OnChainTlcResolution::SettledWithoutPreimage
     );
 }
 


### PR DESCRIPTION
## Problem

When a force-closed channel is settled on-chain, the watchtower records the settlement preimage for each consumed TLC. If that preimage does not hash to the TLC's full 32-byte payment hash, `resolve_onchain_tlc` classifies the exact settlement record as `Unknown`.

`Unknown` records are ignored by both the fulfillment and the timeout collectors, so the affected TLC is never reconciled. As a result the channel stays in `ONCHAIN_SETTLEMENT_CONFIRMED` and cannot complete its on-chain settlement.

## Fix

Treat an exact settlement record whose preimage fails the full-hash check as `SettledWithoutPreimage` rather than `Unknown`. The on-chain output has already been spent, so the TLC is settled; it simply can no longer be fulfilled upstream. This lets the timeout collector reconcile the TLC and finalize the channel.

## Test

Renamed `resolve_returns_unknown_when_preimage_mismatches` to `resolve_returns_settled_without_preimage_when_preimage_mismatches`.

```
cargo test -p fnn --features sqlite fiber::tests::onchain_tlc_reconcile::
```

passes (15/15).