### PR TITLE
quic: initial QUIC support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -186,6 +186,45 @@ name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "async-iterator"
@@ -831,7 +870,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -841,7 +891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1645,6 +1695,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,7 +1847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1968,6 +2027,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2248,7 +2321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2367,7 +2440,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ef0454b7ac3e87de49cab71ef0f27f716d00974cedb1b00426ab7b822212d8"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "hmac 0.12.1",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
@@ -2380,7 +2453,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827476eed3d2915d79c9809e71a7089f44cde5d9a4fa7c7045cd0f2d5e56fb95"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "hmac 0.12.1",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
@@ -2892,8 +2965,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3686,7 +3762,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4030,7 +4106,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -4178,6 +4254,12 @@ checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -4452,7 +4534,17 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4469,6 +4561,15 @@ checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
  "itoa",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4562,6 +4663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -4718,6 +4828,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -4917,7 +5037,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4929,7 +5049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5257,6 +5377,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5319,7 +5496,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -5341,6 +5518,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.2",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5401,6 +5589,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5416,6 +5610,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5463,6 +5666,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -5668,6 +5884,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5690,7 +5915,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5727,6 +5952,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -6170,7 +6396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -6181,7 +6407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -6193,7 +6419,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -6205,7 +6431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -6596,7 +6822,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6618,7 +6844,11 @@ dependencies = [
  "molecule",
  "nohash-hasher",
  "parking_lot",
+ "quinn",
  "rand 0.8.6",
+ "rcgen",
+ "ring",
+ "rustls",
  "socket2 0.6.4",
  "tentacle-multiaddr",
  "tentacle-secio",
@@ -6631,6 +6861,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "winapi",
+ "x509-parser",
 ]
 
 [[package]]
@@ -7637,7 +7868,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7958,6 +8189,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7977,6 +8225,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,6 +2723,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "socket2 0.6.4",
  "strum 0.28.0",
  "tempfile",
  "tentacle",

--- a/config/mainnet/config.yml
+++ b/config/mainnet/config.yml
@@ -2,10 +2,14 @@
 # All options' descriptions can be found via `fnn --help` and be overridden by command line arguments or environment variables.
 fiber:
   listening_addr: "/ip4/0.0.0.0/tcp/8228"
-  # Additional listening addresses are appended to listening_addr.
+  # Additional listening addresses are appended to listening_addr. Comment out `listening_addr`
+  # above if you want these to be the only listeners (the default TCP listener is then not added).
+  # Every entry must use a distinct transport/port combination.
   # listening_addrs:
   #   - "/ip6/::/tcp/8228"
   #   - "/ip4/0.0.0.0/udp/8228/quic-v1"
+  # Note: QUIC runs over UDP and cannot be routed through `proxy.proxy_url` below. When a proxy is
+  # configured, outbound QUIC is refused and QUIC addresses are not announced.
   # Node name announced to the Fiber network. It is shown in RPC responses,
   # the TUI header, and the network graph.
   # announced_node_name: "my-fiber-node"

--- a/config/mainnet/config.yml
+++ b/config/mainnet/config.yml
@@ -5,6 +5,7 @@ fiber:
   # Additional listening addresses are appended to listening_addr.
   # listening_addrs:
   #   - "/ip6/::/tcp/8228"
+  #   - "/ip4/0.0.0.0/udp/8228/quic-v1"
   # Node name announced to the Fiber network. It is shown in RPC responses,
   # the TUI header, and the network graph.
   # announced_node_name: "my-fiber-node"
@@ -18,6 +19,7 @@ fiber:
     # If you want to announce your fiber node public address to the network, you need to add the address here.
     # Please change the ip to your public ip accordingly, and make sure the port is open and reachable from the internet.
     # - "/ip4/YOUR-FIBER-NODE-PUBLIC-IP/tcp/8228"
+    # - "/ip4/YOUR-FIBER-NODE-PUBLIC-IP/udp/8228/quic-v1"
   chain: mainnet
 
   ## SOCKS5 proxy settings

--- a/config/mainnet/config.yml
+++ b/config/mainnet/config.yml
@@ -2,6 +2,9 @@
 # All options' descriptions can be found via `fnn --help` and be overridden by command line arguments or environment variables.
 fiber:
   listening_addr: "/ip4/0.0.0.0/tcp/8228"
+  # Additional listening addresses are appended to listening_addr.
+  # listening_addrs:
+  #   - "/ip6/::/tcp/8228"
   # Node name announced to the Fiber network. It is shown in RPC responses,
   # the TUI header, and the network graph.
   # announced_node_name: "my-fiber-node"

--- a/config/testnet/config.yml
+++ b/config/testnet/config.yml
@@ -2,10 +2,14 @@
 # All options' descriptions can be found via `fnn --help` and be overridden by command line arguments or environment variables.
 fiber:
   listening_addr: "/ip4/0.0.0.0/tcp/8228"
-  # Additional listening addresses are appended to listening_addr.
+  # Additional listening addresses are appended to listening_addr. Comment out `listening_addr`
+  # above if you want these to be the only listeners (the default TCP listener is then not added).
+  # Every entry must use a distinct transport/port combination.
   # listening_addrs:
   #   - "/ip6/::/tcp/8228"
   #   - "/ip4/0.0.0.0/udp/8228/quic-v1"
+  # Note: QUIC runs over UDP and cannot be routed through `proxy.proxy_url` below. When a proxy is
+  # configured, outbound QUIC is refused and QUIC addresses are not announced.
   # Node name announced to the Fiber network. It is shown in RPC responses,
   # the TUI header, and the network graph.
   # announced_node_name: "my-fiber-node"

--- a/config/testnet/config.yml
+++ b/config/testnet/config.yml
@@ -5,6 +5,7 @@ fiber:
   # Additional listening addresses are appended to listening_addr.
   # listening_addrs:
   #   - "/ip6/::/tcp/8228"
+  #   - "/ip4/0.0.0.0/udp/8228/quic-v1"
   # Node name announced to the Fiber network. It is shown in RPC responses,
   # the TUI header, and the network graph.
   # announced_node_name: "my-fiber-node"
@@ -17,6 +18,7 @@ fiber:
   announced_addrs:
     # If you want to announce your fiber node public address to the network, you need to add the address here, please change the ip to your public ip accordingly.
     # - "/ip4/YOUR-FIBER-NODE-PUBLIC-IP/tcp/8228"
+    # - "/ip4/YOUR-FIBER-NODE-PUBLIC-IP/udp/8228/quic-v1"
   chain: testnet
 
   ## SOCKS5 proxy settings

--- a/config/testnet/config.yml
+++ b/config/testnet/config.yml
@@ -2,6 +2,9 @@
 # All options' descriptions can be found via `fnn --help` and be overridden by command line arguments or environment variables.
 fiber:
   listening_addr: "/ip4/0.0.0.0/tcp/8228"
+  # Additional listening addresses are appended to listening_addr.
+  # listening_addrs:
+  #   - "/ip6/::/tcp/8228"
   # Node name announced to the Fiber network. It is shown in RPC responses,
   # the TUI header, and the network graph.
   # announced_node_name: "my-fiber-node"

--- a/crates/fiber-json-types/src/peer.rs
+++ b/crates/fiber-json-types/src/peer.rs
@@ -15,6 +15,8 @@ pub enum TransportType {
     Ws,
     /// WebSocket Secure transport (e.g. /dns/example.com/tcp/443/wss)
     Wss,
+    /// QUIC v1 transport (e.g. /ip4/1.2.3.4/udp/8228/quic-v1)
+    QuicV1,
 }
 
 /// Parameters for connecting to a peer.

--- a/crates/fiber-json-types/src/peer.rs
+++ b/crates/fiber-json-types/src/peer.rs
@@ -32,8 +32,9 @@ pub struct ConnectPeerParams {
     /// Whether to save the peer address to the peer store.
     pub save: Option<bool>,
     /// Filter addresses by transport type when connecting by pubkey.
-    /// If not specified, the node uses target-specific defaults:
-    /// native builds choose from `tcp` addresses only, while wasm builds choose from `ws`/`wss`.
+    /// If not specified, the node prefers the transport that is native to the current build
+    /// (`tcp` on native builds, `ws`/`wss` on wasm builds) and falls back to any other
+    /// dialable transport published by the peer.
     pub addr_type: Option<TransportType>,
 }
 

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -64,6 +64,8 @@ hyper = { version = "1.5" }
 jsonrpsee = { version = "0.25.1", features = ["client", "server", "macros"] }
 lnd-grpc-tonic-client = "0.3.0"
 tonic = "0.11.0"
+# Used to set IPV6_V6ONLY on tentacle's listening sockets, keep in sync with tentacle's socket2.
+socket2 = "0.6"
 tentacle = { version = "0.7.7", default-features = false, features = [
   "upnp",
   "parking_lot",

--- a/crates/fiber-lib/Cargo.toml
+++ b/crates/fiber-lib/Cargo.toml
@@ -64,13 +64,14 @@ hyper = { version = "1.5" }
 jsonrpsee = { version = "0.25.1", features = ["client", "server", "macros"] }
 lnd-grpc-tonic-client = "0.3.0"
 tonic = "0.11.0"
-tentacle = { version = "0.7", default-features = false, features = [
+tentacle = { version = "0.7.7", default-features = false, features = [
   "upnp",
   "parking_lot",
   "openssl-vendored",
   "tokio-runtime",
   "tokio-timer",
   "ws",
+  "quic",
 ] }
 tokio = { version = "1", features = [
   "io-util",
@@ -104,7 +105,7 @@ jsonrpsee = { version = "0.25.1", features = [
   "server-core",
   "wasm-client",
 ] }
-tentacle = { version = "0.7", default-features = false, features = [
+tentacle = { version = "0.7.7", default-features = false, features = [
   "wasm-timer",
 ] }
 tokio = { version = "1", features = ["io-util", "macros", "rt", "sync"] }

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -126,6 +126,17 @@ pub struct FiberConfig {
     #[arg(name = "FIBER_LISTENING_ADDR", long = "fiber-listening-addr", env)]
     pub(crate) listening_addr: Option<String>,
 
+    /// additional listening addresses for fiber network, merged with `listening_addr`
+    #[arg(
+        name = "FIBER_LISTENING_ADDRS",
+        long = "fiber-listening-addrs",
+        env,
+        value_parser,
+        num_args = 0..,
+        value_delimiter = ','
+    )]
+    pub(crate) listening_addrs: Vec<String>,
+
     /// whether to announce listening address [default: false]
     #[arg(
         name = "FIBER_ANNOUNCE_LISTENING_ADDR",
@@ -528,6 +539,14 @@ impl FiberConfig {
         self.listening_addr
             .as_deref()
             .unwrap_or(DEFAULT_LISTENING_ADDR)
+    }
+
+    /// Returns the effective listening addresses. The legacy `listening_addr` is always first,
+    /// followed by all entries from `listening_addrs`.
+    pub fn listening_addrs(&self) -> Vec<&str> {
+        std::iter::once(self.listening_addr())
+            .chain(self.listening_addrs.iter().map(String::as_str))
+            .collect()
     }
 
     pub fn announce_listening_addr(&self) -> bool {

--- a/crates/fiber-lib/src/fiber/config.rs
+++ b/crates/fiber-lib/src/fiber/config.rs
@@ -126,7 +126,8 @@ pub struct FiberConfig {
     #[arg(name = "FIBER_LISTENING_ADDR", long = "fiber-listening-addr", env)]
     pub(crate) listening_addr: Option<String>,
 
-    /// additional listening addresses for fiber network, merged with `listening_addr`
+    /// additional listening addresses for fiber network, merged with `listening_addr`.
+    /// When `listening_addr` is unset, only these addresses are used (no default TCP listener).
     #[arg(
         name = "FIBER_LISTENING_ADDRS",
         long = "fiber-listening-addrs",
@@ -541,12 +542,27 @@ impl FiberConfig {
             .unwrap_or(DEFAULT_LISTENING_ADDR)
     }
 
-    /// Returns the effective listening addresses. The legacy `listening_addr` is always first,
-    /// followed by all entries from `listening_addrs`.
+    /// Returns the effective listening addresses, in order and without duplicates.
+    ///
+    /// * If `listening_addr` is set explicitly it always comes first, followed by `listening_addrs`.
+    /// * If `listening_addr` is not set but `listening_addrs` is, only `listening_addrs` is used.
+    ///   This makes it possible to opt out of the default TCP listener, e.g. to listen on QUIC only.
+    /// * If neither is set, the default listening address is used.
     pub fn listening_addrs(&self) -> Vec<&str> {
-        std::iter::once(self.listening_addr())
-            .chain(self.listening_addrs.iter().map(String::as_str))
-            .collect()
+        let mut addrs: Vec<&str> = Vec::with_capacity(self.listening_addrs.len() + 1);
+        match self.listening_addr.as_deref() {
+            Some(addr) => addrs.push(addr),
+            // Only fall back to the default listener when no address is configured at all,
+            // otherwise a node could never listen on a non-default transport exclusively.
+            None if self.listening_addrs.is_empty() => addrs.push(DEFAULT_LISTENING_ADDR),
+            None => {}
+        }
+        for addr in self.listening_addrs.iter().map(String::as_str) {
+            if !addrs.contains(&addr) {
+                addrs.push(addr);
+            }
+        }
+        addrs
     }
 
     pub fn announce_listening_addr(&self) -> bool {

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -2558,7 +2558,6 @@ where
                     (saved_peers_to_connect, graph_nodes_to_connect)
                 };
 
-                let mut rng = rand::rng();
                 for (pubkey, addresses) in saved_peers_to_connect {
                     debug!("Peer to connect: {:?}, {:?}", pubkey, addresses);
                     if let Some(peer) = state.peer_session_map.get(&pubkey) {
@@ -2577,16 +2576,14 @@ where
                     }
 
                     // Randomly pick one address to connect
-                    if let Some(addr) = addresses
-                        .iter()
-                        .filter(|addr| outbound_address_allowed(addr, state.outbound_proxy_enabled))
-                        .choose(&mut rng)
+                    if let Some(addr) =
+                        select_outbound_address(addresses, state.outbound_proxy_enabled)
                     {
                         state
                             .network
                             .send_message(NetworkActorMessage::new_command(
                                 NetworkActorCommand::ConnectPeer(
-                                    addr.clone(),
+                                    addr,
                                     false,
                                     PeerConnectSource::Automatic,
                                     None,
@@ -2614,16 +2611,14 @@ where
                     }
 
                     // Randomly pick one address to connect
-                    if let Some(addr) = addresses
-                        .iter()
-                        .filter(|addr| outbound_address_allowed(addr, state.outbound_proxy_enabled))
-                        .choose(&mut rng)
+                    if let Some(addr) =
+                        select_outbound_address(addresses, state.outbound_proxy_enabled)
                     {
                         state
                             .network
                             .send_message(NetworkActorMessage::new_command(
                                 NetworkActorCommand::ConnectPeer(
-                                    addr.clone(),
+                                    addr,
                                     false,
                                     PeerConnectSource::Automatic,
                                     None,
@@ -7284,6 +7279,12 @@ where
             (None, None)
         };
 
+        // Resolve the listening addresses before building the service: an invalid address must
+        // abort startup with a readable error instead of panicking, and the socket options below
+        // are derived from the complete address set.
+        #[cfg(not(target_arch = "wasm32"))]
+        let addresses_to_listen = resolve_listening_addresses(&config)?;
+
         // Build service with or without gossip protocol based on configuration
         #[cfg(not(target_arch = "wasm32"))]
         let mut service = {
@@ -7293,6 +7294,20 @@ where
                 .quic_config(tentacle::quic::config::QuicConfig::default());
             if let Some(gossip_handle) = gossip_handle_opt {
                 builder = builder.insert_protocol(gossip_handle.create_meta());
+            }
+
+            // On dual stack hosts an IPv6 wildcard listener also accepts IPv4 traffic, so binding
+            // both `/ip4/0.0.0.0/tcp/P` and `/ip6/::/tcp/P` fails with `EADDRINUSE`. Restrict the
+            // IPv6 socket to IPv6 whenever the same port is also served by an IPv4 listener.
+            let ipv6_only_ports = dual_stack_conflicting_ports(&addresses_to_listen);
+            if !ipv6_only_ports.is_empty() {
+                info!(
+                    "Setting IPV6_V6ONLY on IPv6 listeners for ports {:?} because the same ports are also served by IPv4 listeners",
+                    ipv6_only_ports
+                );
+                builder = builder.tcp_config(move |socket, context| {
+                    set_ipv6_only_for_listener(socket, context, &ipv6_only_ports)
+                });
             }
 
             // Set SOCKS5 proxy config
@@ -7345,30 +7360,11 @@ where
 
         #[cfg(not(target_arch = "wasm32"))]
         let listening_addr = {
-            let mut addresses_to_listen = config
-                .listening_addrs()
-                .into_iter()
-                .map(|addr| MultiAddr::from_str(addr).expect("valid tentacle listening address"))
-                .collect::<Vec<_>>();
-            if config.reuse_port_for_websocket {
-                // Re-use the same port for websocket
-                let ws_listens = addresses_to_listen
-                    .iter()
-                    .cloned()
-                    .filter_map(|mut addr| {
-                        if matches!(find_type(&addr), TransportType::Tcp) {
-                            addr.push(Protocol::Ws);
-                            Some(addr)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                addresses_to_listen.extend(ws_listens);
-            }
             let mut listening_addr = vec![];
             for addr in addresses_to_listen.into_iter() {
-                let mut current_addr = service.listen(addr).await.expect("listen tentacle");
+                let mut current_addr = service.listen(addr.clone()).await.map_err(|err| {
+                    anyhow::anyhow!("Failed to listen on configured address {addr}: {err}")
+                })?;
 
                 current_addr.push(Protocol::P2P(Cow::Owned(my_peer_id.clone().into_bytes())));
                 if config.announce_listening_addr() {
@@ -7410,6 +7406,35 @@ where
 
         if !config.announce_private_addr.unwrap_or_default() {
             announced_addrs.retain(crate::utils::is_addr_reachable);
+        }
+
+        // A SOCKS5 proxy is normally configured to hide the node's real network location, but a
+        // QUIC listener bypasses it: it binds UDP directly and would advertise the real address to
+        // the whole network. Outbound QUIC is already refused in this case, so announcing a QUIC
+        // address would only leak the node location without being usable by proxied peers.
+        #[cfg(not(target_arch = "wasm32"))]
+        if config.proxy.proxy_url.is_some() {
+            announced_addrs.retain(|addr| {
+                let is_quic = find_type(addr) == TransportType::QuicV1;
+                if is_quic {
+                    warn!(
+                        "Not announcing QUIC address {} because proxy.proxy_url is configured: \
+                        announcing it would disclose the real node address that the proxy hides",
+                        addr
+                    );
+                }
+                !is_quic
+            });
+            if listening_addr
+                .iter()
+                .any(|addr| find_type(addr) == TransportType::QuicV1)
+            {
+                warn!(
+                    "A QUIC listener is configured together with proxy.proxy_url. Inbound QUIC \
+                    connections bypass the SOCKS5 proxy and expose the real node address; remove \
+                    the QUIC entry from listening_addrs if the proxy is used for privacy"
+                );
+            }
         }
 
         // Start Tor onion hidden service if configured
@@ -8002,6 +8027,112 @@ pub(crate) fn find_type(addr: &Multiaddr) -> TransportType {
     tentacle::utils::find_type(addr)
 }
 
+/// Parse and validate the configured listening addresses.
+///
+/// Duplicated entries are dropped so that an address is never listened on (and announced) twice,
+/// and the websocket companion listeners are appended here when `reuse_port_for_websocket` is on.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn resolve_listening_addresses(
+    config: &FiberConfig,
+) -> Result<Vec<MultiAddr>, anyhow::Error> {
+    let mut addresses: Vec<MultiAddr> = Vec::new();
+    for addr in config.listening_addrs() {
+        let parsed = MultiAddr::from_str(addr).map_err(|err| {
+            anyhow::anyhow!("Invalid listening address {addr:?} in config: {err}")
+        })?;
+        if !addresses.contains(&parsed) {
+            addresses.push(parsed);
+        }
+    }
+
+    if config.reuse_port_for_websocket {
+        // Re-use the same port for websocket
+        let ws_listens = addresses
+            .iter()
+            .cloned()
+            .filter_map(|mut addr| {
+                if matches!(find_type(&addr), TransportType::Tcp) {
+                    addr.push(Protocol::Ws);
+                    Some(addr)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        addresses.extend(ws_listens);
+    }
+
+    Ok(addresses)
+}
+
+/// Returns the TCP ports that are served by both an IPv4 and an IPv6 listener.
+///
+/// Binding an IPv6 wildcard socket on a dual stack host implicitly covers the IPv4 space, so such
+/// ports need `IPV6_V6ONLY` to keep both listeners working. Port `0` is excluded because the
+/// kernel picks a distinct random port for every socket.
+#[cfg(not(target_arch = "wasm32"))]
+fn dual_stack_conflicting_ports(addresses: &[MultiAddr]) -> HashSet<u16> {
+    let mut ipv4_ports = HashSet::new();
+    let mut ipv6_ports = HashSet::new();
+    for addr in addresses {
+        // Only TCP listeners share the socket transformer, QUIC listeners bind their own UDP
+        // endpoint which tentacle does not expose for configuration.
+        let Some(socket_addr) = tentacle::utils::multiaddr_to_socketaddr(addr) else {
+            continue;
+        };
+        if socket_addr.port() == 0 {
+            continue;
+        }
+        match socket_addr.ip() {
+            std::net::IpAddr::V4(_) => ipv4_ports.insert(socket_addr.port()),
+            std::net::IpAddr::V6(_) => ipv6_ports.insert(socket_addr.port()),
+        };
+    }
+    ipv6_ports
+        .intersection(&ipv4_ports)
+        .copied()
+        .collect::<HashSet<_>>()
+}
+
+/// Socket transformer that sets `IPV6_V6ONLY` on the IPv6 listeners whose port is also bound by an
+/// IPv4 listener. Dial sockets are returned untouched, so proxy and onion dialing are unaffected.
+#[cfg(not(target_arch = "wasm32"))]
+fn set_ipv6_only_for_listener(
+    socket: tentacle::service::TcpSocket,
+    context: tentacle::service::TransformerContext,
+    ipv6_only_ports: &HashSet<u16>,
+) -> std::io::Result<tentacle::service::TcpSocket> {
+    if context.state != tentacle::service::SocketState::Listen
+        || !context.address.is_ipv6()
+        || !ipv6_only_ports.contains(&context.address.port())
+    {
+        return Ok(socket);
+    }
+
+    // safety: the raw handle is immediately re-wrapped and given back to tentacle, and socket2
+    // does not perform any operation other than a `setsockopt` on it.
+    unsafe {
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::{FromRawFd, IntoRawFd};
+            let socket2_socket = socket2::Socket::from_raw_fd(socket.into_raw_fd());
+            socket2_socket.set_only_v6(true)?;
+            Ok(tentacle::service::TcpSocket::from_raw_fd(
+                socket2_socket.into_raw_fd(),
+            ))
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::{FromRawSocket, IntoRawSocket};
+            let socket2_socket = socket2::Socket::from_raw_socket(socket.into_raw_socket());
+            socket2_socket.set_only_v6(true)?;
+            Ok(tentacle::service::TcpSocket::from_raw_socket(
+                socket2_socket.into_raw_socket(),
+            ))
+        }
+    }
+}
+
 pub(crate) fn select_connect_peer_address<I>(
     addresses: I,
     addr_type: Option<TransportType>,
@@ -8010,22 +8141,26 @@ pub(crate) fn select_connect_peer_address<I>(
 where
     I: IntoIterator<Item = Multiaddr>,
 {
-    let mut rng = rand::rng();
-
     match addr_type {
+        // An explicit transport filter is an explicit user request, honour it verbatim.
         Some(transport) => addresses
             .into_iter()
             .filter(|addr| outbound_address_allowed(addr, outbound_proxy_enabled))
             .filter(|addr| find_type(addr) == transport)
-            .choose(&mut rng),
-        None => addresses
-            .into_iter()
-            .filter(|addr| outbound_address_allowed(addr, outbound_proxy_enabled))
-            .filter(target_default_transport_matches)
-            .choose(&mut rng),
+            .choose(&mut rand::rng()),
+        None => select_outbound_address(addresses, outbound_proxy_enabled),
     }
 }
 
+/// Pick an address to dial out of the addresses known for a peer.
+///
+/// This is the single policy shared by every path that dials a peer without an explicit transport
+/// (manual `connect_peer` by pubkey, reconnect backoff, channel maintenance, bootnodes, ...), so
+/// that automatic and manual connections never disagree on which transports are usable.
+///
+/// The transport preferred by the current target is used whenever the peer publishes one, and any
+/// other dialable transport is used as a fallback. That keeps TCP the default on native builds
+/// while still allowing a peer that only publishes QUIC (or websocket) addresses to be reached.
 pub(crate) fn select_outbound_address<I>(
     addresses: I,
     outbound_proxy_enabled: bool,
@@ -8033,14 +8168,42 @@ pub(crate) fn select_outbound_address<I>(
 where
     I: IntoIterator<Item = Multiaddr>,
 {
-    addresses
+    let mut rng = rand::rng();
+    let candidates = addresses
         .into_iter()
         .filter(|addr| outbound_address_allowed(addr, outbound_proxy_enabled))
-        .choose(&mut rand::rng())
+        .filter(target_can_dial_transport)
+        .collect::<Vec<_>>();
+
+    candidates
+        .iter()
+        .filter(|addr| target_default_transport_matches(addr))
+        .choose(&mut rng)
+        .cloned()
+        .or_else(|| candidates.into_iter().choose(&mut rng))
 }
 
 fn outbound_address_allowed(addr: &Multiaddr, outbound_proxy_enabled: bool) -> bool {
     !outbound_proxy_enabled || find_type(addr) != TransportType::QuicV1
+}
+
+/// Whether the current build is able to dial the transport of `addr` at all.
+#[cfg(target_arch = "wasm32")]
+fn target_can_dial_transport(addr: &Multiaddr) -> bool {
+    // Browsers can only open websocket connections.
+    matches!(find_type(addr), TransportType::Ws | TransportType::Wss)
+}
+
+/// Whether the current build is able to dial the transport of `addr` at all.
+#[cfg(not(target_arch = "wasm32"))]
+fn target_can_dial_transport(addr: &Multiaddr) -> bool {
+    matches!(
+        find_type(addr),
+        TransportType::Tcp | TransportType::Ws | TransportType::Wss | TransportType::QuicV1
+        // Onion dialing additionally requires the onion/proxy configuration, tentacle reports a
+        // dial error when it is missing.
+        | TransportType::Onion
+    )
 }
 
 fn outbound_quic_proxy_error(addr: &Multiaddr) -> String {

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -7323,8 +7323,11 @@ where
 
         #[cfg(not(target_arch = "wasm32"))]
         let listening_addr = {
-            let mut addresses_to_listen = vec![MultiAddr::from_str(config.listening_addr())
-                .expect("valid tentacle listening address")];
+            let mut addresses_to_listen = config
+                .listening_addrs()
+                .into_iter()
+                .map(|addr| MultiAddr::from_str(addr).expect("valid tentacle listening address"))
+                .collect::<Vec<_>>();
             if config.reuse_port_for_websocket {
                 // Re-use the same port for websocket
                 let ws_listens = addresses_to_listen

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -12,7 +12,7 @@ use ractor::concurrency::Duration;
 use ractor::{
     call_t, forward, Actor, ActorCell, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent,
 };
-use rand::seq::{IndexedRandom, IteratorRandom};
+use rand::seq::IteratorRandom;
 use secp256k1::SECP256K1;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -2324,6 +2324,14 @@ where
             NetworkActorCommand::ConnectPeer(addr, save, source, rpc_reply) => {
                 // TODO: It is more than just dialing a peer. We need to exchange capabilities of the peer,
                 // e.g. whether the peer support some specific feature.
+                if !outbound_address_allowed(&addr, state.outbound_proxy_enabled) {
+                    let err = outbound_quic_proxy_error(&addr);
+                    warn!("{}", err);
+                    if let Some(reply) = rpc_reply {
+                        let _ = reply.send(Err(err));
+                    }
+                    return Ok(());
+                }
                 if matches!(source, PeerConnectSource::Manual) {
                     state.resume_peer_auto_reconnect_by_address(&addr);
                 }
@@ -2351,7 +2359,12 @@ where
             NetworkActorCommand::ConnectPeerWithPubkey(pubkey, addr_type, source, reply) => {
                 let addresses = state.get_peer_addresses_by_pubkey(&pubkey);
                 let has_known_addresses = !addresses.is_empty();
-                let address = select_connect_peer_address(addresses, addr_type);
+                if state.outbound_proxy_enabled && addr_type == Some(TransportType::QuicV1) {
+                    let _ = reply.send(Err(outbound_quic_proxy_error_for_peer(&pubkey)));
+                    return Ok(());
+                }
+                let address =
+                    select_connect_peer_address(addresses, addr_type, state.outbound_proxy_enabled);
                 let Some(addr) = address else {
                     let err = if let Some(transport) = addr_type {
                         Error::NoMatchingAddress(pubkey, transport)
@@ -2429,11 +2442,13 @@ where
                 debug_event!(myself, "PeerReconnectBackoffAttempt");
 
                 let addresses = state.get_peer_addresses_by_pubkey(&pubkey);
-                if let Some(addr) = addresses.iter().choose(&mut rand::rng()) {
+                if let Some(addr) =
+                    select_outbound_address(addresses.iter().cloned(), state.outbound_proxy_enabled)
+                {
                     myself
                         .send_message(NetworkActorMessage::new_command(
                             NetworkActorCommand::ConnectPeer(
-                                addr.clone(),
+                                addr,
                                 false,
                                 PeerConnectSource::Automatic,
                                 None,
@@ -2480,11 +2495,14 @@ where
                         &channel_id, &pubkey, &channel_state, &addresses
                     );
 
-                    if let Some(addr) = addresses.iter().choose(&mut rand::rng()) {
+                    if let Some(addr) = select_outbound_address(
+                        addresses.iter().cloned(),
+                        state.outbound_proxy_enabled,
+                    ) {
                         myself
                             .send_message(NetworkActorMessage::new_command(
                                 NetworkActorCommand::ConnectPeer(
-                                    addr.to_owned(),
+                                    addr,
                                     false,
                                     PeerConnectSource::Automatic,
                                     None,
@@ -2559,7 +2577,11 @@ where
                     }
 
                     // Randomly pick one address to connect
-                    if let Some(addr) = addresses.choose(&mut rng) {
+                    if let Some(addr) = addresses
+                        .iter()
+                        .filter(|addr| outbound_address_allowed(addr, state.outbound_proxy_enabled))
+                        .choose(&mut rng)
+                    {
                         state
                             .network
                             .send_message(NetworkActorMessage::new_command(
@@ -2592,7 +2614,11 @@ where
                     }
 
                     // Randomly pick one address to connect
-                    if let Some(addr) = addresses.choose(&mut rng) {
+                    if let Some(addr) = addresses
+                        .iter()
+                        .filter(|addr| outbound_address_allowed(addr, state.outbound_proxy_enabled))
+                        .choose(&mut rng)
+                    {
                         state
                             .network
                             .send_message(NetworkActorMessage::new_command(
@@ -5055,6 +5081,9 @@ pub struct NetworkActorState<S, C> {
     // This immutable attribute is placed here because we need to create it in
     // the pre_start function.
     control: ServiceAsyncControl,
+    // SOCKS5 proxying is currently available only for TCP-based transports.
+    // Keep this policy here so every outbound dial path can fail closed.
+    outbound_proxy_enabled: bool,
     peer_message_policy: Arc<StdMutex<PeerMessagePolicy>>,
     // Cancellation token for the onion service background task.
     #[cfg(not(target_arch = "wasm32"))]
@@ -7268,23 +7297,15 @@ where
 
             // Set SOCKS5 proxy config
             if let Some(proxy_url) = &config.proxy.proxy_url {
-                match super::proxy::check_proxy_url(proxy_url) {
-                    Ok(()) => {
-                        builder = builder
-                            .tcp_proxy_config(proxy_url)
-                            .tcp_proxy_random_auth(config.proxy.proxy_random_auth);
-                        info!(
-                            "Set tcp_proxy_config: {:?}, proxy_random_auth: {}",
-                            proxy_url, config.proxy.proxy_random_auth
-                        );
-                    }
-                    Err(err) => {
-                        error!(
-                            "Invalid proxy_url in config, skipping tcp_proxy_config. proxy_url={:?}, error={}",
-                            proxy_url, err
-                        );
-                    }
-                }
+                super::proxy::check_proxy_url(proxy_url)
+                    .map_err(|err| anyhow::anyhow!("Invalid proxy_url in config: {err}"))?;
+                builder = builder
+                    .tcp_proxy_config(proxy_url)
+                    .tcp_proxy_random_auth(config.proxy.proxy_random_auth);
+                info!(
+                    "Set tcp_proxy_config: {:?}, proxy_random_auth: {}",
+                    proxy_url, config.proxy.proxy_random_auth
+                );
             }
 
             // Set onion proxy config (for .onion address connections via Tor SOCKS5)
@@ -7475,6 +7496,7 @@ where
             default_shutdown_script,
             network: myself.clone(),
             control,
+            outbound_proxy_enabled: config.proxy.proxy_url.is_some(),
             peer_message_policy,
             #[cfg(not(target_arch = "wasm32"))]
             onion_service_token,
@@ -7980,6 +8002,7 @@ pub(crate) fn find_type(addr: &Multiaddr) -> TransportType {
 pub(crate) fn select_connect_peer_address<I>(
     addresses: I,
     addr_type: Option<TransportType>,
+    outbound_proxy_enabled: bool,
 ) -> Option<Multiaddr>
 where
     I: IntoIterator<Item = Multiaddr>,
@@ -7989,13 +8012,44 @@ where
     match addr_type {
         Some(transport) => addresses
             .into_iter()
+            .filter(|addr| outbound_address_allowed(addr, outbound_proxy_enabled))
             .filter(|addr| find_type(addr) == transport)
             .choose(&mut rng),
         None => addresses
             .into_iter()
+            .filter(|addr| outbound_address_allowed(addr, outbound_proxy_enabled))
             .filter(target_default_transport_matches)
             .choose(&mut rng),
     }
+}
+
+pub(crate) fn select_outbound_address<I>(
+    addresses: I,
+    outbound_proxy_enabled: bool,
+) -> Option<Multiaddr>
+where
+    I: IntoIterator<Item = Multiaddr>,
+{
+    addresses
+        .into_iter()
+        .filter(|addr| outbound_address_allowed(addr, outbound_proxy_enabled))
+        .choose(&mut rand::rng())
+}
+
+fn outbound_address_allowed(addr: &Multiaddr, outbound_proxy_enabled: bool) -> bool {
+    !outbound_proxy_enabled || find_type(addr) != TransportType::QuicV1
+}
+
+fn outbound_quic_proxy_error(addr: &Multiaddr) -> String {
+    format!(
+        "outbound QUIC address {addr} is disabled while proxy.proxy_url is configured because the SOCKS5 proxy supports TCP connections only"
+    )
+}
+
+fn outbound_quic_proxy_error_for_peer(pubkey: &Pubkey) -> String {
+    format!(
+        "outbound QUIC connection to peer {pubkey:?} is disabled while proxy.proxy_url is configured because the SOCKS5 proxy supports TCP connections only"
+    )
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -7496,7 +7496,10 @@ where
             default_shutdown_script,
             network: myself.clone(),
             control,
+            #[cfg(not(target_arch = "wasm32"))]
             outbound_proxy_enabled: config.proxy.proxy_url.is_some(),
+            #[cfg(target_arch = "wasm32")]
+            outbound_proxy_enabled: false,
             peer_message_policy,
             #[cfg(not(target_arch = "wasm32"))]
             onion_service_token,

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -7260,7 +7260,8 @@ where
         let mut service = {
             let mut builder = ServiceBuilder::default()
                 .insert_protocol(fiber_handle.create_meta())
-                .handshake_type(secio_kp.into());
+                .handshake_type(secio_kp.into())
+                .quic_config(tentacle::quic::config::QuicConfig::default());
             if let Some(gossip_handle) = gossip_handle_opt {
                 builder = builder.insert_protocol(gossip_handle.create_meta());
             }
@@ -7973,15 +7974,7 @@ pub async fn start_network<
 }
 
 pub(crate) fn find_type(addr: &Multiaddr) -> TransportType {
-    let mut iter = addr.iter();
-
-    iter.find_map(|proto| match proto {
-        Protocol::Ws => Some(TransportType::Ws),
-        Protocol::Wss => Some(TransportType::Wss),
-        Protocol::Onion3(_) => Some(TransportType::Onion),
-        _ => None,
-    })
-    .unwrap_or(TransportType::Tcp)
+    tentacle::utils::find_type(addr)
 }
 
 pub(crate) fn select_connect_peer_address<I>(

--- a/crates/fiber-lib/src/fiber/proxy.rs
+++ b/crates/fiber-lib/src/fiber/proxy.rs
@@ -7,7 +7,10 @@ pub struct ProxyConfig {
     /// SOCKS5 proxy URL for outbound Fiber TCP connections.
     ///
     /// Outbound QUIC is disabled when this option is set because QUIC uses UDP and is not
-    /// supported by the proxy transport. Inbound QUIC listeners remain available.
+    /// supported by the proxy transport. QUIC addresses are also excluded from the announced
+    /// addresses, since advertising them would disclose the very network location the proxy is
+    /// meant to hide. Inbound QUIC listeners remain available but bypass the proxy, so the node
+    /// logs a warning when one is configured together with this option.
     /// Example: socks5://username:password@127.0.0.1:1080
     pub proxy_url: Option<String>,
 

--- a/crates/fiber-lib/src/fiber/proxy.rs
+++ b/crates/fiber-lib/src/fiber/proxy.rs
@@ -4,7 +4,11 @@ use url::Url;
 /// SOCKS5 proxy configuration
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProxyConfig {
-    /// Socks5 proxy URL for fiber. e.g. socks5://username:password@127.0.0.1:1080
+    /// SOCKS5 proxy URL for outbound Fiber TCP connections.
+    ///
+    /// Outbound QUIC is disabled when this option is set because QUIC uses UDP and is not
+    /// supported by the proxy transport. Inbound QUIC listeners remain available.
+    /// Example: socks5://username:password@127.0.0.1:1080
     pub proxy_url: Option<String>,
 
     /// Use random auth for each proxy connection [default: true]

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -13,7 +13,10 @@ use crate::{
         CkbChainMessage, CkbTxTracingResult,
     },
     fiber::{
-        config::{DEFAULT_AUTO_ACCEPT_CHANNEL_CKB_FUNDING_AMOUNT, DEFAULT_TLC_EXPIRY_DELTA},
+        config::{
+            FiberConfig, DEFAULT_AUTO_ACCEPT_CHANNEL_CKB_FUNDING_AMOUNT, DEFAULT_LISTENING_ADDR,
+            DEFAULT_TLC_EXPIRY_DELTA,
+        },
         gossip::{GossipActorMessage, GossipMessageStore},
         graph::ChannelUpdateInfo,
         network::{
@@ -595,6 +598,142 @@ fn test_automatic_address_selection_rejects_quic_with_proxy() {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
+fn test_outbound_address_selection_prefers_default_transport_on_native() {
+    let tcp = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8346").expect("valid tcp multiaddr");
+    let quic = Multiaddr::from_str("/ip4/1.1.1.1/udp/8346/quic-v1").expect("valid QUIC multiaddr");
+    let ws = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8347/ws").expect("valid ws multiaddr");
+
+    // TCP wins whenever the peer publishes one.
+    assert_eq!(
+        select_outbound_address(vec![quic.clone(), ws.clone(), tcp.clone()], false),
+        Some(tcp.clone())
+    );
+    // The manual `connect_peer` path without an explicit transport uses the very same policy.
+    assert_eq!(
+        select_connect_peer_address(vec![quic, ws, tcp.clone()], None, false),
+        Some(tcp)
+    );
+}
+
+/// A peer that only publishes non-default (but dialable) transports must still be reachable,
+/// and the automatic and manual dial paths must agree about it.
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_outbound_address_selection_falls_back_to_other_transports() {
+    let quic = Multiaddr::from_str("/ip4/1.1.1.1/udp/8346/quic-v1").expect("valid QUIC multiaddr");
+    let ws = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8347/ws").expect("valid ws multiaddr");
+
+    assert_eq!(
+        select_outbound_address(vec![quic.clone()], false),
+        Some(quic.clone())
+    );
+    assert_eq!(
+        select_connect_peer_address(vec![quic.clone()], None, false),
+        Some(quic)
+    );
+    assert_eq!(
+        select_connect_peer_address(vec![ws.clone()], None, false),
+        Some(ws)
+    );
+}
+
+/// Both dial paths must skip transports the current build cannot dial at all.
+#[cfg(target_arch = "wasm32")]
+#[test]
+fn test_outbound_address_selection_skips_undialable_transports_on_wasm() {
+    let tcp = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8346").expect("valid tcp multiaddr");
+    let quic = Multiaddr::from_str("/ip4/1.1.1.1/udp/8346/quic-v1").expect("valid QUIC multiaddr");
+    let ws = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8347/ws").expect("valid ws multiaddr");
+
+    assert_eq!(
+        select_outbound_address(vec![tcp.clone(), quic.clone(), ws.clone()], false),
+        Some(ws)
+    );
+    assert_eq!(select_outbound_address(vec![tcp, quic], false), None);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_resolve_listening_addresses_deduplicates_and_appends_websocket() {
+    use crate::fiber::network::resolve_listening_addresses;
+
+    let mut config = FiberConfig {
+        listening_addr: Some("/ip4/0.0.0.0/tcp/8228".to_string()),
+        listening_addrs: vec![
+            // Duplicated on purpose, it must not produce a second listener.
+            "/ip4/0.0.0.0/tcp/8228".to_string(),
+            "/ip4/0.0.0.0/udp/8228/quic-v1".to_string(),
+        ],
+        reuse_port_for_websocket: false,
+        ..Default::default()
+    };
+
+    let addresses = resolve_listening_addresses(&config).expect("valid listening addresses");
+    assert_eq!(
+        addresses,
+        vec![
+            Multiaddr::from_str("/ip4/0.0.0.0/tcp/8228").unwrap(),
+            Multiaddr::from_str("/ip4/0.0.0.0/udp/8228/quic-v1").unwrap(),
+        ]
+    );
+
+    // Only the TCP listener gets a websocket companion, QUIC is left alone.
+    config.reuse_port_for_websocket = true;
+    let addresses = resolve_listening_addresses(&config).expect("valid listening addresses");
+    assert_eq!(
+        addresses,
+        vec![
+            Multiaddr::from_str("/ip4/0.0.0.0/tcp/8228").unwrap(),
+            Multiaddr::from_str("/ip4/0.0.0.0/udp/8228/quic-v1").unwrap(),
+            Multiaddr::from_str("/ip4/0.0.0.0/tcp/8228/ws").unwrap(),
+        ]
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_resolve_listening_addresses_reports_invalid_address() {
+    use crate::fiber::network::resolve_listening_addresses;
+
+    let config = FiberConfig {
+        listening_addr: Some("not-a-multiaddr".to_string()),
+        ..Default::default()
+    };
+
+    let err = resolve_listening_addresses(&config).expect_err("invalid address must be rejected");
+    assert!(
+        err.to_string().contains("Invalid listening address"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `listening_addr` must not be forced into the listener set when the operator only configured
+/// `listening_addrs`, otherwise a QUIC-only (or websocket-only) node is impossible.
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_listening_addrs_allows_opting_out_of_the_default_listener() {
+    let mut config = FiberConfig {
+        reuse_port_for_websocket: false,
+        ..Default::default()
+    };
+
+    assert_eq!(config.listening_addrs(), vec![DEFAULT_LISTENING_ADDR]);
+
+    config.listening_addrs = vec!["/ip4/0.0.0.0/udp/8228/quic-v1".to_string()];
+    assert_eq!(
+        config.listening_addrs(),
+        vec!["/ip4/0.0.0.0/udp/8228/quic-v1"]
+    );
+
+    config.listening_addr = Some("/ip4/0.0.0.0/tcp/8228".to_string());
+    assert_eq!(
+        config.listening_addrs(),
+        vec!["/ip4/0.0.0.0/tcp/8228", "/ip4/0.0.0.0/udp/8228/quic-v1"]
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
 fn test_send_payment_data_trampoline_hops_validation_errors() {
     let target = gen_rand_fiber_public_key();
     let payment_hash = gen_rand_sha256_hash();
@@ -777,6 +916,49 @@ async fn test_public_quic_announced_address_is_saved_to_graph() {
     assert_eq!(nodes.len(), 1);
     assert_eq!(nodes[0].node_id, node.get_public_key());
     assert!(nodes[0].addresses.contains(&expected_addr));
+}
+
+/// A SOCKS5 proxy hides the real node location, but QUIC bypasses it. Announcing a QUIC address
+/// would therefore disclose exactly what the proxy is supposed to hide, while being unusable for
+/// proxied peers anyway.
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_quic_announced_address_is_dropped_when_proxy_is_configured() {
+    let quic_addr = "/ip4/1.1.1.1/udp/8346/quic-v1".to_string();
+    let tcp_addr = "/ip4/1.1.1.1/tcp/8346".to_string();
+    let announced_addrs = vec![quic_addr.clone(), tcp_addr.clone()];
+    let mut node = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(move |config| {
+                config.announce_listening_addr = Some(false);
+                config.announce_private_addr = Some(false);
+                config.announced_addrs = announced_addrs;
+                config.proxy.proxy_url = Some("socks5://127.0.0.1:65535".to_string());
+            })
+            .build(),
+    )
+    .await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    node.stop().await;
+
+    let peer_id = PeerId::from_public_key(&crate::fiber::types::pubkey_to_tentacle(node.pubkey));
+    let quic_addr = Multiaddr::from_str(&format!("{quic_addr}/p2p/{peer_id}"))
+        .expect("valid announced QUIC multiaddr");
+    let tcp_addr = Multiaddr::from_str(&format!("{tcp_addr}/p2p/{peer_id}"))
+        .expect("valid announced tcp multiaddr");
+    let nodes = node.get_network_graph_nodes().await;
+
+    assert_eq!(nodes.len(), 1);
+    assert!(
+        !nodes[0].addresses.contains(&quic_addr),
+        "QUIC address must not be announced while a proxy is configured: {:?}",
+        nodes[0].addresses
+    );
+    assert!(
+        nodes[0].addresses.contains(&tcp_addr),
+        "proxyable addresses must still be announced: {:?}",
+        nodes[0].addresses
+    );
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -17,8 +17,9 @@ use crate::{
         gossip::{GossipActorMessage, GossipMessageStore},
         graph::ChannelUpdateInfo,
         network::{
-            select_connect_peer_address, AcceptChannelCommand, DebugEvent, FiberMessageWithTarget,
-            NetworkActorStateStore, OpenChannelCommand, PeerDisconnectReason, TestFiberMessageKind,
+            select_connect_peer_address, select_outbound_address, AcceptChannelCommand, DebugEvent,
+            FiberMessageWithTarget, NetworkActorStateStore, OpenChannelCommand,
+            PeerDisconnectReason, TestFiberMessageKind,
         },
         payment::{SendPaymentCommand, SendPaymentDataExt},
         types::{
@@ -520,7 +521,7 @@ fn test_select_connect_peer_address_by_quic_transport() {
 
     assert_eq!(tentacle::utils::find_type(&quic), TransportType::QuicV1);
     assert_eq!(
-        select_connect_peer_address(vec![tcp, quic.clone()], Some(TransportType::QuicV1)),
+        select_connect_peer_address(vec![tcp, quic.clone()], Some(TransportType::QuicV1), false,),
         Some(quic)
     );
 }
@@ -531,7 +532,8 @@ fn test_select_connect_peer_address_respects_explicit_transport_filter() {
     let ws = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8347/ws").expect("valid ws multiaddr");
     let wss = build_ws_multiaddr(true);
 
-    let selected = select_connect_peer_address(vec![tcp, ws.clone(), wss], Some(TransportType::Ws));
+    let selected =
+        select_connect_peer_address(vec![tcp, ws.clone(), wss], Some(TransportType::Ws), false);
 
     assert_eq!(selected, Some(ws));
 }
@@ -543,7 +545,7 @@ fn test_select_connect_peer_address_defaults_to_tcp_on_native() {
     let ws = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8347/ws").expect("valid ws multiaddr");
     let wss = build_ws_multiaddr(true);
 
-    let selected = select_connect_peer_address(vec![tcp.clone(), ws, wss], None);
+    let selected = select_connect_peer_address(vec![tcp.clone(), ws, wss], None, false);
 
     assert_eq!(selected, Some(tcp));
 }
@@ -555,9 +557,40 @@ fn test_select_connect_peer_address_defaults_to_websocket_on_wasm() {
     let ws = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8347/ws").expect("valid ws multiaddr");
     let wss = build_ws_multiaddr(true);
 
-    let selected = select_connect_peer_address(vec![tcp, ws.clone(), wss.clone()], None);
+    let selected = select_connect_peer_address(vec![tcp, ws.clone(), wss.clone()], None, false);
 
     assert!(matches!(selected, Some(addr) if addr == ws || addr == wss));
+}
+
+#[test]
+fn test_select_connect_peer_address_rejects_quic_with_proxy() {
+    let tcp = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8346").expect("valid tcp multiaddr");
+    let quic = Multiaddr::from_str("/ip4/1.1.1.1/udp/8346/quic-v1").expect("valid QUIC multiaddr");
+
+    assert_eq!(
+        select_connect_peer_address(
+            vec![tcp.clone(), quic.clone()],
+            Some(TransportType::Tcp),
+            true,
+        ),
+        Some(tcp)
+    );
+    assert_eq!(
+        select_connect_peer_address(vec![quic], Some(TransportType::QuicV1), true),
+        None
+    );
+}
+
+#[test]
+fn test_automatic_address_selection_rejects_quic_with_proxy() {
+    let tcp = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8346").expect("valid tcp multiaddr");
+    let quic = Multiaddr::from_str("/ip4/1.1.1.1/udp/8346/quic-v1").expect("valid QUIC multiaddr");
+
+    assert_eq!(
+        select_outbound_address(vec![quic.clone(), tcp.clone()], true),
+        Some(tcp)
+    );
+    assert_eq!(select_outbound_address(vec![quic], true), None);
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -720,6 +720,33 @@ async fn test_set_announced_addrs_without_p2p() {
 }
 
 #[tokio::test]
+async fn test_public_quic_announced_address_is_saved_to_graph() {
+    let addr = "/ip4/1.1.1.1/udp/8346/quic-v1".to_string();
+    let announced_addr = addr.clone();
+    let mut node = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(move |config| {
+                config.announce_listening_addr = Some(false);
+                config.announce_private_addr = Some(false);
+                config.announced_addrs = vec![announced_addr];
+            })
+            .build(),
+    )
+    .await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    node.stop().await;
+
+    let peer_id = PeerId::from_public_key(&crate::fiber::types::pubkey_to_tentacle(node.pubkey));
+    let expected_addr = Multiaddr::from_str(&format!("{addr}/p2p/{peer_id}"))
+        .expect("valid announced QUIC multiaddr");
+    let nodes = node.get_network_graph_nodes().await;
+
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes[0].node_id, node.get_public_key());
+    assert!(nodes[0].addresses.contains(&expected_addr));
+}
+
+#[tokio::test]
 async fn test_sync_channel_announcement_on_startup() {
     init_tracing();
 

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -514,6 +514,18 @@ fn build_ws_multiaddr(use_wss: bool) -> Multiaddr {
 }
 
 #[test]
+fn test_select_connect_peer_address_by_quic_transport() {
+    let tcp = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8346").expect("valid tcp multiaddr");
+    let quic = Multiaddr::from_str("/ip4/1.1.1.1/udp/8346/quic-v1").expect("valid QUIC multiaddr");
+
+    assert_eq!(tentacle::utils::find_type(&quic), TransportType::QuicV1);
+    assert_eq!(
+        select_connect_peer_address(vec![tcp, quic.clone()], Some(TransportType::QuicV1)),
+        Some(quic)
+    );
+}
+
+#[test]
 fn test_select_connect_peer_address_respects_explicit_transport_filter() {
     let tcp = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8346").expect("valid tcp multiaddr");
     let ws = Multiaddr::from_str("/ip4/1.1.1.1/tcp/8347/ws").expect("valid ws multiaddr");

--- a/crates/fiber-lib/src/fiber/tests/peer_reconnect_stress.rs
+++ b/crates/fiber-lib/src/fiber/tests/peer_reconnect_stress.rs
@@ -144,7 +144,7 @@ async fn exercise_peer_reconnects(
 ) -> (NetworkNode, usize) {
     let reconnect_deadline = Instant::now() + duration;
     let node_c_pubkey = node_c.pubkey;
-    let node_c_addr = node_c.listening_addrs[0].clone();
+    let node_c_addr = node_c.announced_addrs[0].clone();
     let mut reconnect_cycles = 0;
 
     while Instant::now() < reconnect_deadline {

--- a/crates/fiber-lib/src/fiber/tests/utils.rs
+++ b/crates/fiber-lib/src/fiber/tests/utils.rs
@@ -88,6 +88,39 @@ fn test_is_addr_reachable_with_private_ipv6_quic_address() {
 }
 
 #[test]
+fn test_is_addr_reachable_rejects_bare_ipv4_udp_address() {
+    let bare_udp_addr =
+        Multiaddr::from_str("/ip4/1.1.1.1/udp/8228").expect("valid bare IPv4 UDP multiaddr");
+
+    assert!(
+        !is_addr_reachable(&bare_udp_addr),
+        "bare IPv4 UDP address should be rejected because Tentacle cannot dial it"
+    );
+}
+
+#[test]
+fn test_is_addr_reachable_rejects_bare_ipv6_udp_address() {
+    let bare_udp_addr = Multiaddr::from_str("/ip6/2606:4700:4700::1111/udp/8228")
+        .expect("valid bare IPv6 UDP multiaddr");
+
+    assert!(
+        !is_addr_reachable(&bare_udp_addr),
+        "bare IPv6 UDP address should be rejected because Tentacle cannot dial it"
+    );
+}
+
+#[test]
+fn test_is_addr_reachable_rejects_bare_dns_udp_address() {
+    let bare_udp_addr =
+        Multiaddr::from_str("/dns4/example.com/udp/8228").expect("valid bare DNS UDP multiaddr");
+
+    assert!(
+        !is_addr_reachable(&bare_udp_addr),
+        "bare DNS UDP address should be rejected because Tentacle cannot dial it"
+    );
+}
+
+#[test]
 fn test_is_addr_reachable_rejects_dns_quic_address() {
     let dns_quic_addr = Multiaddr::from_str("/dns4/example.com/udp/8228/quic-v1")
         .expect("syntactically valid DNS QUIC multiaddr");

--- a/crates/fiber-lib/src/fiber/tests/utils.rs
+++ b/crates/fiber-lib/src/fiber/tests/utils.rs
@@ -66,6 +66,39 @@ fn test_is_addr_reachable_with_private_quic_address() {
 }
 
 #[test]
+fn test_is_addr_reachable_with_public_ipv6_quic_address() {
+    let public_addr = Multiaddr::from_str("/ip6/2606:4700:4700::1111/udp/8228/quic-v1")
+        .expect("valid public IPv6 QUIC multiaddr");
+
+    assert!(
+        is_addr_reachable(&public_addr),
+        "public IPv6 QUIC address should be considered reachable"
+    );
+}
+
+#[test]
+fn test_is_addr_reachable_with_private_ipv6_quic_address() {
+    let private_addr = Multiaddr::from_str("/ip6/fc00::1/udp/8228/quic-v1")
+        .expect("valid private IPv6 QUIC multiaddr");
+
+    assert!(
+        !is_addr_reachable(&private_addr),
+        "private IPv6 QUIC address should not be considered reachable"
+    );
+}
+
+#[test]
+fn test_is_addr_reachable_rejects_dns_quic_address() {
+    let dns_quic_addr = Multiaddr::from_str("/dns4/example.com/udp/8228/quic-v1")
+        .expect("syntactically valid DNS QUIC multiaddr");
+
+    assert!(
+        !is_addr_reachable(&dns_quic_addr),
+        "DNS QUIC address should be rejected because Tentacle does not support dialing it"
+    );
+}
+
+#[test]
 fn test_is_addr_reachable_with_dns4_address() {
     let dns4_addr =
         Multiaddr::from_str("/dns4/example.com/tcp/8228").expect("valid dns4 multiaddr");

--- a/crates/fiber-lib/src/fiber/tests/utils.rs
+++ b/crates/fiber-lib/src/fiber/tests/utils.rs
@@ -1,7 +1,10 @@
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 use tempfile::NamedTempFile;
-use tentacle::multiaddr::Multiaddr;
+use tentacle::{
+    multiaddr::{Multiaddr, Protocol},
+    secio::PeerId,
+};
 
 use crate::utils::encrypt_decrypt_file::decrypt_from_file;
 use crate::utils::encrypt_decrypt_file::encrypt_to_file;
@@ -36,6 +39,29 @@ fn test_is_addr_reachable_with_public_ip() {
     assert!(
         is_addr_reachable(&public_addr),
         "public IP address should be considered reachable"
+    );
+}
+
+#[test]
+fn test_is_addr_reachable_with_public_quic_address() {
+    let mut public_addr =
+        Multiaddr::from_str("/ip4/1.1.1.1/udp/8228/quic-v1").expect("valid public QUIC multiaddr");
+    public_addr.push(Protocol::P2P(Cow::Owned(PeerId::random().into_bytes())));
+
+    assert!(
+        is_addr_reachable(&public_addr),
+        "public QUIC address should be considered reachable"
+    );
+}
+
+#[test]
+fn test_is_addr_reachable_with_private_quic_address() {
+    let private_addr = Multiaddr::from_str("/ip4/192.168.1.1/udp/8228/quic-v1")
+        .expect("valid private QUIC multiaddr");
+
+    assert!(
+        !is_addr_reachable(&private_addr),
+        "private QUIC address should not be considered reachable"
     );
 }
 

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -1865,3 +1865,4 @@ The UDT script which is used to identify the UDT configuration for a Fiber Node.
 * `hash_type` - <em>`ScriptHashType`</em>, The hash type of the script.
 * `args` - <em>`String`</em>, The arguments of the script.
 ---
+

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -1804,6 +1804,7 @@ The type of transport to filter by when resolving peer addresses.
 * `tcp` - TCP transport (e.g. /ip4/1.2.3.4/tcp/8080)
 * `ws` - WebSocket transport (e.g. /ip4/1.2.3.4/tcp/8080/ws)
 * `wss` - WebSocket Secure transport (e.g. /dns/example.com/tcp/443/wss)
+* `quic_v1` - QUIC v1 transport (e.g. /ip4/1.2.3.4/udp/8228/quic-v1)
 ---
 
 <a id="#type-udtarginfo"></a>

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -1026,8 +1026,9 @@ Connect to a peer.
  The node resolves the address from locally synced graph data.
 * `save` - <em>`Option<bool>`</em>, Whether to save the peer address to the peer store.
 * `addr_type` - <em>Option<[TransportType](#type-transporttype)></em>, Filter addresses by transport type when connecting by pubkey.
- If not specified, the node uses target-specific defaults:
- native builds choose from `tcp` addresses only, while wasm builds choose from `ws`/`wss`.
+ If not specified, the node prefers the transport that is native to the current build
+ (`tcp` on native builds, `ws`/`wss` on wasm builds) and falls back to any other
+ dialable transport published by the peer.
 
 ##### Returns
 

--- a/crates/fiber-lib/src/rpc/README.md
+++ b/crates/fiber-lib/src/rpc/README.md
@@ -1865,4 +1865,3 @@ The UDT script which is used to identify the UDT configuration for a Fiber Node.
 * `hash_type` - <em>`ScriptHashType`</em>, The hash type of the script.
 * `args` - <em>`String`</em>, The arguments of the script.
 ---
-

--- a/crates/fiber-lib/src/rpc/peer.rs
+++ b/crates/fiber-lib/src/rpc/peer.rs
@@ -20,6 +20,7 @@ fn to_transport_type(t: fiber_json_types::TransportType) -> TransportType {
         fiber_json_types::TransportType::Tcp => TransportType::Tcp,
         fiber_json_types::TransportType::Ws => TransportType::Ws,
         fiber_json_types::TransportType::Wss => TransportType::Wss,
+        fiber_json_types::TransportType::QuicV1 => TransportType::QuicV1,
     }
 }
 

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -2404,6 +2404,42 @@ async fn test_connect_to_other_node() {
 }
 
 #[tokio::test]
+async fn test_connect_to_other_node_on_additional_listening_address() {
+    let mut node_a = NetworkNode::new().await;
+    let mut node_b = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.listening_addr = Some("/ip4/127.0.0.1/tcp/0".to_string());
+                config.listening_addrs = vec!["/ip4/127.0.0.1/tcp/0".to_string()];
+                config.reuse_port_for_websocket = false;
+            })
+            .build(),
+    )
+    .await;
+
+    assert_eq!(node_b.listening_addrs.len(), 2);
+    let peer_addr = node_b.listening_addrs[1].clone();
+
+    call!(node_a.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
+            peer_addr,
+            false,
+            crate::fiber::network::PeerConnectSource::Manual,
+            Some(rpc_reply),
+        ))
+    })
+    .expect("node is alive")
+    .expect("connect through the additional listening address");
+    node_a
+        .expect_event(|event| {
+            matches!(event, NetworkServiceEvent::PeerConnected(pubkey, _) if pubkey == &node_b.pubkey)
+        })
+        .await;
+    node_a.expect_debug_event("PeerInit").await;
+    node_b.expect_debug_event("PeerInit").await;
+}
+
+#[tokio::test]
 async fn test_restart_network_node() {
     let mut node = NetworkNode::new().await;
     node.restart().await;

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -267,7 +267,12 @@ pub struct NetworkNode {
     pub fiber_config: FiberConfig,
     pub rpc_config: Option<RpcConfig>,
     pub ckb_config: Option<CkbConfig>,
+    /// The addresses the node actually listens on.
     pub listening_addrs: Vec<MultiAddr>,
+    /// The addresses the node announces to the network. This is not the same as
+    /// [`Self::listening_addrs`]: private addresses are filtered out unless
+    /// `announce_private_addr` is set, and QUIC addresses are dropped when a proxy is configured.
+    pub announced_addrs: Vec<MultiAddr>,
     pub network_actor: ActorRef<NetworkActorMessage>,
     pub network_graph: Arc<TokioRwLock<NetworkGraph<Store>>>,
     pub chain_actor: ActorRef<CkbChainMessage>,
@@ -839,7 +844,7 @@ impl NetworkNode {
     }
 
     pub fn get_node_address(&self) -> &MultiAddr {
-        &self.listening_addrs[0]
+        &self.announced_addrs[0]
     }
 
     pub fn get_local_balance_from_channel(&self, channel_id: Hash256) -> u128 {
@@ -1691,7 +1696,7 @@ impl NetworkNode {
         .0;
 
         #[allow(clippy::never_loop)]
-        let (started_pubkey, _listening_addr, announced_addrs) = loop {
+        let (started_pubkey, listening_addrs, announced_addrs) = loop {
             select! {
                 Some(NetworkServiceEvent::NetworkStarted(pubkey, listening_addr, announced_addrs)) = event_receiver.recv() => {
                     break (pubkey, listening_addr, announced_addrs);
@@ -1782,7 +1787,8 @@ impl NetworkNode {
             ckb_config,
             rpc_config,
             channels_tx_map: Default::default(),
-            listening_addrs: announced_addrs,
+            listening_addrs,
+            announced_addrs,
             network_actor,
             chain_client,
             mock_chain_actor_middleware,
@@ -1957,10 +1963,10 @@ impl NetworkNode {
     }
 
     pub async fn connect_to_nonblocking(&mut self, other: &Self) {
-        let peer_addr = other.listening_addrs[0].clone();
+        let peer_addr = other.announced_addrs[0].clone();
         debug!(
             "Trying to connect to {:?} from {:?}",
-            other.listening_addrs, &self.listening_addrs
+            other.announced_addrs, &self.announced_addrs
         );
 
         let result = call!(self.network_actor, |rpc_reply| {
@@ -2410,7 +2416,12 @@ async fn test_connect_to_other_node_on_additional_listening_address() {
         NetworkNodeConfigBuilder::new()
             .fiber_config_updater(|config| {
                 config.listening_addr = Some("/ip4/127.0.0.1/tcp/0".to_string());
-                config.listening_addrs = vec!["/ip4/127.0.0.1/tcp/0".to_string()];
+                config.listening_addrs = vec![
+                    // Duplicated on purpose: it must be deduplicated instead of being listened
+                    // on (and announced) twice.
+                    "/ip4/127.0.0.1/tcp/0".to_string(),
+                    "/ip4/127.0.0.1/tcp/0/ws".to_string(),
+                ];
                 config.reuse_port_for_websocket = false;
             })
             .build(),
@@ -2419,6 +2430,10 @@ async fn test_connect_to_other_node_on_additional_listening_address() {
 
     assert_eq!(node_b.listening_addrs.len(), 2);
     let peer_addr = node_b.listening_addrs[1].clone();
+    assert_eq!(
+        tentacle::utils::find_type(&peer_addr),
+        tentacle::utils::TransportType::Ws
+    );
 
     call!(node_a.network_actor, |rpc_reply| {
         NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
@@ -2437,6 +2452,53 @@ async fn test_connect_to_other_node_on_additional_listening_address() {
         .await;
     node_a.expect_debug_event("PeerInit").await;
     node_b.expect_debug_event("PeerInit").await;
+}
+
+/// A dual stack IPv6 wildcard socket also covers the IPv4 space, so listening on
+/// `/ip4/0.0.0.0/tcp/P` and `/ip6/::/tcp/P` only works when the IPv6 socket is restricted with
+/// `IPV6_V6ONLY`. This is exactly the combination suggested by the shipped config files.
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_listen_on_ipv4_and_ipv6_wildcard_with_the_same_port() {
+    if std::net::TcpListener::bind("[::]:0").is_err() {
+        // No usable IPv6 stack in this environment, nothing to verify.
+        return;
+    }
+    let port = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind an ephemeral port")
+        .local_addr()
+        .expect("read the ephemeral port")
+        .port();
+
+    let node = NetworkNode::new_with_config(
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(move |config| {
+                config.listening_addr = Some(format!("/ip4/0.0.0.0/tcp/{port}"));
+                config.listening_addrs = vec![format!("/ip6/::/tcp/{port}")];
+                config.reuse_port_for_websocket = false;
+            })
+            .build(),
+    )
+    .await;
+
+    assert_eq!(node.listening_addrs.len(), 2);
+}
+
+/// An unusable listening address must abort startup with a readable error instead of panicking.
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_invalid_listening_address_reports_an_error() {
+    use crate::fiber::network::resolve_listening_addresses;
+
+    let config = crate::FiberConfig {
+        listening_addrs: vec!["/ip4/0.0.0.0/tcp/8228".to_string(), "nonsense".to_string()],
+        ..Default::default()
+    };
+    let err = resolve_listening_addresses(&config).expect_err("invalid address must be rejected");
+    assert!(
+        err.to_string().contains("nonsense"),
+        "the error must name the offending address, got: {err}"
+    );
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -2439,6 +2439,47 @@ async fn test_connect_to_other_node_on_additional_listening_address() {
     node_b.expect_debug_event("PeerInit").await;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_connect_to_other_node_over_quic() {
+    let quic_node_config = || {
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(|config| {
+                config.listening_addr = Some("/ip4/127.0.0.1/tcp/0".to_string());
+                config.listening_addrs = vec!["/ip4/127.0.0.1/udp/0/quic-v1".to_string()];
+                config.reuse_port_for_websocket = false;
+            })
+            .build()
+    };
+    let mut node_a = NetworkNode::new_with_config(quic_node_config()).await;
+    let mut node_b = NetworkNode::new_with_config(quic_node_config()).await;
+
+    let peer_addr = node_b
+        .listening_addrs
+        .iter()
+        .find(|addr| tentacle::utils::find_type(addr) == tentacle::utils::TransportType::QuicV1)
+        .expect("node has a QUIC listening address")
+        .clone();
+
+    call!(node_a.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
+            peer_addr,
+            false,
+            crate::fiber::network::PeerConnectSource::Manual,
+            Some(rpc_reply),
+        ))
+    })
+    .expect("node is alive")
+    .expect("connect over QUIC");
+    node_a
+        .expect_event(|event| {
+            matches!(event, NetworkServiceEvent::PeerConnected(pubkey, _) if pubkey == &node_b.pubkey)
+        })
+        .await;
+    node_a.expect_debug_event("PeerInit").await;
+    node_b.expect_debug_event("PeerInit").await;
+}
+
 #[tokio::test]
 async fn test_restart_network_node() {
     let mut node = NetworkNode::new().await;

--- a/crates/fiber-lib/src/tests/test_utils.rs
+++ b/crates/fiber-lib/src/tests/test_utils.rs
@@ -2480,6 +2480,86 @@ async fn test_connect_to_other_node_over_quic() {
     node_b.expect_debug_event("PeerInit").await;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_three_nodes_quic_connections_with_socks5_proxy() {
+    let quic_node_config = |proxy_url: Option<String>| {
+        NetworkNodeConfigBuilder::new()
+            .fiber_config_updater(move |config| {
+                config.listening_addr = Some("/ip4/127.0.0.1/tcp/0".to_string());
+                config.listening_addrs = vec!["/ip4/127.0.0.1/udp/0/quic-v1".to_string()];
+                config.reuse_port_for_websocket = false;
+                config.proxy.proxy_url = proxy_url;
+            })
+            .build()
+    };
+    let mut node_a = NetworkNode::new_with_config(quic_node_config(Some(
+        "socks5://127.0.0.1:65535".to_string(),
+    )))
+    .await;
+    let mut node_b = NetworkNode::new_with_config(quic_node_config(None)).await;
+    let mut node_c = NetworkNode::new_with_config(quic_node_config(None)).await;
+
+    let quic_address = |node: &NetworkNode| {
+        node.listening_addrs
+            .iter()
+            .find(|addr| tentacle::utils::find_type(addr) == tentacle::utils::TransportType::QuicV1)
+            .expect("node has a QUIC listening address")
+            .clone()
+    };
+
+    let rejected = call!(node_a.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
+            quic_address(&node_b),
+            false,
+            crate::fiber::network::PeerConnectSource::Manual,
+            Some(rpc_reply),
+        ))
+    })
+    .expect("proxied node is alive")
+    .expect_err("outbound QUIC must be rejected when SOCKS5 is configured");
+    assert!(
+        rejected.contains("outbound QUIC") && rejected.contains("proxy.proxy_url"),
+        "unexpected rejection: {rejected}"
+    );
+
+    call!(node_b.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
+            quic_address(&node_a),
+            false,
+            crate::fiber::network::PeerConnectSource::Manual,
+            Some(rpc_reply),
+        ))
+    })
+    .expect("node B is alive")
+    .expect("inbound QUIC remains available on the proxied node");
+    node_b
+        .expect_event(|event| {
+            matches!(event, NetworkServiceEvent::PeerConnected(pubkey, _) if pubkey == &node_a.pubkey)
+        })
+        .await;
+    node_b.expect_debug_event("PeerInit").await;
+    node_a.expect_debug_event("PeerInit").await;
+
+    call!(node_c.network_actor, |rpc_reply| {
+        NetworkActorMessage::Command(NetworkActorCommand::ConnectPeer(
+            quic_address(&node_b),
+            false,
+            crate::fiber::network::PeerConnectSource::Manual,
+            Some(rpc_reply),
+        ))
+    })
+    .expect("node C is alive")
+    .expect("unproxied nodes connect over QUIC");
+    node_c
+        .expect_event(|event| {
+            matches!(event, NetworkServiceEvent::PeerConnected(pubkey, _) if pubkey == &node_b.pubkey)
+        })
+        .await;
+    node_c.expect_debug_event("PeerInit").await;
+    node_b.expect_debug_event("PeerInit").await;
+}
+
 #[tokio::test]
 async fn test_restart_network_node() {
     let mut node = NetworkNode::new().await;

--- a/crates/fiber-lib/src/utils/mod.rs
+++ b/crates/fiber-lib/src/utils/mod.rs
@@ -9,8 +9,9 @@ use tentacle::utils::{is_reachable, multiaddr_to_socketaddr, multiaddr_to_udp_so
 
 /// Check whether a multiaddr is publicly reachable.
 ///
-/// For IP-based addresses (`Ip4`/`Ip6`), this extracts either a TCP or UDP
-/// socket address and delegates to tentacle's `is_reachable` check.
+/// For IP-based addresses (`Ip4`/`Ip6`), this extracts a TCP socket address, or
+/// a UDP socket address for QUIC v1 only, and delegates to tentacle's
+/// `is_reachable` check. Other UDP addresses are not dialable and are rejected.
 ///
 /// For DNS-based addresses (`Dns4`/`Dns6`), we treat them as reachable because a DNS name implies
 /// a publicly resolvable endpoint, except for DNS QUIC addresses, which Tentacle does not support.
@@ -18,15 +19,22 @@ use tentacle::utils::{is_reachable, multiaddr_to_socketaddr, multiaddr_to_udp_so
 /// For Tor onion addresses (`Onion3`), we treat them as always reachable
 /// because they are publicly accessible via the Tor network.
 pub(crate) fn is_addr_reachable(addr: &Multiaddr) -> bool {
+    let transport_type = tentacle::utils::find_type(addr);
+    let has_udp_protocol = addr.iter().any(|proto| matches!(proto, Protocol::Udp(_)));
+
+    // Tentacle supports UDP addresses only as part of its QUIC v1 transport. A bare UDP
+    // multiaddr is not dialable and must not be retained or advertised as reachable.
+    if has_udp_protocol && transport_type != tentacle::utils::TransportType::QuicV1 {
+        return false;
+    }
+
     let has_dns_protocol = addr
         .iter()
         .any(|proto| matches!(proto, Protocol::Dns4(_) | Protocol::Dns6(_)));
 
     // Tentacle QUIC currently accepts IP addresses only. Do not retain or gossip a DNS QUIC
     // address that peers cannot dial.
-    if has_dns_protocol
-        && tentacle::utils::find_type(addr) == tentacle::utils::TransportType::QuicV1
-    {
+    if has_dns_protocol && transport_type == tentacle::utils::TransportType::QuicV1 {
         return false;
     }
 
@@ -42,7 +50,11 @@ pub(crate) fn is_addr_reachable(addr: &Multiaddr) -> bool {
     }
 
     multiaddr_to_socketaddr(addr)
-        .or_else(|| multiaddr_to_udp_socketaddr(addr))
+        .or_else(|| {
+            (transport_type == tentacle::utils::TransportType::QuicV1)
+                .then(|| multiaddr_to_udp_socketaddr(addr))
+                .flatten()
+        })
         .map(|socket_addr| is_reachable(socket_addr.ip()))
         .unwrap_or_default()
 }

--- a/crates/fiber-lib/src/utils/mod.rs
+++ b/crates/fiber-lib/src/utils/mod.rs
@@ -12,12 +12,24 @@ use tentacle::utils::{is_reachable, multiaddr_to_socketaddr, multiaddr_to_udp_so
 /// For IP-based addresses (`Ip4`/`Ip6`), this extracts either a TCP or UDP
 /// socket address and delegates to tentacle's `is_reachable` check.
 ///
-/// For DNS-based addresses (`Dns4`/`Dns6`), we treat them as always reachable
-/// because a DNS name implies a publicly resolvable endpoint.
+/// For DNS-based addresses (`Dns4`/`Dns6`), we treat them as reachable because a DNS name implies
+/// a publicly resolvable endpoint, except for DNS QUIC addresses, which Tentacle does not support.
 ///
 /// For Tor onion addresses (`Onion3`), we treat them as always reachable
 /// because they are publicly accessible via the Tor network.
 pub(crate) fn is_addr_reachable(addr: &Multiaddr) -> bool {
+    let has_dns_protocol = addr
+        .iter()
+        .any(|proto| matches!(proto, Protocol::Dns4(_) | Protocol::Dns6(_)));
+
+    // Tentacle QUIC currently accepts IP addresses only. Do not retain or gossip a DNS QUIC
+    // address that peers cannot dial.
+    if has_dns_protocol
+        && tentacle::utils::find_type(addr) == tentacle::utils::TransportType::QuicV1
+    {
+        return false;
+    }
+
     let has_public_protocol = addr.iter().any(|proto| {
         matches!(
             proto,

--- a/crates/fiber-lib/src/utils/mod.rs
+++ b/crates/fiber-lib/src/utils/mod.rs
@@ -5,12 +5,12 @@ pub(crate) mod payment;
 pub mod tx;
 
 use tentacle::multiaddr::{Multiaddr, Protocol};
-use tentacle::utils::{is_reachable, multiaddr_to_socketaddr};
+use tentacle::utils::{is_reachable, multiaddr_to_socketaddr, multiaddr_to_udp_socketaddr};
 
 /// Check whether a multiaddr is publicly reachable.
 ///
-/// For IP-based addresses (`Ip4`/`Ip6`), this delegates to tentacle's
-/// `multiaddr_to_socketaddr` + `is_reachable` check.
+/// For IP-based addresses (`Ip4`/`Ip6`), this extracts either a TCP or UDP
+/// socket address and delegates to tentacle's `is_reachable` check.
 ///
 /// For DNS-based addresses (`Dns4`/`Dns6`), we treat them as always reachable
 /// because a DNS name implies a publicly resolvable endpoint.
@@ -30,6 +30,7 @@ pub(crate) fn is_addr_reachable(addr: &Multiaddr) -> bool {
     }
 
     multiaddr_to_socketaddr(addr)
+        .or_else(|| multiaddr_to_udp_socketaddr(addr))
         .map(|socket_addr| is_reachable(socket_addr.ip()))
         .unwrap_or_default()
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-EXPOSE 8227 8228
+EXPOSE 8227/tcp 8228/tcp 8228/udp
 VOLUME ["/fiber"]
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,6 +20,7 @@ docker run --rm -it \
   -e RUST_LOG='info' \
   -v "$(pwd)/fiber-node:/fiber" \
   -p 8228:8228 \
+  -p 8228:8228/udp \
   nervos/fiber:<release-tag>
 ```
 

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -151,6 +151,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "async-iterator"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +251,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -710,6 +772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,7 +785,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -727,7 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1249,6 +1328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1458,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,7 +1555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1601,6 +1698,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1840,12 @@ dependencies = [
  "strum 0.27.2",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1930,7 +2047,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ef0454b7ac3e87de49cab71ef0f27f716d00974cedb1b00426ab7b822212d8"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "hmac 0.12.1",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
@@ -1943,7 +2060,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827476eed3d2915d79c9809e71a7089f44cde5d9a4fa7c7045cd0f2d5e56fb95"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "hmac 0.12.1",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
@@ -2202,6 +2319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,8 +2478,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3404,7 +3530,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3535,6 +3661,12 @@ checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -3714,10 +3846,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3794,6 +3945,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -3979,6 +4139,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -4193,7 +4363,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4205,7 +4375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4420,6 +4590,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4472,7 +4699,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -4494,6 +4721,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.2",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4554,6 +4792,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4569,6 +4813,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -4741,6 +5007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4772,6 +5047,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4799,6 +5075,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4835,6 +5112,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5195,7 +5473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -5206,7 +5484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -5218,7 +5496,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -5230,7 +5508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -5550,9 +5828,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f236fb0e0985299c3667a1f1d3daefa159d09ffbb01fcb8a7fda4bd3a74f8a7c"
+checksum = "ece1f30bebb1d7e7dcb2c32591aa677b4ca72c66c6b73be721886b041f22e470"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5567,7 +5845,11 @@ dependencies = [
  "molecule",
  "nohash-hasher",
  "parking_lot",
+ "quinn",
  "rand 0.8.6",
+ "rcgen",
+ "ring",
+ "rustls",
  "socket2 0.6.4",
  "tentacle-multiaddr",
  "tentacle-secio",
@@ -5580,13 +5862,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "winapi",
+ "x509-parser",
 ]
 
 [[package]]
 name = "tentacle-multiaddr"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d2d1d3511bbe6d6a662ee13616a31268d0558c73d25dfe6b5a5dcb376719c7"
+checksum = "557b93edd813d6f875e03013f2cf5bb2b4318b9e440d69a98ce8536bb302699e"
 dependencies = [
  "arrayref",
  "bs58",
@@ -5600,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle-secio"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0bfdc28264bd49c81ea0d027a9fa3f39b50960cd2b9c7e1748cfdb72d2265e"
+checksum = "d608a76b7e4947413e54475a077d47f7cec41b58f0ad12d9a27293032b680839"
 dependencies = [
  "bs58",
  "bytes",
@@ -5848,15 +6131,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-yamux"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6489207fc5dedea9723f5dc1c3ab96103c001449fa6056ca6cdba74ffbd84512"
+checksum = "1203db1ac9762aaf041ba62d4fade5959b89af1abd057c5e9bc54ae3e7f00c4b"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "log",
- "nohash-hasher",
  "tokio",
  "tokio-util",
  "web-time",
@@ -6806,6 +7088,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6825,6 +7124,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/openrpc-json-generator/Cargo.lock
+++ b/openrpc-json-generator/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "socket2 0.6.4",
  "strum 0.28.0",
  "tentacle",
  "thiserror 1.0.69",


### PR DESCRIPTION
## What this PR does

Add QUIC transport support to Fiber nodes using Tentacle 0.7.7.

Fiber nodes can now listen on TCP and QUIC addresses simultaneously, connect directly through QUIC, and select QUIC addresses through the `connect_peer` RPC.

## Configuration

QUIC listeners can be configured through the existing `fiber.listening_addrs` option:

```yaml
fiber:
  listening_addr: "/ip4/0.0.0.0/tcp/8228"
  listening_addrs:
    - "/ip4/0.0.0.0/udp/8228/quic-v1"
```

A public QUIC address can be announced with:

```yaml
fiber:
  announced_addrs:
    - "/ip4/YOUR-PUBLIC-IP/udp/8228/quic-v1"
```

The corresponding UDP port must be allowed through the firewall, security group, and container network.

## RPC

`connect_peer` now accepts `quic_v1` as an address transport filter:

```json
{
  "pubkey": "<peer-pubkey>",
  "addr_type": "quic_v1"
}
```

Nodes can also connect directly using a QUIC multiaddr:

```text
/ip4/1.2.3.4/udp/8228/quic-v1/p2p/<peer-id>
```

## Implementation

- Upgrade Tentacle to 0.7.7.
- Enable Tentacle's `quic` feature for native builds.
- Configure the Tentacle service with the default `QuicConfig`.
- Recognize `/udp/.../quic-v1` addresses as `TransportType::QuicV1`.
- Add `quic_v1` to the JSON-RPC transport type.
- Update generated RPC documentation.
- Add QUIC examples to the mainnet and testnet configuration files.
- Expose and document the Fiber UDP port in the Docker configuration.
- Keep QUIC disabled for WASM builds.

Native automatic address selection still defaults to TCP when no transport is specified. QUIC can be selected explicitly through the RPC transport filter, a direct multiaddr, or a QUIC bootnode address.

## Compatibility

- Existing TCP and WebSocket configurations are unchanged.
- QUIC is additive and does not replace existing transports.
- Existing `listening_addr` configurations continue to work.
- No database migration is required.

## Tests

- Verified QUIC address classification and transport filtering.
- Started two Fiber nodes with TCP and QUIC listeners.
- Connected one node to the other explicitly through its QUIC address.
- Verified `PeerConnected` and bidirectional `PeerInit` protocol exchange.
- Ran native compilation and Clippy with all features.
- Ran WASM Clippy to ensure the native-only QUIC integration does not affect WASM builds.

```text
PASS fnn tests::test_utils::test_connect_to_other_node_over_quic
PASS fnn fiber::tests::network::test_select_connect_peer_address_by_quic_transport
```