### PR TITLE
chore(deps): upgrade rand from 0.8.5 to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,7 +2642,7 @@ dependencies = [
  "parking_lot",
  "pprof",
  "ractor",
- "rand 0.8.6",
+ "rand 0.9.4",
  "regex",
  "scrypt",
  "secp256k1 0.30.0",

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -38,7 +38,7 @@ parking_lot = "0.12"
 ractor = { version = "0.15", features = [
   "async-trait",
 ] }
-rand = "0.8.5"
+rand = "0.9"
 regex = "1.10.5"
 scrypt = "0.11"
 secp256k1 = { version = "0.30.0", features = ["serde", "recovery", "rand", "global-context"] }

--- a/crates/fiber-lib/benches/payment_benchmarks.rs
+++ b/crates/fiber-lib/benches/payment_benchmarks.rs
@@ -155,11 +155,11 @@ fn build_graph_for_find_path_bench(
             }
 
             // Connect to 2 random nodes in next layer
-            let num_connections = rng.gen_range(1..=2.min(next_layer_nodes.len()));
+            let num_connections = rng.random_range(1..=2.min(next_layer_nodes.len()));
             let mut selected: HashSet<usize> = HashSet::new();
 
             while selected.len() < num_connections {
-                let idx = rng.gen_range(0..next_layer_nodes.len());
+                let idx = rng.random_range(0..next_layer_nodes.len());
                 selected.insert(next_layer_nodes[idx]);
             }
 
@@ -170,7 +170,7 @@ fn build_graph_for_find_path_bench(
                     (node_b, node_a)
                 };
                 if used_pairs.insert((low, high)) {
-                    let capacity = MIN_RESERVED_CKB + rng.gen_range(1000..20000);
+                    let capacity = MIN_RESERVED_CKB + rng.random_range(1000..20000);
                     edges.push((low, high, capacity));
                 }
             }
@@ -191,8 +191,8 @@ fn build_graph_for_find_path_bench(
             if edges.len() >= channel_count {
                 break;
             }
-            let idx_a = rng.gen_range(0..layer_nodes.len());
-            let idx_b = rng.gen_range(0..layer_nodes.len());
+            let idx_a = rng.random_range(0..layer_nodes.len());
+            let idx_b = rng.random_range(0..layer_nodes.len());
             if idx_a == idx_b {
                 continue;
             }
@@ -204,7 +204,7 @@ fn build_graph_for_find_path_bench(
                 (node_b, node_a)
             };
             if used_pairs.insert((low, high)) {
-                let capacity = MIN_RESERVED_CKB + rng.gen_range(1000..3000);
+                let capacity = MIN_RESERVED_CKB + rng.random_range(1000..3000);
                 edges.push((low, high, capacity));
             }
         }
@@ -213,10 +213,10 @@ fn build_graph_for_find_path_bench(
     // Step 3: Fill remaining capacity with random edges
     // Prefer connections between adjacent or nearby layers
     while edges.len() < channel_count {
-        let layer_a = rng.gen_range(0..num_layers);
+        let layer_a = rng.random_range(0..num_layers);
         // Prefer connecting to nearby layers (within 1-2 hops)
-        let layer_distance = rng.gen_range(1..=2);
-        let layer_b = if rng.gen_bool(0.5) {
+        let layer_distance = rng.random_range(1..=2);
+        let layer_b = if rng.random_bool(0.5) {
             layer_a.saturating_add(layer_distance).min(num_layers - 1)
         } else {
             layer_a.saturating_sub(layer_distance)
@@ -229,8 +229,8 @@ fn build_graph_for_find_path_bench(
             continue;
         }
 
-        let node_a = nodes_a[rng.gen_range(0..nodes_a.len())];
-        let node_b = nodes_b[rng.gen_range(0..nodes_b.len())];
+        let node_a = nodes_a[rng.random_range(0..nodes_a.len())];
+        let node_b = nodes_b[rng.random_range(0..nodes_b.len())];
 
         if node_a == node_b {
             continue;
@@ -242,7 +242,7 @@ fn build_graph_for_find_path_bench(
             (node_b, node_a)
         };
         if used_pairs.insert((low, high)) {
-            let capacity = MIN_RESERVED_CKB + rng.gen_range(500..4000);
+            let capacity = MIN_RESERVED_CKB + rng.random_range(500..4000);
             edges.push((low, high, capacity));
         }
     }

--- a/crates/fiber-lib/src/fiber/graph.rs
+++ b/crates/fiber-lib/src/fiber/graph.rs
@@ -29,7 +29,7 @@ use fiber_types::{
     Pubkey, RouterHop, SendPaymentData, TlcErr, UdtCfgInfos,
 };
 use parking_lot::Mutex;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -2160,7 +2160,7 @@ where
             .min(max_random_expiry_delta)
             / DEFAULT_TLC_EXPIRY_DELTA;
 
-        thread_rng().gen_range(1..max_rand_expiry_num.max(2)) * DEFAULT_TLC_EXPIRY_DELTA
+        rng().random_range(1..max_rand_expiry_num.max(2)) * DEFAULT_TLC_EXPIRY_DELTA
     }
 
     // A helper function to evaluate whether an edge should be added to the heap of nodes to visit.

--- a/crates/fiber-lib/src/fiber/key.rs
+++ b/crates/fiber-lib/src/fiber/key.rs
@@ -10,7 +10,7 @@ pub struct KeyPair([u8; 32]);
 
 use tentacle::secio::SecioKeyPair;
 
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use std::io::{Error, ErrorKind, Read, Write};
 
 use fiber_types::Privkey;
@@ -19,7 +19,7 @@ impl KeyPair {
     pub fn generate_random_key() -> Self {
         loop {
             let mut key: [u8; 32] = [0; 32];
-            thread_rng().fill(&mut key);
+            rng().fill(&mut key);
             if Self::try_from(key.as_slice()).is_ok() {
                 return Self(key);
             }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -12,7 +12,7 @@ use ractor::concurrency::Duration;
 use ractor::{
     call_t, forward, Actor, ActorCell, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent,
 };
-use rand::seq::{IteratorRandom, SliceRandom};
+use rand::seq::{IndexedRandom, IteratorRandom};
 use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -2429,7 +2429,7 @@ where
                 debug_event!(myself, "PeerReconnectBackoffAttempt");
 
                 let addresses = state.get_peer_addresses_by_pubkey(&pubkey);
-                if let Some(addr) = addresses.iter().choose(&mut rand::thread_rng()) {
+                if let Some(addr) = addresses.iter().choose(&mut rand::rng()) {
                     myself
                         .send_message(NetworkActorMessage::new_command(
                             NetworkActorCommand::ConnectPeer(
@@ -2480,7 +2480,7 @@ where
                         &channel_id, &pubkey, &channel_state, &addresses
                     );
 
-                    if let Some(addr) = addresses.iter().choose(&mut rand::thread_rng()) {
+                    if let Some(addr) = addresses.iter().choose(&mut rand::rng()) {
                         myself
                             .send_message(NetworkActorMessage::new_command(
                                 NetworkActorCommand::ConnectPeer(
@@ -2540,7 +2540,7 @@ where
                     (saved_peers_to_connect, graph_nodes_to_connect)
                 };
 
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 for (pubkey, addresses) in saved_peers_to_connect {
                     debug!("Peer to connect: {:?}, {:?}", pubkey, addresses);
                     if let Some(peer) = state.peer_session_map.get(&pubkey) {
@@ -7988,7 +7988,7 @@ pub(crate) fn select_connect_peer_address<I>(
 where
     I: IntoIterator<Item = Multiaddr>,
 {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     match addr_type {
         Some(transport) => addresses

--- a/crates/fiber-lib/src/fiber/payment.rs
+++ b/crates/fiber-lib/src/fiber/payment.rs
@@ -493,7 +493,7 @@ impl SendPaymentDataExt for SendPaymentData {
                 return Err("keysend payment should not have payment_hash".to_string());
             }
             // generate a random preimage for keysend payment
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let mut result = [0u8; 32];
             rng.fill(&mut result[..]);
             let preimage: Hash256 = result.into();

--- a/crates/fiber-lib/src/fiber/tests/trampoline.rs
+++ b/crates/fiber-lib/src/fiber/tests/trampoline.rs
@@ -11,6 +11,7 @@ use crate::fiber::payment::SendPaymentCommand;
 use crate::fiber::types::{TrampolineHopPayload, TrampolineOnionPacket};
 use crate::fiber::{FeatureVector, PaymentStatus, Privkey, Pubkey};
 use crate::gen_rand_fiber_public_key;
+use crate::gen_rand_secp256k1_keypair_tuple;
 use crate::invoice::{Currency, InvoiceBuilder, InvoiceStore, PreimageStore};
 use crate::tests::test_utils::*;
 use crate::{
@@ -1998,7 +1999,7 @@ async fn test_trampoline_forwarding_rejects_missing_previous_tlc() {
     let node_b = &nodes[1];
     let payment_hash = gen_rand_sha256_hash();
 
-    let (_sk, pk) = SECP256K1.generate_keypair(&mut rand::thread_rng());
+    let (_sk, pk) = gen_rand_secp256k1_keypair_tuple();
     let final_target: Pubkey = pk.into();
     let payloads = vec![
         TrampolineHopPayload::Forward {
@@ -2147,7 +2148,7 @@ async fn test_trampoline_forwarding_fee_insufficient_manual_packet() {
 
     // 1. Construct Trampoline Onion for B
     // B should forward 1000 to some final target.
-    let (_sk, pk) = SECP256K1.generate_keypair(&mut rand::thread_rng());
+    let (_sk, pk) = gen_rand_secp256k1_keypair_tuple();
     let final_target: Pubkey = pk.into();
 
     let forward_payload = TrampolineHopPayload::Forward {
@@ -2248,7 +2249,7 @@ async fn test_trampoline_forwarding_fee_insufficient_equal_amount() {
     let payment_hash = gen_rand_sha256_hash();
 
     // Construct Trampoline Onion for B
-    let (_sk, pk) = SECP256K1.generate_keypair(&mut rand::thread_rng());
+    let (_sk, pk) = gen_rand_secp256k1_keypair_tuple();
     let final_target: Pubkey = pk.into();
 
     let forward_payload = TrampolineHopPayload::Forward {
@@ -3548,7 +3549,7 @@ async fn test_trampoline_forward_invalid_onion_payload_missing_context() {
     let payment_hash = gen_rand_sha256_hash();
 
     fn gen_rand_session_key() -> crate::fiber::Privkey {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut key = [0u8; 32];
         rng.fill(&mut key);
         key.into()
@@ -3638,7 +3639,7 @@ async fn test_trampoline_forward_invalid_amount_in_onion_packet() {
     let payment_hash = gen_rand_sha256_hash();
 
     fn gen_rand_session_key() -> crate::fiber::Privkey {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut key = [0u8; 32];
         rng.fill(&mut key);
         key.into()

--- a/crates/fiber-lib/src/lib.rs
+++ b/crates/fiber-lib/src/lib.rs
@@ -92,7 +92,7 @@ pub fn set_mocked_time(time: u64) {
 }
 
 pub fn gen_rand_sha256_hash() -> Hash256 {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut result = [0u8; 32];
     rng.fill(&mut result[..]);
     result.into()

--- a/crates/fiber-lib/src/rpc/invoice.rs
+++ b/crates/fiber-lib/src/rpc/invoice.rs
@@ -222,8 +222,8 @@ where
                 {
                     return error("Node does not support MPP, please enable MPP feature");
                 }
-                let mut rng = rand::thread_rng();
-                let payment_secret: [u8; 32] = rng.gen();
+                let mut rng = rand::rng();
+                let payment_secret: [u8; 32] = rng.random();
                 invoice_builder = invoice_builder.payment_secret(payment_secret.into());
             }
         };

--- a/crates/fiber-lib/src/store/tests/store.rs
+++ b/crates/fiber-lib/src/store/tests/store.rs
@@ -21,6 +21,7 @@ use crate::fiber::{
 use crate::gen_rand_channel_outpoint;
 use crate::gen_rand_fiber_private_key;
 use crate::gen_rand_fiber_public_key;
+use crate::gen_rand_secp256k1_keypair_tuple;
 use crate::gen_rand_sha256_hash;
 use crate::invoice::*;
 use crate::now_timestamp_as_millis_u64;
@@ -56,14 +57,13 @@ use musig2::secp::MaybeScalar;
 #[cfg(not(target_arch = "wasm32"))]
 use musig2::CompactSignature;
 use musig2::SecNonce;
-use secp256k1::{Keypair, SECP256K1};
 use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use tentacle::secio::PeerId;
 
 fn gen_rand_local_signer() -> LocalSigner {
-    let keypair = Keypair::new(SECP256K1, &mut rand::thread_rng());
-    LocalSigner::new(keypair.secret_key())
+    let (secret_key, _) = gen_rand_secp256k1_keypair_tuple();
+    LocalSigner::new(secret_key)
 }
 
 fn mock_node() -> (Privkey, NodeAnnouncement) {

--- a/crates/fiber-lib/src/tests/gen_utils.rs
+++ b/crates/fiber-lib/src/tests/gen_utils.rs
@@ -14,6 +14,7 @@ use crate::fiber::{
 };
 use crate::now_timestamp_as_millis_u64;
 use fiber_types::protocol::AnnouncedNodeName;
+use rand::Rng;
 
 pub fn gen_rand_fiber_public_key() -> Pubkey {
     gen_rand_secp256k1_public_key().into()
@@ -40,7 +41,13 @@ pub fn gen_rand_secp256k1_public_key() -> PublicKey {
 }
 
 pub fn gen_rand_secp256k1_keypair() -> Keypair {
-    Keypair::new(SECP256K1, &mut rand::thread_rng())
+    let mut rng = rand::rng();
+    loop {
+        let secret_key = SecretKey::from_byte_array(&rng.random());
+        if let Ok(secret_key) = secret_key {
+            return Keypair::from_secret_key(SECP256K1, &secret_key);
+        }
+    }
 }
 
 pub fn gen_rand_secp256k1_keypair_tuple() -> (SecretKey, PublicKey) {

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -19,6 +19,7 @@ use crate::fiber::{
     Attempt, EcdsaSignature, FeatureVector, PaymentCustomRecords, PaymentSession, PaymentStatus,
     Pubkey, SessionRoute,
 };
+use crate::gen_rand_secp256k1_keypair_tuple;
 use crate::gen_rand_sha256_hash;
 use crate::invoice::*;
 use crate::rpc::config::RpcConfig;
@@ -44,9 +45,7 @@ use jsonrpsee::{
 
 use ractor::RpcReplyPort;
 use ractor::{call, Actor, ActorRef};
-use rand::distributions::Alphanumeric;
-use rand::rngs::OsRng;
-use rand::Rng;
+use rand::distr::{Alphanumeric, SampleString};
 use secp256k1::{Message, SECP256K1};
 #[cfg(not(target_arch = "wasm32"))]
 use serde::{de::DeserializeOwned, Serialize};
@@ -240,8 +239,7 @@ pub fn get_fiber_config<P: AsRef<Path>>(base_dir: P, node_name: Option<&str>) ->
 
 // Mock function to create a dummy EcdsaSignature
 pub fn mock_ecdsa_signature() -> EcdsaSignature {
-    let mut rng = OsRng;
-    let (secret_key, _public_key) = SECP256K1.generate_keypair(&mut rng);
+    let (secret_key, _public_key) = gen_rand_secp256k1_keypair_tuple();
     let message = Message::from_digest_slice(&[0u8; 32]).expect("32 bytes");
     let signature = SECP256K1.sign_ecdsa(&message, &secret_key);
     EcdsaSignature(signature)
@@ -375,11 +373,7 @@ impl NetworkNodeConfigBuilder {
 
         // generate a random string as db name to avoid conflict
         // when build multiple nodes in the same NetworkNodeConfig
-        let rand_name: String = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(5)
-            .map(char::from)
-            .collect();
+        let rand_name: String = Alphanumeric.sample_string(&mut rand::rng(), 5);
         let rand_db_dir = Path::new(base_dir.to_str()).join(rand_name);
         let store = open_store(rand_db_dir).expect("create store");
         let fiber_config = get_fiber_config(base_dir.as_ref(), node_name.as_deref());

--- a/crates/fiber-lib/src/utils/encrypt_decrypt_file.rs
+++ b/crates/fiber-lib/src/utils/encrypt_decrypt_file.rs
@@ -24,8 +24,8 @@ pub fn encrypt_to_file<P: AsRef<Path>>(
 ) -> Result<(), String> {
     let mut salt = [0u8; SALT_LEN];
     let mut nonce = [0u8; NONCE_LEN];
-    rand::thread_rng().fill_bytes(&mut salt);
-    rand::thread_rng().fill_bytes(&mut nonce);
+    rand::rng().fill_bytes(&mut salt);
+    rand::rng().fill_bytes(&mut nonce);
 
     let key = derive_key_from_password(password, &salt);
     let cipher = Aes256Gcm::new(&key);

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -2147,7 +2147,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "ractor",
- "rand 0.8.6",
+ "rand 0.9.4",
  "regex",
  "scrypt",
  "secp256k1 0.30.0",


### PR DESCRIPTION
Upgrade the `rand` crate in fiber-lib from 0.8.5 to 0.9 and migrate all usages to the new APIs:

- `rand::thread_rng()` -> `rand::rng()`
- `Rng::gen()` -> `Rng::random()`
- `Rng::gen_range()` -> `Rng::random_range()`
- `Rng::gen_bool()` -> `Rng::random_bool()`
- `rand::distributions::Alphanumeric` -> `rand::distr::{Alphanumeric, SampleString}` + `sample_string()`
- `SliceRandom::choose` -> `IndexedRandom::choose` (slices), iterator `choose` unchanged

secp256k1 0.30's `Keypair::new`/`generate_keypair` are bound to rand 0.8 traits, so the test helpers now generate secret keys via `SecretKey::from_byte_array` with rejection sampling instead.

Verified: native clippy (`--all-targets --all-features -D warnings`), wasm clippy, `cargo fmt`, and nextest (trampoline/store/invoice suites pass).