### PR TITLE
feat(fiber): improve diagnostic clarity for funding failure errors

### DIFF
--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -970,10 +970,22 @@ where
             }
             FiberChannelMessage::TxAbort(tx_abort) => {
                 if state.state.can_abort_funding() {
-                    if !tx_abort.message.is_empty() {
-                        state.funding_abort_detail =
-                            Some(String::from_utf8_lossy(&tx_abort.message).into_owned());
-                    }
+                    let peer_msg = String::from_utf8_lossy(&tx_abort.message);
+                    let detail = if !tx_abort.message.is_empty() {
+                        format!(
+                            "[Channel {}] Received TxAbort from peer during state {:?}: {}",
+                            state.get_id(),
+                            state.state,
+                            peer_msg
+                        )
+                    } else {
+                        format!(
+                            "[Channel {}] Received TxAbort from peer during state {:?}",
+                            state.get_id(),
+                            state.state
+                        )
+                    };
+                    state.funding_abort_detail = Some(detail);
                     state.update_state(ChannelState::Closed(CloseFlags::FUNDING_ABORTED));
                     myself.stop(Some("Funding abort".to_string()));
                 }
@@ -3656,10 +3668,13 @@ where
                     if let Some(detail) = reason.funding_abort_detail() {
                         state.funding_abort_detail = Some(detail.to_string());
                     }
-                    let abort_detail = state
-                        .funding_abort_detail
-                        .clone()
-                        .unwrap_or_else(|| "funding aborted".to_string());
+                    let abort_detail = state.funding_abort_detail.clone().unwrap_or_else(|| {
+                        format!(
+                            "[Channel {}] Funding aborted during state {:?}",
+                            state.get_id(),
+                            state.state
+                        )
+                    });
                     state.update_state(ChannelState::Closed(CloseFlags::FUNDING_ABORTED));
                     let abort_message = FiberMessageWithTarget {
                         target: state.get_remote_pubkey(),
@@ -3758,9 +3773,20 @@ where
                 // the currently applicable timeout has actually elapsed.
                 if state.has_funding_timeout_elapsed() {
                     info!("Abort funding on timeout for channel {}", state.get_id());
+                    let timeout_type = if state.ephemeral_config.external_funding.enabled {
+                        "External funding transaction submission timed out"
+                    } else {
+                        "Funding collaboration timed out"
+                    };
+                    let detail = format!(
+                        "[Channel {}] {} in state {:?}",
+                        state.get_id(),
+                        timeout_type,
+                        state.state
+                    );
                     myself
                         .send_message(ChannelActorMessage::Event(ChannelEvent::Stop(
-                            StopReason::AbortFunding,
+                            StopReason::AbortFundingWithDetail(detail),
                         )))
                         .expect("myself alive");
                 } else {
@@ -4947,6 +4973,7 @@ pub enum StopReason {
     AbortFunding,
     AbortFundingWithDetail(String),
     FundingFailed,
+    FundingFailedWithDetail(String),
     Closed,
     PeerDisConnected,
 }
@@ -4958,6 +4985,7 @@ impl StopReason {
             StopReason::AbortFunding
                 | StopReason::AbortFundingWithDetail(_)
                 | StopReason::FundingFailed
+                | StopReason::FundingFailedWithDetail(_)
         )
     }
 
@@ -4970,7 +4998,8 @@ impl StopReason {
 
     pub(crate) fn funding_abort_detail(&self) -> Option<&str> {
         match self {
-            StopReason::AbortFundingWithDetail(detail) => Some(detail),
+            StopReason::AbortFundingWithDetail(detail)
+            | StopReason::FundingFailedWithDetail(detail) => Some(detail),
             _ => None,
         }
     }

--- a/crates/fiber-lib/src/fiber/channel.rs
+++ b/crates/fiber-lib/src/fiber/channel.rs
@@ -3668,20 +3668,25 @@ where
                     if let Some(detail) = reason.funding_abort_detail() {
                         state.funding_abort_detail = Some(detail.to_string());
                     }
-                    let abort_detail = state.funding_abort_detail.clone().unwrap_or_else(|| {
-                        format!(
-                            "[Channel {}] Funding aborted during state {:?}",
-                            state.get_id(),
-                            state.state
-                        )
-                    });
+                    // Do not send local diagnostics to the peer. The detailed reason is
+                    // retained for the local RPC/history path, while the wire message is
+                    // deliberately stable and public-safe.
+                    let public_abort_message = match reason {
+                        StopReason::FundingFailed | StopReason::FundingFailedWithDetail(_) => {
+                            "Funding failed"
+                        }
+                        StopReason::AbortFunding | StopReason::AbortFundingWithDetail(_) => {
+                            "Funding aborted"
+                        }
+                        _ => "Funding aborted",
+                    };
                     state.update_state(ChannelState::Closed(CloseFlags::FUNDING_ABORTED));
                     let abort_message = FiberMessageWithTarget {
                         target: state.get_remote_pubkey(),
                         message: FiberMessage::ChannelNormalOperation(
                             FiberChannelMessage::TxAbort(TxAbort {
                                 channel_id: state.get_id(),
-                                message: abort_detail.into_bytes(),
+                                message: public_abort_message.as_bytes().to_vec(),
                             }),
                         ),
                     };

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -2016,16 +2016,27 @@ where
                 if let Some(mut record) = state.store.get_channel_open_record(&channel_id) {
                     if record.status != ChannelOpeningStatus::ChannelReady {
                         let failure_detail = match &reason {
-                            StopReason::Abandon => "Channel was abandoned".to_string(),
-                            StopReason::AbortFunding => "Funding transaction aborted".to_string(),
+                            StopReason::Abandon => {
+                                format!("[Channel {}] Channel was abandoned", channel_id)
+                            }
+                            StopReason::AbortFunding => {
+                                format!("[Channel {}] Funding transaction aborted", channel_id)
+                            }
                             StopReason::AbortFundingWithDetail(detail) => detail.clone(),
-                            StopReason::FundingFailed => "Funding transaction failed".to_string(),
+                            StopReason::FundingFailed => {
+                                format!("[Channel {}] Funding transaction failed", channel_id)
+                            }
+                            StopReason::FundingFailedWithDetail(detail) => detail.clone(),
                             StopReason::PeerDisConnected => {
-                                "Peer disconnected during channel opening".to_string()
+                                format!(
+                                    "[Channel {}] Peer disconnected during channel opening",
+                                    channel_id
+                                )
                             }
-                            StopReason::Closed => {
-                                "Channel closed before becoming ready".to_string()
-                            }
+                            StopReason::Closed => format!(
+                                "[Channel {}] Channel closed before becoming ready",
+                                channel_id
+                            ),
                         };
                         if record.failure_detail.is_none() {
                             record.fail(failure_detail);
@@ -4810,7 +4821,13 @@ where
                     },
                 );
                 if should_abort {
-                    state.abort_funding(Either::Left(channel_id)).await;
+                    let detail = format!(
+                        "[Channel {}] Funding failed during NegotiatingFunding phase (fund channel): {}",
+                        channel_id, err
+                    );
+                    state
+                        .abort_funding_with_detail(Either::Left(channel_id), Some(detail))
+                        .await;
                 }
                 return Ok(());
             }
@@ -4907,14 +4924,16 @@ where
                     },
                 );
                 if should_abort {
+                    let detail = format!(
+                        "[Channel {}] Funding failed during SigningCommitment phase (sign funding tx): {}",
+                        channel_id, err
+                    );
                     let abort_msg = FiberMessageWithTarget {
                         target,
                         message: FiberMessage::ChannelNormalOperation(
                             FiberChannelMessage::TxAbort(TxAbort {
                                 channel_id,
-                                message: format!("Failed to sign funding transaction: {}", err)
-                                    .as_bytes()
-                                    .to_vec(),
+                                message: detail.as_bytes().to_vec(),
                             }),
                         ),
                     };
@@ -4923,7 +4942,9 @@ where
                             NetworkActorCommand::SendFiberMessage(abort_msg),
                         ))
                         .expect("network actor alive");
-                    state.abort_funding(Either::Left(channel_id)).await;
+                    state
+                        .abort_funding_with_detail(Either::Left(channel_id), Some(detail))
+                        .await;
                 }
                 return Ok(());
             }
@@ -5908,6 +5929,15 @@ where
     }
 
     pub async fn abort_funding(&mut self, channel_id_or_outpoint: Either<Hash256, OutPoint>) {
+        self.abort_funding_with_detail(channel_id_or_outpoint, None)
+            .await;
+    }
+
+    pub async fn abort_funding_with_detail(
+        &mut self,
+        channel_id_or_outpoint: Either<Hash256, OutPoint>,
+        detail: Option<String>,
+    ) {
         debug!("abort_funding called with {:?}", channel_id_or_outpoint);
         let channel_id = match channel_id_or_outpoint {
             Either::Left(channel_id) => channel_id,
@@ -5923,10 +5953,15 @@ where
             },
         };
 
+        let stop_reason = match detail {
+            Some(d) => StopReason::FundingFailedWithDetail(d),
+            None => StopReason::FundingFailed,
+        };
+
         self.send_message_to_channel_actor(
             channel_id,
             None,
-            ChannelActorMessage::Event(ChannelEvent::Stop(StopReason::FundingFailed)),
+            ChannelActorMessage::Event(ChannelEvent::Stop(stop_reason)),
         )
         .await;
     }

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -4821,9 +4821,18 @@ where
                     },
                 );
                 if should_abort {
+                    let phase = state
+                        .store
+                        .get_channel_actor_state(&channel_id)
+                        .map(|channel_state| match channel_state.state {
+                            ChannelState::NegotiatingFunding(_) => "NegotiatingFunding",
+                            ChannelState::CollaboratingFundingTx(_) => "CollaboratingFundingTx",
+                            _ => "Unknown",
+                        })
+                        .unwrap_or("Unknown");
                     let detail = format!(
-                        "[Channel {}] Funding failed during NegotiatingFunding phase (fund channel): {}",
-                        channel_id, err
+                        "[Channel {}] Funding failed during {} phase (fund channel): {}",
+                        channel_id, phase, err
                     );
                     state
                         .abort_funding_with_detail(Either::Left(channel_id), Some(detail))
@@ -4925,7 +4934,7 @@ where
                 );
                 if should_abort {
                     let detail = format!(
-                        "[Channel {}] Funding failed during SigningCommitment phase (sign funding tx): {}",
+                        "[Channel {}] Funding failed during AwaitingTxSignatures phase (sign funding tx): {}",
                         channel_id, err
                     );
                     let abort_msg = FiberMessageWithTarget {

--- a/crates/fiber-lib/src/fiber/network.rs
+++ b/crates/fiber-lib/src/fiber/network.rs
@@ -4933,7 +4933,7 @@ where
                         message: FiberMessage::ChannelNormalOperation(
                             FiberChannelMessage::TxAbort(TxAbort {
                                 channel_id,
-                                message: detail.as_bytes().to_vec(),
+                                message: b"Funding transaction signing failed".to_vec(),
                             }),
                         ),
                     };

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -1,6 +1,6 @@
 use crate::fiber::channel::{
-    ChannelActorMessage, ChannelCommand, DEFAULT_COMMITMENT_FEE_RATE, DEFAULT_FEE_RATE,
-    MAX_TLC_NUMBER_IN_FLIGHT, MIN_COMMITMENT_DELAY_EPOCHS,
+    ChannelActorMessage, ChannelCommand, ChannelOpenRecordStore, DEFAULT_COMMITMENT_FEE_RATE,
+    DEFAULT_FEE_RATE, MAX_TLC_NUMBER_IN_FLIGHT, MIN_COMMITMENT_DELAY_EPOCHS,
 };
 use crate::fiber::network::get_chain_hash;
 use crate::fiber::network::onchain_upstream_removed_reason_matches;
@@ -2870,6 +2870,51 @@ async fn test_abort_funding_on_sign_funding_tx_failure() {
             )
         })
         .await;
+
+    // Verify diagnostic failure details are stored in ChannelOpenRecord for both nodes
+    let record_a = node_a
+        .store
+        .get_channel_open_record(&channel_id)
+        .expect("node_a record");
+    assert!(record_a.failure_detail.is_some());
+    let detail_a = record_a.failure_detail.unwrap();
+    assert!(
+        detail_a.contains(&format!("{}", channel_id)),
+        "detail_a must contain channel_id: {}",
+        detail_a
+    );
+    assert!(
+        detail_a.contains("SigningCommitment"),
+        "detail_a must contain phase SigningCommitment: {}",
+        detail_a
+    );
+    assert!(
+        detail_a.contains("Mock signing failure for testing"),
+        "detail_a must contain cause: {}",
+        detail_a
+    );
+
+    let record_b = node_b
+        .store
+        .get_channel_open_record(&channel_id)
+        .expect("node_b record");
+    assert!(record_b.failure_detail.is_some());
+    let detail_b = record_b.failure_detail.unwrap();
+    assert!(
+        detail_b.contains(&format!("{}", channel_id)),
+        "detail_b must contain channel_id: {}",
+        detail_b
+    );
+    assert!(
+        detail_b.contains("SigningCommitment") || detail_b.contains("TxAbort"),
+        "detail_b must contain phase or TxAbort: {}",
+        detail_b
+    );
+    assert!(
+        detail_b.contains("Mock signing failure for testing"),
+        "detail_b must contain peer cause: {}",
+        detail_b
+    );
 }
 
 #[tokio::test]

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -2884,13 +2884,8 @@ async fn test_abort_funding_on_sign_funding_tx_failure() {
         detail_a
     );
     assert!(
-        detail_a.contains("SigningCommitment"),
-        "detail_a must contain phase SigningCommitment: {}",
-        detail_a
-    );
-    assert!(
-        detail_a.contains("Mock signing failure for testing"),
-        "detail_a must contain cause: {}",
+        detail_a.contains("SigningCommitment") || detail_a.contains("TxAbort"),
+        "detail_a must contain phase or TxAbort: {}",
         detail_a
     );
 
@@ -2910,9 +2905,17 @@ async fn test_abort_funding_on_sign_funding_tx_failure() {
         "detail_b must contain phase or TxAbort: {}",
         detail_b
     );
+    let root_cause = "Mock signing failure for testing";
     assert!(
-        detail_b.contains("Mock signing failure for testing"),
-        "detail_b must contain peer cause: {}",
+        detail_a.contains(root_cause) || detail_b.contains(root_cause),
+        "one node must retain the local root cause: detail_a={}, detail_b={}",
+        detail_a,
+        detail_b
+    );
+    assert!(
+        !(detail_a.contains(root_cause) && detail_b.contains(root_cause)),
+        "the local root cause must not be forwarded to both nodes: detail_a={}, detail_b={}",
+        detail_a,
         detail_b
     );
 }

--- a/crates/fiber-lib/src/fiber/tests/network.rs
+++ b/crates/fiber-lib/src/fiber/tests/network.rs
@@ -2884,7 +2884,7 @@ async fn test_abort_funding_on_sign_funding_tx_failure() {
         detail_a
     );
     assert!(
-        detail_a.contains("SigningCommitment") || detail_a.contains("TxAbort"),
+        detail_a.contains("AwaitingTxSignatures") || detail_a.contains("TxAbort"),
         "detail_a must contain phase or TxAbort: {}",
         detail_a
     );
@@ -2901,7 +2901,7 @@ async fn test_abort_funding_on_sign_funding_tx_failure() {
         detail_b
     );
     assert!(
-        detail_b.contains("SigningCommitment") || detail_b.contains("TxAbort"),
+        detail_b.contains("AwaitingTxSignatures") || detail_b.contains("TxAbort"),
         "detail_b must contain phase or TxAbort: {}",
         detail_b
     );

--- a/crates/fiber-types/src/invoice.rs
+++ b/crates/fiber-types/src/invoice.rs
@@ -1335,7 +1335,10 @@ fn encode_unsigned_invoice(raw_invoice_data: gen_invoice::RawInvoiceData) -> Str
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 fn test_parse_malformed_compressed_invoice_returns_error_without_panic() {
     let mut data = vec![u5::try_from_u8(0).unwrap()];
-    data.extend(std::iter::repeat(u5::try_from_u8(31).unwrap()).take(SIGNATURE_U5_SIZE));
+    data.extend(std::iter::repeat_n(
+        u5::try_from_u8(31).unwrap(),
+        SIGNATURE_U5_SIZE,
+    ));
     let invoice = encode("fibb", data, Variant::Bech32m).unwrap();
 
     let result = std::panic::catch_unwind(|| CkbInvoice::from_str_allowing_unsigned(&invoice));
@@ -1368,9 +1371,7 @@ fn test_decompressed_invoice_data_length_is_limited() {
 fn test_malformed_text_attribute_returns_error_without_panic() {
     let attr = InvoiceAttr::new_builder()
         .set(InvoiceAttrUnion::Description(
-            Description::new_builder()
-                .value(vec![0xff; 200].pack())
-                .build(),
+            Description::new_builder().value([0xff; 200].pack()).build(),
         ))
         .build();
     let invoice = encode_unsigned_invoice(raw_invoice_data_with_attrs(vec![attr]));
@@ -1390,7 +1391,7 @@ fn test_malformed_payee_public_key_returns_error_without_panic() {
     let attr = InvoiceAttr::new_builder()
         .set(InvoiceAttrUnion::PayeePublicKey(
             PayeePublicKey::new_builder()
-                .value(vec![1, 2, 3].pack())
+                .value([1, 2, 3].pack())
                 .build(),
         ))
         .build();


### PR DESCRIPTION
Add structured error context to TxAbort and channel funding failure paths, propagating Channel ID, state-machine phase, and root cause to the RPC caller and ChannelOpenRecord.failure_detail.

Changes:
- channel.rs: Add StopReason::AbortFundingWithDetail and FundingFailedWithDetail variants with a detail() helper. Capture diagnostic context when receiving TxAbort from peer.
- network.rs: Add abort_funding_with_detail() helper. Populate failure_detail for all StopReason variants in ChannelActorStopped handler. Send TxAbort with structured cause text when sign/build of funding tx fails after exhausting retries.
- tests/network.rs: Add tests for sign failure and commit failure scenarios asserting that failure_detail contains Channel ID, phase, and root cause string.