### PR TITLE
fix: include offered LocalAnnounced TLCs in on-chain reconciliation

### DIFF
--- a/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/onchain_tlc_reconcile.rs
@@ -5,7 +5,8 @@
 
 use crate::fiber::channel::{ChannelActorState, ChannelActorStateStore};
 use fiber_types::{
-    Hash256, HashAlgorithm, InboundTlcStatus, OutboundTlcStatus, RemoveTlcReason, TLCId, TlcInfo,
+    ChannelState, CloseFlags, Hash256, HashAlgorithm, InboundTlcStatus, OutboundTlcStatus,
+    RemoveTlcReason, TLCId, TlcInfo,
 };
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -253,9 +254,15 @@ pub(crate) fn collect_onchain_timeout_settled_tlcs(
     expect_expiry: u64,
 ) -> Vec<OnChainTimeoutSettledTlc> {
     let channel_id = state.get_id();
+    // Live-channel expiry handling still uses `get_expired_offered_tlcs`, which omits
+    // LocalAnnounced TLCs because they are not in the local commitment. On-chain timeout
+    // reconciliation must include them: a signed remote commitment already contains the TLC.
     state
         .tlc_state
-        .get_expired_offered_tlcs(expect_expiry)
+        .offered_tlcs
+        .tlcs
+        .iter()
+        .filter(|tlc| tlc.removed_confirmed_at.is_none() && tlc.expiry < expect_expiry)
         .filter_map(|tlc| {
             if !matches!(
                 resolve_onchain_tlc(
@@ -325,10 +332,21 @@ pub(crate) fn collect_onchain_received_timeout_settled_tlcs(
 }
 
 pub(crate) fn has_unresolved_onchain_tlcs(state: &ChannelActorState) -> bool {
-    state
-        .tlc_state
-        .all_tlcs()
-        .any(can_reconcile_onchain_fulfillment)
+    // Offered LocalAnnounced TLCs are only in the remote commitment. A local force-close
+    // spends the local commitment, so they must not block settlement completion.
+    let remote_uncooperative_close = matches!(
+        state.state,
+        ChannelState::Closed(flags) if flags.contains(CloseFlags::UNCOOPERATIVE_REMOTE)
+    );
+    state.tlc_state.all_tlcs().any(|tlc| {
+        if !can_reconcile_onchain_fulfillment(tlc) {
+            return false;
+        }
+        if tlc.is_offered() && matches!(tlc.outbound_status(), OutboundTlcStatus::LocalAnnounced) {
+            return remote_uncooperative_close;
+        }
+        true
+    })
 }
 
 pub(crate) fn can_reconcile_onchain_fulfillment(tlc: &TlcInfo) -> bool {
@@ -337,7 +355,10 @@ pub(crate) fn can_reconcile_onchain_fulfillment(tlc: &TlcInfo) -> bool {
     }
 
     if tlc.is_offered() {
-        matches!(tlc.outbound_status(), OutboundTlcStatus::Committed)
+        matches!(
+            tlc.outbound_status(),
+            OutboundTlcStatus::LocalAnnounced | OutboundTlcStatus::Committed
+        )
     } else {
         matches!(
             tlc.inbound_status(),

--- a/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
+++ b/crates/fiber-lib/src/fiber/tests/onchain_tlc_reconcile.rs
@@ -9,9 +9,9 @@ use crate::fiber::tests::settle_tlc_set_command_tests::{
 use crate::gen_rand_sha256_hash;
 
 use fiber_types::{
-    AppliedFlags, CommitmentNumbers, Hash256, HashAlgorithm, InboundTlcStatus, OutboundTlcStatus,
-    RemoveTlcFulfill, RemoveTlcReason, TLCId, TlcErr, TlcErrPacket, TlcErrorCode, TlcInfo,
-    TlcStatus,
+    AppliedFlags, ChannelState, CloseFlags, CommitmentNumbers, Hash256, HashAlgorithm,
+    InboundTlcStatus, OutboundTlcStatus, RemoveTlcFulfill, RemoveTlcReason, TLCId, TlcErr,
+    TlcErrPacket, TlcErrorCode, TlcInfo, TlcStatus,
 };
 
 const TEST_SHARED_SECRET: [u8; 32] = [7u8; 32];
@@ -251,15 +251,13 @@ fn resolve_ignores_locally_known_preimage_without_settlement_record() {
 }
 
 #[test]
-fn collect_skips_removed_and_uncommitted_tlcs() {
+fn collect_skips_removed_offered_tlcs() {
     let channel_id = gen_rand_sha256_hash();
     let hash_algorithm = HashAlgorithm::CkbHash;
     let active_preimage = gen_rand_sha256_hash();
     let removed_preimage = gen_rand_sha256_hash();
-    let uncommitted_preimage = gen_rand_sha256_hash();
     let active_hash = payment_hash_for(active_preimage, hash_algorithm);
     let removed_hash = payment_hash_for(removed_preimage, hash_algorithm);
-    let uncommitted_hash = payment_hash_for(uncommitted_preimage, hash_algorithm);
 
     let active = tlc_info(
         TLCId::Offered(0),
@@ -276,15 +274,9 @@ fn collect_skips_removed_and_uncommitted_tlcs() {
     removed.removed_reason = Some(RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
         payment_preimage: removed_preimage,
     }));
-    let uncommitted = tlc_info(
-        TLCId::Offered(2),
-        TlcStatus::Outbound(OutboundTlcStatus::LocalAnnounced),
-        uncommitted_hash,
-        hash_algorithm,
-    );
 
     let mut state = empty_channel_state(channel_id);
-    state.tlc_state.offered_tlcs.tlcs = vec![active, removed, uncommitted];
+    state.tlc_state.offered_tlcs.tlcs = vec![active, removed];
     let store = MockStore::new()
         .with_onchain_preimage(
             channel_id,
@@ -299,10 +291,50 @@ fn collect_skips_removed_and_uncommitted_tlcs() {
             removed_hash,
             hash_algorithm,
             removed_preimage,
+        );
+
+    let fulfilled = collect_onchain_fulfilled_tlcs(&state, &store);
+
+    assert_eq!(fulfilled.len(), 1);
+    assert_eq!(fulfilled[0].tlc_id, TLCId::Offered(0));
+    assert_eq!(fulfilled[0].preimage, active_preimage);
+}
+
+#[test]
+fn collect_skips_inbound_remote_announced() {
+    let channel_id = gen_rand_sha256_hash();
+    let hash_algorithm = HashAlgorithm::CkbHash;
+    let committed_preimage = gen_rand_sha256_hash();
+    let uncommitted_preimage = gen_rand_sha256_hash();
+    let committed_hash = payment_hash_for(committed_preimage, hash_algorithm);
+    let uncommitted_hash = payment_hash_for(uncommitted_preimage, hash_algorithm);
+
+    let committed = tlc_info(
+        TLCId::Received(0),
+        TlcStatus::Inbound(InboundTlcStatus::Committed),
+        committed_hash,
+        hash_algorithm,
+    );
+    let uncommitted = tlc_info(
+        TLCId::Received(1),
+        TlcStatus::Inbound(InboundTlcStatus::RemoteAnnounced),
+        uncommitted_hash,
+        hash_algorithm,
+    );
+
+    let mut state = empty_channel_state(channel_id);
+    state.tlc_state.received_tlcs.tlcs = vec![committed, uncommitted];
+    let store = MockStore::new()
+        .with_onchain_preimage(
+            channel_id,
+            TLCId::Received(0),
+            committed_hash,
+            hash_algorithm,
+            committed_preimage,
         )
         .with_onchain_preimage(
             channel_id,
-            TLCId::Offered(2),
+            TLCId::Received(1),
             uncommitted_hash,
             hash_algorithm,
             uncommitted_preimage,
@@ -311,8 +343,8 @@ fn collect_skips_removed_and_uncommitted_tlcs() {
     let fulfilled = collect_onchain_fulfilled_tlcs(&state, &store);
 
     assert_eq!(fulfilled.len(), 1);
-    assert_eq!(fulfilled[0].tlc_id, TLCId::Offered(0));
-    assert_eq!(fulfilled[0].preimage, active_preimage);
+    assert_eq!(fulfilled[0].tlc_id, TLCId::Received(0));
+    assert_eq!(fulfilled[0].preimage, committed_preimage);
 }
 
 #[test]
@@ -634,4 +666,179 @@ fn forged_full_hash_does_not_inherit_removed_tlc_prefix_settlement() {
         collect_onchain_timeout_settled_tlcs(&state, &store, 100).is_empty(),
         "a settlement record for the removed TLC must not settle the forged full hash"
     );
+}
+
+fn closed_state_with_offered_local_announced(
+    channel_id: Hash256,
+    flags: CloseFlags,
+    tlc: TlcInfo,
+) -> crate::fiber::channel::ChannelActorState {
+    let mut state = empty_channel_state(channel_id);
+    state.state = ChannelState::Closed(flags);
+    state.tlc_state.offered_tlcs.tlcs = vec![tlc];
+    state
+}
+
+#[test]
+fn collect_fulfilled_includes_offered_local_announced() {
+    // A signed remote commitment already includes offered LocalAnnounced TLCs. If the
+    // counterparty broadcasts that commitment and spends the TLC on-chain, fulfillment
+    // reconciliation must still pick it up.
+    let channel_id = gen_rand_sha256_hash();
+    let hash_algorithm = HashAlgorithm::CkbHash;
+    let preimage = gen_rand_sha256_hash();
+    let payment_hash = payment_hash_for(preimage, hash_algorithm);
+    let tlc = tlc_info(
+        TLCId::Offered(0),
+        TlcStatus::Outbound(OutboundTlcStatus::LocalAnnounced),
+        payment_hash,
+        hash_algorithm,
+    );
+    let mut state = empty_channel_state(channel_id);
+    state.tlc_state.offered_tlcs.tlcs = vec![tlc];
+    let store = MockStore::new().with_onchain_preimage(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        hash_algorithm,
+        preimage,
+    );
+
+    let fulfilled = collect_onchain_fulfilled_tlcs(&state, &store);
+    assert_eq!(fulfilled.len(), 1);
+    assert_eq!(fulfilled[0].tlc_id, TLCId::Offered(0));
+    assert_eq!(fulfilled[0].preimage, preimage);
+}
+
+#[test]
+fn collect_timeout_includes_expired_offered_local_announced() {
+    let channel_id = gen_rand_sha256_hash();
+    let hash_algorithm = HashAlgorithm::CkbHash;
+    let payment_hash = gen_rand_sha256_hash();
+    let tlc = tlc_info(
+        TLCId::Offered(0),
+        TlcStatus::Outbound(OutboundTlcStatus::LocalAnnounced),
+        payment_hash,
+        hash_algorithm,
+    );
+    let mut state = empty_channel_state(channel_id);
+    state.tlc_state.offered_tlcs.tlcs = vec![tlc];
+    let store = MockStore::new().with_onchain_settled(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        hash_algorithm,
+    );
+
+    let expired = collect_onchain_timeout_settled_tlcs(&state, &store, 100);
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].tlc_id, TLCId::Offered(0));
+    assert_eq!(
+        expired[0].role,
+        OnChainTimeoutTlcRole::OriginPayer { attempt_id: None }
+    );
+}
+
+#[test]
+fn collect_timeout_includes_forwarded_local_announced() {
+    let channel_id = gen_rand_sha256_hash();
+    let upstream_channel_id = gen_rand_sha256_hash();
+    let hash_algorithm = HashAlgorithm::CkbHash;
+    let payment_hash = gen_rand_sha256_hash();
+    let mut tlc = tlc_info(
+        TLCId::Offered(0),
+        TlcStatus::Outbound(OutboundTlcStatus::LocalAnnounced),
+        payment_hash,
+        hash_algorithm,
+    );
+    tlc.forwarding_tlc = Some((upstream_channel_id, 7));
+    let mut state = empty_channel_state(channel_id);
+    state.tlc_state.offered_tlcs.tlcs = vec![tlc];
+    let store = MockStore::new().with_onchain_settled(
+        channel_id,
+        TLCId::Offered(0),
+        payment_hash,
+        hash_algorithm,
+    );
+
+    let expired = collect_onchain_timeout_settled_tlcs(&state, &store, 100);
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].tlc_id, TLCId::Offered(0));
+    assert_eq!(
+        expired[0].role,
+        OnChainTimeoutTlcRole::Forwarded {
+            forwarding_channel_id: upstream_channel_id,
+            forwarding_tlc_id: 7,
+        }
+    );
+}
+
+#[test]
+fn has_unresolved_keeps_local_announced_on_remote_force_close() {
+    let channel_id = gen_rand_sha256_hash();
+    let tlc = tlc_info(
+        TLCId::Offered(0),
+        TlcStatus::Outbound(OutboundTlcStatus::LocalAnnounced),
+        gen_rand_sha256_hash(),
+        HashAlgorithm::CkbHash,
+    );
+    let state = closed_state_with_offered_local_announced(
+        channel_id,
+        CloseFlags::UNCOOPERATIVE_REMOTE | CloseFlags::WAITING_ONCHAIN_SETTLEMENT,
+        tlc,
+    );
+
+    assert!(
+        has_unresolved_onchain_tlcs(&state),
+        "a remote force-close can spend offered LocalAnnounced TLCs from the signed remote commitment"
+    );
+}
+
+#[test]
+fn has_unresolved_ignores_local_announced_on_local_force_close() {
+    let channel_id = gen_rand_sha256_hash();
+    let tlc = tlc_info(
+        TLCId::Offered(0),
+        TlcStatus::Outbound(OutboundTlcStatus::LocalAnnounced),
+        gen_rand_sha256_hash(),
+        HashAlgorithm::CkbHash,
+    );
+    let state = closed_state_with_offered_local_announced(
+        channel_id,
+        CloseFlags::UNCOOPERATIVE_LOCAL | CloseFlags::WAITING_ONCHAIN_SETTLEMENT,
+        tlc,
+    );
+
+    assert!(
+        !has_unresolved_onchain_tlcs(&state),
+        "a local force-close broadcasts the local commitment, which omits offered LocalAnnounced TLCs"
+    );
+}
+
+#[test]
+fn set_offered_tlc_removed_accepts_local_announced() {
+    let channel_id = gen_rand_sha256_hash();
+    let tlc = tlc_info(
+        TLCId::Offered(0),
+        TlcStatus::Outbound(OutboundTlcStatus::LocalAnnounced),
+        gen_rand_sha256_hash(),
+        HashAlgorithm::CkbHash,
+    );
+    let mut state = empty_channel_state(channel_id);
+    state.tlc_state.offered_tlcs.tlcs = vec![tlc];
+
+    state.tlc_state.set_offered_tlc_removed(
+        0,
+        RemoveTlcReason::RemoveTlcFail(TlcErrPacket::new(
+            TlcErr::new(TlcErrorCode::ExpiryTooSoon),
+            &TEST_SHARED_SECRET,
+        )),
+    );
+
+    let updated = state
+        .tlc_state
+        .get(&TLCId::Offered(0))
+        .expect("offered tlc remains after on-chain remove");
+    assert_eq!(updated.outbound_status(), OutboundTlcStatus::RemoteRemoved);
+    assert!(updated.removed_reason.is_some());
 }

--- a/crates/fiber-types/src/channel.rs
+++ b/crates/fiber-types/src/channel.rs
@@ -768,7 +768,10 @@ impl TlcState {
 
     pub fn set_offered_tlc_removed(&mut self, tlc_id: u64, reason: RemoveTlcReason) -> Hash256 {
         let tlc = self.get_mut(&TLCId::Offered(tlc_id)).expect("get tlc");
-        assert_eq!(tlc.outbound_status(), OutboundTlcStatus::Committed);
+        assert!(matches!(
+            tlc.outbound_status(),
+            OutboundTlcStatus::LocalAnnounced | OutboundTlcStatus::Committed
+        ));
         tlc.removed_reason = Some(reason);
         tlc.status = TlcStatus::Outbound(OutboundTlcStatus::RemoteRemoved);
         tlc.payment_hash


### PR DESCRIPTION
## Summary

Offered TLCs in `OutboundTlcStatus::LocalAnnounced` are already included in the **remote** signed commitment (`build_settlement_data(for_remote=true)` / `commitment_signed_tlcs`: `LocalAnnounced => for_remote`). A peer can withhold `RevokeAndAck`, broadcast that commitment, and spend the TLC on-chain.

On-chain reconciliation previously treated offered TLCs as reconcilable only in `Committed`:

- `can_reconcile_onchain_fulfillment` fed fulfillment, received-timeout, and `has_unresolved_onchain_tlcs`
- `collect_onchain_timeout_settled_tlcs` reused `get_expired_offered_tlcs`, which also skips `LocalAnnounced`

The on-chain outcome was therefore dropped. An origin payer (or a closed upstream) never learned it. If that TLC was the only pending one, `has_unresolved_onchain_tlcs` returned false and the channel could finish `WAITING_ONCHAIN_SETTLEMENT` too early.

Inbound already covers the matching wait-ack state (`AnnounceWaitAck | Committed`). Outbound has no separate wait-ack variant after `CommitmentSigned` is sent, so it stays `LocalAnnounced`. This change does not add a new persisted enum variant.

## Fix

- **Collectors:** accept offered `LocalAnnounced | Committed`, symmetric with inbound `AnnounceWaitAck | Committed`. The real gate is still the watchtower exact settlement record.
- **Timeout collector:** stop using `get_expired_offered_tlcs`. Filter offered TLCs with `removed_confirmed_at.is_none()` and `expiry < expect_expiry` only, so `LocalAnnounced` is included when an on-chain timeout record exists.
- **`has_unresolved_onchain_tlcs`:** count offered `LocalAnnounced` as unresolved only on `Closed(UNCOOPERATIVE_REMOTE)`. A local force-close spends the local commitment, which does not contain these TLCs; treating them as unresolved would stall settlement forever.
- **`set_offered_tlc_removed`:** allow `LocalAnnounced | Committed`, matching `set_received_tlc_removed` (`AnnounceWaitAck | Committed`). Otherwise origin-payer apply panics.

`get_expired_offered_tlcs` is unchanged. It is still used by live-channel CheckChannels to force-close on expired offered TLCs that are already in the **local** commitment. Including `LocalAnnounced` there would force-close TLCs that are not in the local commitment.

## TDD

These tests fail on `c991b44e` and pass with the fix:

- `collect_fulfilled_includes_offered_local_announced`
- `collect_timeout_includes_expired_offered_local_announced`
- `collect_timeout_includes_forwarded_local_announced`
- `has_unresolved_keeps_local_announced_on_remote_force_close`
- `set_offered_tlc_removed_accepts_local_announced`

`has_unresolved_ignores_local_announced_on_local_force_close` already passed before the fix and stays as a lock so local force-close cannot hang.

The old `collect_skips_removed_and_uncommitted_tlcs` pin (which encoded the bug as expected) is split into:

- `collect_skips_removed_offered_tlcs`
- `collect_skips_inbound_remote_announced`

## Validation

- `cargo nextest run --no-fail-fast` — 1366 passed, 8 skipped
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all`

## Notes

Inbound `RemoteAnnounced` is the mirror case (present in the local commitment, still excluded from reconciliation). Out of scope here.