### PR TITLE
chore: upgrade to v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,7 +2330,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiber-bin"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ckb-chain-spec",
  "ckb-resource",
@@ -2347,11 +2347,11 @@ dependencies = [
 
 [[package]]
 name = "fiber-json-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-types 0.9.0",
+ "fiber-types 0.9.1",
  "hex",
  "molecule",
  "musig2",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "fiber-store"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "fiber-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arcode",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "fnn"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2622,7 +2622,7 @@ dependencies = [
  "fiber-json-types",
  "fiber-sphinx 3.0.0",
  "fiber-store",
- "fiber-types 0.9.0",
+ "fiber-types 0.9.1",
  "futures",
  "getrandom 0.3.4",
  "git-version",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "fnn-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ckb-jsonrpc-types",

--- a/crates/fiber-bin/Cargo.toml
+++ b/crates/fiber-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiber-bin"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/fiber-cli/Cargo.toml
+++ b/crates/fiber-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnn-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Command-line interface for Fiber Network Node (FNN)"
 

--- a/crates/fiber-cli/README.md
+++ b/crates/fiber-cli/README.md
@@ -72,7 +72,7 @@ $ fnn-cli -u http://54.178.252.1:8227
  | |    _| || |_\| |____| | \ \
  |_|   |___|____/|______|_|  \_\
 
-[  fnn-cli version ]: 0.9.0
+[  fnn-cli version ]: 0.9.1
 [              url ]: http://54.178.252.1:8227
 [    output format ]: yaml
 [           status ]: Connected

--- a/crates/fiber-json-types/Cargo.toml
+++ b/crates/fiber-json-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiber-json-types"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "RPC JSON request/response types for the Fiber Network"
 license = "MIT"
@@ -23,7 +23,7 @@ molecule = "0.9.2"
 schemars = "1"
 
 # Optional: conversion feature deps
-fiber-types = { version = "0.9.0", path = "../fiber-types", optional = true }
+fiber-types = { version = "0.9.1", path = "../fiber-types", optional = true }
 musig2 = { version = "0.2.4", features = ["secp256k1"], optional = true }
 
 [features]

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -2,7 +2,7 @@
 build = "src/build.rs"
 edition = "2021"
 name = "fnn"
-version = "0.9.0"
+version = "0.9.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/fiber-lib/fuzz/Cargo.lock
+++ b/crates/fiber-lib/fuzz/Cargo.lock
@@ -1825,11 +1825,11 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiber-json-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-types 0.9.0",
+ "fiber-types 0.9.1",
  "hex",
  "molecule 0.9.2",
  "musig2",
@@ -1867,13 +1867,13 @@ dependencies = [
 
 [[package]]
 name = "fiber-store"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
  "console_error_panic_hook",
  "fiber-types 0.8.1",
- "fiber-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fiber-types 0.9.0",
  "fiber-wasm-db-common",
  "serde",
  "thiserror 1.0.69",
@@ -1921,6 +1921,42 @@ dependencies = [
 [[package]]
 name = "fiber-types"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5c8d346af3bee9cf465df7035f7afae22fb96811040fe024d8a1e01f06fa54"
+dependencies = [
+ "anyhow",
+ "arcode",
+ "bech32 0.9.1",
+ "bincode 1.3.3",
+ "bitflags 2.10.0",
+ "bs58",
+ "ckb-gen-types",
+ "ckb-hash",
+ "ckb-jsonrpc-types",
+ "ckb-types",
+ "fiber-sphinx 3.0.0",
+ "getrandom 0.2.17",
+ "hex",
+ "molecule 0.9.2",
+ "musig2",
+ "nom",
+ "num_enum",
+ "paste",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "strum 0.26.3",
+ "tentacle-multiaddr",
+ "thiserror 1.0.69",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "fiber-types"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arcode",
@@ -1947,43 +1983,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "strum 0.26.3",
- "tentacle-multiaddr",
- "thiserror 1.0.69",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "fiber-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf751717e38d435851678fd0f28551766f52d4af552d44bc0617b055e941e2f"
-dependencies = [
- "anyhow",
- "arcode",
- "bech32 0.9.1",
- "bincode 1.3.3",
- "bitflags 2.10.0",
- "bs58",
- "ckb-gen-types",
- "ckb-hash",
- "ckb-jsonrpc-types",
- "ckb-types",
- "fiber-sphinx 3.0.0",
- "getrandom 0.2.17",
- "hex",
- "molecule 0.9.2",
- "musig2",
- "nom",
- "num_enum",
- "paste",
- "secp256k1 0.30.0",
- "serde",
- "serde_json",
- "serde_with",
- "sha2 0.10.9",
- "strum 0.26.3",
+ "strum 0.28.0",
  "tentacle-multiaddr",
  "thiserror 1.0.69",
  "tracing",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "fnn"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2045,7 +2045,7 @@ dependencies = [
  "fiber-json-types",
  "fiber-sphinx 3.0.0",
  "fiber-store",
- "fiber-types 0.9.0",
+ "fiber-types 0.9.1",
  "futures",
  "getrandom 0.3.4",
  "git-version",
@@ -2061,7 +2061,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "ractor",
- "rand 0.8.5",
+ "rand 0.9.2",
  "regex",
  "scrypt",
  "secp256k1 0.30.0",
@@ -2069,7 +2069,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "strum 0.26.3",
+ "strum 0.28.0",
  "tentacle",
  "thiserror 1.0.69",
  "tokio",
@@ -5183,6 +5183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5200,6 +5209,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/crates/fiber-store/Cargo.toml
+++ b/crates/fiber-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiber-store"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Key-value store backends and migration framework for Fiber Network"
 build = "build.rs"

--- a/crates/fiber-types/Cargo.toml
+++ b/crates/fiber-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiber-types"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Core domain types for the Fiber Network"
 license = "MIT"

--- a/fiber-js/package.json
+++ b/fiber-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/fiber-js",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "dist/index.js",
   "license": "MIT",
   "devDependencies": {

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -1910,11 +1910,11 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiber-json-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ckb-jsonrpc-types",
  "ckb-types",
- "fiber-types 0.9.0",
+ "fiber-types 0.9.1",
  "hex",
  "molecule",
  "musig2",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "fiber-store"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "fiber-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arcode",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "fnn"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2131,7 +2131,7 @@ dependencies = [
  "fiber-json-types",
  "fiber-sphinx 3.0.0",
  "fiber-store",
- "fiber-types 0.9.0",
+ "fiber-types 0.9.1",
  "futures",
  "getrandom 0.3.4",
  "git-version",

--- a/openrpc-json-generator/src/main.rs
+++ b/openrpc-json-generator/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
         info: Info {
             title: "Fiber Network RPC",
             description: "RPC interface for Fiber Network",
-            version: "0.9.0",
+            version: "0.9.1",
         },
         methods,
         components: generator.into_components(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         },
         "fiber-js": {
             "name": "@nervosnetwork/fiber-js",
-            "version": "0.9.0",
+            "version": "0.9.1",
             "license": "MIT",
             "dependencies": {
                 "async-mutex": "^0.5.0",


### PR DESCRIPTION
Follow up of #1604, bump all crate versions from 0.9.0 to 0.9.1.

Also fixes an incorrect checksum for the registry `fiber-types 0.9.0` entry in `crates/fiber-lib/fuzz/Cargo.lock`, which was hand-edited in the v0.9.0 bump and caused `cargo update` to fail with a checksum mismatch.