### PR TITLE
quic: support listening multiple address

### DIFF
--- a/config/mainnet/config.yml
+++ b/config/mainnet/config.yml
@@ -2,6 +2,9 @@
 # All options' descriptions can be found via `fnn --help` and be overridden by command line arguments or environment variables.
 fiber:
   listening_addr: "/ip4/0.0.0.0/tcp/8228"
+  # Additional listening addresses are appended to listening_addr.
+  # listening_addrs:
+  #   - "/ip6/::/tcp/8228"
   # Node name announced to the Fiber network. It is shown in RPC responses,
   # the TUI header, and the network graph.
   # announced_node_name: "my-fiber-node"

--- a/config/testnet/config.yml
+++ b/config/testnet/config.yml
@@ -2,6 +2,9 @@
 # All options' descriptions can be found via `fnn --help` and be overridden by command line arguments or environment variables.
 fiber:
   listening_addr: "/ip4/0.0.0.0/tcp/8228"
+  # Additional listening addresses are appended to listening_addr.
+  # listening_addrs:
+  #   - "/ip6/::/tcp/8228"
   # Node name announced to the Fiber network. It is shown in RPC responses,
   # the TUI header, and the network graph.
   # announced_node_name: "my-fiber-node"

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -126,6 +126,17 @@ pub struct FiberConfig {
     #[arg(name = "FIBER_LISTENING_ADDR", long = "fiber-listening-addr", env)]
     pub(crate) listening_addr: Option<String>,
 
+    /// additional listening addresses for fiber network, merged with `listening_addr`
+    #[arg(
+        name = "FIBER_LISTENING_ADDRS",
+        long = "fiber-listening-addrs",
+        env,
+        value_parser,
+        num_args = 0..,
+        value_delimiter = ','
+    )]
+    pub(crate) listening_addrs: Vec<String>,
+
     /// whether to announce listening address [default: false]
     #[arg(
         name = "FIBER_ANNOUNCE_LISTENING_ADDR",
@@ -528,6 +539,14 @@ impl FiberConfig {
         self.listening_addr
             .as_deref()
             .unwrap_or(DEFAULT_LISTENING_ADDR)
+    }
+
+    /// Returns the effective listening addresses. The legacy `listening_addr` is always first,
+    /// followed by all entries from `listening_addrs`.
+    pub fn listening_addrs(&self) -> Vec<&str> {
+        std::iter::once(self.listening_addr())
+            .chain(self.listening_addrs.iter().map(String::as_str))
+            .collect()
     }
 
     pub fn announce_listening_addr(&self) -> bool {

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -7323,8 +7323,11 @@ where
 
         #[cfg(not(target_arch = "wasm32"))]
         let listening_addr = {
-            let mut addresses_to_listen = vec![MultiAddr::from_str(config.listening_addr())
-                .expect("valid tentacle listening address")];
+            let mut addresses_to_listen = config
+                .listening_addrs()
+                .into_iter()
+                .map(|addr| MultiAddr::from_str(addr).expect("valid tentacle listening address"))
+                .collect::<Vec<_>>();
             if config.reuse_port_for_websocket {
                 // Re-use the same port for websocket
                 let ws_listens = addresses_to_listen

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -1865,3 +1865,4 @@ The UDT script which is used to identify the UDT configuration for a Fiber Node.
 * `hash_type` - <em>`ScriptHashType`</em>, The hash type of the script.
 * `args` - <em>`String`</em>, The arguments of the script.
 ---
+

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -1865,4 +1865,3 @@ The UDT script which is used to identify the UDT configuration for a Fiber Node.
 * `hash_type` - <em>`ScriptHashType`</em>, The hash type of the script.
 * `args` - <em>`String`</em>, The arguments of the script.
 ---
-

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -2404,6 +2404,42 @@ async fn test_connect_to_other_node() {
 }
 
 #[tokio::test]
+async fn test_connect_to_other_node_on_additional_listening_address() {
+    let mut node_a = NetworkNode::new().await;
+    let mut node_b = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.listening_addr = Some("/ip4/127.0.0.1/tcp/0".to_string());
+                config.listening_addrs = vec!["/ip4/127.0.0.1/tcp/0".to_string()];
+                config.reuse_port_for_websocket = false;
+            })
+            .build(),
+    )
+    .await;
+
+    assert_eq!(node_b.listening_addrs.len(), 2);
+    let peer_addr = node_b.listening_addrs[1].clone();
+
+    call!(node_a.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
+            peer_addr,
+            false,
+            crate::fiber::network::PeerConnectSource::Manual,
+            Some(rpc_reply),
+        ))
+    })
+    .expect("node is alive")
+    .expect("connect through the additional listening address");
+    node_a
+        .expect_event(|event| {
+            matches!(event, NetworkServiceEvent::PeerConnected(pubkey, _) if pubkey == &node_b.pubkey)
+        })
+        .await;
+    node_a.expect_debug_event("PeerInit").await;
+    node_b.expect_debug_event("PeerInit").await;
+}
+
+#[tokio::test]
 async fn test_restart_network_node() {
     let mut node = NetworkNode::new().await;
     node.restart().await;


### PR DESCRIPTION
## What this PR does

Add support for listening on multiple Fiber network addresses.

A new `fiber.listening_addrs` configuration option is introduced. Its entries are appended to the existing `fiber.listening_addr` value to form the final list of listening addresses.

Existing configurations remain fully backward compatible.

## Configuration

```yaml
fiber:
  listening_addr: "/ip4/0.0.0.0/tcp/8228"

  # Additional listening addresses are appended to listening_addr.
  listening_addrs:
    - "/ip6/::/tcp/8228"
```

The effective listening-address list is:

```text
/ip4/0.0.0.0/tcp/8228
/ip6/::/tcp/8228
```

The option can also be supplied through the CLI or environment variable as a comma-separated list.

## Implementation

- Add `FiberConfig::listening_addrs: Vec<String>`.
- Add a helper that merges the legacy `listening_addr` with the additional addresses.
- Start a Tentacle listener for every effective address.
- Preserve the existing WebSocket port-reuse behavior for each TCP address.
- Document the new option in the mainnet and testnet example configurations.
- Add an integration test that connects to a Fiber node through its second listening address.

## Compatibility

- `fiber.listening_addr` is unchanged and remains the primary listening address.
- When `fiber.listening_addrs` is empty, behavior is identical to previous versions.
- No database migration or RPC API change is required.

## Tests

- `cargo check --locked -p fnn -p fiber-bin`
- `cargo nextest run -p fnn -p fiber-bin -E 'test(test_connect_to_other_node_on_additional_listening_address)'`
- `cargo clippy --all-targets --all-features -p fnn -p fiber-bin -- -D warnings`
- `cargo fmt --all -- --check`