### PR TITLE
fix: scope preimage settlement to local TLCs

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -1400,9 +1400,7 @@ where
         state: &mut ChannelActorState,
         tlc: TlcInfo,
     ) {
-        // Do not settle a forwarding TLC from a globally visible preimage
-        // before the downstream forwarding result is known.
-        if state.is_waiting_forward_result_for_received_tlc(tlc.tlc_id) {
+        if !state.can_auto_fulfill_received_tlc(&tlc) {
             return;
         }
 
@@ -2937,6 +2935,10 @@ where
                         NetworkActorCommand::SettleTlcSet(payment_hash, vec![(state.id, id)]),
                     ))
                     .expect(ASSUME_NETWORK_ACTOR_ALIVE);
+                continue;
+            }
+
+            if !state.can_auto_fulfill_received_tlc(tlc) {
                 continue;
             }
 
@@ -5710,6 +5712,30 @@ impl ChannelActorState {
 
     pub(crate) fn is_waiting_forward_result_for_received_tlc(&self, tlc_id: TLCId) -> bool {
         self.waiting_forward_tlc_tasks.contains_key(&tlc_id)
+    }
+
+    /// Returns whether a received TLC may be fulfilled from a preimage in the local store.
+    ///
+    /// A stored preimage only proves that *some* payment with the same hash succeeded. It does
+    /// not prove that this forwarding attempt succeeded. Forwarded TLCs must therefore be
+    /// resolved by the result from their own downstream `(channel_id, tlc_id)`:
+    ///
+    /// ```text
+    /// incoming TLC
+    ///   |-- final hop ------------------------------> local preimage may fulfill
+    ///   `-- forwarding
+    ///         |-- waiting_forward_tlc_tasks --------> wait for AddTlc result
+    ///         |-- forwarding_tlc = Some(...) -------> wait for downstream RemoveTlc
+    ///         `-- retryable RemoveTlc --------------> preserve the selected failure
+    /// ```
+    pub(crate) fn can_auto_fulfill_received_tlc(&self, tlc: &TlcInfo) -> bool {
+        tlc.is_received()
+            && tlc.removed_reason.is_none()
+            && tlc.forwarding_tlc.is_none()
+            && !self.is_waiting_forward_result_for_received_tlc(tlc.tlc_id)
+            && !self.retryable_tlc_operations.iter().any(|operation| {
+                matches!(operation, RetryableTlcOperation::RemoveTlc(tlc_id, _) if *tlc_id == tlc.tlc_id)
+            })
     }
 
     fn update_graph_for_local_channel_change(&mut self) {

--- a/crates/fiber-lib/src/fiber/tests/channel.rs
+++ b/crates/fiber-lib/src/fiber/tests/channel.rs
@@ -12752,12 +12752,8 @@ mod udt_funding_cell_capacity {
         );
     }
 
-    #[test]
-    fn waiting_forward_result_excludes_received_tlc_from_expiry_sweep() {
-        let mut state = minimal_udt_channel_state();
-        state.core.state = ChannelState::ChannelReady;
-        let tlc_id = TLCId::Received(0);
-        let expired_tlc = TlcInfo {
+    fn committed_received_tlc(tlc_id: TLCId) -> TlcInfo {
+        TlcInfo {
             status: TlcStatus::Inbound(InboundTlcStatus::Committed),
             tlc_id,
             amount: 1000,
@@ -12778,7 +12774,50 @@ mod udt_funding_cell_capacity {
             removed_reason: None,
             removed_confirmed_at: None,
             applied_flags: AppliedFlags::empty(),
-        };
+        }
+    }
+
+    #[test]
+    fn only_final_received_tlc_can_be_auto_fulfilled_from_local_preimage() {
+        let mut state = minimal_udt_channel_state();
+        let tlc_id = TLCId::Received(0);
+        let mut tlc = committed_received_tlc(tlc_id);
+
+        assert!(state.can_auto_fulfill_received_tlc(&tlc));
+
+        state
+            .waiting_forward_tlc_tasks
+            .insert(tlc_id, NO_SHARED_SECRET);
+        assert!(!state.can_auto_fulfill_received_tlc(&tlc));
+
+        state.waiting_forward_tlc_tasks.remove(&tlc_id);
+        tlc.forwarding_tlc = Some((gen_rand_sha256_hash(), 1));
+        assert!(!state.can_auto_fulfill_received_tlc(&tlc));
+
+        tlc.forwarding_tlc = None;
+        state
+            .retryable_tlc_operations
+            .push_back(RetryableTlcOperation::RemoveTlc(
+                tlc_id,
+                RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
+                    payment_preimage: gen_rand_sha256_hash(),
+                }),
+            ));
+        assert!(!state.can_auto_fulfill_received_tlc(&tlc));
+
+        state.retryable_tlc_operations.clear();
+        tlc.removed_reason = Some(RemoveTlcReason::RemoveTlcFulfill(RemoveTlcFulfill {
+            payment_preimage: gen_rand_sha256_hash(),
+        }));
+        assert!(!state.can_auto_fulfill_received_tlc(&tlc));
+    }
+
+    #[test]
+    fn waiting_forward_result_excludes_received_tlc_from_expiry_sweep() {
+        let mut state = minimal_udt_channel_state();
+        state.core.state = ChannelState::ChannelReady;
+        let tlc_id = TLCId::Received(0);
+        let expired_tlc = committed_received_tlc(tlc_id);
         state.tlc_state.received_tlcs.tlcs.push(expired_tlc);
         state
             .waiting_forward_tlc_tasks


### PR DESCRIPTION

## Problem

Test `test_send_payment_with_same_invoice` is not stable, may have a chance to with failure.

```console
thread 'fiber::tests::payment::test_send_payment_with_same_invoice' (14878884) panicked at crates/fiber-lib/src/fiber/tests/payment.rs:10632:5:
assertion `left == right` failed
  left: 2
 right: 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Payment preimages are stored by `payment_hash`, so they are visible to every channel actor on the node. The periodic channel maintenance path treated the presence of a preimage as proof that each committed TLC with that hash had succeeded. With concurrent payments to the same invoice, a preimage learned from one downstream attempt could therefore incorrectly fulfill another upstream forwarding TLC whose own downstream attempt failed.

## Fix

Only auto-fulfill a received TLC from the local preimage store when it is locally terminated. A TLC is excluded when it:

- is waiting for its downstream `AddTlc` result
- is linked to a downstream `(channel_id, tlc_id)`
- already has a retryable removal queued
- already has a removal reason

Forwarded TLCs continue to be resolved by their exact downstream removal result.

